### PR TITLE
Fixing issue "collection was not processed by flush"

### DIFF
--- a/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
@@ -234,6 +234,7 @@ namespace NHibernate.Event.Default
 			try
 			{
 				session.ConnectionManager.FlushBeginning();
+				session.PersistenceContext.Flushing = true;
 				// we need to lock the collection caches before
 				// executing entity inserts/updates in order to
 				// account for bidi associations
@@ -250,6 +251,7 @@ namespace NHibernate.Event.Default
 			}
 			finally
 			{
+				session.PersistenceContext.Flushing = false;
 				session.ConnectionManager.FlushEnding();
 			}
 		}


### PR DESCRIPTION
An NHibernate audit causes “collection was not processed by flush” errors. See more details about issue here:
https://hibernate.onjira.com/browse/HHH-2763
- [x] port test cases from NHibernate
