### PR TITLE
Ability to set query specific timeout on LINQ queries (NH3360)

### DIFF
--- a/src/NHibernate.Test/Linq/QueryTimeoutTests.cs
+++ b/src/NHibernate.Test/Linq/QueryTimeoutTests.cs
@@ -1,0 +1,101 @@
+﻿using System.Linq;
+using NHibernate.AdoNet;
+using NHibernate.Cfg;
+using NHibernate.Engine;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.Linq
+{
+	public class QueryTimeoutTests : LinqTestCase
+	{
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.SetProperty(Environment.BatchStrategy,
+									  typeof(TimeoutCatchingNonBatchingBatcherFactory).AssemblyQualifiedName);
+		}
+
+
+		[Test]
+		public void CanSetTimeoutOnLinqQueries()
+		{
+			var result = (from e in db.Customers
+						  where e.CompanyName == "Corp"
+						  select e).Timeout(17).ToList();
+
+			Assert.That(TimeoutCatchingNonBatchingBatcher.LastCommandTimeout, Is.EqualTo(17));
+		}
+
+
+		[Test]
+		public void CanSetTimeoutOnLinqPagingQuery()
+		{
+			var result = (from e in db.Customers
+						  where e.CompanyName == "Corp"
+						  select e).Skip(5).Take(5).Timeout(17).ToList();
+
+			Assert.That(TimeoutCatchingNonBatchingBatcher.LastCommandTimeout, Is.EqualTo(17));
+		}
+
+
+		[Test]
+		public void CanSetTimeoutBeforeSkipOnLinqOrderedPageQuery()
+		{
+			var result = (from e in db.Customers
+						  orderby e.CompanyName
+						  select e)
+				.Timeout(17).Skip(5).Take(5).ToList();
+
+			Assert.That(TimeoutCatchingNonBatchingBatcher.LastCommandTimeout, Is.EqualTo(17));
+		}
+
+
+		[Test]
+		public void CanSetTimeoutOnLinqGroupPageQuery()
+		{
+			var subQuery = db.Customers.Where(e2 => e2.CompanyName.Contains("a")).Select(e2 => e2.CustomerId)
+							 .Timeout(18); // This Timeout() should not cause trouble, and be ignored.
+
+			var result = (from e in db.Customers
+						  where subQuery.Contains(e.CustomerId)
+						  group e by e.CompanyName
+							  into g
+							  select new { g.Key, Count = g.Count() })
+				.Skip(5).Take(5)
+				.Timeout(17).ToList();
+
+			Assert.That(TimeoutCatchingNonBatchingBatcher.LastCommandTimeout, Is.EqualTo(17));
+		}
+
+
+		public class TimeoutCatchingNonBatchingBatcher : NonBatchingBatcher
+		{
+			// Is there an easier way to inspect the IDbCommand instead of
+			// creating a custom batcher?
+
+
+			public static int LastCommandTimeout;
+
+			public TimeoutCatchingNonBatchingBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+				: base(connectionManager, interceptor)
+			{
+			}
+
+			public override System.Data.IDataReader ExecuteReader(System.Data.IDbCommand cmd)
+			{
+				LastCommandTimeout = cmd.CommandTimeout;
+				return base.ExecuteReader(cmd);
+			}
+		}
+
+
+		public class TimeoutCatchingNonBatchingBatcherFactory : IBatcherFactory
+		{
+			public IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+			{
+				return new TimeoutCatchingNonBatchingBatcher(connectionManager, interceptor);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -504,6 +504,7 @@
     <Compile Include="Linq\CasingTest.cs" />
     <Compile Include="Linq\CharComparisonTests.cs" />
     <Compile Include="Linq\CollectionAssert.cs" />
+    <Compile Include="Linq\QueryTimeoutTests.cs" />
     <Compile Include="Linq\JoinTests.cs" />
     <Compile Include="Linq\CustomExtensionsExample.cs" />
     <Compile Include="Linq\DateTimeTests.cs" />

--- a/src/NHibernate/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/AdoNet/AbstractBatcher.cs
@@ -209,7 +209,7 @@ namespace NHibernate.AdoNet
 			}
 		}
 
-		public IDataReader ExecuteReader(IDbCommand cmd)
+		public virtual IDataReader ExecuteReader(IDbCommand cmd)
 		{
 			CheckReaders();
 			LogCommand(cmd);

--- a/src/NHibernate/Linq/GroupBy/AggregatingGroupByRewriter.cs
+++ b/src/NHibernate/Linq/GroupBy/AggregatingGroupByRewriter.cs
@@ -36,7 +36,8 @@ namespace NHibernate.Linq.GroupBy
 				typeof (FirstResultOperator),
 				typeof (SingleResultOperator),
 				typeof (AnyResultOperator),
-				typeof (AllResultOperator)
+				typeof (AllResultOperator),
+				typeof (TimeoutResultOperator),
 			};
 
 		public static void ReWrite(QueryModel queryModel)

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -47,6 +47,15 @@ namespace NHibernate.Linq
             return new NhQueryable<T>(query.Provider, callExpression);
         }
 
+		public static IQueryable<T> Timeout<T>(this IQueryable<T> query, int timeout)
+		{
+			var method = ReflectionHelper.GetMethodDefinition(() => Timeout<object>(null, 0)).MakeGenericMethod(typeof(T));
+
+			var callExpression = Expression.Call(method, query.Expression, Expression.Constant(timeout));
+
+			return new NhQueryable<T>(query.Provider, callExpression);
+		}
+
         public static IEnumerable<T> ToFuture<T>(this IQueryable<T> query)
         {
             var nhQueryable = query as QueryableBase<T>;

--- a/src/NHibernate/Linq/ReWriters/QueryReferenceExpressionFlattener.cs
+++ b/src/NHibernate/Linq/ReWriters/QueryReferenceExpressionFlattener.cs
@@ -17,11 +17,12 @@ namespace NHibernate.Linq.ReWriters
 		private readonly QueryModel _model;
 		// NOTE: Skip/Take are not completelly flattenable since Take(10).Skip(5).Take(2) should result in a subqueries-tsunami (so far not common understanding from our users)
 		private static readonly List<System.Type> FlattenableResultOperactors = new List<System.Type>
-		                                                                        {
-		                                                                        	typeof(CacheableResultOperator),
-																																							typeof(SkipResultOperator),
-																																							typeof(TakeResultOperator),
-																																						};
+			{
+				typeof (CacheableResultOperator),
+				typeof (TimeoutResultOperator),
+				typeof (SkipResultOperator),
+				typeof (TakeResultOperator),
+			};
 
 		private QueryReferenceExpressionFlattener(QueryModel model)
 		{

--- a/src/NHibernate/Linq/ReWriters/ResultOperatorRewriter.cs
+++ b/src/NHibernate/Linq/ReWriters/ResultOperatorRewriter.cs
@@ -64,6 +64,7 @@ namespace NHibernate.Linq.ReWriters
                     typeof(FetchRequestBase),
                     typeof(OfTypeResultOperator),
                     typeof(CacheableResultOperator),
+                    typeof(TimeoutResultOperator),
                     typeof(CastResultOperator), // see ProcessCast class
                 };
 

--- a/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
@@ -96,6 +96,7 @@ namespace NHibernate.Linq.Visitors
 			ResultOperatorMap.Add<FetchOneRequest, ProcessFetchOne>();
 			ResultOperatorMap.Add<FetchManyRequest, ProcessFetchMany>();
 			ResultOperatorMap.Add<CacheableResultOperator, ProcessCacheable>();
+			ResultOperatorMap.Add<TimeoutResultOperator, ProcessTimeout>();
 			ResultOperatorMap.Add<OfTypeResultOperator, ProcessOfType>();
 			ResultOperatorMap.Add<CastResultOperator, ProcessCast>();
 		}

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessTimeout.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessTimeout.cs
@@ -1,0 +1,11 @@
+﻿
+namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
+{
+    public class ProcessTimeout : IResultOperatorProcessor<TimeoutResultOperator>
+    {
+        public void Process(TimeoutResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+        {
+            tree.AddAdditionalCriteria((q, p) => q.SetTimeout((int) resultOperator.Timeout.Value));
+        }
+    }
+}

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -303,6 +303,7 @@
     <Compile Include="Linq\Visitors\PossibleValueSet.cs" />
     <Compile Include="Linq\Visitors\QuerySourceIdentifier.cs" />
     <Compile Include="Linq\Visitors\ResultOperatorAndOrderByJoinDetector.cs" />
+    <Compile Include="Linq\Visitors\ResultOperatorProcessors\ProcessTimeout.cs" />
     <Compile Include="Linq\Visitors\ResultOperatorProcessors\ProcessAggregateFromSeed.cs" />
     <Compile Include="Linq\Visitors\SelectJoinDetector.cs" />
     <Compile Include="Linq\Visitors\SelectClauseNominator.cs" />


### PR DESCRIPTION
Add Timeout() as an extension of IQueryable<T> to set a query-specific timeout (NH-3360).

It is implemented similar to Cachable() and CacheRegion().
