### PR TITLE
More on NH-2998: AsQueryable() on child collection should be able to operate complex lambda expressions

### DIFF
--- a/src/NHibernate/Linq/NhLinqExpression.cs
+++ b/src/NHibernate/Linq/NhLinqExpression.cs
@@ -7,7 +7,6 @@ using NHibernate.Hql.Ast.ANTLR.Tree;
 using NHibernate.Linq.Visitors;
 using NHibernate.Param;
 using NHibernate.Type;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors;
 
 namespace NHibernate.Linq
 {
@@ -30,8 +29,7 @@ namespace NHibernate.Linq
 
 		public NhLinqExpression(Expression expression)
 		{
-			_expression = PartialEvaluatingExpressionTreeVisitor.EvaluateIndependentSubtrees(expression);
-
+			_expression = NhPartialEvaluatingExpressionTreeVisitor.EvaluateIndependentSubtrees(expression);
 			_expression = NameUnNamedParameters.Visit(_expression);
 
 			_constantToParameterMap = ExpressionParameterVisitor.Visit(_expression);

--- a/src/NHibernate/Linq/Visitors/NhPartialEvaluatingExpressionTreeVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/NhPartialEvaluatingExpressionTreeVisitor.cs
@@ -1,0 +1,26 @@
+using System.Linq.Expressions;
+using Remotion.Linq.Parsing;
+using Remotion.Linq.Parsing.ExpressionTreeVisitors;
+
+namespace NHibernate.Linq.Visitors
+{
+	internal class NhPartialEvaluatingExpressionTreeVisitor : ExpressionTreeVisitor
+	{
+		protected override Expression VisitConstantExpression(ConstantExpression expression)
+		{
+			var value = expression.Value as Expression;
+			if (value == null)
+			{
+				return base.VisitConstantExpression(expression);
+			}
+
+			return EvaluateIndependentSubtrees(value);
+		}
+
+		public static Expression EvaluateIndependentSubtrees(Expression expression)
+		{
+			var evaluatedExpression = PartialEvaluatingExpressionTreeVisitor.EvaluateIndependentSubtrees(expression);
+			return new NhPartialEvaluatingExpressionTreeVisitor().VisitExpression(evaluatedExpression);
+		}
+	}
+}

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -283,6 +283,7 @@
     <Compile Include="LazyInitializationException.cs" />
     <Compile Include="Linq\Clauses\NhJoinClause.cs" />
     <Compile Include="Linq\Functions\DictionaryGenerator.cs" />
+    <Compile Include="Linq\Visitors\NhPartialEvaluatingExpressionTreeVisitor.cs" />
     <Compile Include="Linq\QuerySourceNamer.cs" />
     <Compile Include="Linq\ReWriters\AddJoinsReWriter.cs" />
     <Compile Include="Linq\ReWriters\MoveOrderByToEndRewriter.cs" />


### PR DESCRIPTION
Now PartialEvaluatingExpressionTreeVisitor does not evaluating closures in externally built lambdas, so following query will not execute.

``` csharp
var ids = new[] {1}; // closure

// would be wrapped into ConstantExpression
Expression<Func<TimesheetEntry, bool>> predicate = e => !ids.Contains(e.Id); 

var query = (from timesheet in db.Timesheets
             where timesheet.Entries.AsQueryable().Any(predicate)
             select timesheet).ToList();
```

Added new visitor which is able to partially evaluate lambda expressions inside `ConstantExpression`
