### PR TITLE
Snapshot collection before enumerating in Printer

### DIFF
--- a/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 using NHibernate.Action;
@@ -80,7 +81,7 @@ namespace NHibernate.Event.Default
 					.Append(" removals to ").Append(persistenceContext.CollectionEntries.Count).Append(" collections");
 
 				log.Debug(sb.ToString());
-				new Printer(session.Factory).ToString(persistenceContext.EntitiesByKey.Values.GetEnumerator(), session.EntityMode);
+				new Printer(session.Factory).ToString(persistenceContext.EntitiesByKey.Values.ToArray().GetEnumerator(), session.EntityMode);
 			}
 		}
 


### PR DESCRIPTION
We have ugly entity mapping with side-effects on property 'get', which brings new entities into persistent context when Printer enumerates properties of objects already in context. This results in well-known "collection was modified..." exception
