### PR TITLE
NH-2958 follow up - There is no need to cache XmlSerializer instance

### DIFF
--- a/src/NHibernate/Cfg/NamedXmlDocument.cs
+++ b/src/NHibernate/Cfg/NamedXmlDocument.cs
@@ -8,18 +8,10 @@ namespace NHibernate.Cfg
 {
 	public class NamedXmlDocument
 	{
-		private static readonly XmlSerializer mappingDocumentSerializer = new XmlSerializer(typeof (HbmMapping));
 		private readonly string name;
 		private readonly HbmMapping document;
 
-		static NamedXmlDocument() { }
-
 		public NamedXmlDocument(string name, XmlDocument document)
-			: this(name, document, mappingDocumentSerializer)
-		{
-		}
-
-		public NamedXmlDocument(string name, XmlDocument document, XmlSerializer serializer)
 		{
 			if (document == null)
 			{
@@ -32,7 +24,7 @@ namespace NHibernate.Cfg
 			}
 			using (var reader = new StringReader(document.DocumentElement.OuterXml))
 			{
-				this.document = (HbmMapping)serializer.Deserialize(reader);
+				this.document = (HbmMapping)new XmlSerializer(typeof (HbmMapping)).Deserialize(reader);
 			}
 		}
 


### PR DESCRIPTION
There is no need to cache XmlSerializer instance, as it's creation is slow only on first creation

On first creation of XmlSerializer object, the serialization assembly is created on the fly, so it is slow, but subsequent creations are fast. Follow up to discussion with all the details in pull request https://github.com/nhibernate/nhibernate-core/pull/250