### PR TITLE
NH-3578 - Subcriteria.UniqueResult<T> for value types should return default(T), same as CriteriaImpl.UniqueResult<T> when result is null

### DIFF
--- a/src/NHibernate.Test/Criteria/ProjectionsTest.cs
+++ b/src/NHibernate.Test/Criteria/ProjectionsTest.cs
@@ -71,7 +71,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UsingSqlFunctions_Concat_WithCast()
 		{
-			if(Dialect is Oracle8iDialect)
+			if (Dialect is Oracle8iDialect)
 			{
 				Assert.Ignore("Not supported by the active dialect:{0}.", Dialect);
 			}
@@ -347,6 +347,29 @@ namespace NHibernate.Test.Criteria
 			}
 		}
 
+		[Test]
+		public void UseSumWithNullResultWithProjection()
+		{
+			using (ISession session = sessions.OpenSession())
+			{
+				long sum = session.CreateCriteria(typeof(Reptile))
+					.SetProjection(Projections.Sum(Projections.Id()))
+					.UniqueResult<long>();
+				Assert.AreEqual(0, sum);
+			}
+		}
 
+		[Test]
+		public void UseSubquerySumWithNullResultWithProjection()
+		{
+			using (ISession session = sessions.OpenSession())
+			{
+				int sum = session.CreateCriteria(typeof(Enrolment))
+					.CreateCriteria("Student", "s")
+					.SetProjection(Projections.Sum(Projections.SqlFunction("length", NHibernateUtil.Int32, Projections.Property("s.Name"))))
+					.UniqueResult<int>();
+				Assert.AreEqual(0, sum);
+			}
+		}
 	}
 }

--- a/src/NHibernate/Impl/CriteriaImpl.cs
+++ b/src/NHibernate/Impl/CriteriaImpl.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Impl
 		}
 
 		public CriteriaImpl(string entityOrClassName, ISessionImplementor session)
-			: this(entityOrClassName, CriteriaSpecification.RootAlias, session) {}
+			: this(entityOrClassName, CriteriaSpecification.RootAlias, session) { }
 
 		public CriteriaImpl(string entityOrClassName, string alias, ISessionImplementor session)
 		{
@@ -123,13 +123,13 @@ namespace NHibernate.Impl
 		{
 			get { return projection; }
 		}
-		
+
 		/// <inheritdoc />
 		public bool IsReadOnlyInitialized
 		{
 			get { return (readOnly != null); }
 		}
-		
+
 		/// <inheritdoc />
 		public bool IsReadOnly
 		{
@@ -280,13 +280,13 @@ namespace NHibernate.Impl
 		public T UniqueResult<T>()
 		{
 			object result = UniqueResult();
-			if (result == null && typeof (T).IsValueType)
+			if (result == null && typeof(T).IsValueType)
 			{
 				return default(T);
 			}
 			else
 			{
-				return (T) result;
+				return (T)result;
 			}
 		}
 
@@ -471,12 +471,12 @@ namespace NHibernate.Impl
 
 		public ICriteria SetProjection(params IProjection[] projections)
 		{
-			if(projections==null)
+			if (projections == null)
 				throw new ArgumentNullException("projections");
-			if(projections.Length ==0)
+			if (projections.Length == 0)
 				throw new ArgumentException("projections must contain a least one projection");
 
-			if(projections.Length==1)
+			if (projections.Length == 1)
 			{
 				projection = projections[0];
 			}
@@ -566,7 +566,7 @@ namespace NHibernate.Impl
 				}
 				else
 				{
-					ICriteria clonedProjectionCriteria = (ICriteria) projectionCriteria.Clone();
+					ICriteria clonedProjectionCriteria = (ICriteria)projectionCriteria.Clone();
 					clone.projectionCriteria = clonedProjectionCriteria;
 				}
 			}
@@ -662,7 +662,7 @@ namespace NHibernate.Impl
 			}
 
 			internal Subcriteria(CriteriaImpl root, ICriteria parent, string path, string alias, JoinType joinType)
-				: this(root, parent, path, alias, joinType, null) {}
+				: this(root, parent, path, alias, joinType, null) { }
 
 			internal Subcriteria(CriteriaImpl root, ICriteria parent, string path, JoinType joinType)
 				: this(root, parent, path, null, joinType) { }
@@ -702,12 +702,12 @@ namespace NHibernate.Impl
 			{
 				get { return root.IsReadOnlyInitialized; }
 			}
-			
+
 			public bool IsReadOnly
 			{
 				get { return root.IsReadOnly; }
 			}
-				
+
 			public ICriteria SetLockMode(LockMode lockMode)
 			{
 				this.lockMode = lockMode;
@@ -808,14 +808,13 @@ namespace NHibernate.Impl
 			public T UniqueResult<T>()
 			{
 				object result = UniqueResult();
-				if (result == null && typeof (T).IsValueType)
+				if (result == null && typeof(T).IsValueType)
 				{
-					throw new InvalidCastException(
-						"UniqueResult<T>() cannot cast null result to value type. Call UniqueResult<T?>() instead");
+					return default(T);
 				}
 				else
 				{
-					return (T) result;
+					return (T)result;
 				}
 			}
 
@@ -897,13 +896,13 @@ namespace NHibernate.Impl
 				root.SetProjection(projections);
 				return this;
 			}
-			
+
 			public ICriteria SetReadOnly(bool readOnly)
 			{
 				root.SetReadOnly(readOnly);
 				return this;
 			}
-			
+
 			public ICriteria GetCriteriaByPath(string path)
 			{
 				return root.GetCriteriaByPath(path);


### PR DESCRIPTION
Subcriteria.UniqueResult<T> for value types should return default(T), same as CriteriaImpl.UniqueResult<T> when result is null
