### PR TITLE
FIX NH-2898: Fix CastException when assembling object from 2nd level cach

### DIFF
--- a/src/NHibernate/Engine/ForeignKeys.cs
+++ b/src/NHibernate/Engine/ForeignKeys.cs
@@ -177,7 +177,7 @@ namespace NHibernate.Engine
 		/// </remarks>
 		public static bool IsTransient(string entityName, object entity, bool? assumed, ISessionImplementor session)
 		{
-			if (entity == Intercept.LazyPropertyInitializer.UnfetchedProperty)
+			if (Equals(Intercept.LazyPropertyInitializer.UnfetchedProperty, entity))
 			{
 				// an unfetched association can only point to
 				// an entity that already exists in the db

--- a/src/NHibernate/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Engine/TwoPhaseLoad.cs
@@ -74,7 +74,7 @@ namespace NHibernate.Engine
 			for (int i = 0; i < hydratedState.Length; i++)
 			{
 				object value = hydratedState[i];
-				if (value != LazyPropertyInitializer.UnfetchedProperty && value != BackrefPropertyAccessor.Unknown)
+				if (!Equals(LazyPropertyInitializer.UnfetchedProperty, value) && !(Equals(BackrefPropertyAccessor.Unknown, value)))
 				{
 					hydratedState[i] = types[i].ResolveIdentifier(value, session, entity);
 				}

--- a/src/NHibernate/Event/Default/AbstractVisitor.cs
+++ b/src/NHibernate/Event/Default/AbstractVisitor.cs
@@ -129,7 +129,7 @@ namespace NHibernate.Event.Default
 
 		internal bool IncludeProperty(object[] values, int i)
 		{
-			return values[i] != Intercept.LazyPropertyInitializer.UnfetchedProperty;
+			return !Equals(Intercept.LazyPropertyInitializer.UnfetchedProperty, values[i]);
 		}
 	}
 }

--- a/src/NHibernate/Intercept/ILazyPropertyInitializer.cs
+++ b/src/NHibernate/Intercept/ILazyPropertyInitializer.cs
@@ -1,3 +1,4 @@
+using System;
 using NHibernate.Engine;
 
 namespace NHibernate.Intercept
@@ -5,7 +6,7 @@ namespace NHibernate.Intercept
 	public struct LazyPropertyInitializer
 	{
 		/// <summary> Marker value for uninitialized properties</summary>
-		public readonly static object UnfetchedProperty= new object();
+		public readonly static object UnfetchedProperty = new Guid(0x8cbd57d5, 0xe58, 0x48a6, 0xa8, 0xf3, 0xec, 0xd4, 0xc2, 0x16, 0x35, 0xee);
 	}
 
 	/// <summary> Contract for controlling how lazy properties get initialized. </summary>

--- a/src/NHibernate/Properties/BackrefPropertyAccessor.cs
+++ b/src/NHibernate/Properties/BackrefPropertyAccessor.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Properties
 	[Serializable]
 	public class BackrefPropertyAccessor : IPropertyAccessor
 	{
-		public static readonly object Unknown = new object();
+		public static readonly object Unknown = new Guid(0x3dbd938f, 0xb1f8, 0x4a98, 0xa2, 0xf9, 0x62, 0xbd, 0x3b, 0x2, 0x8d, 0xcf);
 		private readonly string propertyName;
 		private readonly string entityName;
 

--- a/src/NHibernate/Tuple/Component/PocoComponentTuplizer.cs
+++ b/src/NHibernate/Tuple/Component/PocoComponentTuplizer.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Tuple.Component
 		public override object[] GetPropertyValues(object component)
 		{
 			// NH Different behavior : for NH-1101
-			if (component == BackrefPropertyAccessor.Unknown || component == null)
+			if (Equals(BackrefPropertyAccessor.Unknown, component) || component == null)
 			{
 				return new object[propertySpan];
 			}

--- a/src/NHibernate/Tuple/Entity/AbstractEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/AbstractEntityTuplizer.cs
@@ -275,7 +275,7 @@ namespace NHibernate.Tuple.Entity
 
 			for (int j = 0; j < entityMetamodel.PropertySpan; j++)
 			{
-				if (setAll || values[j] != LazyPropertyInitializer.UnfetchedProperty)
+				if (setAll || !Equals(LazyPropertyInitializer.UnfetchedProperty, values[j]))
 				{
 					setters[j].Set(entity, values[j]);
 				}

--- a/src/NHibernate/Type/TypeHelper.cs
+++ b/src/NHibernate/Type/TypeHelper.cs
@@ -24,7 +24,7 @@ namespace NHibernate.Type
 			{
 				if (copy[i])
 				{
-					if (values[i] == LazyPropertyInitializer.UnfetchedProperty || values[i] == BackrefPropertyAccessor.Unknown)
+					if (Equals(LazyPropertyInitializer.UnfetchedProperty, values[i]) || Equals(BackrefPropertyAccessor.Unknown, values[i]))
 					{
 						target[i] = values[i];
 					}
@@ -44,7 +44,7 @@ namespace NHibernate.Type
 		{
 			for (int i = 0; i < types.Length; i++)
 			{
-				if (row[i] != LazyPropertyInitializer.UnfetchedProperty && row[i] != BackrefPropertyAccessor.Unknown)
+				if (!Equals(LazyPropertyInitializer.UnfetchedProperty, row[i]) && !Equals(BackrefPropertyAccessor.Unknown, row[i]))
 				{
 					types[i].BeforeAssemble(row[i], session);
 				}
@@ -64,7 +64,7 @@ namespace NHibernate.Type
 			var assembled = new object[row.Length];
 			for (int i = 0; i < row.Length; i++)
 			{
-				if (row[i] == LazyPropertyInitializer.UnfetchedProperty || row[i] == BackrefPropertyAccessor.Unknown)
+				if (Equals(LazyPropertyInitializer.UnfetchedProperty, row[i]) || Equals(BackrefPropertyAccessor.Unknown, row[i]))
 				{
 					assembled[i] = row[i];
 				}
@@ -92,7 +92,7 @@ namespace NHibernate.Type
 				{
 					disassembled[i] = LazyPropertyInitializer.UnfetchedProperty;
 				}
-				else if (row[i] == LazyPropertyInitializer.UnfetchedProperty || row[i] == BackrefPropertyAccessor.Unknown)
+				else if (Equals(LazyPropertyInitializer.UnfetchedProperty, row[i]) || Equals(BackrefPropertyAccessor.Unknown, row[i]))
 				{
 					disassembled[i] = row[i];
 				}
@@ -120,7 +120,7 @@ namespace NHibernate.Type
 			var copied = new object[original.Length];
 			for (int i = 0; i < original.Length; i++)
 			{
-				if (original[i] == LazyPropertyInitializer.UnfetchedProperty || original[i] == BackrefPropertyAccessor.Unknown)
+				if (Equals(LazyPropertyInitializer.UnfetchedProperty, original[i]) || Equals(BackrefPropertyAccessor.Unknown, original[i]))
 				{
 					copied[i] = target[i];
 				}
@@ -150,7 +150,7 @@ namespace NHibernate.Type
 			object[] copied = new object[original.Length];
 			for (int i = 0; i < types.Length; i++)
 			{
-				if (original[i] == LazyPropertyInitializer.UnfetchedProperty || original[i] == BackrefPropertyAccessor.Unknown)
+				if (Equals(LazyPropertyInitializer.UnfetchedProperty, original[i]) || Equals(BackrefPropertyAccessor.Unknown, original[i]))
 				{
 					copied[i] = target[i];
 				}
@@ -182,7 +182,7 @@ namespace NHibernate.Type
 			object[] copied = new object[original.Length];
 			for (int i = 0; i < types.Length; i++)
 			{
-				if (original[i] == LazyPropertyInitializer.UnfetchedProperty || original[i] == BackrefPropertyAccessor.Unknown)
+				if (Equals(LazyPropertyInitializer.UnfetchedProperty, original[i]) || Equals(BackrefPropertyAccessor.Unknown, original[i]))
 				{
 					copied[i] = target[i];
 				}
@@ -239,7 +239,7 @@ namespace NHibernate.Type
 			for (int i = 0; i < span; i++)
 			{
 				bool dirty =
-					currentState[i] != LazyPropertyInitializer.UnfetchedProperty &&
+					!Equals(LazyPropertyInitializer.UnfetchedProperty, currentState[i]) &&
 					properties[i].IsDirtyCheckable(anyUninitializedProperties)
 					&& properties[i].Type.IsDirty(previousState[i], currentState[i], includeColumns[i], session);
 
@@ -290,7 +290,7 @@ namespace NHibernate.Type
 			for (int i = 0; i < span; i++)
 			{
 				bool dirty =
-					currentState[i] != LazyPropertyInitializer.UnfetchedProperty &&
+					!Equals(LazyPropertyInitializer.UnfetchedProperty, currentState[i]) &&
 					properties[i].IsDirtyCheckable(anyUninitializedProperties)
 					&& properties[i].Type.IsModified(previousState[i], currentState[i], includeColumns[i], session);
 


### PR DESCRIPTION
FIX NH-2898: Fix CastException when assembling object from 2nd level cache with lazy properties
