### PR TITLE
MsSql2005 dialect

### DIFF
--- a/src/NHibernate/Dialect/MsSql2005Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2005Dialect.cs
@@ -18,6 +18,7 @@ namespace NHibernate.Dialect
 		protected override void RegisterCharacterTypeMappings()
 		{
 			base.RegisterCharacterTypeMappings();
+            RegisterColumnType(DbType.Binary, "VARBINARY(MAX)");
 			RegisterColumnType(DbType.String, SqlClientDriver.MaxSizeForClob, "NVARCHAR(MAX)");
 			RegisterColumnType(DbType.AnsiString, SqlClientDriver.MaxSizeForAnsiClob, "VARCHAR(MAX)");
 			RegisterColumnType(DbType.Binary, SqlClientDriver.MaxSizeForBlob, "VARBINARY(MAX)");


### PR DESCRIPTION
Dialects: Fixing maximum size for blob in MSSQL2005 dialect when not informed.
