### PR TITLE
NH-3001: regression - count on joined group by throws exception

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/CountTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/CountTests.cs
@@ -82,5 +82,21 @@ namespace NHibernate.Test.Linq.ByMethod
 
 			Assert.That(result, Is.EqualTo(830));
 		}
+
+		[Test]
+		public void CountOnJoinedGroupBy()
+		{
+			//NH-3001
+			var query = from o in db.Orders
+						join ol in db.OrderLines
+						on o equals ol.Order
+						group ol by ol.Product.ProductId
+							into temp
+							select new { temp.Key, count = temp.Count() };
+
+			var result = query.ToList();
+
+			Assert.That(result.Count, Is.EqualTo(77));
+		}
 	}
 }

--- a/src/NHibernate/Linq/ReWriters/MergeAggregatingResultsRewriter.cs
+++ b/src/NHibernate/Linq/ReWriters/MergeAggregatingResultsRewriter.cs
@@ -77,8 +77,11 @@ namespace NHibernate.Linq.ReWriters
 
 		private static Expression TransformCountExpression(Expression expression)
 		{
-			if (expression.NodeType == ExpressionType.MemberInit || expression.NodeType == ExpressionType.New)
+			if (expression.NodeType == ExpressionType.MemberInit || 
+				expression.NodeType == ExpressionType.New ||
+				expression.NodeType == QuerySourceReferenceExpression.ExpressionType)
 			{
+				//Probably it should be done by CountResultOperatorProcessor
 				return new NhStarExpression(expression);
 			}
 


### PR DESCRIPTION
After #39 following test fails 

``` csharp
var query = from foo in Session.Query<Foo>() 
            join bar in Session.Query<Bar>() 
              on foo equals bar.Foo 
            group bar by bar.RunTask.Id 
              into temp 
            select new { temp.Key, count = temp.Count()}; 

var result = query.ToList(); 
```

```
NHibernate.HibernateException: Query Source could not be identified: ItemName = <generated>_1, ItemType = Namespace.Bar, Expression = from Bar <generated>_1 in [foo] 
```

JIRA: https://nhibernate.jira.com/browse/NH-3001
