### PR TITLE
NH-3291 Optional caching of AliasToBeanResultTransformer instances

### DIFF
--- a/src/NHibernate/Transform/Transformers.cs
+++ b/src/NHibernate/Transform/Transformers.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 
 namespace NHibernate.Transform
 {
@@ -16,18 +17,63 @@ namespace NHibernate.Transform
 		/// <summary> Each row of results is a <see cref="IList"/></summary>
 		public static readonly ToListResultTransformer ToList = new ToListResultTransformer();
 
+		private static readonly Dictionary<System.Type, AliasToBeanResultTransformer> aliasToBeanInstances = new Dictionary<System.Type, AliasToBeanResultTransformer>();
+
 		/// <summary>
-		/// Creates a resulttransformer that will inject aliased values into instances
+		/// Creates an IResultTransformer that will inject aliased values into instances
 		/// of <paramref name="target"/> via property methods or fields.
+		/// <param name="target">The class type used to transform the result set</param>
 		/// </summary>
 		public static IResultTransformer AliasToBean(System.Type target)
 		{
-			return new AliasToBeanResultTransformer(target);
+			return AliasToBean(target, false);
 		}
 
+		
+		/// <summary>
+		/// Returns an IResultTransformer that will inject aliased values into instances
+		/// of <paramref name="target"/> via property methods or fields.
+		/// </summary>
+		/// <param name="target">The class type used to transform the result set</param>
+		/// <param name="useInstanceCache">Secifies whether to return a cached or new instance</param>	
+		public static IResultTransformer AliasToBean(System.Type target, bool useInstanceCache)
+		{
+			AliasToBeanResultTransformer transformer = null;
+
+			if (useInstanceCache)
+			{
+				if (aliasToBeanInstances.ContainsKey(target))
+				{
+					return aliasToBeanInstances[target];
+				}
+
+				transformer = new AliasToBeanResultTransformer(target);
+
+				aliasToBeanInstances.Add(target, transformer);
+			}
+
+			return transformer ?? new AliasToBeanResultTransformer(target);
+		}
+
+		/// <summary>
+		/// Creates an IResultTransformer that will inject aliased values into instances
+		/// of <paramref name="target"/> via property methods or fields.
+		/// <param name="target">The class type used to transform the result set</param>
+		/// </summary>
 		public static IResultTransformer AliasToBean<T>()
 		{
 			return AliasToBean(typeof(T));
+		}
+
+		/// <summary>
+		/// Returns an IResultTransformer that will inject aliased values into instances
+		/// of <paramref name="target"/> via property methods or fields.
+		/// </summary>
+		/// <param name="target">The class type used to transform the result set</param>
+		/// <param name="useInstanceCache">Secifies whether to return a cached or new instance</param>	
+		public static IResultTransformer AliasToBean<T>(bool useInstanceCache)
+		{
+			return AliasToBean(typeof(T), useInstanceCache);
 		}
 
 		public static readonly IResultTransformer DistinctRootEntity = new DistinctRootEntityResultTransformer();


### PR DESCRIPTION
https://nhibernate.jira.com/browse/NH-3291

Memory consumption would increase depending upon how many different types are used. However I was thinking that it would be preferable to have more memory usage versus the cost of reflection every time a new transformer is created.

New transformer instances will not be automatically cached.  Instead method overloads have been added which have a parameter that specifies whether or not to use the cache.  The cache is not used by default in order to maintain backwards compatibility.
