### PR TITLE
Fixed both dynamic-update cases for NH-3512

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3512/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3512/Entity.cs
@@ -1,0 +1,15 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3512
+{
+	class Person
+	{
+		public virtual int Id { get; protected set; }
+		public virtual byte[] Version { get; set; }
+		public virtual string Name { get; set; }
+		public virtual int Age { get; set; }
+	}
+
+	class Employee : Person
+	{
+		public virtual int Salary { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3512/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3512/Fixture.cs
@@ -1,0 +1,111 @@
+﻿using NHibernate.Cfg;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3512
+{
+
+
+	public class Fixture : BugTestCase
+	{
+		private int _id;
+
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var employee = new Employee {Name = "Bob", Age = 33, Salary = 100};
+				session.Save(employee);
+
+				transaction.Commit();
+
+				_id = employee.Id;
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				transaction.Commit();
+			}
+		}
+
+		protected void UpdateBaseEntity()
+		{
+			using (ISession session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var person = session.Get<Person>(_id);
+
+				var before = person.Version;
+
+				person.Age++;
+
+				transaction.Commit();
+
+				CollectionAssert.AreNotEqual(before, person.Version);
+			}
+		}
+
+		protected void UpdateDerivedEntity()
+		{
+			using (ISession session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var employee = session.Get<Employee>(_id);
+
+				var before = employee.Version;
+
+				employee.Salary += 10;
+
+				transaction.Commit();
+
+				CollectionAssert.AreNotEqual(before, employee.Version);
+			}
+		}
+	}
+
+	[TestFixture]
+	public class DynamicUpdateOn : Fixture
+	{
+		protected override void Configure(Configuration configuration)
+		{
+			foreach (var mapping in configuration.ClassMappings)
+			{
+				mapping.DynamicUpdate = true;
+			}
+		}
+
+		[Test]
+		public void ShouldChangeVersionWhenBasePropertyChanged()
+		{
+			UpdateBaseEntity();
+		}
+
+		[Test]
+		public void ShouldChangeVersionWhenDerivedPropertyChanged()
+		{
+			UpdateDerivedEntity();
+		}
+	}
+
+	[TestFixture]
+	public class DynamicUpdateOff : Fixture
+	{
+		[Test]
+		public void ShouldChangeVersionWhenBasePropertyChanged()
+		{
+			UpdateBaseEntity();
+		}
+
+		[Test]
+		public void ShouldChangeVersionWhenDerivedPropertyChanged()
+		{
+			UpdateDerivedEntity();
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3512/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3512/Mappings.hbm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3512">
+
+	<class name="Person">
+		<id name="Id" generator="identity" />
+		<version name="Version" generated="always" unsaved-value="null" type="BinaryBlob">
+			<column name="Version" not-null="false" sql-type="timestamp"/>
+		</version>
+		<property name="Name" />
+		<property name="Age" />
+
+		<joined-subclass name="Employee">
+			<key column="Id" />
+			<property name="Salary" />
+		</joined-subclass>
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -719,6 +719,8 @@
     <Compile Include="NHSpecificTest\NH1082\SessionInterceptorThatThrowsExceptionAtBeforeTransactionCompletion.cs" />
     <Compile Include="NHSpecificTest\NH3571\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3571\Product.cs" />
+    <Compile Include="NHSpecificTest\NH3512\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3512\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3459\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3459\Order.cs" />
     <Compile Include="NHSpecificTest\NH2692\Fixture.cs" />
@@ -3080,6 +3082,7 @@
     <EmbeddedResource Include="Unionsubclass\DatabaseKeyword.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH1082\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3571\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\NH3512\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3487\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2692\Mappings.hbm.xml">
       <SubType>Designer</SubType>

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1106,7 +1106,7 @@ namespace NHibernate.Persister.Entity
 		/// The return here is an array of boolean values with each index corresponding
 		/// to a given table in the scope of this persister.
 		/// </remarks>
-		private bool[] GetTableUpdateNeeded(int[] dirtyProperties, bool hasDirtyCollection)
+		protected virtual bool[] GetTableUpdateNeeded(int[] dirtyProperties, bool hasDirtyCollection)
 		{
 			if (dirtyProperties == null)
 			{
@@ -3585,7 +3585,7 @@ namespace NHibernate.Persister.Entity
 		/// <summary> 
 		/// Transform the array of property indexes to an array of booleans, true when the property is dirty
 		/// </summary>
-		protected bool[] GetPropertiesToUpdate(int[] dirtyProperties, bool hasDirtyCollection)
+		protected virtual bool[] GetPropertiesToUpdate(int[] dirtyProperties, bool hasDirtyCollection)
 		{
 			bool[] propsToUpdate = new bool[entityMetamodel.PropertySpan];
 			bool[] updateability = PropertyUpdateability; //no need to check laziness, dirty checking handles that

--- a/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
@@ -590,5 +590,54 @@ namespace NHibernate.Persister.Entity
 			}
 			return base.GetSubclassPropertyDeclarer(propertyPath);
 		}
+
+		protected override bool[] GetTableUpdateNeeded(int[] dirtyProperties, bool hasDirtyCollection)
+		{
+			bool[] tableUpdateNeeded = base.GetTableUpdateNeeded(dirtyProperties, hasDirtyCollection);
+
+			if (IsVersioned && IsVersionPropertyGenerated)
+			{
+				// NH-3512: if this is table-per-subclass inheritance and version property is generated,
+				// then it should be updated even if no other base class properties changed
+
+				tableUpdateNeeded[0] = true;
+			}
+
+			return tableUpdateNeeded;
+		}
+
+		protected override bool[] GetPropertiesToUpdate(int[] dirtyProperties, bool hasDirtyCollection)
+		{
+			bool[] propsToUpdate = base.GetPropertiesToUpdate(dirtyProperties, hasDirtyCollection);
+
+			if (IsVersioned && IsVersionPropertyGenerated)
+			{
+				// NH-3512
+				// find first updatable property in base class to include it in
+				bool found = false;
+
+				for (int i = 0; i < propsToUpdate.Length; ++i)
+				{
+					if (i == VersionProperty || !IsPropertyOfTable(i, 0))
+					{
+						continue;
+					}
+
+					if (PropertyUpdateability[i])
+					{
+						propsToUpdate[i] = true;
+						found = true;
+						break;
+					}
+				}
+
+				if (!found)
+				{
+					// TODO: we failed to find suitable property, so version won't be updated and optimistic concurrency check won't work
+				}
+			}
+
+			return propsToUpdate;
+		}
 	}
 }


### PR DESCRIPTION
This is rebased and squashed copy of #220.
There is still issue is narrow base class (for example with Id only) when we can simulate fake base class property update to force version increment...