### PR TITLE
Paging for MsSql2012 changed to the new recommended standard syntax (replaces #78)

### DIFF
--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -1,4 +1,6 @@
-﻿using NHibernate.Dialect.Function;
+﻿using System.Collections.Generic;
+using NHibernate.Dialect.Function;
+using NHibernate.SqlCommand;
 
 namespace NHibernate.Dialect
 {
@@ -50,6 +52,63 @@ namespace NHibernate.Dialect
 		{
 			base.RegisterFunctions();
 			RegisterFunction("iif", new StandardSafeSQLFunction("iif", 3));
+		}
+
+		public override SqlString GetLimitString(SqlString queryString, SqlString offset, SqlString limit)
+		{
+			var result = new SqlStringBuilder(queryString);
+
+			int orderIndex = queryString.LastIndexOfCaseInsensitive(" order by ");
+
+			//don't use the order index if it is contained within a larger statement(assuming
+			//a statement with non matching parenthesis is part of a larger block)
+			if (orderIndex < 0 || !HasMatchingParens(queryString.Substring(orderIndex).ToString()))
+			{
+				// Use order by first column if no explicit ordering is provided
+				result.Add(" ORDER BY ")
+					.Add("1");
+			}
+
+			result.Add(" OFFSET ")
+				.Add(offset ?? new SqlString("0"))
+				.Add(" ROWS");
+
+			if (limit != null)
+			{
+				result.Add(" FETCH FIRST ").Add(limit).Add(" ROWS ONLY");
+			}
+
+			return result.ToSqlString();
+		}
+
+		/// <summary>
+		/// Indicates whether the string fragment contains matching parenthesis
+		/// </summary>
+		/// <param name="statement"> the statement to evaluate</param>
+		/// <returns>true if the statment contains no parenthesis or an equal number of
+		///  opening and closing parenthesis;otherwise false </returns>
+		private static bool HasMatchingParens(IEnumerable<char> statement)
+		{
+			//unmatched paren count
+			int unmatchedParen = 0;
+
+			//increment the counts based in the opening and closing parens in the statement
+			foreach (char item in statement)
+			{
+				switch (item)
+				{
+					case '(':
+						unmatchedParen++;
+						break;
+					case ')':
+						unmatchedParen--;
+						if (unmatchedParen < 0)
+							return false;
+						break;
+				}
+			}
+
+			return unmatchedParen == 0;
 		}
 	}
 }


### PR DESCRIPTION
Created new MSSQL2012 Dialect. Implemented new paging syntax with
select xxx from yyy order by zzz offset @p1 rows fetch first @p2 rows only
Existing paging unit tests work fine with it.

Recreated because of the concurrent changes on MSSQL2005Dialect.
