### PR TITLE
Fix NH-3316

### DIFF
--- a/src/NHibernate.Test/MappingByCode/ExpliticMappingTests/BagOfNestedComponentsWithParentTest.cs
+++ b/src/NHibernate.Test/MappingByCode/ExpliticMappingTests/BagOfNestedComponentsWithParentTest.cs
@@ -49,7 +49,7 @@ namespace NHibernate.Test.MappingByCode.ExpliticMappingTests
 				cm.Bag(x => x.Addresses, cp => { }, cr => { });
 			});
 			HbmMapping mapping = mapper.CompileMappingFor(new[] { typeof(Person) });
-			VerifyMapping(mapping);
+            VerifyMapping(mapping, "Street", "Number", "Owner");
 		}
 
 		[Test]
@@ -72,7 +72,7 @@ namespace NHibernate.Test.MappingByCode.ExpliticMappingTests
 				}));
 			});
 			HbmMapping mapping = mapper.CompileMappingFor(new[] { typeof(Person) });
-			VerifyMapping(mapping);
+            VerifyMapping(mapping, "Street", "Number", "Owner");
 		}
 
 		[Test]
@@ -94,10 +94,10 @@ namespace NHibernate.Test.MappingByCode.ExpliticMappingTests
 				}));
 			});
 			HbmMapping mapping = mapper.CompileMappingFor(new[] { typeof(Person) });
-			VerifyMapping(mapping);
+            VerifyMapping(mapping, "Street", "Number");
 		}
 
-		private void VerifyMapping(HbmMapping mapping)
+		private void VerifyMapping(HbmMapping mapping, params string[] properties)
 		{
 			HbmClass rc = mapping.RootClasses.First(r => r.Name.Contains("Person"));
 			var relation = rc.Properties.First(p => p.Name == "Addresses");
@@ -108,8 +108,8 @@ namespace NHibernate.Test.MappingByCode.ExpliticMappingTests
 			
 			// This test was modified because when the "owner" is an entity it can be mapped as many-to-one or as parent and without an explicit
 			// definition of the property representing the bidiretional-relation we can't know is the mapping element (many-to-one or parent)
-			elementRelation.Properties.Should().Have.Count.EqualTo(3);
-			elementRelation.Properties.Select(p => p.Name).Should().Have.SameValuesAs("Street", "Number", "Owner");
+			elementRelation.Properties.Should().Have.Count.EqualTo(properties.Length);
+			elementRelation.Properties.Select(p => p.Name).Should().Have.SameValuesAs(properties);
 			//elementRelation.Parent.Should().Not.Be.Null();
 			//elementRelation.Parent.name.Should().Be.EqualTo("Owner");
 			

--- a/src/NHibernate.Test/NHSpecificTest/NH3316/ByCodeFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3316/ByCodeFixture.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.Cfg.MappingSchema;
+using NHibernate.Mapping.ByCode;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3316
+{
+    [TestFixture]
+    public class ByCodeFixture : TestCaseMappingByCode
+    {
+        protected override HbmMapping GetMappings()
+        {
+            var mapper = new ModelMapper();
+            mapper.Class<Entity>(e =>
+            {
+                e.Id(x => x.Id, id => id.Generator(Generators.GuidComb));
+                e.Set(x => x.Children, c =>
+                {
+                    c.Key(key => key.Column("EntityId"));
+                    c.Cascade(NHibernate.Mapping.ByCode.Cascade.All | NHibernate.Mapping.ByCode.Cascade.DeleteOrphans);
+                },
+                r =>
+                {
+                    r.Component(c =>
+                    {
+                        c.Parent(x => x.Parent);
+                        c.Property(x => x.Value);
+                    });
+                });
+            });
+
+            return mapper.CompileMappingForAllExplicitlyAddedEntities();
+        }
+
+        protected override void OnTearDown()
+        {
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+                session.Delete("from System.Object");
+
+                session.Flush();
+                transaction.Commit();
+            }
+        }
+
+        [Test]
+        public void Test_That_Parent_Property_Can_Be_Persisted_And_Retrieved()
+        {
+            Guid id = Guid.Empty;
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+                Entity e = new Entity();
+                e.AddChild(1);
+                e.AddChild(2);
+
+                session.Save(e);
+                session.Flush();
+                transaction.Commit();
+                id = e.Id;
+            }
+
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+                Entity e = session.Get<Entity>(id);
+                Assert.AreEqual(2, e.Children.Count());
+                foreach (ChildComponent c in e.Children)
+                    Assert.AreEqual(e, c.Parent);
+
+                session.Flush();
+                transaction.Commit();
+            }
+        }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3316/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3316/Entity.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3316
+{
+    class Entity
+    {
+        public Entity()
+        {
+            Children = new HashSet<ChildComponent>();    
+        }
+
+        public virtual Guid Id { get; set; }
+
+        public virtual ICollection<ChildComponent> Children { get; protected set; }
+
+        public virtual void AddChild(int value)
+        {
+            Children.Add(new ChildComponent(this, value));
+        }
+
+        public override bool Equals(object obj)
+        {
+            Entity other = obj as Entity;
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Id == other.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+    }
+
+    class ChildComponent
+    {
+        protected ChildComponent()
+        {
+        }
+
+        public ChildComponent(Entity parent, int value)
+        {
+            Parent = parent;
+            Value = value;
+        }
+
+        public virtual Entity Parent { get; protected set; }
+
+        public virtual int Value { get; protected set; }
+
+        public override bool Equals(object obj)
+        {
+            ChildComponent other = obj as ChildComponent;
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Parent == other.Parent && Value == other.Value;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            unchecked
+            {
+                hash = (hash * 23) + Parent.GetHashCode();
+                hash = (hash * 23) + Value.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -668,6 +668,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3316\ByCodeFixture.cs" />
+    <Compile Include="NHSpecificTest\NH3316\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3408\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3408\Model.cs" />
     <Compile Include="NHSpecificTest\NH2297\CustomCompositeUserType.cs" />

--- a/src/NHibernate/Mapping/ByCode/ModelMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/ModelMapper.cs
@@ -1130,9 +1130,12 @@ namespace NHibernate.Mapping.ByCode
 
 		protected MemberInfo GetComponentParentReferenceProperty(IEnumerable<MemberInfo> persistentProperties, System.Type propertiesContainerType)
 		{
-			return modelInspector.IsComponent(propertiesContainerType)
-			       	? persistentProperties.FirstOrDefault(pp => pp.GetPropertyOrFieldType() == propertiesContainerType)
-			       	: null;
+            // if container is component, then all properties referencing container are assumed parent reference
+            if (modelInspector.IsComponent(propertiesContainerType))
+                return persistentProperties.FirstOrDefault(pp => pp.GetPropertyOrFieldType() == propertiesContainerType);
+
+            // return the first non-many-to-one property
+            return persistentProperties.Where(pp => !modelInspector.IsManyToOne(pp)).FirstOrDefault(pp => pp.GetPropertyOrFieldType() == propertiesContainerType);
 		}
 
 		private void MapBag(MemberInfo member, PropertyPath propertyPath, System.Type propertyType, ICollectionPropertiesContainerMapper propertiesContainer,


### PR DESCRIPTION
Tests covering NH3316
Fix some other bad unit tests

The problem was that when resolving the parent, it was checking if the propertiesContainerType was a component and returning null if it wasn't, and most of the time it was not. It would only resolve the parent type when using nested components.
