### PR TITLE
Throw exception when driver assembly could not be found

### DIFF
--- a/src/NHibernate/Driver/OracleManagedDataClientDriver.cs
+++ b/src/NHibernate/Driver/OracleManagedDataClientDriver.cs
@@ -35,13 +35,13 @@ namespace NHibernate.Driver
 				connectionTypeName,
 				commandTypeName)
 		{
-			var oracleCommandType = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleCommand", driverAssemblyName, false);
+			var oracleCommandType = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleCommand", driverAssemblyName, true);
 			oracleCommandBindByName = oracleCommandType.GetProperty("BindByName");
 
-			var parameterType = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleParameter", driverAssemblyName, false);
+			var parameterType = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleParameter", driverAssemblyName, true);
 			oracleDbType = parameterType.GetProperty("OracleDbType");
 
-			var oracleDbTypeEnum = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleDbType", driverAssemblyName, false);
+			var oracleDbTypeEnum = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleDbType", driverAssemblyName, true);
 			oracleDbTypeRefCursor = Enum.Parse(oracleDbTypeEnum, "RefCursor");
 			oracleDbTypeXmlType = Enum.Parse(oracleDbTypeEnum, "XmlType");
 		}


### PR DESCRIPTION
When the managed oracle driver is not found, a nullreference exception is thrown. This is solved by letting the reflectionhelper throw an exception when the assemble is not found.
