### PR TITLE
NH-3008: InExpression.GetTypedValues no longer includes projection values

### DIFF
--- a/src/NHibernate.Test/ExpressionTest/InExpressionFixture.cs
+++ b/src/NHibernate.Test/ExpressionTest/InExpressionFixture.cs
@@ -40,5 +40,25 @@ namespace NHibernate.Test.ExpressionTest
 			Assert.AreEqual("1=0", sql.ToString());
 			session.Close();
 		}
+
+		[Test]
+		public void InSqlFunctionTest()
+		{
+			using (var session = factory.OpenSession())
+			{
+				CreateObjects(typeof(Simple), session);
+				var inExpression = Restrictions.In(
+					Projections.SqlFunction(
+						"substring",
+						NHibernateUtil.String,
+						Projections.Property("Name"),
+						Projections.Constant(1),
+						Projections.Constant(1)),
+					new object[] { "A", "B" });
+				var sql = inExpression.ToSqlString(criteria, criteriaQuery, new CollectionHelper.EmptyMapClass<string, IFilter>());
+				Assert.That(sql.ToString(), Is.EqualTo("substring(sql_alias.Name, ?, ?) in (?, ?)"));
+				Assert.That(criteriaQuery.CollectedParameters.Count, Is.EqualTo(4));
+			}
+		}
 	}
 }

--- a/src/NHibernate/Criterion/InExpression.cs
+++ b/src/NHibernate/Criterion/InExpression.cs
@@ -124,7 +124,6 @@ namespace NHibernate.Criterion
 					throw new QueryException("Cannot use projections that return more than a single column with InExpression");
 				}
 				type = types[0];
-				list.AddRange(_projection.GetTypedValues(criteria, criteriaQuery));
 			}
 
 			if (type.IsComponentType)


### PR DESCRIPTION
Resolves https://nhibernate.jira.com/browse/NH-3008 and includes a new unit test. All existing unit tests pass.
