### PR TITLE
Testcase for NH3171 - Missing join in sql when restricting by composite ...

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3171/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3171/Fixture.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using NHibernate.Criterion;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3171
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		[Test]
+		public void SqlShouldIncludeAliasAsJoinWhenRestrictingByCompositeKeyColumn()
+		{
+			try
+			{
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					var entrant = new Artist
+					{
+						Name = "Alex Swings Oscar Sings",
+						Song = new Song { Name = "Miss Kiss Kiss Bang" },
+						Country = new Country { Name = "Germany" }
+					};
+
+					s.Save(entrant.Country);
+					s.Save(entrant.Song);
+					s.Save(entrant);
+				}
+
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					// Should not throw
+					// The multi-part identifier "s1_.Name" could not be bound.
+					IList<Artist> artists = s.CreateCriteria<Artist>("a")
+						.CreateAlias("a.Song", "s")
+						.Add(Restrictions.Eq("s.Name", "Miss Kiss Kiss Bang"))
+						.List<Artist>();
+				}
+			}
+			finally
+			{
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete("from Artist");
+					s.Delete("from Song");
+					s.Delete("from Country");
+					t.Commit();
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3171/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3171/Mappings.hbm.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.NH3171" >
+  <class name="Artist">
+    <composite-id>
+      <key-many-to-one class="Song" name="Song"/>
+      <key-many-to-one class="Country" name="Country"/>
+    </composite-id>
+    <property name="Name"/>
+  </class>
+  
+  <class name="Song">
+    <id name="Id">
+      <generator class="native"/>
+    </id>
+    <property name="Name"/>
+  </class>
+  
+  <class name="Country">
+    <id name="Id">
+      <generator class="native"/>
+    </id>
+    <property name="Name"/>
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3171/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3171/Model.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NHibernate.Test.NHSpecificTest.NH3171
+{
+	public class Artist
+	{
+		public virtual string Name { get; set; }
+		public virtual Song Song { get; set; }
+		public virtual Country Country { get; set; }
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null || GetType() != obj.GetType())
+			{
+				return false;
+			}
+
+			Artist other = obj as Artist;
+			return other.Song.Id == Song.Id && other.Country.Id == Country.Id;
+		}
+
+		public override int GetHashCode()
+		{
+			const int hashMultiplier = 31;
+
+			var items = new object[] { Song.Id, Country.Id };
+			return items.Where(item => item != null).Aggregate(0, (accumulator, next) => accumulator = (accumulator * hashMultiplier) ^ next.GetHashCode());
+		}
+	}
+
+	public class Song
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+
+	public class Country
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+
+		public virtual ICollection<Artist> Artists { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -663,6 +663,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3171\Model.cs" />
+    <Compile Include="NHSpecificTest\NH3171\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3070\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2789\Entities.cs" />
     <Compile Include="NHSpecificTest\NH2789\Fixture.cs" />
@@ -2848,6 +2850,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3171\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2898\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2808\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2789\Mappings.hbm.xml" />


### PR DESCRIPTION
...column in criteria query

https://nhibernate.jira.com/browse/NH-3171

With a simple Criteria query such as: 

s.CreateCriteria<Artist>("a") 
.CreateAlias("a.Song", "s") 
.Add(Restrictions.Eq("s.Name", "Miss Kiss Kiss Bang")) 

NHibernate fails to include the join to Song in the SQL query when Song is a composite column. 
