### PR TITLE
sequence drop fix for MS SQL 2012 dialect

### DIFF
--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -29,8 +29,10 @@ namespace NHibernate.Dialect
 		}
 
 		public override string GetDropSequenceString(string sequenceName)
-		{
-			return "drop sequence " + sequenceName;
+        {
+            string dropSequence = "IF EXISTS (select * from sys.sequences where name = N'{0}') DROP SEQUENCE {0}";
+
+            return string.Format(dropSequence, sequenceName);
 		}
 
 		public override string GetSequenceNextValString(string sequenceName)


### PR DESCRIPTION
sometimes when You try regenerate schema, u r unabled to do that bcoz drop statements is failing.

this ficture fixs nhibernate sequence drops and checks if exists

https://nhibernate.jira.com/browse/NH-3496
