### PR TITLE
NH-3126: InvalidCastException when cascading saves to transient dictionary values

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3126/InvalidCastTestCase.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3126/InvalidCastTestCase.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3126
+{
+	[TestFixture]
+	public class InvalidCastWithGenericDictionaryOnCascadeTest : BugTestCase
+	{
+		[Test]
+		public void Test()
+		{
+			var property = new Property { Name = "Property 1" };
+			using (var session = OpenSession())
+			{
+				using (var tx = session.BeginTransaction())
+				{
+					session.Save(property);
+
+					tx.Commit();
+				}
+
+				var item = new Item();
+				using (var tx = session.BeginTransaction())
+				{
+					item.Name = "Item 1";
+					item.PropertyValues = new Dictionary<Guid, PropertyValue>
+											  {
+												  {property.Id, new PropertyValue {Value = "Value 1"}}
+											  };
+
+					session.Save(item);
+
+					tx.Commit();
+				}
+				session.Clear();
+
+				var savedItem = session.Get<Item>(item.Id);
+				Assert.AreEqual(1, savedItem.PropertyValues.Count);
+				Assert.AreEqual("Value 1", savedItem.PropertyValues[property.Id].Value);
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			base.OnTearDown();
+			using (var session = OpenSession())
+			{
+				session.Delete("from System.Object");
+				session.Flush();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3126/Item.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3126/Item.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3126
+{
+	public class Item
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual string Name { get; set; }
+
+		public virtual IDictionary<Guid, PropertyValue> PropertyValues { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3126/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3126/Mappings.hbm.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" 
+                   assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.NH3126">
+  <class name="Item" table="Item">
+    <id name="Id" type="guid">
+      <generator class="guid.comb" />
+    </id>
+    <property name="Name" />
+    <map name="PropertyValues" inverse="false" table="PropertyValue" cascade="all-delete-orphan">
+      <key column="ItemId" not-null="true" />
+      <index column="PropertyId" type="guid" />
+      <one-to-many class="PropertyValue" />
+    </map>
+  </class>
+  <class name="Property" table="Property">
+    <id name="Id" type="guid">
+      <generator class="guid.comb" />
+    </id>
+    <property name="Name" />
+  </class>
+  <class name="PropertyValue" table="PropertyValue">
+    <id name="Id" type="guid">
+      <generator class="guid.comb" />
+    </id>
+    <property name="Value" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3126/Property.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3126/Property.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3126
+{
+	public class Property
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3126/PropertyValue.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3126/PropertyValue.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3126
+{
+	public class PropertyValue
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual string Value { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -962,6 +962,10 @@
     <Compile Include="NHSpecificTest\NH3004\TestSqlClientDriver.cs" />
     <Compile Include="NHSpecificTest\NH3074\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3074\Model.cs" />
+    <Compile Include="NHSpecificTest\NH3126\InvalidCastTestCase.cs" />
+    <Compile Include="NHSpecificTest\NH3126\Item.cs" />
+    <Compile Include="NHSpecificTest\NH3126\Property.cs" />
+    <Compile Include="NHSpecificTest\NH3126\PropertyValue.cs" />
     <Compile Include="NHSpecificTest\NH941\Domain.cs" />
     <Compile Include="NHSpecificTest\NH941\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH941\FixtureUsingList.cs" />
@@ -2815,6 +2819,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3126\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2664\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2214\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2960\Mappings.hbm.xml" />

--- a/src/NHibernate/Type/MapType.cs
+++ b/src/NHibernate/Type/MapType.cs
@@ -107,11 +107,14 @@ namespace NHibernate.Type
 
 		public override object IndexOf(object collection, object element)
 		{
-			IEnumerable iter = (IDictionary)collection;
-			foreach (DictionaryEntry me in iter)
+			var dictionary = (IDictionary) collection;
+			var enumerator = dictionary.GetEnumerator();
+			while (enumerator.MoveNext())
 			{
-				if (me.Value == element)
-					return me.Key;				
+				if (enumerator.Value == element)
+				{
+					return enumerator.Key;
+				}
 			}
 			return null;
 		}


### PR DESCRIPTION
When using a <map> collection with cascade="all-delete-orphan" where the index is a simple type and the value is an entity referenced with a one-to-many a InvalidCastException occurs when saving the owning entity. 

JIRA: https://nhibernate.jira.com/browse/NH-3126

PS: To which branch should it be merged?
