### PR TITLE
Allowing 2nd level cache for sessions with a user provided connection

### DIFF
--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -474,7 +474,8 @@ namespace NHibernate.Impl
 			{
 				throw new ArgumentNullException("sessionLocalInterceptor");
 			}
-			return OpenSession(connection, false, long.MinValue, sessionLocalInterceptor);
+            long timestamp = settings.CacheProvider.NextTimestamp();
+            return OpenSession(connection, false, timestamp, sessionLocalInterceptor);
 		}
 
 		public ISession OpenSession(IInterceptor sessionLocalInterceptor)


### PR DESCRIPTION
I don't see a reason for disabling 2nd level cache when user provide their own connection.
