### PR TITLE
NH-2982: SimpleExpression.ToString() can result in unwanted loading of lazy objects including test

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH2982/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2982/Fixture.cs
@@ -1,0 +1,69 @@
+﻿using NUnit.Framework;
+using NHibernate.Criterion;
+
+namespace NHibernate.Test.NHSpecificTest.NH2982
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			base.OnSetUp();
+
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var e1 = new Entity { Id = 1, Name = "A" };
+				session.Save(e1);
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+				session.Flush();
+				transaction.Commit();
+			}
+
+			base.OnTearDown();
+		}
+
+		[Test]
+		public void SimpleExpressionWithProxy()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var a = session.Load<Entity>(1);
+				var restriction = Restrictions.Eq("A", a);
+				Assert.AreEqual("A = Entity#1", restriction.ToString());
+			}
+		}
+
+		[Test]
+		public void SimpleExpressionWithNewInstance()
+		{
+			var a = new Entity() { Id = 2, Name = "2" };
+			var restriction = Restrictions.Eq("A", a);
+			Assert.AreEqual(@"A = Entity@" + a.GetHashCode() + "(hash)", restriction.ToString());
+		}
+
+		[Test]
+		public void SimpleExpressionWithNull()
+		{
+			var restriction = Restrictions.Eq("A", null);
+			Assert.AreEqual("A = null", restriction.ToString());
+		}
+
+		[Test]
+		public void SimpleExpressionWithPrimitive()
+		{
+			var restriction = Restrictions.Eq("A", 5);
+			Assert.AreEqual("A = 5", restriction.ToString());
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2982/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2982/Mappings.hbm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping
+	xmlns="urn:nhibernate-mapping-2.2"
+	assembly="NHibernate.Test"
+	namespace="NHibernate.Test.NHSpecificTest.NH2982">
+
+	<class name="Entity">
+		<id name="Id"/>
+		<property name="Name" />
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH2982/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2982/Model.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Globalization;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH2982
+{
+    public class Entity
+    {
+        public virtual int Id { get; set; }
+        public virtual string Name { get; set; }
+        public override string ToString()
+        {
+            throw new InvalidOperationException(".ToString() is called which can result in lazy loading side effects.");
+        }
+    }
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -937,6 +937,8 @@
     <Compile Include="NHSpecificTest\NH2913\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2959\Entity.cs" />
     <Compile Include="NHSpecificTest\NH2959\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH2982\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH2982\Model.cs" />
     <Compile Include="NHSpecificTest\NH3004\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3004\TestSqlClientDriver.cs" />
     <Compile Include="NHSpecificTest\NH941\Domain.cs" />
@@ -2797,6 +2799,7 @@
     <Compile Include="IdGen\Enhanced\Forcedtable\BasicForcedTableSequenceTest.cs" />
     <Compile Include="IdGen\Enhanced\Forcedtable\HiLoForcedTableSequenceTest.cs" />
     <Compile Include="IdGen\Enhanced\Forcedtable\PooledForcedTableSequenceTest.cs" />
+    <EmbeddedResource Include="NHSpecificTest\NH2982\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2914\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2959\Mappings.hbm.xml" />
     <Compile Include="IdGen\Enhanced\Table\Entity.cs" />

--- a/src/NHibernate/Criterion/SimpleExpression.cs
+++ b/src/NHibernate/Criterion/SimpleExpression.cs
@@ -161,7 +161,7 @@ namespace NHibernate.Criterion
 
 		public override string ToString()
 		{
-			return (_projection ?? (object)propertyName) + Op + value;
+			return (_projection ?? (object)propertyName) + Op + ValueToStrings();
 		}
 
 		/// <summary>
@@ -171,6 +171,15 @@ namespace NHibernate.Criterion
 		protected virtual string Op
 		{
 			get { return op; }
+		}
+
+		string ValueToStrings()
+		{
+			if(value!=null && value.GetType().IsPrimitive)
+			{
+				return value.ToString();
+			}
+			return ObjectUtils.IdentityToString(value);
 		}
 	}
 }

--- a/src/NHibernate/Util/ObjectUtils.cs
+++ b/src/NHibernate/Util/ObjectUtils.cs
@@ -98,13 +98,18 @@ namespace NHibernate.Util
 		{
 			if (obj == null)
 			{
-				return null;
+				return "null";
 			}
-			return new StringBuilder()
-				.Append(obj.GetType().FullName)
-				.Append('@')
-				.Append(obj.GetHashCode())
-				.ToString();
+
+			var proxy = obj as NHibernate.Proxy.INHibernateProxy;
+
+			if (null != proxy)
+			{
+				var init = proxy.HibernateLazyInitializer;
+				return StringHelper.Unqualify(init.EntityName) + "#" + init.Identifier;
+			}
+
+			return StringHelper.Unqualify(obj.GetType().FullName) + "@" + obj.GetHashCode() + "(hash)";
 		}
 
 		private class NullClass


### PR DESCRIPTION
SimpleExpression.ToString() can result in unwanted loading of lazy objects. This is because it called value.ToString() to get a string representation of an entity. The entity ToString() can access lazy loaded properties thus in unwanted loading of entities.

Code changed so that the string value is retrieved via ObjectUtils. The implementation of ObjectUtils now checks if the supplied instance implements INHibernateProxy and used that to return an identification without calling .ToString().
