### PR TITLE
NH-3184: Linq - add ability to use ToFutureValue with aggregating queries

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/Futures/LinqFutureFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/LinqFutureFixture.cs
@@ -219,8 +219,8 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 				}
 			}
 
-			using (ISession s = OpenSession())
-			using (ITransaction tx = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
 				s.Delete("from Person");
 				tx.Commit();
@@ -315,5 +315,6 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 			}
 
 		}
+
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/Futures/LinqToFutureValueFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/LinqToFutureValueFixture.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.Futures
+{
+	public class LinqToFutureValueFixture : FutureFixture
+	{
+		[Test]
+		public void CanExecuteToFutureValueCount()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var personsCount = session.Query<Person>()
+					.Where(x => x.Name == "Test1")
+					.ToFutureValue(x => x.Count());
+
+				Assert.AreEqual(1, personsCount.Value);
+			}
+		}
+
+		[Test]
+		public void CanExecuteToFutureValueCountWithPredicate()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var personsCount = session.Query<Person>()
+					.ToFutureValue(q => q.Count(x => x.Name == "Test1"));
+
+				Assert.AreEqual(1, personsCount.Value);
+			}
+		}
+
+		protected override void OnSetUp()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Save(new Person {Name = "Test1"});
+				session.Save(new Person {Name = "Test2"});
+				session.Save(new Person {Name = "Test3"});
+				session.Save(new Person {Name = "Test4"});
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+				transaction.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -707,6 +707,7 @@
     <Compile Include="NHSpecificTest\NH3202\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
+    <Compile Include="NHSpecificTest\Futures\LinqToFutureValueFixture.cs" />
     <Compile Include="NHSpecificTest\NH2955\Employee.cs" />
     <Compile Include="NHSpecificTest\NH2955\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3175\Fixture.cs" />

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using NHibernate.Impl;
 using Remotion.Linq;
+using Remotion.Linq.Parsing.ExpressionTreeVisitors;
 
 namespace NHibernate.Linq
 {
@@ -52,8 +53,8 @@ namespace NHibernate.Linq
 			if (nhQueryable == null)
 				throw new NotSupportedException("Query needs to be of type QueryableBase<T>");
 
-
-			var future = ((INhQueryProvider) nhQueryable.Provider).ExecuteFuture(nhQueryable.Expression);
+			var provider = (INhQueryProvider) nhQueryable.Provider;
+			var future = provider.ExecuteFuture(nhQueryable.Expression);
 			return (IEnumerable<T>) future;
 		}
 
@@ -63,12 +64,29 @@ namespace NHibernate.Linq
 			if (nhQueryable == null)
 				throw new NotSupportedException("Query needs to be of type QueryableBase<T>");
 
-			var future = ((INhQueryProvider) nhQueryable.Provider).ExecuteFuture(nhQueryable.Expression);
+			var provider = (INhQueryProvider) nhQueryable.Provider;
+			var future = provider.ExecuteFuture(nhQueryable.Expression);
 			if (future is IEnumerable<T>)
 			{
 				return new FutureValue<T>(() => ((IEnumerable<T>) future));
 			}
+
 			return (IFutureValue<T>) future;
+		}
+
+		public static IFutureValue<TResult> ToFutureValue<T, TResult>(this IQueryable<T> query, Expression<Func<IQueryable<T>, TResult>> selector)
+		{
+			var nhQueryable = query as QueryableBase<T>;
+			if (nhQueryable == null)
+				throw new NotSupportedException("Query needs to be of type QueryableBase<T>");
+
+			var provider = (INhQueryProvider) query.Provider;
+
+			var expression = ReplacingExpressionTreeVisitor.Replace(selector.Parameters.Single(),
+																	query.Expression,
+																	selector.Body);
+
+			return (IFutureValue<TResult>) provider.ExecuteFuture(expression);
 		}
 	}
 }


### PR DESCRIPTION
Add ability to use ToFutureValue with aggregating queiries such as Count, Sum, etc. 

Proposed syntax: 

var futurePerson = session.Query<Person>() 
.Where(x => x.Id == personId) 
.ToFutureValue(x=>x.Count()); 

Discussions: 

http://stackoverflow.com/questions/4955685/getting-count-with-nhibernate-linq-future 

http://sessionfactory.blogspot.com/2011/02/getting-row-count-with-future-linq.html

JIRA: https://nhibernate.jira.com/browse/NH-3184
