### PR TITLE
Fixed typo - PositionalParameterValues is object[]

### DIFF
--- a/src/NHibernate/Engine/QueryParameters.cs
+++ b/src/NHibernate/Engine/QueryParameters.cs
@@ -62,7 +62,7 @@ namespace NHibernate.Engine
 		                       string comment, object[] collectionKeys, IResultTransformer transformer)
 		{
 			PositionalParameterTypes = positionalParameterTypes ?? new IType[0];
-			PositionalParameterValues = positionalParameterValues ?? new IType[0];
+			PositionalParameterValues = positionalParameterValues ?? new object[0];
 			NamedParameters = namedParameters ?? new Dictionary<string, TypedValue>(1);
 			LockModes = lockModes;
 			RowSelection = rowSelection;


### PR DESCRIPTION
`IType` is possible produced by copy-paste:)
