### PR TITLE
Fix NH-3252

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3252/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3252/Fixture.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using NHibernate.Linq;
+
+namespace NHibernate.Test.NHSpecificTest.NH3252
+{
+    [TestFixture]
+    public class Fixture : TestCase
+    {
+        protected override string MappingsAssembly
+        {
+            get { return "NHibernate.Test"; }
+        }
+
+        protected override IList Mappings
+        {
+            get { return new string[] { "NHSpecificTest.NH3252.Mappings.hbm.xml" }; }
+        }
+
+        [Test]
+        public void VerifyThatWeCanSaveAndLoad()
+        {
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+
+                session.Save(new Note { Text = new String('0', 9000) });
+                transaction.Commit();
+            }
+
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+
+                var note = session.Query<Note>().First();
+                Assert.AreEqual(9000, note.Text.Length);
+            }
+        }
+
+        protected override void OnTearDown()
+        {
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+                session.Delete("from System.Object");
+
+                session.Flush();
+                transaction.Commit();
+            }
+        }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3252/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3252/Mappings.hbm.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" namespace="NHibernate.Test.NHSpecificTest.NH3252" assembly="NHibernate.Test">
+  <class name="Note">
+    <id name="Id" type="Int32">
+      <generator class="identity" />
+    </id>
+    <property name="Text" type="AnsiString" length="10000" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3252/Note.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3252/Note.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3252
+{
+    class Note
+    {
+        public virtual int Id { get; protected set; }
+
+        public virtual string Text { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -668,6 +668,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3252\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3252\Note.cs" />
     <Compile Include="NHSpecificTest\NH3408\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3408\Model.cs" />
     <Compile Include="NHSpecificTest\NH2297\CustomCompositeUserType.cs" />
@@ -2882,6 +2884,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3252\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3408\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2408\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2297\MappingsNames.hbm.xml" />

--- a/src/NHibernate/Driver/SqlClientDriver.cs
+++ b/src/NHibernate/Driver/SqlClientDriver.cs
@@ -134,7 +134,7 @@ namespace NHibernate.Driver
 			{
 				case DbType.AnsiString:
 				case DbType.AnsiStringFixedLength:
-					dbParam.Size = MaxSizeForLengthLimitedAnsiString;
+                    dbParam.Size = IsAnsiText(dbParam, sqlType) ? MaxSizeForAnsiClob : MaxSizeForLengthLimitedAnsiString;
 					break;
 				case DbType.Binary:
 					dbParam.Size = IsBlob(dbParam, sqlType) ? MaxSizeForBlob : MaxSizeForLengthLimitedBinary;
@@ -155,6 +155,17 @@ namespace NHibernate.Driver
 					break;
 			}
 		}
+
+        /// <summary>
+        /// Interprets if a parameter is a Clob (for the purposes of setting its default size)
+        /// </summary>
+        /// <param name="dbParam">The parameter</param>
+        /// <param name="sqlType">The <see cref="SqlType" /> of the parameter</param>
+        /// <returns>True, if the parameter should be interpreted as a Clob, otherwise False</returns>
+        protected static bool IsAnsiText(IDbDataParameter dbParam, SqlType sqlType)
+        {
+            return ((DbType.AnsiString == dbParam.DbType || DbType.AnsiStringFixedLength == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MaxSizeForLengthLimitedAnsiString));
+        }
 
 		/// <summary>
 		/// Interprets if a parameter is a Clob (for the purposes of setting its default size)


### PR DESCRIPTION
This is similar to the fix proposed on jira for NH-3252. Basically size is handled the same way as string. Without this, can't do varchar(max), only nvarchar(max).