### PR TITLE
Fix for ShowBuildMenu with Blanks in Folder Names

### DIFF
--- a/ShowBuildMenu.bat
+++ b/ShowBuildMenu.bat
@@ -138,7 +138,7 @@ set /p FOLDER=<folder.tmp
 del folder.tmp
 mkdir "%CURRENT_CONFIGURATION%" 2> nul
 del /q "%CURRENT_CONFIGURATION%\*"
-copy %FOLDER%\* "%CURRENT_CONFIGURATION%"
+copy "%FOLDER%\*" "%CURRENT_CONFIGURATION%"
 echo Configuration activated.
 goto main-menu
 


### PR DESCRIPTION
Activating a Test Configuration did not work before adding those quotation marks.
