### PR TITLE
NH3392 - Unit test and fix

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3392/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3392/Fixture.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3392
+{
+    [TestFixture]
+    public class Fixture : BugTestCase
+	{
+        protected override void OnTearDown()
+        {
+            using (ISession session = OpenSession())
+            using (ITransaction transaction = session.BeginTransaction())
+            {
+                session.Delete("from Kid");
+                session.Delete("from FriendOfTheFamily");
+                session.Delete("from Dad");
+                session.Delete("from Mum");
+                session.Flush();
+                transaction.Commit();
+            }
+        }
+
+        [Test]
+        public void ExpandSubCollectionWithEmbeddedCompositeID()
+        {
+            using (ISession s = OpenSession())
+            {
+
+                var jenny = new Mum { Name = "Jenny" };
+                s.Save(jenny);
+                var benny = new Dad { Name = "Benny" };
+                s.Save(benny);
+                var lenny = new Dad { Name = "Lenny" };
+                s.Save(lenny);
+                var jimmy = new Kid { Name = "Jimmy", MumId = jenny.Id, DadId = benny.Id };
+                s.Save(jimmy);
+                var timmy = new Kid { Name = "Timmy", MumId = jenny.Id, DadId = lenny.Id };
+                s.Save(jimmy);
+                s.Flush();
+            }
+
+            using (var s = OpenSession())
+            {
+                var result=s.Query<Mum>().Select(x => new { x, x.Kids }).ToList();
+                Assert.That(result.Count, Is.EqualTo(1));
+                Assert.That(result[0].x.Kids, Is.EquivalentTo(result[0].Kids));
+            }
+        }
+
+        [Test]
+        public void ExpandSubCollectionWithCompositeID()
+        {
+            using (ISession s = OpenSession())
+            {
+
+                var jenny = new Mum { Name = "Jenny" };
+                s.Save(jenny);
+                var benny = new Dad { Name = "Benny" };
+                s.Save(benny);
+                var lenny = new Dad { Name = "Lenny" };
+                s.Save(lenny);
+                var jimmy = new FriendOfTheFamily { Name = "Jimmy", Id = new MumAndDadId { MumId = jenny.Id, DadId = benny.Id } };
+                s.Save(jimmy);
+                var timmy = new FriendOfTheFamily { Name = "Timmy", Id = new MumAndDadId { MumId = jenny.Id, DadId = lenny.Id } };
+                s.Save(jimmy);
+                s.Flush();
+            }
+
+            using (var s = OpenSession())
+            {
+                var result=s.Query<Mum>().Select(x => new { x, x.Friends }).ToList();
+                Assert.That(result.Count, Is.EqualTo(1));
+                Assert.That(result[0].x.Friends, Is.EquivalentTo(result[0].Friends));
+            }
+        }
+
+		
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3392/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3392/Mappings.hbm.xml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+           namespace="NHibernate.Test.NHSpecificTest.NH3392"
+           assembly="NHibernate.Test">
+  <class name="Dad" >
+    <id name="Id">
+      <generator class="native"/>
+    </id>
+    <property name="Name" />
+    <set cascade="save-update" name="Kids" inverse="true">
+      <key>
+        <column name="DadId" />
+      </key>
+      <one-to-many class="Kid" />
+    </set>
+    <set cascade="save-update" name="Friends" inverse="true">
+      <key>
+        <column name="DadId" />
+      </key>
+      <one-to-many class="FriendOfTheFamily" />
+    </set>
+  </class>
+
+  <class name="Mum" >
+    <id name="Id">
+      <generator class="native"/>
+    </id>
+    <property name="Name" />
+    <set cascade="save-update" name="Kids" inverse="true">
+      <key>
+        <column name="MumId" />
+      </key>
+      <one-to-many class="Kid" />
+    </set>
+    <set cascade="save-update" name="Friends" inverse="true">
+      <key>
+        <column name="MumId" />
+      </key>
+      <one-to-many class="FriendOfTheFamily" />
+    </set>
+  </class>
+
+  <class name="Kid" >
+    <composite-id>
+      <key-property name="MumId"  />
+      <key-property name="DadId" />
+    </composite-id>
+    <property name="Name" />
+  </class>
+
+  <class name="FriendOfTheFamily" >
+    <composite-id name="Id" class="MumAndDadId">
+      <key-property name="MumId"  />
+      <key-property name="DadId" />
+    </composite-id>
+    <property name="Name" />
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3392/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3392/Model.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3392
+{
+    public class Dad
+    {
+        public virtual int Id { get; set; }
+        public virtual string Name { get; set; }
+        public virtual ISet<Kid> Kids { get; set; }
+        public virtual ISet<FriendOfTheFamily> Friends { get; set; }
+    }
+    public class Mum
+    {
+        public virtual int Id { get; set; }
+        public virtual string Name { get; set; }
+        public virtual ISet<Kid> Kids { get; set; }
+        public virtual ISet<FriendOfTheFamily> Friends { get; set; }
+    }
+    public class Kid
+    {
+        public virtual int MumId { get; set; }
+        public virtual int DadId { get; set; }
+        public virtual string Name { get; set; }
+
+        public override int GetHashCode()
+        {
+            return (MumId + "|" + DadId).GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var child = obj as Kid;
+            return child != null && (MumId == child.MumId && DadId == child.DadId);
+        }
+    }
+
+    public class FriendOfTheFamily
+    {
+        public virtual MumAndDadId Id { get; set; }
+        public virtual string Name { get; set; }
+    }
+
+    public class MumAndDadId
+    {
+        public virtual int MumId { get; set; }
+        public virtual int DadId { get; set; }
+        public override int GetHashCode()
+        {
+            return (MumId + "|" + DadId).GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var child = obj as MumAndDadId;
+            return child != null && (MumId == child.MumId && DadId == child.DadId);
+        }
+    }
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -676,6 +676,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3392\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3392\Model.cs" />
     <Compile Include="NHSpecificTest\NH3459\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3459\Order.cs" />
     <Compile Include="NHSpecificTest\NH2692\Fixture.cs" />
@@ -2861,6 +2863,7 @@
     <EmbeddedResource Include="NHSpecificTest\LoadingNullEntityInSet\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
     <Service Include="{B4F97281-0DBD-4835-9ED8-7DFB966E87FF}" />
   </ItemGroup>
   <ItemGroup>
@@ -2971,6 +2974,9 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3392\Mappings.hbm.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="NHSpecificTest\NH2692\Mappings.hbm.xml">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
@@ -223,8 +223,16 @@ namespace NHibernate.Linq.NestedSelects
 			var classMetadata = sessionFactory.GetClassMetadata(expression.Type);
 			if (classMetadata == null)
 				return Expression.Constant(null);
-			
-			return ConvertToObject(Expression.PropertyOrField(expression, classMetadata.IdentifierPropertyName));
+
+            var propertyName=classMetadata.IdentifierPropertyName;
+            NHibernate.Type.EmbeddedComponentType componentType;
+            if (propertyName == null && (componentType=classMetadata.IdentifierType as NHibernate.Type.EmbeddedComponentType)!=null)
+            {
+                //The identifier is an embedded composite key. We only need one property from it for a null check
+                propertyName = componentType.PropertyNames.First();
+            }
+
+            return ConvertToObject(Expression.PropertyOrField(expression, propertyName));
 		}
 
 		private static LambdaExpression CreateSelector(IEnumerable<ExpressionHolder> expressions, int tuple)


### PR DESCRIPTION
https://nhibernate.jira.com/browse/NH-3392

"Add ability to expand subcollections with composites ids with WCF Data Services"

Actually a bug where collections of types with embedded composite ids could not be projected.
