### PR TITLE
NH-3026: Linq order by grouped count before select clause gives wrong sql

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
@@ -128,7 +128,6 @@ namespace NHibernate.Test.Linq.ByMethod
 
 
 		[Test]
-		[Ignore("Generates incorrect SQL. Reported as NH-3026.")]
 		public void SingleKeyPropertyGroupAndOrderByCountBeforeProjection()
 		{
 			// NH-3026, variation of NH-2560.

--- a/src/NHibernate/Linq/ReWriters/MergeAggregatingResultsRewriter.cs
+++ b/src/NHibernate/Linq/ReWriters/MergeAggregatingResultsRewriter.cs
@@ -75,6 +75,11 @@ namespace NHibernate.Linq.ReWriters
 			whereClause.TransformExpressions(e => MergeAggregatingResultsInExpressionRewriter.Rewrite(e, new NameGenerator(queryModel)));
 		}
 
+		public override void VisitOrdering(Ordering ordering, QueryModel queryModel, OrderByClause orderByClause, int index)
+		{
+			ordering.TransformExpressions(e => MergeAggregatingResultsInExpressionRewriter.Rewrite(e, new NameGenerator(queryModel)));
+		}
+
 		private static Expression TransformCountExpression(Expression expression)
 		{
 			if (expression.NodeType == ExpressionType.MemberInit || 


### PR DESCRIPTION
JIRA: https://nhibernate.jira.com/browse/NH-3026
