### PR TITLE
NH-2819 fix with test case added

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH2819/Entities.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2819/Entities.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using Iesi.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH2819
+{
+	public class Address
+	{
+		public virtual Guid Id { get; protected set; }
+
+		public virtual T GenericMethod<T>(T arg)
+		{
+			return arg;
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2819/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2819/Fixture.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using NHibernate.Proxy;
+using NUnit.Framework;
+using SharpTestsEx;
+
+namespace NHibernate.Test.NHSpecificTest.NH2819
+{
+	public class Fixture2819 : BugTestCase
+	{
+		[Test]
+		public void should_be_able_to_call_generic_methods_on_a_proxy()
+		{
+			var addressId = Guid.Empty;
+			using (ISession session = sessions.OpenSession())
+			{
+				using (ITransaction tx = session.BeginTransaction())
+				{
+					
+					var address = new Address();
+
+					session.SaveOrUpdate(address);
+					tx.Commit();
+					addressId = address.Id;
+				}
+			}
+
+			using (ISession session = sessions.OpenSession())
+			{
+				using (session.BeginTransaction())
+				{
+					var address = session.Load<Address>(addressId);
+
+					Assert.That(address, Is.AssignableTo<INHibernateProxy>());
+
+					// call to generic method on a proxy will fail on .Net 4.0
+					var res = address.GenericMethod<int>(42);
+					Assert.That(res, Is.EqualTo(42));
+				}
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			base.OnTearDown();
+
+			using (ISession session = sessions.OpenSession())
+			{
+				using (ITransaction tx = session.BeginTransaction())
+				{
+					foreach (var address in session.QueryOver<Address>().List())
+					{
+						session.Delete(address);
+					}
+					tx.Commit();
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2819/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2819/Mappings.hbm.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+				   namespace="NHibernate.Test.NHSpecificTest.NH2819"
+				   assembly="NHibernate.Test">
+	
+	<class name="Address" table="address_nh2819" lazy="true">
+		<id name="Id" type="Guid">
+			<generator class="guid" />
+		</id>		
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -665,6 +665,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH2819\Entities.cs" />
+    <Compile Include="NHSpecificTest\NH2819\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3093\Domain.cs" />
     <Compile Include="NHSpecificTest\NH3093\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2806\Domain.cs" />
@@ -2889,6 +2891,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH2819\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3057\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2969\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2806\Mappings.hbm.xml">

--- a/src/NHibernate/Intercept/DefaultDynamicLazyFieldInterceptor.cs
+++ b/src/NHibernate/Intercept/DefaultDynamicLazyFieldInterceptor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using NHibernate.Proxy.DynamicProxy;
 using NHibernate.Util;
 
@@ -59,7 +60,12 @@ namespace NHibernate.Intercept
 				}
 			}
 
-			return info.TargetMethod.Invoke(TargetInstance, info.Arguments);
+			MethodInfo targetMethod = info.TargetMethod;
+			if (info.TypeArguments != null && info.TypeArguments.Length != 0)
+			{
+				targetMethod = targetMethod.MakeGenericMethod(info.TypeArguments);
+			}
+			return targetMethod.Invoke(TargetInstance, info.Arguments);
 		}
 	}
 }

--- a/src/NHibernate/Proxy/DefaultLazyInitializer.cs
+++ b/src/NHibernate/Proxy/DefaultLazyInitializer.cs
@@ -34,7 +34,12 @@ namespace NHibernate.Proxy
 					return returnValue;
 				}
 
-				returnValue = info.TargetMethod.Invoke(GetImplementation(), info.Arguments);
+				MethodInfo targetMethod = info.TargetMethod;
+				if (info.TypeArguments != null && info.TypeArguments.Length != 0)
+				{
+					targetMethod = targetMethod.MakeGenericMethod(info.TypeArguments);
+				}
+				returnValue = targetMethod.Invoke(GetImplementation(), info.Arguments);
 			}
 			catch (TargetInvocationException ex)
 			{


### PR DESCRIPTION
There is a problem with calling generic methods on proxy in .Net 4.0. The fix is based on a patch attached to https://nhibernate.jira.com/browse/NH-2819 with additional fixes

Added test case does not fail on .Net 3.5 even without a fix, but fails on .Net 4.0
