### PR TITLE
NH-3087 pre-work

### DIFF
--- a/src/NHibernate.DomainModel/CustomPersister.cs
+++ b/src/NHibernate.DomainModel/CustomPersister.cs
@@ -317,7 +317,7 @@ namespace NHibernate.DomainModel
 			if (obj != null)
 			{
 				clone = (Custom)obj.Clone();
-				TwoPhaseLoad.AddUninitializedEntity(new EntityKey(id, this, session.EntityMode), clone, this, LockMode.None, false,
+                TwoPhaseLoad.AddUninitializedEntity(session.GenerateEntityKey(id, this), clone, this, LockMode.None, false,
 				                                    session);
 				TwoPhaseLoad.PostHydrate(this, id, new String[] {obj.Name}, null, clone, LockMode.None, false, session);
 				TwoPhaseLoad.InitializeEntity(clone, false, session, new PreLoadEvent((IEventSource) session),

--- a/src/NHibernate.Test/CacheTest/CacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/CacheFixture.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Test.CacheTest
 
 		private CacheKey CreateCacheKey(string text)
 		{
-			return new CacheKey(text, NHibernateUtil.String, "Foo", EntityMode.Poco, null);
+			return new CacheKey(text, NHibernateUtil.String, "Foo", EntityMode.Poco, null, null);
 		}
 
 		public void DoTestCache(ICacheProvider cacheProvider)

--- a/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
+++ b/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Test.FilterTest
 				.GetCollectionPersister(typeof(Salesperson).FullName + ".Orders");
 			Assert.IsTrue(persister.HasCache, "No cache for collection");
 			CacheKey cacheKey =
-				new CacheKey(testData.steveId, persister.KeyType, persister.Role, EntityMode.Poco, (ISessionFactoryImplementor) sessions);
+				new CacheKey(testData.steveId, persister.KeyType, persister.Role, EntityMode.Poco, null, (ISessionFactoryImplementor) sessions);
 			CollectionCacheEntry cachedData = (CollectionCacheEntry)persister.Cache.Cache.Get(cacheKey);
 			Assert.IsNotNull(cachedData, "collection was not in cache");
 

--- a/src/NHibernate/Action/CollectionAction.cs
+++ b/src/NHibernate/Action/CollectionAction.cs
@@ -96,7 +96,7 @@ namespace NHibernate.Action
 			// second-level cache invalidation only)
 			if (persister.HasCache)
 			{
-				CacheKey ck = new CacheKey(key, persister.KeyType, persister.Role, session.EntityMode, session.Factory);
+                CacheKey ck = session.GenerateCacheKey(key, persister.KeyType, persister.Role);
 				softLock = persister.Cache.Lock(ck, null);
 			}
 		}
@@ -120,7 +120,7 @@ namespace NHibernate.Action
 				{
 					if (persister.HasCache)
 					{
-						CacheKey ck = new CacheKey(key, persister.KeyType, persister.Role, Session.EntityMode, Session.Factory);
+                        CacheKey ck = Session.GenerateCacheKey(key, persister.KeyType, persister.Role);
 						persister.Cache.Release(ck, softLock);
 					}
 				});
@@ -138,7 +138,7 @@ namespace NHibernate.Action
 		{
 			if (persister.HasCache)
 			{
-				CacheKey ck = new CacheKey(key, persister.KeyType, persister.Role, session.EntityMode, session.Factory);
+                CacheKey ck = session.GenerateCacheKey(key, persister.KeyType, persister.Role);
 				persister.Cache.Evict(ck);
 			}
 		}

--- a/src/NHibernate/Action/CollectionUpdateAction.cs
+++ b/src/NHibernate/Action/CollectionUpdateAction.cs
@@ -130,7 +130,7 @@ namespace NHibernate.Action
 					// NH Different behavior: to support unlocking collections from the cache.(r3260)
 					if (Persister.HasCache)
 					{
-						CacheKey ck = new CacheKey(Key, Persister.KeyType, Persister.Role, Session.EntityMode, Session.Factory);
+                        CacheKey ck = Session.GenerateCacheKey(Key, Persister.KeyType, Persister.Role);
 
 						if (success)
 						{

--- a/src/NHibernate/Action/EntityDeleteAction.cs
+++ b/src/NHibernate/Action/EntityDeleteAction.cs
@@ -57,7 +57,7 @@ namespace NHibernate.Action
 			CacheKey ck;
 			if (persister.HasCache)
 			{
-				ck = new CacheKey(id, persister.IdentifierType, persister.RootEntityName, session.EntityMode, session.Factory);
+				ck = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
 				sLock = persister.Cache.Lock(ck, version);
 			}
 			else
@@ -83,7 +83,7 @@ namespace NHibernate.Action
 			}
 			entry.PostDelete();
 
-			EntityKey key = new EntityKey(entry.Id, entry.Persister, session.EntityMode);
+            EntityKey key = session.GenerateEntityKey(entry.Id, entry.Persister);
 			persistenceContext.RemoveEntity(key);
 			persistenceContext.RemoveProxy(key);
 
@@ -131,7 +131,7 @@ namespace NHibernate.Action
 		{
 			if (Persister.HasCache)
 			{
-				CacheKey ck = new CacheKey(Id, Persister.IdentifierType, Persister.RootEntityName, Session.EntityMode, Session.Factory);
+                CacheKey ck = Session.GenerateCacheKey(Id, Persister.IdentifierType, Persister.RootEntityName);
 				Persister.Cache.Release(ck, sLock);
 			}
 			if (success)

--- a/src/NHibernate/Action/EntityIdentityInsertAction.cs
+++ b/src/NHibernate/Action/EntityIdentityInsertAction.cs
@@ -41,7 +41,7 @@ namespace NHibernate.Action
 				if (!isDelayed)
 					throw new HibernateException("Cannot request delayed entity-key for non-delayed post-insert-id generation");
 
-				return new EntityKey(new DelayedPostInsertIdentifier(), Persister, Session.EntityMode);
+                return Session.GenerateEntityKey(new DelayedPostInsertIdentifier(), Persister);
 			}
 		}
 

--- a/src/NHibernate/Action/EntityInsertAction.cs
+++ b/src/NHibernate/Action/EntityInsertAction.cs
@@ -84,7 +84,7 @@ namespace NHibernate.Action
 				CacheEntry ce = new CacheEntry(state, persister, persister.HasUninitializedLazyProperties(instance, session.EntityMode), version, session, instance);
 				cacheEntry = persister.CacheEntryStructure.Structure(ce);
 
-				CacheKey ck = new CacheKey(id, persister.IdentifierType, persister.RootEntityName, Session.EntityMode, Session.Factory);
+                CacheKey ck = Session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
 				bool put = persister.Cache.Insert(ck, cacheEntry, version);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
@@ -108,7 +108,7 @@ namespace NHibernate.Action
 			IEntityPersister persister = Persister;
 			if (success && IsCachePutEnabled(persister))
 			{
-				CacheKey ck = new CacheKey(Id, persister.IdentifierType, persister.RootEntityName, Session.EntityMode, Session.Factory);
+                CacheKey ck = Session.GenerateCacheKey(Id, persister.IdentifierType, persister.RootEntityName);
 				bool put = persister.Cache.AfterInsert(ck, cacheEntry, version);
 
 				if (put && Session.Factory.Statistics.IsStatisticsEnabled)

--- a/src/NHibernate/Action/EntityUpdateAction.cs
+++ b/src/NHibernate/Action/EntityUpdateAction.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Action
 			CacheKey ck = null;
 			if (persister.HasCache)
 			{
-				ck = new CacheKey(id, persister.IdentifierType, persister.RootEntityName, session.EntityMode, factory);
+                ck = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
 				slock = persister.Cache.Lock(ck, previousVersion);
 			}
 
@@ -140,7 +140,7 @@ namespace NHibernate.Action
 			IEntityPersister persister = Persister;
 			if (persister.HasCache)
 			{
-				CacheKey ck = new CacheKey(Id, persister.IdentifierType, persister.RootEntityName, Session.EntityMode, Session.Factory);
+                CacheKey ck = Session.GenerateCacheKey(Id, persister.IdentifierType, persister.RootEntityName);
 
 				if (success && cacheEntry != null)
 				{

--- a/src/NHibernate/Cache/CacheKey.cs
+++ b/src/NHibernate/Cache/CacheKey.cs
@@ -17,25 +17,27 @@ namespace NHibernate.Cache
 		private readonly string entityOrRoleName;
 		private readonly int hashCode;
 		private readonly EntityMode entityMode;
+        private readonly string tenantId;
 
-		/// <summary> 
-		/// Construct a new key for a collection or entity instance.
-		/// Note that an entity name should always be the root entity 
-		/// name, not a subclass entity name. 
-		/// </summary>
-		/// <param name="id">The identifier associated with the cached data </param>
-		/// <param name="type">The Hibernate type mapping </param>
-		/// <param name="entityOrRoleName">The entity or collection-role name. </param>
-		/// <param name="entityMode">The entiyt mode of the originating session </param>
-		/// <param name="factory">The session factory for which we are caching </param>
-		public CacheKey(object id, IType type, string entityOrRoleName, EntityMode entityMode, ISessionFactoryImplementor factory)
-		{
-			key = id;
-			this.type = type;
-			this.entityOrRoleName = entityOrRoleName;
-			this.entityMode = entityMode;
-			hashCode = type.GetHashCode(key, entityMode, factory);
-		}
+        /// <summary> 
+        /// Construct a new key for a collection or entity instance.
+        /// Note that an entity name should always be the root entity 
+        /// name, not a subclass entity name. 
+        /// </summary>
+        /// <param name="id">The identifier associated with the cached data </param>
+        /// <param name="type">The Hibernate type mapping </param>
+        /// <param name="entityOrRoleName">The entity or collection-role name. </param>
+        /// <param name="entityMode">The entiyt mode of the originating session </param>
+        /// <param name="factory">The session factory for which we are caching </param>
+        public CacheKey(object id, IType type, string entityOrRoleName, EntityMode entityMode, string tenantId, ISessionFactoryImplementor factory)
+        {
+            key = id;
+            this.type = type;
+            this.entityOrRoleName = entityOrRoleName;
+            this.entityMode = entityMode;
+            this.tenantId = tenantId;
+            hashCode = type.GetHashCode(key, entityMode, factory);
+        }
 
 		//Mainly for SysCache and Memcache
 		public override String ToString()

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -90,6 +90,9 @@ namespace NHibernate.Cfg
 		/// <summary>The EntityMode in which set the Session opened from the SessionFactory.</summary>
 		public const string DefaultEntityMode = "default_entity_mode";
 
+        /// <summary>The multi tenancy strategy to use</summary>
+        public const string MultiTenancyStrategy = "multi_tenancy_strategy";
+
 		/// <summary>
 		/// When using an enhanced id generator and pooled optimizers (<see cref="NHibernate.Id.Enhanced.IOptimizer"/>),
 		/// prefer interpreting the database value as the lower (lo) boundary. The default is to interpret it as the high boundary.

--- a/src/NHibernate/Cfg/MultiTenancyStrategy.cs
+++ b/src/NHibernate/Cfg/MultiTenancyStrategy.cs
@@ -1,0 +1,51 @@
+﻿
+namespace NHibernate.Cfg
+{
+    public enum MultiTenancyStrategy
+    {
+        /// <summary>
+        /// Multi-tenancy implemented by use of discriminator columns (i.e. tenantId)
+        /// </summary>
+        Discriminator,
+
+        /// <summary>
+        /// Tenant per-schema
+        /// </summary>
+        Schema,
+
+        /// <summary>
+        /// Tenant per-database
+        /// </summary>
+        Database,
+
+        /// <summary>
+        /// No multi-tenancy (default)
+        /// </summary>
+        None
+    }
+
+    public static class MultiTenancyStrategyParser
+    {
+        public const string DiscriminatorXmlName = "discriminator";
+        public const string SchemaXmlName = "per-schema";
+        public const string DatabaseXmlName = "per-database";
+        public const string NoneXmlName = "none";
+
+        public static MultiTenancyStrategy Convert(string value)
+        {
+            switch (value)
+            {
+                case NoneXmlName:
+                    return MultiTenancyStrategy.None;
+                case SchemaXmlName:
+                    throw new HibernateException("multi-tenancy strategies are not yet supported");
+                case DatabaseXmlName:
+                    throw new HibernateException("multi-tenancy strategies are not yet supported");
+                case DiscriminatorXmlName:
+                    throw new HibernateException("multi-tenancy strategies are not yet supported");
+                default:
+                    throw new HibernateException(string.Format("unknown multi-tenancy strategy: {0}", value));
+            }
+        }
+    }
+}

--- a/src/NHibernate/Cfg/Settings.cs
+++ b/src/NHibernate/Cfg/Settings.cs
@@ -50,6 +50,8 @@ namespace NHibernate.Cfg
 
 		public string DefaultCatalogName { get; internal set; }
 
+        public MultiTenancyStrategy MultiTenancyStrategy { get; internal set; }
+
 		public string SessionFactoryName { get; internal set; }
 
 		public bool IsAutoCreateSchema { get; internal set; }

--- a/src/NHibernate/Cfg/SettingsFactory.cs
+++ b/src/NHibernate/Cfg/SettingsFactory.cs
@@ -111,6 +111,11 @@ namespace NHibernate.Cfg
 			settings.DefaultSchemaName = defaultSchema;
 			settings.DefaultCatalogName = defaultCatalog;
 
+            string multiTenancyStrategy = PropertiesHelper.GetString(
+                Environment.MultiTenancyStrategy, properties, MultiTenancyStrategyParser.NoneXmlName);
+            settings.MultiTenancyStrategy = MultiTenancyStrategyParser.Convert(multiTenancyStrategy);
+            log.Info("multi-tenancy strategy: " + multiTenancyStrategy);
+
 			int batchFetchSize = PropertiesHelper.GetInt32(Environment.DefaultBatchFetchSize, properties, 1);
 			log.Info("Default batch fetch size: " + batchFetchSize);
 			settings.DefaultBatchFetchSize = batchFetchSize;

--- a/src/NHibernate/Engine/BatchFetchQueue.cs
+++ b/src/NHibernate/Engine/BatchFetchQueue.cs
@@ -167,7 +167,7 @@ namespace NHibernate.Engine
 						end = i;
 						//checkForEnd = false;
 					}
-					else if (!IsCached(ce.LoadedKey, collectionPersister, entityMode))
+					else if (!IsCached(ce.LoadedKey, collectionPersister))
 					{
 						keys[i++] = ce.LoadedKey;
 						//count++;
@@ -220,7 +220,7 @@ namespace NHibernate.Engine
 					}
 					else
 					{
-						if (!IsCached(key, persister, entityMode))
+						if (!IsCached(key, persister))
 						{
 							ids[i++] = key.Identifier;
 						}
@@ -236,24 +236,21 @@ namespace NHibernate.Engine
 			return ids; //we ran out of ids to try
 		}
 
-		private bool IsCached(EntityKey entityKey, IEntityPersister persister, EntityMode entityMode)
+		private bool IsCached(EntityKey entityKey, IEntityPersister persister)
 		{
 			if (persister.HasCache)
 			{
-				CacheKey key =
-					new CacheKey(entityKey.Identifier, persister.IdentifierType, entityKey.EntityName, entityMode,
-					             context.Session.Factory);
+				CacheKey key = context.Session.GenerateCacheKey(entityKey.Identifier, persister.IdentifierType, entityKey.EntityName);
 				return persister.Cache.Cache.Get(key) != null;
 			}
 			return false;
 		}
 
-		private bool IsCached(object collectionKey, ICollectionPersister persister, EntityMode entityMode)
+		private bool IsCached(object collectionKey, ICollectionPersister persister)
 		{
 			if (persister.HasCache)
 			{
-				CacheKey cacheKey =
-					new CacheKey(collectionKey, persister.KeyType, persister.Role, entityMode, context.Session.Factory);
+			    CacheKey cacheKey = context.Session.GenerateCacheKey(collectionKey, persister.KeyType, persister.Role);
 				return persister.Cache.Cache.Get(cacheKey) != null;
 			}
 			return false;

--- a/src/NHibernate/Engine/Collections.cs
+++ b/src/NHibernate/Engine/Collections.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Engine
 				//    throw new AssertionFailure("Unable to determine collection owner identifier for orphan-delete processing");
 				//  }
 				//}
-				EntityKey key = new EntityKey(ownerId, loadedPersister.OwnerEntityPersister, session.EntityMode);
+                EntityKey key = session.GenerateEntityKey(ownerId, loadedPersister.OwnerEntityPersister);
 				object owner = persistenceContext.GetEntity(key);
 				if (owner == null)
 				{

--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using NHibernate.AdoNet;
+using NHibernate.Cache;
 using NHibernate.Collection;
 using NHibernate.Engine.Query.Sql;
 using NHibernate.Event;
@@ -303,5 +304,14 @@ namespace NHibernate.Engine
 		ITransactionContext TransactionContext { get; set; }
 
 		void CloseSessionFromDistributedTransaction();
+
+        /// <summary>
+        /// The tenant identifier of this session
+        /// </summary>
+        string TenantIdentifier { get; }
+
+        EntityKey GenerateEntityKey(object id, IEntityPersister persister);
+
+        CacheKey GenerateCacheKey(object id, IType type, string entityOrRoleName);
 	}
 }

--- a/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
+++ b/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
@@ -323,7 +323,7 @@ namespace NHibernate.Engine.Loading
 			}
 
 			CollectionCacheEntry entry = new CollectionCacheEntry(lce.Collection, persister);
-			CacheKey cacheKey = new CacheKey(lce.Key, persister.KeyType, persister.Role, session.EntityMode, factory);
+            CacheKey cacheKey = session.GenerateCacheKey(lce.Key, persister.KeyType, persister.Role);
 			bool put = persister.Cache.Put(cacheKey, persister.CacheEntryStructure.Structure(entry), 
 			                    session.Timestamp, version, versionComparator,
 													factory.Settings.IsMinimalPutsEnabled && session.CacheMode != CacheMode.Refresh);

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -330,7 +330,7 @@ namespace NHibernate.Engine
 		/// </summary>
 		public object[] GetDatabaseSnapshot(object id, IEntityPersister persister)
 		{
-			EntityKey key = new EntityKey(id, persister, session.EntityMode);
+            EntityKey key = session.GenerateEntityKey(id, persister);
 			object cached;
 			if (entitySnapshotsByKey.TryGetValue(key, out cached))
 			{
@@ -532,7 +532,7 @@ namespace NHibernate.Engine
 																bool disableVersionIncrement, bool lazyPropertiesAreUnfetched)
 		{
 			EntityEntry e =
-				new EntityEntry(status, loadedState, rowId, id, version, lockMode, existsInDatabase, persister, session.EntityMode,
+				new EntityEntry(status, loadedState, rowId, id, version, lockMode, existsInDatabase, persister, session.EntityMode, session.TenantIdentifier,
 				                disableVersionIncrement, lazyPropertiesAreUnfetched);
 			entityEntries[entity] = e;
 
@@ -614,7 +614,7 @@ namespace NHibernate.Engine
 			if (li.Session != Session)
 			{
 				IEntityPersister persister = session.Factory.GetEntityPersister(li.EntityName);
-				EntityKey key = new EntityKey(li.Identifier, persister, session.EntityMode);
+                EntityKey key = session.GenerateEntityKey(li.Identifier, persister);
 				// any earlier proxy takes precedence
 				if (!proxiesByKey.ContainsKey(key))
 				{
@@ -777,13 +777,13 @@ namespace NHibernate.Engine
 		{
 			EntityEntry e = GetEntry(impl);
 			IEntityPersister p = e.Persister;
-			return ProxyFor(p, new EntityKey(e.Id, p, session.EntityMode), impl);
+            return ProxyFor(p, session.GenerateEntityKey(e.Id, p), impl);
 		}
 
 		/// <summary> Get the entity that owns this persistent collection</summary>
 		public object GetCollectionOwner(object key, ICollectionPersister collectionPersister)
 		{
-			return GetEntity(new EntityKey(key, collectionPersister.OwnerEntityPersister, session.EntityMode));
+            return GetEntity(session.GenerateEntityKey(key, collectionPersister.OwnerEntityPersister));
 		}
 
 		/// <summary> Get the entity that owned this persistent collection when it was loaded </summary>
@@ -1351,7 +1351,7 @@ namespace NHibernate.Engine
 			var oldEntry = (EntityEntry) tempObject2;
 			parentsByChild.Clear();
 
-			var newKey = new EntityKey(generatedId, oldEntry.Persister, Session.EntityMode);
+            var newKey = Session.GenerateEntityKey(generatedId, oldEntry.Persister);
 			AddEntity(newKey, entity);
 			AddEntry(entity, oldEntry.Status, oldEntry.LoadedState, oldEntry.RowId, generatedId, oldEntry.Version,
 			         oldEntry.LockMode, oldEntry.ExistsInDatabase, oldEntry.Persister, oldEntry.IsBeingReplicated,

--- a/src/NHibernate/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Engine/TwoPhaseLoad.cs
@@ -106,7 +106,7 @@ namespace NHibernate.Engine
 				object version = Versioning.GetVersion(hydratedState, persister);
 				CacheEntry entry =
 					new CacheEntry(hydratedState, persister, entityEntry.LoadedWithLazyPropertiesUnfetched, version, session, entity);
-				CacheKey cacheKey = new CacheKey(id, persister.IdentifierType, persister.RootEntityName, session.EntityMode, session.Factory);
+                CacheKey cacheKey = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
 				bool put =
 					persister.Cache.Put(cacheKey, persister.CacheEntryStructure.Structure(entry), session.Timestamp, version,
 										persister.IsVersioned ? persister.VersionType.Comparator : null,

--- a/src/NHibernate/Event/Default/AbstractLockUpgradeEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractLockUpgradeEventListener.cs
@@ -47,7 +47,7 @@ namespace NHibernate.Event.Default
 				CacheKey ck;
 				if (persister.HasCache)
 				{
-					ck = new CacheKey(entry.Id, persister.IdentifierType, persister.RootEntityName, source.EntityMode, source.Factory);
+                    ck = source.GenerateCacheKey(entry.Id, persister.IdentifierType, persister.RootEntityName);
 					slock = persister.Cache.Lock(ck, entry.Version);
 				}
 				else

--- a/src/NHibernate/Event/Default/AbstractReassociateEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractReassociateEventListener.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Event.Default
 			}
 
 			IEventSource source = @event.Session;
-			EntityKey key = new EntityKey(id, persister, source.EntityMode);
+            EntityKey key = source.GenerateEntityKey(id, persister);
 
 			source.PersistenceContext.CheckUniqueness(key, entity);
 

--- a/src/NHibernate/Event/Default/AbstractSaveEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractSaveEventListener.cs
@@ -160,7 +160,7 @@ namespace NHibernate.Event.Default
 			EntityKey key;
 			if (!useIdentityColumn)
 			{
-				key = new EntityKey(id, persister, source.EntityMode);
+                key = source.GenerateEntityKey(id, persister);
 				object old = source.PersistenceContext.GetEntity(key);
 				if (old != null)
 				{
@@ -260,7 +260,7 @@ namespace NHibernate.Event.Default
 					id = insert.GeneratedId;
 					//now done in EntityIdentityInsertAction
 					//persister.setIdentifier( entity, id, source.getEntityMode() );
-					key = new EntityKey(id, persister, source.EntityMode);
+                    key = source.GenerateEntityKey(id, persister);
 					source.PersistenceContext.CheckUniqueness(key, entity);
 					//source.getBatcher().executeBatch(); //found another way to ensure that all batched joined inserts have been executed
 				}

--- a/src/NHibernate/Event/Default/DefaultDeleteEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultDeleteEventListener.cs
@@ -65,7 +65,7 @@ namespace NHibernate.Event.Default
 					throw new TransientObjectException("the detached instance passed to delete() had a null identifier");
 				}
 
-				EntityKey key = new EntityKey(id, persister, source.EntityMode);
+                EntityKey key = source.GenerateEntityKey(id, persister);
 
 				persistenceContext.CheckUniqueness(key, entity);
 
@@ -197,7 +197,7 @@ namespace NHibernate.Event.Default
 
 			// before any callbacks, etc, so subdeletions see that this deletion happened first
 			persistenceContext.SetEntryStatus(entityEntry, Status.Deleted);
-			EntityKey key = new EntityKey(entityEntry.Id, persister, session.EntityMode);
+            EntityKey key = session.GenerateEntityKey(entityEntry.Id, persister);
 
 			CascadeBeforeDelete(session, persister, entity, entityEntry, transientEntities);
 

--- a/src/NHibernate/Event/Default/DefaultEvictEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultEvictEventListener.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Event.Default
 				{
 					throw new ArgumentException("null identifier");
 				}
-				EntityKey key = new EntityKey(id, persister, source.EntityMode);
+                EntityKey key = source.GenerateEntityKey(id, persister);
 				persistenceContext.RemoveProxy(key);
 				if (!li.IsUninitialized)
 				{

--- a/src/NHibernate/Event/Default/DefaultFlushEntityEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultFlushEntityEventListener.cs
@@ -522,7 +522,7 @@ namespace NHibernate.Event.Default
 			else
 			{
 				//TODO: optimize away this lookup for entities w/o unsaved-value="undefined"
-				EntityKey entityKey = new EntityKey(id, persister, session.EntityMode);
+                EntityKey entityKey = session.GenerateEntityKey(id, persister);
 				return session.PersistenceContext.GetCachedDatabaseSnapshot(entityKey);
 			}
 		}

--- a/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -80,7 +80,7 @@ namespace NHibernate.Event.Default
 			{
 				ISessionFactoryImplementor factory = source.Factory;
 
-				CacheKey ck = new CacheKey(id, persister.KeyType, persister.Role, source.EntityMode, factory);
+                CacheKey ck = source.GenerateCacheKey(id, persister.KeyType, persister.Role);
 				object ce = persister.Cache.Get(ck, source.Timestamp);
 
 				if (factory.Statistics.IsStatisticsEnabled)

--- a/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
@@ -65,7 +65,7 @@ namespace NHibernate.Event.Default
 				}
 			}
 
-			EntityKey keyToLoad = new EntityKey(@event.EntityId, persister, source.EntityMode);
+            EntityKey keyToLoad = source.GenerateEntityKey(@event.EntityId, persister);
 			try
 			{
 				if (loadType.IsNakedEntityReturned)
@@ -248,7 +248,7 @@ namespace NHibernate.Event.Default
 			CacheKey ck;
 			if (persister.HasCache)
 			{
-				ck = new CacheKey(@event.EntityId, persister.IdentifierType, persister.RootEntityName, source.EntityMode, source.Factory);
+                ck = source.GenerateCacheKey(@event.EntityId, persister.IdentifierType, persister.RootEntityName);
 				sLock = persister.Cache.Lock(ck, null);
 			}
 			else
@@ -420,7 +420,7 @@ namespace NHibernate.Event.Default
 			{
 				ISessionFactoryImplementor factory = source.Factory;
 
-				CacheKey ck = new CacheKey(@event.EntityId, persister.IdentifierType, persister.RootEntityName, source.EntityMode, factory);
+                CacheKey ck = source.GenerateCacheKey(@event.EntityId, persister.IdentifierType, persister.RootEntityName);
 				object ce = persister.Cache.Get(ck, source.Timestamp);
 
 				if (factory.Statistics.IsStatisticsEnabled)
@@ -468,7 +468,7 @@ namespace NHibernate.Event.Default
 			object result = optionalObject ?? session.Instantiate(subclassPersister, id);
 
 			// make it circular-reference safe
-			EntityKey entityKey = new EntityKey(id, subclassPersister, session.EntityMode);
+            EntityKey entityKey = session.GenerateEntityKey(id, subclassPersister);
 			TwoPhaseLoad.AddUninitializedCachedEntity(entityKey, result, subclassPersister, LockMode.None, entry.AreLazyPropertiesUnfetched, entry.Version, session);
 
 			IType[] types = subclassPersister.PropertyTypes;

--- a/src/NHibernate/Event/Default/DefaultMergeEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultMergeEventListener.cs
@@ -138,7 +138,7 @@ namespace NHibernate.Event.Default
 						object id = persister.GetIdentifier(entity, source.EntityMode);
 						if (id != null)
 						{
-							EntityKey key = new EntityKey(id, persister, source.EntityMode);
+                            EntityKey key = source.GenerateEntityKey(id, persister);
 							object managedEntity = source.PersistenceContext.GetEntity(key);
 							entry = source.PersistenceContext.GetEntry(managedEntity);
 							if (entry != null)
@@ -437,7 +437,7 @@ namespace NHibernate.Event.Default
 				object id = persister.GetIdentifier(entity, source.EntityMode);
 				if (id != null)
 				{
-					EntityKey key = new EntityKey(id, persister, source.EntityMode);
+                    EntityKey key = source.GenerateEntityKey(id, persister);
 					object managedEntity = source.PersistenceContext.GetEntity(key);
 					entry = source.PersistenceContext.GetEntry(managedEntity);
 				}

--- a/src/NHibernate/Event/Default/DefaultRefreshEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultRefreshEventListener.cs
@@ -56,7 +56,7 @@ namespace NHibernate.Event.Default
 				{
 					log.Debug("refreshing transient " + MessageHelper.InfoString(persister, id, source.Factory));
 				}
-				EntityKey key = new EntityKey(id, persister, source.EntityMode);
+                EntityKey key = source.GenerateEntityKey(id, persister);
 				if (source.PersistenceContext.GetEntry(key) != null)
 				{
 					throw new PersistentObjectException("attempted to refresh transient instance when persistent instance was already associated with the Session: " + 
@@ -84,7 +84,7 @@ namespace NHibernate.Event.Default
 
 			if (e != null)
 			{
-				EntityKey key = new EntityKey(id, persister, source.EntityMode);
+                EntityKey key = source.GenerateEntityKey(id, persister);
 				source.PersistenceContext.RemoveEntity(key);
 				if (persister.HasCollections)
 					new EvictVisitor(source).Process(obj, persister);
@@ -92,7 +92,7 @@ namespace NHibernate.Event.Default
 
 			if (persister.HasCache)
 			{
-				CacheKey ck = new CacheKey(id, persister.IdentifierType, persister.RootEntityName, source.EntityMode, source.Factory);
+                CacheKey ck = source.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
 				persister.Cache.Remove(ck);
 			}
 

--- a/src/NHibernate/Event/Default/DefaultReplicateEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultReplicateEventListener.cs
@@ -95,7 +95,7 @@ namespace NHibernate.Event.Default
 				}
 
 				bool regenerate = persister.IsIdentifierAssignedByInsert; // prefer re-generation of identity!
-				EntityKey key = regenerate ? null : new EntityKey(id, persister, source.EntityMode);
+                EntityKey key = regenerate ? null : source.GenerateEntityKey(id, persister);
 
 				PerformSaveOrReplicate(entity, key, persister, regenerate, replicationMode, source, true);
 			}
@@ -113,8 +113,8 @@ namespace NHibernate.Event.Default
 			source.PersistenceContext.AddEntity(
 				entity, 
 				persister.IsMutable ? Status.Loaded : Status.ReadOnly,
-				null, 
-				new EntityKey(id, persister, source.EntityMode), 
+				null,
+                source.GenerateEntityKey(id, persister), 
 				version, 
 				LockMode.None, 
 				true, 

--- a/src/NHibernate/Event/Default/DefaultSaveOrUpdateEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultSaveOrUpdateEventListener.cs
@@ -222,7 +222,7 @@ namespace NHibernate.Event.Default
 
 			IEventSource source = @event.Session;
 
-			EntityKey key = new EntityKey(@event.RequestedId, persister, source.EntityMode);
+            EntityKey key = source.GenerateEntityKey(@event.RequestedId, persister);
 
 			source.PersistenceContext.CheckUniqueness(key, entity);
 

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Impl
 			{
 				CheckAndUpdateSessionStatus();
 				IEntityPersister persister = Factory.GetEntityPersister(entityName);
-				object loaded = temporaryPersistenceContext.GetEntity(new EntityKey(id, persister, EntityMode.Poco));
+                object loaded = temporaryPersistenceContext.GetEntity(GenerateEntityKey(id, persister, EntityMode.Poco));
 				if (loaded != null)
 				{
 					return loaded;
@@ -827,7 +827,7 @@ namespace NHibernate.Impl
 
 				if (persister.HasCache)
 				{
-					CacheKey ck = new CacheKey(id, persister.IdentifierType, persister.RootEntityName, EntityMode, Factory);
+					CacheKey ck = GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
 					persister.Cache.Remove(ck);
 				}
 

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -313,7 +313,7 @@ namespace NHibernate.Loader
 
 			if (optionalObject != null && !string.IsNullOrEmpty(optionalEntityName))
 			{
-				return new EntityKey(optionalId, session.GetEntityPersister(optionalEntityName, optionalObject), session.EntityMode);
+                return session.GenerateEntityKey(optionalId, session.GetEntityPersister(optionalEntityName, optionalObject));
 			}
 			else
 			{
@@ -799,7 +799,7 @@ namespace NHibernate.Loader
 				}
 			}
 
-			return resultId == null ? null : new EntityKey(resultId, persister, session.EntityMode);
+            return resultId == null ? null : session.GenerateEntityKey(resultId, persister);
 		}
 
 		/// <summary>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -125,13 +125,16 @@
     <Compile Include="Cfg\ImprovedNamingStrategy.cs" />
     <Compile Include="Cfg\INamingStrategy.cs" />
     <Compile Include="Cfg\Mappings.cs" />
+    <Compile Include="Cfg\MultiTenancyStrategy.cs" />
     <Compile Include="Cfg\Settings.cs" />
     <Compile Include="Cfg\SettingsFactory.cs" />
     <Compile Include="Collection\IPersistentCollection.cs" />
+    <Compile Include="Connection\AbstractMultiTenantConnectionProvider.cs" />
     <Compile Include="Connection\ConnectionProvider.cs" />
     <Compile Include="Connection\ConnectionProviderFactory.cs" />
     <Compile Include="Connection\DriverConnectionProvider.cs" />
     <Compile Include="Connection\IConnectionProvider.cs" />
+    <Compile Include="Connection\IMultiTenantConnectionProvider.cs" />
     <Compile Include="Connection\UserSuppliedConnectionProvider.cs" />
     <Compile Include="Criterion\IEnhancedProjection.cs" />
     <Compile Include="Dialect\DB2Dialect.cs" />

--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -613,7 +613,7 @@ namespace NHibernate.Persister.Collection
 			IPersistenceContext persistenceContext = session.PersistenceContext;
 
 			SubselectFetch subselect =
-				persistenceContext.BatchFetchQueue.GetSubselect(new EntityKey(key, OwnerEntityPersister, session.EntityMode));
+                persistenceContext.BatchFetchQueue.GetSubselect(session.GenerateEntityKey(key, OwnerEntityPersister));
 
 			if (subselect == null)
 			{

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1208,7 +1208,7 @@ namespace NHibernate.Persister.Entity
 
 			if (HasCache)
 			{
-				CacheKey cacheKey = new CacheKey(id, IdentifierType, EntityName, session.EntityMode, Factory);
+                CacheKey cacheKey = session.GenerateCacheKey(id, IdentifierType, EntityName);
 				object ce = Cache.Get(cacheKey, session.Timestamp);
 				if (ce != null)
 				{
@@ -3076,7 +3076,7 @@ namespace NHibernate.Persister.Entity
 				// first we need to locate the "loaded" state
 				//
 				// Note, it potentially could be a proxy, so perform the location the safe way...
-				EntityKey key = new EntityKey(id, this, session.EntityMode);
+                EntityKey key = session.GenerateEntityKey(id, this);
 				object entity = session.PersistenceContext.GetEntity(key);
 				if (entity != null)
 				{
@@ -3719,7 +3719,7 @@ namespace NHibernate.Persister.Entity
 			// check to see if it is in the second-level cache
 			if (HasCache)
 			{
-				CacheKey ck = new CacheKey(id, IdentifierType, RootEntityName, session.EntityMode, session.Factory);
+                CacheKey ck = session.GenerateCacheKey(id, IdentifierType, RootEntityName);
 				if (Cache.Get(ck, session.Timestamp) != null)
 					return false;
 			}

--- a/src/NHibernate/Persister/Entity/NamedQueryLoader.cs
+++ b/src/NHibernate/Persister/Entity/NamedQueryLoader.cs
@@ -46,7 +46,7 @@ namespace NHibernate.Persister.Entity
 			// now look up the object we are really interested in!
 			// (this lets us correctly handle proxies and multi-row
 			// or multi-column queries)
-			return session.PersistenceContext.GetEntity(new EntityKey(id, persister, session.EntityMode));
+            return session.PersistenceContext.GetEntity(session.GenerateEntityKey(id, persister));
 		}
 	}
 }

--- a/src/NHibernate/Proxy/AbstractLazyInitializer.cs
+++ b/src/NHibernate/Proxy/AbstractLazyInitializer.cs
@@ -199,7 +199,7 @@ namespace NHibernate.Proxy
 		/// <returns>The Persistent Object this proxy is Proxying, or <see langword="null" />.</returns>
 		public object GetImplementation(ISessionImplementor s)
 		{
-			EntityKey key = new EntityKey(Identifier, s.Factory.GetEntityPersister(EntityName), s.EntityMode);
+            EntityKey key = s.GenerateEntityKey(Identifier, s.Factory.GetEntityPersister(EntityName));
 			return s.PersistenceContext.GetEntity(key);
 		}
 
@@ -249,7 +249,7 @@ namespace NHibernate.Proxy
 			if (id == null || s == null || entityName == null)
 				return null;
 
-			return new EntityKey(id, s.Factory.GetEntityPersister(entityName), s.EntityMode);
+            return s.GenerateEntityKey(id, s.Factory.GetEntityPersister(entityName));
 		}
 		
 		private void CheckTargetState()

--- a/src/NHibernate/Proxy/Poco/BasicLazyInitializer.cs
+++ b/src/NHibernate/Proxy/Poco/BasicLazyInitializer.cs
@@ -111,7 +111,7 @@ namespace NHibernate.Proxy.Poco
 
 					if (Target == null & Session != null)
 					{
-						EntityKey key = new EntityKey(Identifier, Session.Factory.GetEntityPersister(EntityName), Session.EntityMode);
+                        EntityKey key = Session.GenerateEntityKey(Identifier, Session.Factory.GetEntityPersister(EntityName));
 						object entity = Session.PersistenceContext.GetEntity(key);
 						if (entity != null)
 							SetImplementation(entity);

--- a/src/NHibernate/Type/ManyToOneType.cs
+++ b/src/NHibernate/Type/ManyToOneType.cs
@@ -92,7 +92,7 @@ namespace NHibernate.Type
 			if (uniqueKeyPropertyName == null && id != null)
 			{
 				IEntityPersister persister = session.Factory.GetEntityPersister(GetAssociatedEntityName());
-				EntityKey entityKey = new EntityKey(id, persister, session.EntityMode);
+				EntityKey entityKey = session.GenerateEntityKey(id, persister);
 				if (!session.PersistenceContext.ContainsEntity(entityKey))
 				{
 					session.PersistenceContext.BatchFetchQueue.AddBatchLoadableEntityKey(entityKey);

--- a/src/NHibernate/Type/OneToOneType.cs
+++ b/src/NHibernate/Type/OneToOneType.cs
@@ -74,7 +74,7 @@ namespace NHibernate.Type
 				IEntityPersister ownerPersister = session.Factory.GetEntityPersister(entityName);
 				object id = session.GetContextEntityIdentifier(owner);
 
-				EntityKey entityKey = new EntityKey(id, ownerPersister, session.EntityMode);
+				EntityKey entityKey = session.GenerateEntityKey(id, ownerPersister);
 
 				return session.PersistenceContext.IsPropertyNull(entityKey, PropertyName);
 			}
@@ -104,7 +104,7 @@ namespace NHibernate.Type
 					object[] values = ownerIdType.GetPropertyValues(identifier, session);
 					object id = componentType.ResolveIdentifier(values, session, null);
 					IEntityPersister persister = session.Factory.GetEntityPersister(type.ReturnedClass.FullName);
-					var key = new EntityKey(id, persister, session.EntityMode);
+                    var key = session.GenerateEntityKey(id, persister);
 					return session.PersistenceContext.GetEntity(key);
 				}
 			}


### PR DESCRIPTION
https://nhibernate.jira.com/browse/NH-3087

Some pre-work refactoring to support multi tenancy feature, to be implemented later.
- Refactored EntityKey and CacheKey creation to be centralized to ISessionImplementor (implemented in AbstractSessionImpl)
- Key creation takes tenantIdentifier into account
- Added MultiTenancyStrategy enum for SessionFactory configuration and integrated into Settings
- Changed SessionFactoryImpl.EvictEntity(string entityName, object id) and EvictCollection(string roleName, object id) to throw an exception when the multi-tenancy strategy is not NONE and there is no session context

No change to the public API and no new features added. Tests passed ok after refactoring. I would have added a test for the SessionFactory cache eviction change but it looks like those methods are untested currently.
