### PR TITLE
add unit test and fix for NH-3614

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3614/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3614/Entity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3614
+{
+	public class Entity
+	{
+		public virtual int Id { get; protected set; }
+		public virtual IList<string> SomeStrings { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3614/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3614/Fixture.cs
@@ -1,0 +1,51 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.Linq;
+
+namespace NHibernate.Test.NHSpecificTest.NH3614
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		[Test]
+		public void CanProjectListOfStrings()
+		{
+			int id;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var testEntity = new Entity
+				{
+					SomeStrings = new List<string> { "Hello", "World" }
+				};
+				s.Save(testEntity);
+
+				tx.Commit();
+
+				id = testEntity.Id;
+			}
+
+			using (var s = OpenSession())
+			{
+				var result = s.Query<Entity>()
+					.Where(x => x.Id == id)
+					.Select(x => x.SomeStrings)
+					.ToList();
+
+				Assert.AreEqual(1, result.Count);
+
+				Assert.AreEqual(2, result.Single().Count);
+			}
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Delete("from Entity");
+				tx.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3614/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3614/Mappings.hbm.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+	assembly="NHibernate.Test"
+	namespace="NHibernate.Test.NHSpecificTest.NH3614">
+
+<class name="Entity">
+	<id name="Id">
+		<generator class="native" />
+	</id>
+
+	<bag name="SomeStrings" table="SomeStrings" cascade="all-delete-orphan" >
+		<key>
+			<column name="ParentId" />
+		</key>
+		<element type="System.String, mscorlib">
+			<column name="StringValue" />
+		</element>
+	</bag>
+</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -670,6 +670,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Domain.cs" />
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3614\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3614\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3505\Student.cs" />
     <Compile Include="NHSpecificTest\NH3505\Teacher.cs" />
     <Compile Include="NHSpecificTest\NH3505\Fixture.cs" />
@@ -2901,6 +2903,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3614\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3505\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3428\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3408\Mappings.hbm.xml" />

--- a/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
@@ -217,6 +217,9 @@ namespace NHibernate.Linq.NestedSelects
 
 		private static Expression GetIdentifier(ISessionFactory sessionFactory, Expression expression)
 		{
+			if (expression.Type.IsPrimitive || expression.Type == typeof(string))
+				return expression;
+
 			var classMetadata = sessionFactory.GetClassMetadata(expression.Type);
 			if (classMetadata == null)
 				return Expression.Constant(null);


### PR DESCRIPTION
when getting the identifier in the selectrewiter it was returning a null constant when there was no class metadata, as it the case for type string
