### PR TITLE
NH-3529 add linqtohql.generatorsregistry to property enum

### DIFF
--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -115,6 +115,7 @@
 								<xs:enumeration value="collectiontype.factory_class" />
 								<xs:enumeration value="interceptors.beforetransactioncompletion_ignore_exceptions" />
                 <xs:enumeration value="order_inserts" />
+                <xs:enumeration value="linqtohql.generatorsregistry" />
               </xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>


### PR DESCRIPTION
Minor: add "linqtohql.generatorsregistry" to the nhibernate-configuration.xsd so it can be configured via xml.

Fixes: https://nhibernate.jira.com/browse/NH-3529
