### PR TITLE
fix NPE in Path.Combine if binPath isn't set

### DIFF
--- a/src/NHibernate/Logging.cs
+++ b/src/NHibernate/Logging.cs
@@ -85,7 +85,7 @@ namespace NHibernate
 				string baseDir = AppDomain.CurrentDomain.BaseDirectory;
 				string relativeSearchPath = AppDomain.CurrentDomain.RelativeSearchPath;
 				string binPath = relativeSearchPath == null ? baseDir : Path.Combine(baseDir, relativeSearchPath);
-				var log4NetDllPath = Path.Combine(binPath, "log4net.dll");
+				string log4NetDllPath = binPath == null ? "log4net.dll" : Path.Combine(binPath, "log4net.dll");
 
 				if (File.Exists(log4NetDllPath))
 				{


### PR DESCRIPTION
in some special environments (e.g. game engines) AppDomain BaseDirectory isn't set.
Workaround:

```
        new Configuration().SetProperty(
            "nhibernate-logger",
            typeof(Log4NetLoggerFactory).AssemblyQualifiedName
        )
```
