### PR TITLE
[NH-3238] Add Sql2008ClientDriver support in DatabaseSetup for testing

### DIFF
--- a/src/NHibernate.TestDatabaseSetup/TestDatabaseSetup.cs
+++ b/src/NHibernate.TestDatabaseSetup/TestDatabaseSetup.cs
@@ -16,6 +16,7 @@ namespace NHibernate.TestDatabaseSetup
 		private static readonly IDictionary<string, Action<Cfg.Configuration>> SetupMethods = new Dictionary<string, Action<Cfg.Configuration>>
 			{
 				{"NHibernate.Driver.SqlClientDriver", SetupSqlServer},
+				{"NHibernate.Driver.Sql2008ClientDriver", SetupSqlServer},
 				{"NHibernate.Driver.OdbcDriver", SetupSqlServerOdbc},
 				{"NHibernate.Driver.FirebirdClientDriver", SetupFirebird},
 				{"NHibernate.Driver.SQLite20Driver", SetupSQLite},


### PR DESCRIPTION
Add "NHibernate.Driver.Sql2008ClientDriver" support in "NHibernate.TestDatabaseSetup.DatabaseSetup" for testing against SQL Server 2008 or later.
