### PR TITLE
New test method named AggregateDistinctCount() and AggregateNoDistinctCount().

### DIFF
--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -92,6 +92,46 @@ namespace NHibernate.Test.Hql
 			}
 		}
 
+        [Test]
+        public void AggregateDistinctCount()
+        {
+            using (ISession s = OpenSession())
+            {
+                Animal a1 = new Animal("a1", 20);
+                Animal a2 = new Animal("a2", 10);
+                s.Save(a1);
+                s.Save(a2);
+                s.Flush();
+            }
+            using (ISession s = OpenSession())
+            {
+                // Count in select
+                object result = s.CreateQuery("select count(distinct concat(a.Description,'number')) from Animal a").UniqueResult();
+                Assert.AreEqual(typeof(long), result.GetType());
+                Assert.AreEqual(2, result);
+            }
+        }
+
+        [Test]
+        public void AggregateNoDistinctCount()
+        {
+            using (ISession s = OpenSession())
+            {
+                Animal a1 = new Animal("a1", 20);
+                Animal a2 = new Animal("a2", 10);
+                s.Save(a1);
+                s.Save(a2);
+                s.Flush();
+            }
+            using (ISession s = OpenSession())
+            {
+                // Count in select
+                object result = s.CreateQuery("select count(concat(a.Description,'number')) from Animal a").UniqueResult();
+                Assert.AreEqual(typeof(long), result.GetType());
+                Assert.AreEqual(2, result);
+            }
+        }
+
 		[Test]
 		public void AggregateAvg()
 		{


### PR DESCRIPTION
Hi,
the problem is when I try to use a scalar function into count function, and the strange case is when I use my own custom count function (example counter, with the same implementation of count), this one (my count function) works, but when I try to introduce a distinct keyword, this throws an exception on HqlParser.cs file 
(method HqlParser.selectFrom_return selectFrom()).

Please, executes my methods in order to understand the problem.

Thanks a lot.

Manuel
