### PR TITLE
Byte.Equals in LINQ Where clauses throws NotSupportedException

### DIFF
--- a/src/NHibernate.Test/Linq/FunctionTests.cs
+++ b/src/NHibernate.Test/Linq/FunctionTests.cs
@@ -309,8 +309,18 @@ namespace NHibernate.Test.Linq
 						select item;
 
 			ObjectDumper.Write(query);
+		}
+
+		[Test]
+		public void WhereByteEqual()
+		{
+			var query = from item in session.Query<Foo>()
+						where item.Byte.Equals(1)
+						select item;
+
+			ObjectDumper.Write(query);
 		}	
-	
+
 		[Test]
 		public void WhereDecimalEqual()
 		{

--- a/src/NHibernate.Test/NHSpecificTest/NH2812/Entities.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2812/Entities.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH2812
+{
+    public class EntityWithAByteValue
+    {
+        public virtual Guid Id { get; protected set; }
+        public virtual byte ByteValue { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2812/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2812/Fixture.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.Test.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH2812
+{
+    [TestFixture]
+    public class Fixture : BugTestCase
+    {
+        protected override void OnSetUp()
+        {
+            using (ISession session = OpenSession())
+            {
+                using (ITransaction tx = session.BeginTransaction())
+                {
+                    var entity = new EntityWithAByteValue();
+                    entity.ByteValue = 1;
+                    session.Save(entity);
+                    tx.Commit();
+                }
+            }
+        }
+
+        protected override void OnTearDown()
+        {
+            base.OnTearDown();            
+            using (ISession session = OpenSession())
+            {
+                using (ITransaction tx = session.BeginTransaction())
+                {
+                    session.Delete("from EntityWithAByteValue");
+                    tx.Commit();
+                }
+            }
+        }
+
+        [Test]
+        public void Performing_a_query_on_a_byte_column_should_not_throw()
+        {
+            using (var session = sessions.OpenSession())
+            {
+                var query = (from e in session.Query<EntityWithAByteValue>()
+                             where e.ByteValue == 1
+                             select e)
+                             .ToList();
+
+                // this should not fail if fixed
+                Assert.AreEqual(1, query.Count);
+            }
+        }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2812/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2812/Mappings.hbm.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+				   namespace="NHibernate.Test.NHSpecificTest.NH2812"
+				   assembly="NHibernate.Test">
+	<class name="EntityWithAByteValue">
+		<id name="Id" type="Guid">
+			<generator class="guid" />
+		</id>
+		<property name="ByteValue" not-null="true" />
+	</class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -667,6 +667,8 @@
     <Compile Include="NHSpecificTest\NH2664\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2214\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2214\Model.cs" />
+    <Compile Include="NHSpecificTest\NH2812\Entities.cs" />
+    <Compile Include="NHSpecificTest\NH2812\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2880\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2880\Model.cs" />
     <Compile Include="NHSpecificTest\NH2500\Fixture.cs" />
@@ -2815,6 +2817,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH2812\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2664\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2214\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2960\Mappings.hbm.xml" />

--- a/src/NHibernate/Linq/Functions/EqualsGenerator.cs
+++ b/src/NHibernate/Linq/Functions/EqualsGenerator.cs
@@ -23,7 +23,8 @@ namespace NHibernate.Linq.Functions
 			                   		ReflectionHelper.GetMethodDefinition<double>(x => x.Equals(default(double))),
 			                   		ReflectionHelper.GetMethodDefinition<float>(x => x.Equals(default(float))),
 			                   		ReflectionHelper.GetMethodDefinition<decimal>(x => x.Equals(default(decimal))),
-			                   		ReflectionHelper.GetMethodDefinition<char>(x => x.Equals(default(char)))
+			                   		ReflectionHelper.GetMethodDefinition<char>(x => x.Equals(default(char))),
+									ReflectionHelper.GetMethodDefinition<byte>(x => x.Equals(default(byte)))
 			                   	};
 		}
 


### PR DESCRIPTION
- Added a unit test for LINQ byte.Equals, and added its definition to EqualsGenerator
- Could not repeat NH-2812, it's appears fixed in 3.3 (possibly a Remotion Linq issue)
