### PR TITLE
NH-3559 - UnionSubclassEntityPersister does not quote column names

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -1181,6 +1181,9 @@
     <Compile Include="TypesTest\XDocTypeFixture.cs" />
     <Compile Include="TypesTest\XmlDocClass.cs" />
     <Compile Include="TypesTest\XmlDocTypeFixture.cs" />
+    <Compile Include="Unionsubclass\DatabaseKeyword.cs" />
+    <Compile Include="Unionsubclass\DatabaseKeywordBase.cs" />
+    <Compile Include="Unionsubclass\DatabaseKeywordsFixture.cs" />
     <Compile Include="UtilityTest\ArrayHelperTests.cs" />
     <Compile Include="UtilityTest\IdentitySetFixture.cs" />
     <Compile Include="UtilityTest\EnumerableExtensionsTests\AnyExtensionTests.cs" />
@@ -2971,6 +2974,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Unionsubclass\DatabaseKeyword.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2692\Mappings.hbm.xml">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/src/NHibernate.Test/Unionsubclass/DatabaseKeyword.cs
+++ b/src/NHibernate.Test/Unionsubclass/DatabaseKeyword.cs
@@ -1,0 +1,34 @@
+﻿namespace NHibernate.Test.Unionsubclass
+{
+	public class DatabaseKeyword : DatabaseKeywordBase
+	{
+		private string table;
+		private string create;
+		private string view;
+		private string user;
+
+		public virtual string Table
+		{
+			get { return table; }
+			set { table = value; }
+		}
+
+		public virtual string Create
+		{
+			get { return create; }
+			set { create = value; }
+		}
+
+		public virtual string View
+		{
+			get { return view; }
+			set { view = value; }
+		}
+
+		public virtual string User
+		{
+			get { return user; }
+			set { user = value; }
+		}
+	}
+}

--- a/src/NHibernate.Test/Unionsubclass/DatabaseKeyword.hbm.xml
+++ b/src/NHibernate.Test/Unionsubclass/DatabaseKeyword.hbm.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.Unionsubclass" default-access="field">
+	<class name="DatabaseKeywordBase" abstract="true">
+
+		<id name="id" unsaved-value="0" column="id">
+			<generator class="hilo">
+				<param name="table">being_id</param>
+				<param name="column">next_id</param>
+			</generator>
+		</id>
+
+		<union-subclass name="DatabaseKeyword" table="databaseKeywords">
+			<property name="table" />
+			<property name="create" />
+			<property name="view" />
+			<property name="user" />
+		</union-subclass>
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/Unionsubclass/DatabaseKeywordBase.cs
+++ b/src/NHibernate.Test/Unionsubclass/DatabaseKeywordBase.cs
@@ -1,0 +1,13 @@
+﻿namespace NHibernate.Test.Unionsubclass
+{
+	public abstract class DatabaseKeywordBase
+	{
+		private long id;
+
+		public virtual long Id
+		{
+			get { return id; }
+			set { id = value; }
+		}
+	}
+}

--- a/src/NHibernate.Test/Unionsubclass/DatabaseKeywordsFixture.cs
+++ b/src/NHibernate.Test/Unionsubclass/DatabaseKeywordsFixture.cs
@@ -1,0 +1,47 @@
+﻿using NHibernate.Cfg;
+using NUnit.Framework;
+using System.Collections;
+
+namespace NHibernate.Test.Unionsubclass
+{
+	[TestFixture]
+	public class DatabaseKeywordsFixture : TestCase
+	{
+		protected override string MappingsAssembly
+		{
+			get { return "NHibernate.Test"; }
+		}
+
+		protected override IList Mappings
+		{
+			get { return new string[] { "Unionsubclass.DatabaseKeyword.hbm.xml" }; }
+		}
+
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+
+			configuration.SetProperty(Environment.Hbm2ddlKeyWords, "auto-quote");
+		}
+
+		[Test]
+		public void UnionSubClassQuotesReservedColumnNames()
+		{
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				s.Save(new DatabaseKeyword() { User = "user", View = "view", Table = "table", Create = "create" });
+
+				t.Commit();
+			}
+
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				s.Delete("from DatabaseKeywordBase");
+
+				t.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
@@ -1,14 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Cache;
-using NHibernate.Cfg;
 using NHibernate.Engine;
 using NHibernate.Id;
 using NHibernate.Mapping;
 using NHibernate.SqlCommand;
-using NHibernate.SqlTypes;
 using NHibernate.Util;
-using System.Linq;
 
 namespace NHibernate.Persister.Entity
 {
@@ -25,8 +23,9 @@ namespace NHibernate.Persister.Entity
 		private readonly string[] constraintOrderedTableNames;
 		private readonly string[][] constraintOrderedKeyColumnNames;
 
-		public UnionSubclassEntityPersister(PersistentClass persistentClass, ICacheConcurrencyStrategy cache, 
-			ISessionFactoryImplementor factory, IMapping mapping):base(persistentClass, cache, factory)
+		public UnionSubclassEntityPersister(PersistentClass persistentClass, ICacheConcurrencyStrategy cache,
+			ISessionFactoryImplementor factory, IMapping mapping)
+			: base(persistentClass, cache, factory)
 		{
 			if (IdentifierGenerator is IdentityGenerator)
 			{
@@ -178,7 +177,7 @@ namespace NHibernate.Persister.Entity
 
 		public override string DiscriminatorSQLValue
 		{
-			get { return discriminatorSQLValue;}
+			get { return discriminatorSQLValue; }
 		}
 
 		public override object DiscriminatorValue
@@ -332,7 +331,7 @@ namespace NHibernate.Persister.Entity
 							var sqlType = col.GetSqlTypeCode(mapping);
 							buf.Append(dialect.GetSelectClauseNullString(sqlType)).Append(" as ");
 						}
-						buf.Append(col.Name);
+						buf.Append(col.GetQuotedName(dialect));
 						buf.Append(StringHelper.CommaSpace);
 					}
 					buf.Append(clazz.SubclassId).Append(" as clazz_");


### PR DESCRIPTION
UnionSubclassEntityPersister does not quote column names when "hbm2ddl.keywords" is enabled. This for example makes NHibernate generated queries fail when quering class with reserved keyword as property name (for example 'User', 'Table', etc.)

Reported at https://nhibernate.jira.com/browse/NH-3559
