### PR TITLE
failing test for NH-3074

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3074/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3074/Fixture.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using SharpTestsEx;
+
+namespace NHibernate.Test.NHSpecificTest.NH3074
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		private const int id =123;
+
+		protected override void OnSetUp()
+		{
+			using (var s = OpenSession())
+			{
+				using (var tx = s.BeginTransaction())
+				{
+					var cat = new Cat {Id = id, NumberOfLegs = 2, Weight = 100};
+					s.Save(cat);
+					tx.Commit();
+				}
+			}
+		}
+
+		[Test]
+		public void CanSetLockMode()
+		{
+			using (var s = OpenSession())
+			{
+				using (s.BeginTransaction())
+				{
+					s.CreateQuery("select c from Animal c where c.Id=:id")
+						.SetInt32("id", id)
+						.SetLockMode("c", LockMode.Upgrade)
+						.List<Cat>()
+						.Should().Not.Be.Empty();
+				}
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			{
+				using (var tx = s.BeginTransaction())
+				{
+					s.Delete(s.Get<Cat>(id));
+					tx.Commit();
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3074/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3074/Mappings.hbm.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+			assembly="NHibernate.Test"
+			namespace="NHibernate.Test.NHSpecificTest.NH3074">
+
+	<class name="Animal">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Weight" />
+
+		<union-subclass name="Cat">
+			<property name="NumberOfLegs" />
+		</union-subclass>
+	</class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3074/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3074/Model.cs
@@ -1,0 +1,13 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3074
+{
+	public class Animal
+	{
+		public virtual int Id { get; set; }
+		public virtual int Weight { get; set; }
+	}
+
+	public class Cat :Animal
+	{
+		public virtual int NumberOfLegs { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -899,6 +899,8 @@
     <Compile Include="NHSpecificTest\NH2869\MyLinqExtensions.cs" />
     <Compile Include="NHSpecificTest\NH2869\MyLinqToHqlGeneratorsRegistry.cs" />
     <Compile Include="NHSpecificTest\NH2893\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3074\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3074\Model.cs" />
     <Compile Include="NHSpecificTest\NH941\Domain.cs" />
     <Compile Include="NHSpecificTest\NH941\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH941\FixtureUsingList.cs" />
@@ -2748,6 +2750,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3074\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2869\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH0000\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2828\Mappings.hbm.xml" />


### PR DESCRIPTION
Failing test for NH-3074. Combining union-subclass with SetLockMode throws if querying for superclass.
