### PR TITLE
NH-3072: OneToManyPersister improvements

### DIFF
--- a/src/NHibernate/Persister/Collection/OneToManyPersister.cs
+++ b/src/NHibernate/Persister/Collection/OneToManyPersister.cs
@@ -161,47 +161,41 @@ namespace NHibernate.Persister.Collection
 
 				if (RowDeleteEnabled)
 				{
-					bool useBatch = true;
+					IExpectation deleteExpectation = Expectations.AppropriateExpectation(DeleteCheckStyle);
+					bool useBatch = deleteExpectation.CanBeBatched;
+					SqlCommandInfo sql = SqlDeleteRowString;
 					IDbCommand st = null;
 					// update removed rows fks to null
 					try
 					{
 						int i = 0;
 						IEnumerable entries = collection.Entries(this);
-						IExpectation expectation = Expectations.None;
 
 						foreach (object entry in entries)
 						{
 							if (collection.NeedsUpdating(entry, i, ElementType))
 							{
 								// will still be issued when it used to be null
-								if (st == null)
+								if (useBatch)
 								{
-									SqlCommandInfo sql = SqlDeleteRowString;
-									if (DeleteCallable)
-									{
-										expectation = Expectations.AppropriateExpectation(DeleteCheckStyle);
-										useBatch = expectation.CanBeBatched;
-										st = useBatch
-												? session.Batcher.PrepareBatchCommand(SqlDeleteRowString.CommandType, sql.Text, SqlDeleteRowString.ParameterTypes)
-												: session.Batcher.PrepareCommand(SqlDeleteRowString.CommandType, sql.Text, SqlDeleteRowString.ParameterTypes);
-										//offset += expectation.prepare(st);
-									}
-									else
-									{
-										st = session.Batcher.PrepareBatchCommand(SqlDeleteRowString.CommandType, sql.Text, SqlDeleteRowString.ParameterTypes);
-									}
+									st = session.Batcher.PrepareBatchCommand(SqlDeleteRowString.CommandType, sql.Text,
+																			 SqlDeleteRowString.ParameterTypes);
+								}
+								else
+								{
+									st = session.Batcher.PrepareCommand(SqlDeleteRowString.CommandType, sql.Text,
+																		SqlDeleteRowString.ParameterTypes);
 								}
 
 								int loc = WriteKey(st, id, offset, session);
 								WriteElementToWhere(st, collection.GetSnapshotElement(entry, i), loc, session);
 								if (useBatch)
 								{
-									session.Batcher.AddToBatch(expectation);
+									session.Batcher.AddToBatch(deleteExpectation);
 								}
 								else
 								{
-									expectation.VerifyOutcomeNonBatched(session.Batcher.ExecuteNonQuery(st), st);
+									deleteExpectation.VerifyOutcomeNonBatched(session.Batcher.ExecuteNonQuery(st), st);
 								}
 								count++;
 							}
@@ -227,9 +221,9 @@ namespace NHibernate.Persister.Collection
 
 				if (RowInsertEnabled)
 				{
-					IExpectation expectation = Expectations.AppropriateExpectation(InsertCheckStyle);
+					IExpectation insertExpectation = Expectations.AppropriateExpectation(InsertCheckStyle);
 					//bool callable = InsertCallable;
-					bool useBatch = expectation.CanBeBatched;
+					bool useBatch = insertExpectation.CanBeBatched;
 					SqlCommandInfo sql = SqlInsertRowString;
 					IDbCommand st = null;
 
@@ -244,17 +238,16 @@ namespace NHibernate.Persister.Collection
 							{
 								if (useBatch)
 								{
-									if (st == null)
-									{
-										st = session.Batcher.PrepareBatchCommand(SqlInsertRowString.CommandType, sql.Text, SqlInsertRowString.ParameterTypes);
-									}
+									st = session.Batcher.PrepareBatchCommand(SqlInsertRowString.CommandType, sql.Text,
+																			 SqlInsertRowString.ParameterTypes);
 								}
 								else
 								{
-									st = session.Batcher.PrepareCommand(SqlInsertRowString.CommandType, sql.Text, SqlInsertRowString.ParameterTypes);
+									st = session.Batcher.PrepareCommand(SqlInsertRowString.CommandType, sql.Text,
+																		SqlInsertRowString.ParameterTypes);
 								}
 
-								//offset += expectation.Prepare(st, Factory.ConnectionProvider.Driver);
+								//offset += insertExpectation.Prepare(st, Factory.ConnectionProvider.Driver);
 								int loc = WriteKey(st, id, offset, session);
 								if (HasIndex && !indexContainsFormula)
 								{
@@ -263,11 +256,11 @@ namespace NHibernate.Persister.Collection
 								WriteElementToWhere(st, collection.GetElement(entry), loc, session);
 								if (useBatch)
 								{
-									session.Batcher.AddToBatch(expectation);
+									session.Batcher.AddToBatch(insertExpectation);
 								}
 								else
 								{
-									expectation.VerifyOutcomeNonBatched(session.Batcher.ExecuteNonQuery(st), st);
+									insertExpectation.VerifyOutcomeNonBatched(session.Batcher.ExecuteNonQuery(st), st);
 								}
 								count++;
 							}


### PR DESCRIPTION
All of the changes were ported from Hibernate from this changeset:
https://github.com/hibernate/hibernate-orm/commit/08d9fe2117a1afc60ad15cb1b6124b057b6eae32#hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java

I ported these changes with the following points in mind:
- (Minor point): Hibernate still uses the code that resulted from the Hibernate changeset I linked, so it can't be that wrong.
- Removal of "if (st == null)" conditions: The AbstractBatcher already handles the reusing or recreation of the command. Additional checks in the OneToManyPersister are not needed and might even be wrong depending on the AbstractBatcher recreation logic (which might change at some time in the future, will anyone remember to change the OneToManyPersister then?).
- Removal of the "if (DeleteCallable)" condition: That code just doesn't make sense. Why should "expectation" and "useBatch" only be changed to values that depend on some logic if "DeleteCallable" is true? I can't see a reason why it shouldn't be possible to have a different expectation than "None" with a "DeleteCallable" value of false. Same for "useBatch": Why should we always use BatchCommands (default value of "useBatch" is true) when "DeleteCallable" is false? The change that was done in the Hibernate code makes sense: Seperate the expectation and batching behaviour from the callable value. That way all combinations are allowed. And it then also uses the same logical flow as the row insert section below.
- Removal of the "DeleteCallable" allthogether: Yes, Hibernate still uses this in calls to "getBatchStatement" and "prepareStatement", but it also does this in the row insert section below where NHibernate also doesn't use it. It seems like NHibernate doesn't need this information in the AbstractBatcher, so the usage of this property isn't needed any more (like "InsertCallable" isn't used in the row insert section).

Jira issue: https://nhibernate.jira.com/browse/NH-3072
