### PR TITLE
NH-3739 - Fix usage of SqlString.Append method

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
@@ -85,7 +85,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 				}
 				if (whereJoinFragment.Length > 0)
 				{
-					whereJoinFragment.Append(" and ");
+					whereJoinFragment = whereJoinFragment.Append(" and ");
 				}
 			}
 


### PR DESCRIPTION
I develop NHibernate Driver for DBMS Linter SQL and found a problem in 88 line of AbstractStatementExecutor.cs. The problem is in this code:
whereJoinFragment.Append(" and ");
it should be:
whereJoinFragment = whereJoinFragment.Append(" and ");

Because of this bug I have problems in 6 tests. For example, NHibernate.Test.Hql.Ast.BulkManipulation.DeleteOnJoinedSubclass. In this test I have the following query with error:
insert into $$$TMP_Mammal SELECT mammal0_.animal as animal FROM Mammal
mammal0_, Animal mammal0_1_ WHERE
mammal0_.animal=mammal0_1_.idbody_weight>150