### PR TITLE
Tuple equality

### DIFF
--- a/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
@@ -200,7 +200,7 @@ namespace NHibernate.Linq.NestedSelects
 									"ReferenceEquals",
 									System.Type.EmptyTypes,
 									Expression.ArrayIndex(
-										Expression.MakeMemberAccess(t, Tuple.ItemsField),
+										Expression.Property(t, Tuple.ItemsProperty),
 										Expression.Constant(index)),
 									Expression.Constant(null))),
 				t);
@@ -226,9 +226,7 @@ namespace NHibernate.Linq.NestedSelects
 			var newArrayInit = Expression.NewArrayInit(typeof(object), initializers);
 
 			return Expression.Lambda(
-				Expression.MemberInit(
-					Expression.New(typeof(Tuple)),
-					Expression.Bind(Tuple.ItemsField, newArrayInit)),
+					Expression.New(Tuple.Constructor, newArrayInit),
 				parameter);
 		}
 

--- a/src/NHibernate/Linq/NestedSelects/SelectClauseRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/SelectClauseRewriter.cs
@@ -54,8 +54,8 @@ namespace NHibernate.Linq.NestedSelects
 
 			return Expression.Convert(
 				Expression.ArrayIndex(
-					Expression.MakeMemberAccess(parameter,
-												Tuple.ItemsField),
+					Expression.Property(parameter,
+												Tuple.ItemsProperty),
 					Expression.Constant(expressions.Count - 1)),
 				expression.Type);
 		}

--- a/src/NHibernate/Linq/NestedSelects/Tuple.cs
+++ b/src/NHibernate/Linq/NestedSelects/Tuple.cs
@@ -6,18 +6,26 @@ namespace NHibernate.Linq.NestedSelects
 {
 	internal class Tuple : IEquatable<Tuple>
 	{
-		public static readonly FieldInfo ItemsField = typeof (Tuple).GetField("Items");
+        public static readonly ConstructorInfo Constructor = typeof (Tuple).GetConstructor(new [] { typeof(object[]) });
+		public static readonly PropertyInfo ItemsProperty = typeof (Tuple).GetProperty("Items");
 
-		public object[] Items;
+        public object[] Items { get; private set; }
+
+        public Tuple(object[] items)
+        {
+            Items = items;
+        }
 
 		public bool Equals(Tuple other)
 		{
 			if (other == null) return false;
+            if (ReferenceEquals(this, other)) return true;
 
+            // SequenceEqual checks this as well
 			if (other.Items.Length != Items.Length)
 				return false;
 
-			return !other.Items.Where((t, index) => !Equals(t, Items[index])).Any();
+			return Enumerable.SequenceEqual<object>(Items, other.Items);
 		}
 
 		public override bool Equals(object obj)
@@ -27,7 +35,9 @@ namespace NHibernate.Linq.NestedSelects
 
 		public override int GetHashCode()
 		{
-			return (Items != null ? Items.Length.GetHashCode() : 0);
+            // TODO: it looks like in the scenarios this class is used, tuples will be of the same length,
+            // so may be it would be better to use another hash code, for example Items[0].GetHashCode()
+			return Items.Length.GetHashCode();
 		}
 	}
 }


### PR DESCRIPTION
Late night and I have no access to SQL to re-run tests, but idea should be clear:

Let's make clear statement that Tuple can't have null Items and Items
can't change (as well as Tuple's hash code)

And do we still need this code?

```
    private static LambdaExpression MakePredicate(int index)
    {
        // t => Not(ReferenceEquals(t.Items[index], null))
        var t = Expression.Parameter(typeof(Tuple), "t");
        return Expression.Lambda(
            Expression.Not(
                Expression.Call(typeof(object),
                                "ReferenceEquals",
                                System.Type.EmptyTypes,
                                Expression.ArrayIndex(
                                    Expression.Property(t, Tuple.ItemsProperty),
                                    Expression.Constant(index)),
                                Expression.Constant(null))),
            t);
    }
```
