### PR TITLE
NH-2967: Fix for OverflowException on VARCHAR(MAX) columns with mysql

### DIFF
--- a/src/NHibernate/Dialect/Schema/FirebirdMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/FirebirdMetaData.cs
@@ -73,7 +73,17 @@ namespace NHibernate.Dialect.Schema
 
 			aValue = rs["COLUMN_SIZE"];
 			if (aValue != DBNull.Value)
-				ColumnSize = Convert.ToInt32(aValue);
+			{
+				long originalColumnSize = Convert.ToInt64(aValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
+			}
 
 			aValue = rs["NUMERIC_PRECISION"];
 			if (aValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/MsSqlCeMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/MsSqlCeMetaData.cs
@@ -66,7 +66,17 @@ namespace NHibernate.Dialect.Schema
 
 			object aValue = rs["CHARACTER_MAXIMUM_LENGTH"];
 			if (aValue != DBNull.Value)
-				ColumnSize = Convert.ToInt32(aValue);
+			{
+				long originalColumnSize = Convert.ToInt64(aValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
+			}
 
 			aValue = rs["NUMERIC_PRECISION"];
 			if (aValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/MsSqlMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/MsSqlMetaData.cs
@@ -67,7 +67,17 @@ namespace NHibernate.Dialect.Schema
 
 			aValue = rs["CHARACTER_MAXIMUM_LENGTH"];
 			if (aValue != DBNull.Value)
-				ColumnSize = Convert.ToInt32(aValue);
+			{
+				long originalColumnSize = Convert.ToInt64(aValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
+			}
 
 			aValue = rs["NUMERIC_PRECISION"];
 			if (aValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/MySQLMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/MySQLMetaData.cs
@@ -77,7 +77,17 @@ namespace NHibernate.Dialect.Schema
 
 			aValue = rs["CHARACTER_MAXIMUM_LENGTH"];
 			if (aValue != DBNull.Value)
-				ColumnSize = Convert.ToInt32(aValue);
+			{
+				long originalColumnSize = Convert.ToInt64(aValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
+			}
 
 			aValue = rs["NUMERIC_PRECISION"];
 			if (aValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/OracleMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/OracleMetaData.cs
@@ -107,7 +107,17 @@ namespace NHibernate.Dialect.Schema
 
 			aValue = rs["LENGTH"];
 			if (aValue != DBNull.Value)
-				ColumnSize = Convert.ToInt32(aValue);
+			{
+				long originalColumnSize = Convert.ToInt64(aValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
+			}
 
 			aValue = rs["PRECISION"];
 			if (aValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/PostgreSQLMetadata.cs
+++ b/src/NHibernate/Dialect/Schema/PostgreSQLMetadata.cs
@@ -83,7 +83,15 @@ namespace NHibernate.Dialect.Schema
 			object objValue = rs["CHARACTER_MAXIMUM_LENGTH"];
 			if (objValue != DBNull.Value)
 			{
-				ColumnSize = Convert.ToInt32(objValue);
+				long originalColumnSize = Convert.ToInt64(objValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
 			}
 			objValue = rs["NUMERIC_PRECISION"];
 			if (objValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/SQLiteMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/SQLiteMetaData.cs
@@ -72,7 +72,15 @@ namespace NHibernate.Dialect.Schema
 			object objValue = rs["CHARACTER_MAXIMUM_LENGTH"];
 			if (objValue != DBNull.Value)
 			{
-				ColumnSize = Convert.ToInt32(objValue);
+				long originalColumnSize = Convert.ToInt64(objValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
 			}
 			objValue = rs["NUMERIC_PRECISION"];
 			if (objValue != DBNull.Value)

--- a/src/NHibernate/Dialect/Schema/SybaseAnywhereMetaData.cs
+++ b/src/NHibernate/Dialect/Schema/SybaseAnywhereMetaData.cs
@@ -120,7 +120,15 @@ namespace NHibernate.Dialect.Schema
 			object objValue = rs["COLUMN_SIZE"];
 			if (objValue != DBNull.Value)
 			{
-				ColumnSize = Convert.ToInt32(objValue);
+				long originalColumnSize = Convert.ToInt64(objValue);
+				if (originalColumnSize > (long)int.MaxValue)
+				{
+					ColumnSize = int.MaxValue;
+				}
+				else
+				{
+					ColumnSize = (int)originalColumnSize;
+				}
 			}
 			objValue = rs["PRECISION"];
 			if (objValue != DBNull.Value)


### PR DESCRIPTION
Using the SchemaUpdate tool with MySQL 5 database fails without throwing an exception. It simply runs several seconds, then returns. The following exception can be found in the log files (if they are active):

2011-12-07 09:49:53.467 | 10 | ERROR | SchemaUpdate | could not complete schema update
Exception OverflowException: Der Wert für einen Int32 war zu groß oder zu klein.
   bei System.Convert.ToInt32(Int64 value)
   bei System.Int64.System.IConvertible.ToInt32(IFormatProvider provider)
   bei System.Convert.ToInt32(Object value)
   bei NHibernate.Dialect.Schema.MySQLColumnMetadata..ctor(DataRow rs) 

MySQL reports a column size of 2^32, which is too large for Int32. Because I did not want to modify the interface, I have created a simple workaround that works for us. Please note that the changes in this pull request ae different from the patch I added to the JIRA issue some weeks ago. I have done the same changes to all metadata classes because the same thing could happen on all other database types, too.
