### PR TITLE
NH-3527 - UnionSubclassMapper should mark an abstract type as abstract in the generated HbmMapping

### DIFF
--- a/src/NHibernate.Test/MappingByCode/MappersTests/UnionSubclassMapperTests/AbstractAttributeTests.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/UnionSubclassMapperTests/AbstractAttributeTests.cs
@@ -1,0 +1,42 @@
+﻿using NHibernate.Cfg.MappingSchema;
+using NHibernate.Mapping.ByCode.Impl;
+using NUnit.Framework;
+
+namespace NHibernate.Test.MappingByCode.MappersTests.UnionSubclassMapperTests
+{
+	[TestFixture]
+	public class AbstractAttributeTests
+	{
+		private abstract class EntityBase
+		{
+		}
+
+		private abstract class Item : EntityBase
+		{
+		}
+
+		private class InventoryItem : Item
+		{
+		}
+
+		[Test]
+		public void CanSetAbstractAttributeOnAbstractClass()
+		{
+			var mapping = new HbmMapping();
+			var mapper = new UnionSubclassMapper(typeof(Item), mapping);
+
+			Assert.That(mapping.UnionSubclasses[0].abstractSpecified, Is.True);
+			Assert.That(mapping.UnionSubclasses[0].@abstract, Is.True);
+		}
+
+		[Test]
+		public void CanSetAbstractAttributeOnConcreteClass()
+		{
+			var mapping = new HbmMapping();
+			var mapper = new UnionSubclassMapper(typeof(InventoryItem), mapping);
+
+			Assert.That(mapping.UnionSubclasses[0].abstractSpecified, Is.False);
+			Assert.That(mapping.UnionSubclasses[0].@abstract, Is.False);
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -676,6 +676,7 @@
     <Compile Include="MappingByCode\MappersTests\SubclassMapperTests\SetPersisterTests.cs" />
     <Compile Include="MappingByCode\MappersTests\SubclassMapperTests\TablesSincronizationTests.cs" />
     <Compile Include="MappingByCode\MappersTests\SubclassMapperWithJoinPropertiesTest.cs" />
+    <Compile Include="MappingByCode\MappersTests\UnionSubclassMapperTests\AbstractAttributeTests.cs" />
     <Compile Include="MappingByCode\MappersTests\UnionSubclassMapperTests\SetPersisterTests.cs" />
     <Compile Include="MappingByCode\MappersTests\UnionSubclassMapperTests\TablesSincronizationTests.cs" />
     <Compile Include="MappingByCode\MixAutomapping\ArrayCollectionTests.cs" />

--- a/src/NHibernate/Mapping/ByCode/Impl/UnionSubclassMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/UnionSubclassMapper.cs
@@ -17,6 +17,11 @@ namespace NHibernate.Mapping.ByCode.Impl
 			var toAdd = new[] {classMapping};
 			classMapping.name = subClass.GetShortClassName(mapDoc);
 			classMapping.extends = subClass.BaseType.GetShortClassName(mapDoc);
+			if (subClass.IsAbstract)
+			{
+				classMapping.@abstract = true;
+				classMapping.abstractSpecified = true;
+			}
 			mapDoc.Items = mapDoc.Items == null ? toAdd : mapDoc.Items.Concat(toAdd).ToArray();
 		}
 
@@ -170,7 +175,7 @@ namespace NHibernate.Mapping.ByCode.Impl
 			if (!Container.GetBaseTypes().Contains(baseType))
 			{
 				throw new ArgumentOutOfRangeException("baseType",
-				                                      string.Format("{0} is a valid super-class of {1}", baseType, Container));
+													  string.Format("{0} is a valid super-class of {1}", baseType, Container));
 			}
 			classMapping.extends = baseType.GetShortClassName(MapDoc);
 		}


### PR DESCRIPTION
Replacing PR for #223 