### PR TITLE
NH-3524 - QueryOver<T> doesn't support date's property functions for DateTimeOffset

### DIFF
--- a/src/NHibernate.Test/Criteria/Lambda/Mappings.hbm.xml
+++ b/src/NHibernate.Test/Criteria/Lambda/Mappings.hbm.xml
@@ -11,6 +11,7 @@
 		<property name="Name" />
 		<property name="Age" />
 		<property name="BirthDate" />
+		<property name="BirthDateAsDateTimeOffset" />
 		<property name="Blood" />
 		<component name="Detail" class="PersonDetail">
 			<property name="MaidenName" />

--- a/src/NHibernate.Test/Criteria/Lambda/Model.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/Model.cs
@@ -19,21 +19,23 @@ namespace NHibernate.Test.Criteria.Lambda
 			Children = new List<Child>();
 			Blood = 'O';
 			BirthDate = new DateTime(1950, 01, 01);
+			BirthDateAsDateTimeOffset = new DateTimeOffset(BirthDate);
 		}
 
 		public static string StaticName;
 
-		public virtual int					Id			{ get; set; }
-		public virtual string				Name		{ get; set; }
-		public virtual int					Age			{ get; set; }
-		public virtual PersonGender			Gender		{ get; set; }
-		public virtual int					Height		{ get; set; }
-		public virtual bool					HasCar		{ get; set; }
-		public virtual Person				Father		{ get; set; }
-		public virtual bool					IsParent	{ get; set; }
-		public virtual char					Blood		{ get; set; }
-		public virtual DateTime				BirthDate	{ get; set; }
-		public virtual PersonDetail			Detail		{ get; set; }
+		public virtual int					Id							{ get; set; }
+		public virtual string				Name						{ get; set; }
+		public virtual int					Age							{ get; set; }
+		public virtual PersonGender			Gender						{ get; set; }
+		public virtual int					Height						{ get; set; }
+		public virtual bool					HasCar						{ get; set; }
+		public virtual Person				Father						{ get; set; }
+		public virtual bool					IsParent					{ get; set; }
+		public virtual char					Blood						{ get; set; }
+		public virtual DateTime				BirthDate					{ get; set; }
+		public virtual DateTimeOffset		BirthDateAsDateTimeOffset	{ get; set; }
+		public virtual PersonDetail			Detail						{ get; set; }
 
 		public virtual int?					NullableAge			{ get; set; }
 		public virtual PersonGender?		NullableGender		{ get; set; }

--- a/src/NHibernate.Test/Criteria/Lambda/ProjectionsFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/ProjectionsFixture.cs
@@ -152,6 +152,20 @@ namespace NHibernate.Test.Criteria.Lambda
 		}
 
 		[Test]
+		public void SelectSingleFunctionOfDateTimeOffset()
+		{
+			ICriteria expected =
+				CreateTestCriteria(typeof(Person))
+					.SetProjection(Projections.SqlFunction("year", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")));
+
+			var actual =
+				CreateTestQueryOver<Person>()
+					.Select(p => p.BirthDateAsDateTimeOffset.YearPart());
+
+			AssertCriteriaAreEqual(expected, actual);
+		}
+
+		[Test]
 		public void SelectMultipleFunction()
 		{
 			ICriteria expected =
@@ -166,6 +180,25 @@ namespace NHibernate.Test.Criteria.Lambda
 					.SelectList(list => list
 						.Select(p => p.BirthDate.YearPart())
 						.Select(() => personAlias.BirthDate.MonthPart()));
+
+			AssertCriteriaAreEqual(expected, actual);
+		}
+
+		[Test]
+		public void SelectMultipleFunctionOfDateTimeOffset()
+		{
+			ICriteria expected =
+				CreateTestCriteria(typeof(Person), "personAlias")
+					.SetProjection(Projections.ProjectionList()
+						.Add(Projections.SqlFunction("year", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")))
+						.Add(Projections.SqlFunction("month", NHibernateUtil.Int32, Projections.Property("personAlias.BirthDateAsDateTimeOffset"))));
+
+			Person personAlias = null;
+			var actual =
+				CreateTestQueryOver<Person>(() => personAlias)
+					.SelectList(list => list
+						.Select(p => p.BirthDateAsDateTimeOffset.YearPart())
+						.Select(() => personAlias.BirthDateAsDateTimeOffset.MonthPart()));
 
 			AssertCriteriaAreEqual(expected, actual);
 		}

--- a/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
@@ -645,6 +645,21 @@ namespace NHibernate.Test.Criteria.Lambda
 		}
 
 		[Test]
+		public void OrderByFunctionOfDateTimeOffset()
+		{
+			ICriteria expected =
+				CreateTestCriteria(typeof(Person), "personAlias")
+					.AddOrder(Order.Desc(Projections.SqlFunction("year", NHibernateUtil.Int32, Projections.Property("personAlias.BirthDateAsDateTimeOffset"))));
+
+			Person personAlias = null;
+			IQueryOver<Person> actual =
+				CreateTestQueryOver<Person>(() => personAlias)
+					.OrderBy(() => personAlias.BirthDateAsDateTimeOffset.YearPart()).Desc;
+
+			AssertCriteriaAreEqual(expected, actual);
+		}
+
+		[Test]
 		public void AllowSingleCallSyntax()
 		{
 			ICriteria expected = CreateTestCriteria(typeof(Person));

--- a/src/NHibernate.Test/Criteria/Lambda/RestrictionsFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/RestrictionsFixture.cs
@@ -258,6 +258,8 @@ namespace NHibernate.Test.Criteria.Lambda
 		[Test]
 		public void FunctionExtensions()
 		{
+			var date = new DateTime(1970, 1, 1);
+
 			ICriteria expected =
 				CreateTestCriteria(typeof(Person))
 					.Add(Restrictions.Eq(Projections.SqlFunction("year", NHibernateUtil.Int32, Projections.Property("BirthDate")), 1970))
@@ -266,6 +268,14 @@ namespace NHibernate.Test.Criteria.Lambda
 					.Add(Restrictions.Eq(Projections.SqlFunction("hour", NHibernateUtil.Int32, Projections.Property("BirthDate")), 1))
 					.Add(Restrictions.Eq(Projections.SqlFunction("minute", NHibernateUtil.Int32, Projections.Property("BirthDate")), 1))
 					.Add(Restrictions.Eq(Projections.SqlFunction("second", NHibernateUtil.Int32, Projections.Property("BirthDate")), 1))
+					.Add(Restrictions.Eq(Projections.SqlFunction("date", NHibernateUtil.Date, Projections.Property("BirthDate")), date))
+					.Add(Restrictions.Eq(Projections.SqlFunction("date", NHibernateUtil.Date, Projections.Property("BirthDateAsDateTimeOffset")), date))
+					.Add(Restrictions.Eq(Projections.SqlFunction("year", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")), 1970))
+					.Add(Restrictions.Eq(Projections.SqlFunction("day", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")), 1))
+					.Add(Restrictions.Eq(Projections.SqlFunction("month", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")), 1))
+					.Add(Restrictions.Eq(Projections.SqlFunction("hour", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")), 1))
+					.Add(Restrictions.Eq(Projections.SqlFunction("minute", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")), 1))
+					.Add(Restrictions.Eq(Projections.SqlFunction("second", NHibernateUtil.Int32, Projections.Property("BirthDateAsDateTimeOffset")), 1))
 					.Add(Restrictions.Eq(Projections.SqlFunction("sqrt", NHibernateUtil.Double, Projections.Property("Height")), 10d))
 					.Add(Restrictions.Eq(Projections.SqlFunction("lower", NHibernateUtil.String, Projections.Property("Name")), "test"))
 					.Add(Restrictions.Eq(Projections.SqlFunction("upper", NHibernateUtil.String, Projections.Property("Name")), "TEST"))
@@ -288,6 +298,14 @@ namespace NHibernate.Test.Criteria.Lambda
 					.And(p => p.BirthDate.HourPart() == 1)
 					.And(p => p.BirthDate.MinutePart() == 1)
 					.And(p => p.BirthDate.SecondPart() == 1)
+					.And(p => p.BirthDate.DatePart() == date)
+					.And(p => p.BirthDateAsDateTimeOffset.DatePart() == date)
+					.And(p => p.BirthDateAsDateTimeOffset.YearPart() == 1970)
+					.And(p => p.BirthDateAsDateTimeOffset.DayPart() == 1)
+					.And(p => p.BirthDateAsDateTimeOffset.MonthPart() == 1)
+					.And(p => p.BirthDateAsDateTimeOffset.HourPart() == 1)
+					.And(p => p.BirthDateAsDateTimeOffset.MinutePart() == 1)
+					.And(p => p.BirthDateAsDateTimeOffset.SecondPart() == 1)
 					.And(p => p.Height.Sqrt() == 10)
 					.And(p => p.Name.Lower() == "test")
 					.And(p => p.Name.Upper() == "TEST")

--- a/src/NHibernate/Criterion/ProjectionsExtensions.cs
+++ b/src/NHibernate/Criterion/ProjectionsExtensions.cs
@@ -111,6 +111,126 @@ namespace NHibernate.Criterion
 		}
 
 		/// <summary>
+		/// Project SQL function date()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static DateTime DatePart(this DateTime dateTimeProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessDatePart(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("date", NHibernateUtil.Date, property);
+		}
+
+		/// <summary>
+		/// Project SQL function date()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static DateTime DatePart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessDatePartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("date", NHibernateUtil.Date, property);
+		}
+
+		/// <summary>
+		/// Project SQL function year()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static int YearPart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessYearPartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("year", NHibernateUtil.Int32, property);
+		}
+
+		/// <summary>
+		/// Project SQL function day()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static int DayPart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessDayPartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("day", NHibernateUtil.Int32, property);
+		}
+
+		/// <summary>
+		/// Project SQL function month()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static int MonthPart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessMonthPartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("month", NHibernateUtil.Int32, property);
+		}
+
+		/// <summary>
+		/// Project SQL function hour()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static int HourPart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessHourPartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("hour", NHibernateUtil.Int32, property);
+		}
+
+		/// <summary>
+		/// Project SQL function minute()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static int MinutePart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessMinutePartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("minute", NHibernateUtil.Int32, property);
+		}
+
+		/// <summary>
+		/// Project SQL function second()
+		/// Note: throws an exception outside of a QueryOver expression
+		/// </summary>
+		public static int SecondPart(this DateTimeOffset dateTimeOffsetProperty)
+		{
+			throw new Exception("Not to be used directly - use inside QueryOver expression");
+		}
+
+		internal static IProjection ProcessSecondPartOfDateTimeOffset(MethodCallExpression methodCallExpression)
+		{
+			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
+			return Projections.SqlFunction("second", NHibernateUtil.Int32, property);
+		}
+
+		/// <summary>
 		/// Project SQL function sqrt()
 		/// Note: throws an exception outside of a QueryOver expression
 		/// </summary>

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -165,6 +165,14 @@ namespace NHibernate.Impl
 			RegisterCustomProjection(() => ProjectionsExtensions.HourPart(default(DateTime)), ProjectionsExtensions.ProcessHourPart);
 			RegisterCustomProjection(() => ProjectionsExtensions.MinutePart(default(DateTime)), ProjectionsExtensions.ProcessMinutePart);
 			RegisterCustomProjection(() => ProjectionsExtensions.SecondPart(default(DateTime)), ProjectionsExtensions.ProcessSecondPart);
+			RegisterCustomProjection(() => ProjectionsExtensions.DatePart(default(DateTime)), ProjectionsExtensions.ProcessDatePart);
+			RegisterCustomProjection(() => ProjectionsExtensions.DatePart(default(DateTimeOffset)), ProjectionsExtensions.ProcessDatePartOfDateTimeOffset);
+			RegisterCustomProjection(() => ProjectionsExtensions.YearPart(default(DateTimeOffset)), ProjectionsExtensions.ProcessYearPartOfDateTimeOffset);
+			RegisterCustomProjection(() => ProjectionsExtensions.DayPart(default(DateTimeOffset)), ProjectionsExtensions.ProcessDayPartOfDateTimeOffset);
+			RegisterCustomProjection(() => ProjectionsExtensions.MonthPart(default(DateTimeOffset)), ProjectionsExtensions.ProcessMonthPartOfDateTimeOffset);
+			RegisterCustomProjection(() => ProjectionsExtensions.HourPart(default(DateTimeOffset)), ProjectionsExtensions.ProcessHourPartOfDateTimeOffset);
+			RegisterCustomProjection(() => ProjectionsExtensions.MinutePart(default(DateTimeOffset)), ProjectionsExtensions.ProcessMinutePartOfDateTimeOffset);
+			RegisterCustomProjection(() => ProjectionsExtensions.SecondPart(default(DateTimeOffset)), ProjectionsExtensions.ProcessSecondPartOfDateTimeOffset);
 			RegisterCustomProjection(() => ProjectionsExtensions.Sqrt(default(int)), ProjectionsExtensions.ProcessSqrt);
 			RegisterCustomProjection(() => ProjectionsExtensions.Sqrt(default(double)), ProjectionsExtensions.ProcessSqrt);
 			RegisterCustomProjection(() => ProjectionsExtensions.Sqrt(default(decimal)), ProjectionsExtensions.ProcessSqrt);


### PR DESCRIPTION
Patch for NH-3524 (https://nhibernate.jira.com/browse/NH-3524) - QueryOver<T> doesn't support date's property functions for DateTimeOffset.
