### PR TITLE
Support for custom functions in the select clause

### DIFF
--- a/src/NHibernate/Linq/Visitors/SelectClauseHqlNominator.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseHqlNominator.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Linq.Expressions;
+using System.Collections.ObjectModel;
+using NHibernate.Linq.Functions;
+using NHibernate.Linq.Expressions;
+
+namespace NHibernate.Linq.Visitors
+{
+    public class SelectClauseHqlNominator : NhExpressionTreeVisitor
+    {
+        private ILinqToHqlGeneratorsRegistry _functionRegistry;
+
+        private HashSet<Expression> _candidates;
+        private bool _canBeCandidate;
+        Stack<bool> _stateStack;
+        public SelectClauseHqlNominator(VisitorParameters parameters)
+        {
+            _functionRegistry = parameters.SessionFactory.Settings.LinqToHqlGeneratorsRegistry;
+        }
+
+
+        public override Expression VisitExpression(Expression expression)
+        {
+            try
+            {
+                bool projectConstantsInHql = _stateStack.Peek();
+                if (!projectConstantsInHql && expression != null && IsRegisteredFunction(expression))
+                {
+                    projectConstantsInHql = true;
+                }
+                _stateStack.Push(projectConstantsInHql);
+
+                if (expression == null)
+                    return expression;
+
+
+                bool saveCanBeCandidate = _canBeCandidate;
+                _canBeCandidate = true;
+
+                if (CanBeEvaluatedInHqlStatementShortcut(expression))
+                {
+                    _candidates.Add(expression);
+                    return expression;
+                }
+
+                base.VisitExpression(expression);
+
+                if (_canBeCandidate)
+                {
+                    if (CanBeEvaluatedInHqlSelectStatement(expression, projectConstantsInHql))
+                    {
+                        _candidates.Add(expression);
+                    }
+                    else
+                    {
+                        _canBeCandidate = false;
+                    }
+                }
+
+                _canBeCandidate = _canBeCandidate & saveCanBeCandidate;
+
+                return expression;
+            }
+            finally
+            {
+                _stateStack.Pop();
+            }
+        }
+
+        private bool IsRegisteredFunction(Expression expression)
+        {
+            if (expression.NodeType == ExpressionType.Call)
+            {
+                IHqlGeneratorForMethod methodGenerator;
+                if (_functionRegistry.TryGetGenerator(((MethodCallExpression)expression).Method, out methodGenerator))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+
+
+        private bool CanBeEvaluatedInHqlSelectStatement(Expression expression, bool projectConstantsInHql)
+        {
+
+            // Hql can't do New or Member Init
+            if ((expression.NodeType == ExpressionType.MemberInit) || (expression.NodeType == ExpressionType.New))
+            {
+                return false;
+            }
+
+            //Constants will only be evaluated in Hql if they're inside a method call
+            if (expression.NodeType == ExpressionType.Constant)
+            {
+                return projectConstantsInHql;
+            }
+
+
+
+            if (expression.NodeType == ExpressionType.Call)
+            {
+                // Depends if it's in the function registry
+                if (!IsRegisteredFunction(expression))
+                    return false;
+            }
+
+            // Assume all is good
+            return true;
+        }
+
+
+
+        private static bool CanBeEvaluatedInHqlStatementShortcut(Expression expression)
+        {
+            return ((NhExpressionType)expression.NodeType) == NhExpressionType.Count;
+        }
+
+        internal HashSet<Expression> Nominate(Expression expression)
+        {
+            _candidates = new HashSet<Expression>();
+            _canBeCandidate = true;
+            _stateStack = new Stack<bool>();
+            _stateStack.Push(false);
+            VisitExpression(expression);
+            return _candidates;
+        }
+
+    }
+}

--- a/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Linq.Visitors
         public void Visit(Expression expression)
         {
             // First, find the sub trees that can be expressed purely in HQL
-            _hqlNodes = new Nominator(CanBeEvaluatedInHqlSelectStatement, CanBeEvaluatedInHqlStatementShortcut).Nominate(expression);
+            _hqlNodes = new SelectClauseHqlNominator(_parameters).Nominate(expression);
 
             // Now visit the tree
             Expression projection = VisitExpression(expression);

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -283,6 +283,7 @@
     <Compile Include="Linq\Visitors\PossibleValueSet.cs" />
     <Compile Include="Linq\Visitors\ResultOperatorProcessors\ProcessAggregateFromSeed.cs" />
     <Compile Include="Linq\Visitors\SelectAndOrderByJoinDetector.cs" />
+    <Compile Include="Linq\Visitors\SelectClauseHqlNominator.cs" />
     <Compile Include="Linq\Visitors\WhereJoinDetector.cs" />
     <Compile Include="Loader\TopologicalSorter.cs" />
     <Compile Include="Loader\Loader.cs" />


### PR DESCRIPTION
After a discussion on the nhusers list ( http://groups.google.com/group/nhusers/browse_thread/thread/95c62c412e839892/f9531a4a3c685d9b?hl=en&lnk=gst ) I found that when using parametrized custom extension methods in a LINQ projection, NHibernate will always fall back to executing them locally (in .NET code). This is due to any ConstantExpression being regarded as something that should not be projected using HQL. While that may be sound for plain value projections, it's not good as a default for method projections.

My commit brings the HQL nomination into its very own nominator, which uses a simple Stack<bool> to keep track of where it's at in the expression tree. Reusing the standard Nominator would be possible, but I actually think this is less complex. 
