### PR TITLE
Improved debugging

### DIFF
--- a/src/NHibernate/Linq/Visitors/HqlGeneratorExpressionTreeVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/HqlGeneratorExpressionTreeVisitor.cs
@@ -139,7 +139,7 @@ namespace NHibernate.Linq.Visitors
 							//    return VisitNhNew((NhNewExpression)expression);
 					}
 
-					throw new NotSupportedException(expression.GetType().Name);
+					throw new NotSupportedException(expression.ToString());
 			}
 		}
 


### PR DESCRIPTION
Use ToString of the expression as message, this allows usage of
PartialEvaluationExceptionExpression ToString output

Should help when debugging the following stacktrace:

System.NotSupportedException: PartialEvaluationExceptionExpression
   at NHibernate.Linq.Visitors.HqlGeneratorExpressionTreeVisitor.VisitExpression(Expression expression)
   at NHibernate.Linq.Visitors.HqlGeneratorExpressionTreeVisitor.VisitBinaryExpression(BinaryExpression expression)
...
