### PR TITLE
Failing test for NH-2907

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH2907/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2907/Entity.cs
@@ -1,0 +1,26 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH2907
+{
+	public class Group
+	{
+		public Group()
+		{
+			Name = string.Empty;
+		}
+
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+
+		public override int GetHashCode()
+		{
+			return Id.GetHashCode();
+		}
+
+		public override bool Equals(object obj)
+		{
+			var casted = obj as Group;
+			if (casted == null)
+				return false;
+			return casted.Id==Id && casted.Name.Equals(Name);
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2907/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2907/Fixture.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using SharpTestsEx;
+
+namespace NHibernate.Test.NHSpecificTest.NH2907
+{
+	/// <summary>
+	/// Similar to NH-2113 but with dynamic entity
+	/// </summary>
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		[Test]
+		public void ShouldNotEagerLoadKeyManyToOneWhenOverridingGetHashCode()
+		{
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var grp = new Group();
+				s.Save(grp);
+
+				var loanId = new Dictionary<string, object>
+								{
+									{"Id", 1},
+									{"Group", grp}
+								};
+				var loan = new Dictionary<string, object>
+								{
+									{"CompId", loanId}, 
+									{"Name", "money!!!"}
+								};
+				s.Save("Loan", loan);
+
+				tx.Commit();
+			}
+
+			bool isInitialized;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var loan = s.CreateQuery("select l from Loan l")
+					 .UniqueResult<IDictionary>();
+
+				var compId = (IDictionary)loan["CompId"];
+				var group = compId["Group"];
+
+				group.Should().Not.Be.Null();
+
+				isInitialized = NHibernateUtil.IsInitialized(group);
+
+				tx.Commit();
+			}
+			isInitialized.Should().Be.False();
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Delete("from System.Object");
+				tx.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2907/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2907/Mappings.hbm.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+							assembly="NHibernate.Test"
+							namespace="NHibernate.Test.NHSpecificTest.NH2907">
+	<class entity-name="Loan" table="loans">
+		<composite-id name="CompId">
+			<key-property name="Id" type="int" />
+			<key-many-to-one name="Group"
+								  column="GroupID"
+								  class="Group"/>
+		</composite-id>
+		<property name="Name" type="string"/>
+	</class>
+
+	<class name="Group" table="groups">
+		<id name="Id">
+			<column name="GroupId"/>
+			<generator class="native"/>
+		</id>
+		<property name="Name" type="string"/>
+	</class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -640,6 +640,8 @@
     <Compile Include="NHSpecificTest\AccessAndCorrectPropertyName\Model.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH2907\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH2907\Fixture.cs" />
     <Compile Include="NHSpecificTest\DataReaderWrapperTest\Fixture.cs" />
     <Compile Include="NHSpecificTest\DataReaderWrapperTest\Model.cs" />
     <Compile Include="NHSpecificTest\DataReaderWrapperTest\TheUserType.cs" />
@@ -2748,6 +2750,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH2907\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2869\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH0000\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2828\Mappings.hbm.xml" />


### PR DESCRIPTION
NH force eager loading of key-many-to-one entity with overriden GetHashCode using dynamic entity. 
Similar to https://nhibernate.jira.com/browse/NH-2113, but the issue still exist when using a dynamic model (entity-name). 

JIRA: https://nhibernate.jira.com/browse/NH-2907
