### PR TITLE
Converting strings to enums should be case insensitive

### DIFF
--- a/src/NHibernate/Type/AbstractEnumType.cs
+++ b/src/NHibernate/Type/AbstractEnumType.cs
@@ -38,9 +38,9 @@ namespace NHibernate.Type
 
 		#region IIdentifierType Members
 
-		public object StringToObject(string xml)
+		public virtual object StringToObject(string xml)
 		{
-			return Enum.Parse(enumType, xml);
+			return Enum.Parse(enumType, xml, true);
 		}
 
 		#endregion


### PR DESCRIPTION
In AbstractEnumType.cs, the StringToObject method is trying to convert
strings to enums - but values in DB tables may have been written without
regard to case.  So make the enum.parse be case insentive

Additionally (or alternatively) StringToObject should be virtual
so that we can override this behaviour (StringToObject is called
by derived classes)
