### PR TITLE
Test and fix for NH-3141

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3141/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3141/Entity.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3141
+{
+	public class Entity
+	{
+		public virtual int Id { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3141/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3141/Mappings.hbm.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+				   assembly="NHibernate.Test"
+				   namespace="NHibernate.Test.NHSpecificTest.NH3141">
+	<class name="Entity">
+		<id name="Id" type="int">
+			<generator class="native"/>
+		</id>
+	</class>
+</hibernate-mapping>
+

--- a/src/NHibernate.Test/NHSpecificTest/NH3141/ProxyIdPerformanceTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3141/ProxyIdPerformanceTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3141
+{
+	[TestFixture]
+	public class ProxyIdPerformanceTest : BugTestCase
+	{
+		private int id;
+
+		protected override void OnSetUp()
+		{
+			using (var s = OpenSession())
+			{
+				using (var tx = s.BeginTransaction())
+				{
+					id = (int)s.Save(new Entity());
+					tx.Commit();
+				}
+			}
+		}
+
+		[Test, Explicit("No logical test - just to compare before/after fix")]
+		public void ShouldUseIdDirectlyFromProxy()
+		{
+			var proxyEntity = createInitializedProxy();
+
+			const int loop = 1000000;
+			var watch = new Stopwatch();
+			watch.Start();
+			const int dummyValue = 0;
+			for (var i = 0; i < loop; i++)
+			{
+				dummyValue.CompareTo(proxyEntity.Id);
+			}
+			watch.Stop();
+
+			//before fix: 2.2s
+			//after fix: 0.8s
+			Console.WriteLine(watch.Elapsed);
+		}
+
+		private Entity createInitializedProxy()
+		{
+			using (var s = OpenSession())
+			{
+				using (s.BeginTransaction())
+				{
+					var proxyEntity = s.Load<Entity>(id);
+					NHibernateUtil.Initialize(proxyEntity);
+					return proxyEntity;
+				}
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			{
+				using (var tx = s.BeginTransaction())
+				{
+					s.CreateQuery("delete from Entity e").ExecuteUpdate();
+					tx.Commit();
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -964,6 +964,8 @@
     <Compile Include="NHSpecificTest\NH3074\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3074\Model.cs" />
     <Compile Include="NHSpecificTest\NH3124\FixtureByCode.cs" />
+    <Compile Include="NHSpecificTest\NH3141\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3141\ProxyIdPerformanceTest.cs" />
     <Compile Include="NHSpecificTest\NH941\Domain.cs" />
     <Compile Include="NHSpecificTest\NH941\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH941\FixtureUsingList.cs" />
@@ -2817,6 +2819,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3141\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2664\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2214\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2960\Mappings.hbm.xml" />

--- a/src/NHibernate/Proxy/Poco/BasicLazyInitializer.cs
+++ b/src/NHibernate/Proxy/Poco/BasicLazyInitializer.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Proxy.Poco
 				{
 					return IdentityEqualityComparer.GetHashCode(proxy);
 				}
-				else if (IsUninitialized && IsEqualToIdentifierMethod(method))
+				else if (IsEqualToIdentifierMethod(method))
 				{
 					return Identifier;
 				}


### PR DESCRIPTION
Pull request for
https://nhibernate.jira.com/browse/NH-3141

This patch will always return id directly from proxy instead from target (for perf reasons). Including a ignored test to measure perf before/after.

This patch shouldn't change any logic. All tests are still green.
