### PR TITLE
NH-3009: Linq is trying to add parameters twice if same predicate is used in query more then once

### DIFF
--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -549,5 +549,18 @@ namespace NHibernate.Test.Linq
 			 select a).FirstOrDefault();
 		}
 
+		[Test]
+		public void TimeSheetsWithSamePredicateTwoTimes()
+		{
+			//NH-3009
+			Expression<Func<Timesheet, bool>> predicate = timesheet => timesheet.Entries.Any(e => e.Id != 1);
+
+			var query = db.Timesheets
+				.Where(predicate)
+				.Where(predicate)
+				.ToList();
+
+			Assert.AreEqual(2, query.Count);
+		}
 	}
 }

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Linq.Visitors
 
 		protected override Expression VisitConstantExpression(ConstantExpression expression)
 		{
-			if (!typeof(IQueryable).IsAssignableFrom(expression.Type) && !IsNullObject(expression))
+			if (!_parameters.ContainsKey(expression) && !typeof(IQueryable).IsAssignableFrom(expression.Type) && !IsNullObject(expression))
 			{
 				// We use null for the type to indicate that the caller should let HQL figure it out.
 				IType type = null;
@@ -46,7 +46,7 @@ namespace NHibernate.Linq.Visitors
 			return base.VisitConstantExpression(expression);
 		}
 
-		private bool IsNullObject(ConstantExpression expression)
+		private static bool IsNullObject(ConstantExpression expression)
 		{
 			return expression.Type == typeof(Object) && expression.Value == null;
 		}


### PR DESCRIPTION
```
 Expression<Func<Timesheet, bool>> predicate = timesheet => timesheet.Entries.Any(e => e.Id != 1); 

            var query = db.Timesheets 
                .Where(predicate) 
                .Where(predicate) // don't ask why I need this 
                .ToList(); 
```

This query throws exception 

```
System.ArgumentException : An item with the same key has already been added. 
at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource) 
at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add) 
at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value) 
at NHibernate.Linq.Visitors.ExpressionParameterVisitor.VisitConstantExpression(ConstantExpression expression) in ExpressionParameterVisitor.cs: line 43 
... 
at NHibernate.Linq.Visitors.ExpressionParameterVisitor.Visit(Expression expression) in ExpressionParameterVisitor.cs: line 21 
at NHibernate.Linq.NhLinqExpression..ctor(Expression expression) in NhLinqExpression.cs: line 35 
at NHibernate.Linq.DefaultQueryProvider.PrepareQuery(Expression expression, ref IQuery query, ref NhLinqExpression nhQuery) in DefaultQueryProvider.cs: line 67 
at NHibernate.Linq.DefaultQueryProvider.Execute(Expression expression) in DefaultQueryProvider.cs: line 33 
at NHibernate.Linq.DefaultQueryProvider.Execute(Expression expression) in DefaultQueryProvider.cs: line 40 
at Remotion.Linq.QueryableBase`1.GetEnumerator() in c:\build\Remotion\working\Relinq\Core\QueryableBase.cs: line 132 
at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection) 
at System.Linq.Enumerable.ToList(IEnumerable`1 source) 
```

JIRA: https://nhibernate.jira.com/browse/NH-3009
