### PR TITLE
NH-3680 - Fixed performance issues with SortInsertActions for large batches.

### DIFF
--- a/src/NHibernate/Engine/ActionQueue.cs
+++ b/src/NHibernate/Engine/ActionQueue.cs
@@ -356,15 +356,15 @@ namespace NHibernate.Engine
 					// associated with the action...)
 					int lastPos = nameList.LastIndexOf(thisEntityName);
 					object[] states = action.State;
-					for (int i = 0; i < states.Length; i++)
+					for (int j = lastPos + 1; j < nameList.Count; j++)
 					{
-						for (int j = 0; j < nameList.Count; j++)
+						List<EntityInsertAction> tmpList = positionToAction[j];
+						for (int k = 0; k < tmpList.Count; k++)
 						{
-							List<EntityInsertAction> tmpList = positionToAction[j];
-							for (int k = 0; k < tmpList.Count; k++)
+							EntityInsertAction checkAction = tmpList[k];
+							for (int i = 0; i < states.Length; i++)
 							{
-								EntityInsertAction checkAction = tmpList[k];
-								if (checkAction.Instance == states[i] && j > lastPos)
+								if (checkAction.Instance == states[i])
 								{
 									// 'checkAction' is inserting an entity upon which 'action' depends...
 									// note: this is an assumption and may not be correct in the case of one-to-one


### PR DESCRIPTION
The way this function was written, a huge number of senseless iterations and comparisons were performed before simply being negated by the && j > lastPos check. By making the loop over the nameList the outermost loop and start at lastPos + 1, CPU usage on large insert batches is significantly reduced and there should be no functional change. 
