### PR TITLE
Fixed PropertyExpression.ToString when RHS is a projection

### DIFF
--- a/src/NHibernate/Criterion/PropertyExpression.cs
+++ b/src/NHibernate/Criterion/PropertyExpression.cs
@@ -124,7 +124,7 @@ namespace NHibernate.Criterion
 		/// <summary></summary>
 		public override string ToString()
 		{
-			return (_lhsProjection ?? (object)_lhsPropertyName) + Op + _rhsPropertyName;
+			return (_lhsProjection ?? (object)_lhsPropertyName) + Op + (_rhsProjection ?? (object)_rhsPropertyName);
 		}
 
 		public override IProjection[] GetProjections()


### PR DESCRIPTION
Code to reproduce:

```
Restrictions.EqProperty("A", Projections.Property("B")).ToString()
```

Expected output:

```
"A = B"
```

Actual output:

```
"A = "
```
