### PR TITLE
Makes the session available to ISQLExceptionConverter.

### DIFF
--- a/src/NHibernate.Test/ExceptionsTest/NullQueryTest.cs
+++ b/src/NHibernate.Test/ExceptionsTest/NullQueryTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
 using System.Data;
+using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ExceptionsTest
@@ -35,7 +37,7 @@ namespace NHibernate.Test.ExceptionsTest
 			catch (Exception sqle)
 			{
 				Assert.DoesNotThrow(
-					() => ADOExceptionHelper.Convert(sessions.SQLExceptionConverter, sqle, "could not get or update next value", null));
+					() => ADOExceptionHelper.Convert((ISessionImplementor)session, sessions.SQLExceptionConverter, sqle, "could not get or update next value", null));
 			}
 			finally
 			{

--- a/src/NHibernate.Test/Insertordering/InsertOrderingFixture.cs
+++ b/src/NHibernate.Test/Insertordering/InsertOrderingFixture.cs
@@ -85,8 +85,8 @@ namespace NHibernate.Test.Insertordering
 			private static IList<int> batchSizes = new List<int>();
 			private static int currentBatch = -1;
 
-			public StatsBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
-				: base(connectionManager, interceptor) {}
+			public StatsBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
+				: base(connectionManager, interceptor, session) {}
 
 			public static IList<int> BatchSizes
 			{
@@ -139,9 +139,9 @@ namespace NHibernate.Test.Insertordering
 		{
 			#region IBatcherFactory Members
 
-			public IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+            public IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 			{
-				return new StatsBatcher(connectionManager, interceptor);
+				return new StatsBatcher(connectionManager, interceptor, session);
 			}
 
 			#endregion

--- a/src/NHibernate.Test/Linq/QueryTimeoutTests.cs
+++ b/src/NHibernate.Test/Linq/QueryTimeoutTests.cs
@@ -77,8 +77,8 @@ namespace NHibernate.Test.Linq
 
 			public static int LastCommandTimeout;
 
-			public TimeoutCatchingNonBatchingBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
-				: base(connectionManager, interceptor)
+            public TimeoutCatchingNonBatchingBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
+				: base(connectionManager, interceptor, session)
 			{
 			}
 
@@ -92,9 +92,9 @@ namespace NHibernate.Test.Linq
 
 		public class TimeoutCatchingNonBatchingBatcherFactory : IBatcherFactory
 		{
-			public IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+            public IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 			{
-				return new TimeoutCatchingNonBatchingBatcher(connectionManager, interceptor);
+				return new TimeoutCatchingNonBatchingBatcher(connectionManager, interceptor, session);
 			}
 		}
 	}

--- a/src/NHibernate/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/AdoNet/AbstractBatcher.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using NHibernate.Driver;
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
 using NHibernate.Util;
@@ -27,8 +28,9 @@ namespace NHibernate.AdoNet
 		private readonly ConnectionManager _connectionManager;
 		private readonly ISessionFactoryImplementor _factory;
 		private readonly IInterceptor _interceptor;
+	    private readonly ISessionImplementor _session;
 
-		// batchCommand used to be called batchUpdate - that name to me implied that updates
+	    // batchCommand used to be called batchUpdate - that name to me implied that updates
 		// were being sent - however this could be just INSERT/DELETE/SELECT SQL statement not
 		// just update.  However I haven't seen this being used with read statements...
 		private IDbCommand _batchCommand;
@@ -45,11 +47,12 @@ namespace NHibernate.AdoNet
 		/// </summary>
 		/// <param name="connectionManager">The <see cref="ConnectionManager"/> owning this batcher.</param>
 		/// <param name="interceptor"></param>
-		protected AbstractBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+		protected AbstractBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 		{
 			_connectionManager = connectionManager;
 			_interceptor = interceptor;
-			_factory = connectionManager.Factory;
+		    _session = session;
+		    _factory = connectionManager.Factory;
 		}
 
 		protected IDriver Driver
@@ -539,7 +542,7 @@ namespace NHibernate.AdoNet
 
 		protected Exception Convert(Exception sqlException, string message)
 		{
-			return ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqlException, message);
+            return ADOExceptionHelper.Convert(_session, Factory.SQLExceptionConverter, sqlException, message);
 		}
 
 		#region IDisposable Members

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -58,7 +58,7 @@ namespace NHibernate.AdoNet
 			this.connectionReleaseMode = connectionReleaseMode;
 
 			this.interceptor = interceptor;
-			batcher = session.Factory.Settings.BatcherFactory.CreateBatcher(this, interceptor);
+			batcher = session.Factory.Settings.BatcherFactory.CreateBatcher(this, interceptor, session);
 
 			ownConnection = suppliedConnection == null;
 		}
@@ -312,7 +312,7 @@ namespace NHibernate.AdoNet
 
 		void IDeserializationCallback.OnDeserialization(object sender)
 		{
-			batcher = session.Factory.Settings.BatcherFactory.CreateBatcher(this, interceptor);
+			batcher = session.Factory.Settings.BatcherFactory.CreateBatcher(this, interceptor, session);
 		}
 
 		#endregion

--- a/src/NHibernate/AdoNet/IBatcherFactory.cs
+++ b/src/NHibernate/AdoNet/IBatcherFactory.cs
@@ -5,6 +5,6 @@ namespace NHibernate.AdoNet
 	/// <summary> Factory for <see cref="IBatcher"/> instances.</summary>
 	public interface IBatcherFactory
 	{
-		IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor);
+        IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session);
 	}
 }

--- a/src/NHibernate/AdoNet/MySqlClientBatchingBatcherFactory.cs
+++ b/src/NHibernate/AdoNet/MySqlClientBatchingBatcherFactory.cs
@@ -4,9 +4,9 @@ namespace NHibernate.AdoNet
 {
 	public class MySqlClientBatchingBatcherFactory : IBatcherFactory
 	{
-		public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+        public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 		{
-			return new MySqlClientBatchingBatcher(connectionManager, interceptor);
+			return new MySqlClientBatchingBatcher(connectionManager, interceptor, session);
 		}
 	}
 }

--- a/src/NHibernate/AdoNet/NonBatchingBatcher.cs
+++ b/src/NHibernate/AdoNet/NonBatchingBatcher.cs
@@ -16,8 +16,8 @@ namespace NHibernate.AdoNet
 		/// </summary>
 		/// <param name="connectionManager">The <see cref="ConnectionManager"/> for this batcher.</param>
 		/// <param name="interceptor"></param>
-		public NonBatchingBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
-			: base(connectionManager, interceptor)
+        public NonBatchingBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
+			: base(connectionManager, interceptor, session)
 		{
 		}
 

--- a/src/NHibernate/AdoNet/NonBatchingBatcherFactory.cs
+++ b/src/NHibernate/AdoNet/NonBatchingBatcherFactory.cs
@@ -8,9 +8,9 @@ namespace NHibernate.AdoNet
 	/// </summary>
 	public class NonBatchingBatcherFactory : IBatcherFactory
 	{
-		public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+        public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 		{
-			return new NonBatchingBatcher(connectionManager, interceptor);
+			return new NonBatchingBatcher(connectionManager, interceptor, session);
 		}
 	}
 }

--- a/src/NHibernate/AdoNet/OracleDataClientBatchingBatcherFactory.cs
+++ b/src/NHibernate/AdoNet/OracleDataClientBatchingBatcherFactory.cs
@@ -4,9 +4,9 @@ namespace NHibernate.AdoNet
 {
 	public class OracleDataClientBatchingBatcherFactory : IBatcherFactory
 	{
-		public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+        public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 		{
-			return new OracleDataClientBatchingBatcher(connectionManager, interceptor);
+			return new OracleDataClientBatchingBatcher(connectionManager, interceptor, session);
 		}
 	}
 }

--- a/src/NHibernate/AdoNet/SqlClientBatchingBatcherFactory.cs
+++ b/src/NHibernate/AdoNet/SqlClientBatchingBatcherFactory.cs
@@ -4,9 +4,9 @@ namespace NHibernate.AdoNet
 {
 	public class SqlClientBatchingBatcherFactory : IBatcherFactory
 	{
-		public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+        public virtual IBatcher CreateBatcher(ConnectionManager connectionManager, IInterceptor interceptor, ISessionImplementor session)
 		{
-			return new SqlClientBatchingBatcher(connectionManager, interceptor);
+			return new SqlClientBatchingBatcher(connectionManager, interceptor, session);
 		}
 	}
 }

--- a/src/NHibernate/Dialect/Lock/SelectLockingStrategy.cs
+++ b/src/NHibernate/Dialect/Lock/SelectLockingStrategy.cs
@@ -101,7 +101,8 @@ namespace NHibernate.Dialect.Lock
 				                       		Message = "could not lock: " + MessageHelper.InfoString(lockable, id, factory),
 				                       		Sql = sql.ToString(),
 				                       		EntityName = lockable.EntityName,
-				                       		EntityId = id
+				                       		EntityId = id,
+                                            Session = session
 				                       	};
 				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, exceptionContext);
 			}

--- a/src/NHibernate/Dialect/Lock/UpdateLockingStrategy.cs
+++ b/src/NHibernate/Dialect/Lock/UpdateLockingStrategy.cs
@@ -113,7 +113,8 @@ namespace NHibernate.Dialect.Lock
 				                       		Message = "could not lock: " + MessageHelper.InfoString(lockable, id, factory),
 				                       		Sql = sql.ToString(),
 				                       		EntityName = lockable.EntityName,
-				                       		EntityId = id
+				                       		EntityId = id,
+                                            Session = session
 				                       	};
 				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, exceptionContext);
 			}

--- a/src/NHibernate/Engine/Query/NativeSQLQueryPlan.cs
+++ b/src/NHibernate/Engine/Query/NativeSQLQueryPlan.cs
@@ -109,7 +109,7 @@ namespace NHibernate.Engine.Query
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 												 "could not execute native bulk manipulation query:" + sourceQuery);
 			}
 

--- a/src/NHibernate/Engine/TransactionHelper.cs
+++ b/src/NHibernate/Engine/TransactionHelper.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Data.Common;
 using NHibernate.Engine.Transaction;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 
 namespace NHibernate.Engine
 {
@@ -33,7 +34,7 @@ namespace NHibernate.Engine
 				}
 				catch (DbException sqle)
 				{
-					throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle, "could not get or update next value", null);
+					throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle, "could not get or update next value", null);
 				}
 			}
 

--- a/src/NHibernate/Exceptions/AdoExceptionContextInfo.cs
+++ b/src/NHibernate/Exceptions/AdoExceptionContextInfo.cs
@@ -1,4 +1,6 @@
 using System;
+using NHibernate.Engine;
+using NHibernate.Impl;
 
 namespace NHibernate.Exceptions
 {
@@ -36,5 +38,10 @@ namespace NHibernate.Exceptions
 		/// Optional EntityId where available in the original exception context.
 		/// </summary>
 		public object EntityId { get; set; }
+
+        /// <summary>
+        /// Session from which the exception was thrown.
+        /// </summary>
+        public ISessionImplementor Session { get; set; }
 	}
 }

--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/BasicExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/BasicExecutor.cs
@@ -9,6 +9,7 @@ using Antlr.Runtime.Tree;
 using NHibernate.Engine;
 using NHibernate.Exceptions;
 using NHibernate.Hql.Ast.ANTLR.Tree;
+using NHibernate.Impl;
 using NHibernate.Param;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
@@ -89,7 +90,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 																 "could not execute update query", sql);
 			}
 		}

--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableDeleteExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableDeleteExecutor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NHibernate.Engine;
 using NHibernate.Exceptions;
 using NHibernate.Hql.Ast.ANTLR.Tree;
+using NHibernate.Impl;
 using NHibernate.Param;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
@@ -103,7 +104,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 				}
 				catch (DbException e)
 				{
-					throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "could not insert/select ids for bulk delete", idInsertSelect);
+                    throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, e, "could not insert/select ids for bulk delete", idInsertSelect);
 				}
 
 				// Start performing the deletes
@@ -126,7 +127,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 					}
 					catch (DbException e)
 					{
-						throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "error performing bulk delete", deletes[i]);
+                        throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, e, "error performing bulk delete", deletes[i]);
 					}
 				}
 

--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableUpdateExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableUpdateExecutor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NHibernate.Engine;
 using NHibernate.Exceptions;
 using NHibernate.Hql.Ast.ANTLR.Tree;
+using NHibernate.Impl;
 using NHibernate.Param;
 using NHibernate.Persister.Entity;
 using NHibernate.SqlCommand;
@@ -131,7 +132,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 				}
 				catch (DbException e)
 				{
-					throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "could not insert/select ids for bulk update",
+                    throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, e, "could not insert/select ids for bulk update",
 					                                 idInsertSelect);
 				}
 
@@ -168,7 +169,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 					}
 					catch (DbException e)
 					{
-						throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "error performing bulk update", updates[i]);
+                        throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, e, "error performing bulk update", updates[i]);
 					}
 				}
 

--- a/src/NHibernate/Id/Enhanced/SequenceStructure.cs
+++ b/src/NHibernate/Id/Enhanced/SequenceStructure.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
 
@@ -132,7 +133,7 @@ namespace NHibernate.Id.Enhanced
 				}
 				catch (DbException sqle)
 				{
-					throw ADOExceptionHelper.Convert(_session.Factory.SQLExceptionConverter, sqle, "could not get next sequence value", _owner._sql);
+                    throw ADOExceptionHelper.Convert(_session, _session.Factory.SQLExceptionConverter, sqle, "could not get next sequence value", _owner._sql);
 				}
 			}
 

--- a/src/NHibernate/Id/IncrementGenerator.cs
+++ b/src/NHibernate/Id/IncrementGenerator.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.Type;
 using NHibernate.Util;
 using System.Data.Common;
@@ -130,7 +131,7 @@ namespace NHibernate.Id
 			catch (DbException sqle)
 			{
 				log.Error("could not get increment value", sqle);
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 												 "could not fetch initial value for increment generator");
 			}
 		}

--- a/src/NHibernate/Id/Insert/AbstractReturningDelegate.cs
+++ b/src/NHibernate/Id/Insert/AbstractReturningDelegate.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Data.Common;
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.SqlCommand;
 
 namespace NHibernate.Id.Insert
@@ -48,7 +49,7 @@ namespace NHibernate.Id.Insert
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 				                                 "could not insert: " + persister.GetInfoString(), insertSQL.Text);
 			}
 		}

--- a/src/NHibernate/Id/Insert/AbstractSelectingDelegate.cs
+++ b/src/NHibernate/Id/Insert/AbstractSelectingDelegate.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Id.Insert
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 				                                 "could not insert: " + persister.GetInfoString(), insertSQL.Text);
 			}
 
@@ -74,7 +74,7 @@ namespace NHibernate.Id.Insert
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 				                                 "could not retrieve generated id after insert: " + persister.GetInfoString(),
 				                                 insertSQL.Text);
 			}

--- a/src/NHibernate/Id/NativeGuidGenerator.cs
+++ b/src/NHibernate/Id/NativeGuidGenerator.cs
@@ -3,6 +3,7 @@ using System.Data;
 
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
 using NHibernate.Type;
@@ -49,7 +50,7 @@ namespace NHibernate.Id
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle, "could not retrieve GUID", sql);
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle, "could not retrieve GUID", sql);
 			}
 		}
 

--- a/src/NHibernate/Id/SequenceGenerator.cs
+++ b/src/NHibernate/Id/SequenceGenerator.cs
@@ -4,6 +4,7 @@ using System.Data;
 
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
 using NHibernate.Type;
@@ -141,7 +142,7 @@ namespace NHibernate.Id
 			catch (DbException sqle)
 			{
 				log.Error("error generating sequence", sqle);
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle, "could not get next sequence value");
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle, "could not get next sequence value");
 			}
 		}
 

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -425,7 +425,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				return ADOExceptionHelper.Convert(factory.SQLExceptionConverter, sqlException, message);
+				return ADOExceptionHelper.Convert(this, factory.SQLExceptionConverter, sqlException, message);
 			}
 		}
 

--- a/src/NHibernate/Impl/EnumerableImpl.cs
+++ b/src/NHibernate/Impl/EnumerableImpl.cs
@@ -119,7 +119,7 @@ namespace NHibernate.Impl
 			}
 			catch (DbException e)
 			{
-				throw ADOExceptionHelper.Convert(_session.Factory.SQLExceptionConverter, e, "Error executing Enumerable() query",
+                throw ADOExceptionHelper.Convert(_session, _session.Factory.SQLExceptionConverter, e, "Error executing Enumerable() query",
 												   new SqlString(_cmd.CommandText));
 			}
 			PostMoveNext(readResult);
@@ -144,7 +144,7 @@ namespace NHibernate.Impl
 			}
 			catch (DbException e)
 			{
-				throw ADOExceptionHelper.Convert(_session.Factory.SQLExceptionConverter, e, "Error executing Enumerable() query",
+                throw ADOExceptionHelper.Convert(_session, _session.Factory.SQLExceptionConverter, e, "Error executing Enumerable() query",
 												 new SqlString(_cmd.CommandText));
 			}
 		}

--- a/src/NHibernate/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Impl/MultiCriteriaImpl.cs
@@ -260,7 +260,7 @@ namespace NHibernate.Impl
 			{
 				var message = string.Format("Failed to execute multi criteria: [{0}]", resultSetsCommand.Sql);
 				log.Error(message, sqle);
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle, "Failed to execute multi criteria", resultSetsCommand.Sql);
+				throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle, "Failed to execute multi criteria", resultSetsCommand.Sql);
 			}
 			if (statsEnabled)
 			{

--- a/src/NHibernate/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Impl/MultiQueryImpl.cs
@@ -605,7 +605,7 @@ namespace NHibernate.Impl
 			{
 				var message = string.Format("Failed to execute multi query: [{0}]", resultSetsCommand.Sql);
 				log.Error(message, sqle);
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle, "Failed to execute multi query", resultSetsCommand.Sql);
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle, "Failed to execute multi query", resultSetsCommand.Sql);
 			}
 
 			if (statsEnabled)

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -287,7 +287,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle, "could not read next row of results",
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle, "could not read next row of results",
 												 SqlString, queryParameters.PositionalParameterValues,
 												 queryParameters.NamedParameters);
 			}
@@ -1285,7 +1285,7 @@ namespace NHibernate.Loader
 			catch (Exception sqle)
 			{
 				ILoadable[] persisters = EntityPersisters;
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not load an entity: "
 												 +
 												 MessageHelper.InfoString(persisters[persisters.Length - 1], id, identifierType,
@@ -1312,7 +1312,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(_factory.SQLExceptionConverter, sqle, "could not collection element by index",
+                throw ADOExceptionHelper.Convert(session, _factory.SQLExceptionConverter, sqle, "could not collection element by index",
 												 SqlString);
 			}
 
@@ -1349,7 +1349,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not load an entity batch: "
 												 + MessageHelper.InfoString(persister, ids, Factory), SqlString);
 				// NH: Hibernate3 passes EntityPersisters[0] instead of persister, I think it's wrong.
@@ -1381,7 +1381,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not initialize a collection: "
 												 + MessageHelper.InfoString(CollectionPersisters[0], id), SqlString);
 			}
@@ -1412,7 +1412,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not initialize a collection batch: "
 												 + MessageHelper.InfoString(CollectionPersisters[0], ids), SqlString);
 			}
@@ -1440,7 +1440,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not load collection by subselect: "
 												 + MessageHelper.InfoString(CollectionPersisters[0], ids), SqlString,
 												 parameterValues, namedParameters);
@@ -1570,7 +1570,7 @@ namespace NHibernate.Loader
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle, "could not execute query", SqlString,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle, "could not execute query", SqlString,
 												 queryParameters.PositionalParameterValues, queryParameters.NamedParameters);
 			}
 			if (statsEnabled)

--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -1062,7 +1062,7 @@ namespace NHibernate.Persister.Collection
 				}
 				catch (DbException sqle)
 				{
-					throw ADOExceptionHelper.Convert(sqlExceptionConverter, sqle,
+                    throw ADOExceptionHelper.Convert(session, sqlExceptionConverter, sqle,
 													 "could not delete collection: " + MessageHelper.InfoString(this, id));
 				}
 			}
@@ -1126,7 +1126,7 @@ namespace NHibernate.Persister.Collection
 				}
 				catch (DbException sqle)
 				{
-					throw ADOExceptionHelper.Convert(sqlExceptionConverter, sqle,
+                    throw ADOExceptionHelper.Convert(session, sqlExceptionConverter, sqle,
 													 "could not insert collection: " + MessageHelper.InfoString(this, id));
 				}
 			}
@@ -1235,7 +1235,7 @@ namespace NHibernate.Persister.Collection
 				}
 				catch (DbException sqle)
 				{
-					throw ADOExceptionHelper.Convert(sqlExceptionConverter, sqle,
+                    throw ADOExceptionHelper.Convert(session, sqlExceptionConverter, sqle,
 													 "could not delete collection rows: " + MessageHelper.InfoString(this, id));
 				}
 			}
@@ -1288,7 +1288,7 @@ namespace NHibernate.Persister.Collection
 				}
 				catch (DbException sqle)
 				{
-					throw ADOExceptionHelper.Convert(sqlExceptionConverter, sqle,
+                    throw ADOExceptionHelper.Convert(session, sqlExceptionConverter, sqle,
 													 "could not insert collection rows: " + MessageHelper.InfoString(this, id));
 				}
 			}
@@ -1532,7 +1532,7 @@ namespace NHibernate.Persister.Collection
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not retrieve collection size: "
 												 + MessageHelper.InfoString(this, key, Factory), GenerateSelectSizeString(session));
 			}
@@ -1583,7 +1583,7 @@ namespace NHibernate.Persister.Collection
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not check row existence: " + MessageHelper.InfoString(this, key, Factory),
 												 GenerateSelectSizeString(session));
 			}
@@ -1626,7 +1626,7 @@ namespace NHibernate.Persister.Collection
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, Factory.SQLExceptionConverter, sqle,
 												 "could not read row: " + MessageHelper.InfoString(this, key, Factory),
 												 GenerateSelectSizeString(session));
 			}

--- a/src/NHibernate/Persister/Collection/BasicCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/BasicCollectionPersister.cs
@@ -244,7 +244,7 @@ namespace NHibernate.Persister.Collection
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, SQLExceptionConverter, sqle,
 												 "could not update collection rows: " + MessageHelper.InfoString(this, id),
 												 SqlUpdateRowString.Text);
 			}

--- a/src/NHibernate/Persister/Collection/OneToManyPersister.cs
+++ b/src/NHibernate/Persister/Collection/OneToManyPersister.cs
@@ -294,7 +294,7 @@ namespace NHibernate.Persister.Collection
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(SQLExceptionConverter, sqle, "could not update collection rows: " + MessageHelper.InfoString(this, id));
+                throw ADOExceptionHelper.Convert(session, SQLExceptionConverter, sqle, "could not update collection rows: " + MessageHelper.InfoString(this, id));
 			}
 		}
 

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1277,7 +1277,8 @@ namespace NHibernate.Persister.Entity
 												"could not initialize lazy properties: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = SQLLazySelectString.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+											EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -1449,7 +1450,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not retrieve snapshot: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = SQLSnapshotSelectString.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -1632,7 +1634,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not retrieve version: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = VersionSelectString.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -1694,7 +1697,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not retrieve version: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = VersionSelectString.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -2669,7 +2673,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not insert: " + MessageHelper.InfoString(this, id),
 											Sql = sql.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -2812,7 +2817,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not update: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = sql.Text.ToString(),
 																	EntityName = EntityName,
-																	EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -2932,7 +2938,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not delete: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = sql.Text.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -4020,7 +4027,8 @@ namespace NHibernate.Persister.Entity
 											Message = "unable to select generated column values",
 											Sql = selectionSQL.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}
@@ -4111,7 +4119,8 @@ namespace NHibernate.Persister.Entity
 											Message = "could not retrieve snapshot: " + MessageHelper.InfoString(this, id, Factory),
 											Sql = sql.ToString(),
 											EntityName = EntityName,
-											EntityId = id
+                                            EntityId = id,
+                                            Session = session
 										};
 				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, exceptionContext);
 			}

--- a/src/NHibernate/Tool/hbm2ddl/DatabaseMetadata.cs
+++ b/src/NHibernate/Tool/hbm2ddl/DatabaseMetadata.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 
 using NHibernate.Dialect.Schema;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.Mapping;
 using NHibernate.Util;
 
@@ -94,7 +95,7 @@ namespace NHibernate.Tool.hbm2ddl
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(sqlExceptionConverter, sqle, "could not get table metadata: " + name);
+                throw ADOExceptionHelper.Convert(null, sqlExceptionConverter, sqle, "could not get table metadata: " + name);
 			}
 		}
 

--- a/src/NHibernate/Transaction/AdoNetTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetTransactionFactory.cs
@@ -85,7 +85,7 @@ namespace NHibernate.Transaction
 					}
 					else if (t is DbException)
 					{
-						throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, t,
+                        throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, t,
 														 "error performing isolated work");
 					}
 					else

--- a/src/NHibernate/Type/DbTimestampType.cs
+++ b/src/NHibernate/Type/DbTimestampType.cs
@@ -74,7 +74,7 @@ namespace NHibernate.Type
 			}
 			catch (DbException sqle)
 			{
-				throw ADOExceptionHelper.Convert(session.Factory.SQLExceptionConverter, sqle,
+                throw ADOExceptionHelper.Convert(session, session.Factory.SQLExceptionConverter, sqle,
 				                                 "could not select current db timestamp", tsSelect);
 			}
 			finally

--- a/src/NHibernate/Type/EntityType.cs
+++ b/src/NHibernate/Type/EntityType.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Xml;
 using NHibernate.Engine;
 using NHibernate.Exceptions;
+using NHibernate.Impl;
 using NHibernate.Persister.Entity;
 using NHibernate.Proxy;
 using NHibernate.Util;
@@ -572,7 +573,7 @@ namespace NHibernate.Type
 			}
 			catch (Exception sqle)
 			{
-				throw ADOExceptionHelper.Convert(factory.SQLExceptionConverter, sqle, "Error performing LoadByUniqueKey");
+                throw ADOExceptionHelper.Convert(session, factory.SQLExceptionConverter, sqle, "Error performing LoadByUniqueKey");
 			}
 		}
 


### PR DESCRIPTION
Enables more advanced exception translations based on the persistence
context.

When using batching, details about the entity name and ID which caused a failure are unavailable to the exception converter. Given the name of a violated constraint, however, it is often possible to determine the offending entity by type if we have access to the persistence context. This commit makes the relevant information available to exception converters.
