### PR TITLE
NH-2504 - Can't use Cacheable with Group By

### DIFF
--- a/src/NHibernate.Test/Linq/QueryCacheableTests.cs
+++ b/src/NHibernate.Test/Linq/QueryCacheableTests.cs
@@ -114,5 +114,36 @@ namespace NHibernate.Test.Linq
             Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(2));
             Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
         }
+
+		  [Test]
+		  public void GroupByQueryIsCacheable()
+		  {
+			  Sfi.Statistics.Clear();
+			  Sfi.QueryCache.Clear();
+
+			  var c = db
+				  .Customers
+				  .GroupBy(x => x.Address.Country)
+				  .Select(x => x.Key)
+				  .Cacheable()
+				  .ToList();
+
+			  c = db
+				 .Customers
+				 .GroupBy(x => x.Address.Country)
+				 .Select(x => x.Key)
+				 .ToList();
+
+			  c = db
+				 .Customers
+				 .GroupBy(x => x.Address.Country)
+				 .Select(x => x.Key)
+				 .Cacheable()
+				 .ToList();
+
+			  Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(2));
+			  Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(1));
+			  Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+		  }
     }
 }

--- a/src/NHibernate/Linq/GroupBy/AggregatingGroupByRewriter.cs
+++ b/src/NHibernate/Linq/GroupBy/AggregatingGroupByRewriter.cs
@@ -38,6 +38,7 @@ namespace NHibernate.Linq.GroupBy
 				typeof (AnyResultOperator),
 				typeof (AllResultOperator),
 				typeof (TimeoutResultOperator),
+				typeof (CacheableResultOperator)
 			};
 
 		public static void ReWrite(QueryModel queryModel)


### PR DESCRIPTION
This fixes the second case mentioned in the JIRA issue (and the one I needed to fix). Applying Cacheble earlier in the query still throws an exception. That is of course fixable, but IMHO I think the problems are caused by treating Cacheable as ResultOperator. Both Cacheable and Timeout are environmental query settings, and letting them pollute and complicate the expression tree and the handling of this tree is really unnecessary. I think we could reduce complexity and solve a couple of outstanding issues by investingating and removing MethodCallExpressions to Cacheable and Timeout, before all the other tree parsing commences.