### PR TITLE
NH-3217: SqlString SplitWithRegex preserves parameter BackTracks.

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/OrderByTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/OrderByTests.cs
@@ -197,5 +197,12 @@ namespace NHibernate.Test.Linq.ByMethod
 
 			AssertOrderedBy.Descending(result.Take(5).ToList(), x => x.ShippingDate);
 		}
+
+        [Test]
+        public void OrderByNullCompareAndSkipAndTake()
+        {
+            var result = db.Orders.OrderBy(o => o.Shipper == null ? 0 : o.Shipper.ShipperId)
+                .Skip(3).Take(4).ToList();
+        }
 	}
 }

--- a/src/NHibernate/SqlCommand/SqlString.cs
+++ b/src/NHibernate/SqlCommand/SqlString.cs
@@ -560,7 +560,14 @@ namespace NHibernate.SqlCommand
 
 		internal SqlString[] SplitWithRegex(string pattern)
 		{
-			return Regex.Split(ToString(), pattern).Select(s => SqlString.Parse(s)).ToArray();
+			var sql = Regex.Split(ToString(), pattern).Select(s => SqlString.Parse(s)).ToArray();
+		    int i = 0;
+            foreach (var p in sql.SelectMany(s => s.GetParameters()))
+            {
+                p.BackTrack = GetParameters().ElementAt(i).BackTrack;
+                i++;
+            }
+		    return sql;
 		}
 
 		private IEnumerable<SqlString> SplitParts(string splitter)


### PR DESCRIPTION
This patch fixes SqlString SplitWithRegex. It lost parameter TrackBacks.
