### PR TITLE
Additional test for NH-2698

### DIFF
--- a/src/NHibernate.Test/DynamicProxyTests/GenericMethodsTests/GenericMethodShouldBeProxied.cs
+++ b/src/NHibernate.Test/DynamicProxyTests/GenericMethodsTests/GenericMethodShouldBeProxied.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using NHibernate.Proxy.DynamicProxy;
 using NUnit.Framework;
 using SharpTestsEx;
@@ -11,7 +10,7 @@ namespace NHibernate.Test.DynamicProxyTests.GenericMethodsTests
 		{
 			public virtual object Method<T>()
 			{
-				if(typeof(T) == typeof(int))
+				if (typeof(T) == typeof(int))
 				{
 					return 5;
 				}
@@ -23,6 +22,14 @@ namespace NHibernate.Test.DynamicProxyTests.GenericMethodsTests
 			}
 
 			public virtual TRequestedType As<TRequestedType>() where TRequestedType : MyClass
+			{
+				return this as TRequestedType;
+			}
+		}
+
+		public class MyGenericClass<TId>
+		{
+			public virtual TRequestedType As<TRequestedType>() where TRequestedType : MyGenericClass<TId>
 			{
 				return this as TRequestedType;
 			}
@@ -43,6 +50,14 @@ namespace NHibernate.Test.DynamicProxyTests.GenericMethodsTests
 			var factory = new ProxyFactory();
 			var c = (MyClass)factory.CreateProxy(typeof(MyClass), new PassThroughInterceptor(new MyClass()), null);
 			c.As<MyClass>().Should().Not.Be.Null();
+		}
+
+		[Test]
+		public void ProxyOfSelfCastingMethodInGenericClass()
+		{
+			var factory = new ProxyFactory();
+			var c = (MyGenericClass<int>)factory.CreateProxy(typeof(MyGenericClass<int>), new PassThroughInterceptor(new MyGenericClass<int>()), null);
+			c.As<MyGenericClass<int>>().Should().Not.Be.Null();
 		}
 	}
 }


### PR DESCRIPTION
This is an additional test for NH-2698 that shows that this issue isn't fixed.

Other than the previous problems this fails when executed in the .NET 2.0 runtime too. Also, the exception is already thrown when the proxy is created, so the problem seems to be in the proxy generation itself and not where it is called.

JIRA issue: https://nhibernate.jira.com/browse/NH-2698
