### PR TITLE
Fixed a misspelled word

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableDeleteExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableDeleteExecutor.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			log.Debug("Generated ID-INSERT-SELECT SQL (multi-table delete) : " + idInsertSelect);
 
 			string[] tableNames = persister.ConstraintOrderedTableNameClosure;
-			string[][] columnNames = persister.ContraintOrderedTableKeyColumnClosure;
+			string[][] columnNames = persister.ConstraintOrderedTableKeyColumnClosure;
 			string idSubselect = GenerateIdSubselect(persister);
 
 			deletes = new SqlString[tableNames.Length];

--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableUpdateExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/MultiTableUpdateExecutor.cs
@@ -40,7 +40,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			log.Debug("Generated ID-INSERT-SELECT SQL (multi-table update) : " + idInsertSelect);
 
 			string[] tableNames = persister.ConstraintOrderedTableNameClosure;
-			string[][] columnNames = persister.ContraintOrderedTableKeyColumnClosure;
+			string[][] columnNames = persister.ConstraintOrderedTableKeyColumnClosure;
 
 			string idSubselect = GenerateIdSubselect(persister);
 			IList<AssignmentSpecification> assignmentSpecifications = Walker.AssignmentSpecifications;

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -998,7 +998,7 @@ namespace NHibernate.Persister.Entity
 			get { return entityMetamodel.NaturalIdentifierProperties; }
 		}
 
-		public abstract string[][] ContraintOrderedTableKeyColumnClosure { get;}
+		public abstract string[][] ConstraintOrderedTableKeyColumnClosure { get;}
 		public abstract IType DiscriminatorType { get;}
 		public abstract string[] ConstraintOrderedTableNameClosure { get;}
 		public abstract string DiscriminatorSQLValue { get;}

--- a/src/NHibernate/Persister/Entity/IQueryable.cs
+++ b/src/NHibernate/Persister/Entity/IQueryable.cs
@@ -59,7 +59,7 @@ namespace NHibernate.Persister.Entity
 		/// The second dimension should have the same length across all the elements in
 		/// the first dimension.  If not, that'd be a problem ;) 
 		/// </returns>
-		string[][] ContraintOrderedTableKeyColumnClosure { get;}
+		string[][] ConstraintOrderedTableKeyColumnClosure { get;}
 
 		/// <summary> 
 		/// Get the name of the temporary table to be used to (potentially) store id values

--- a/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
@@ -389,7 +389,7 @@ namespace NHibernate.Persister.Entity
 			get { return constraintOrderedTableNames; }
 		}
 
-		public override string[][] ContraintOrderedTableKeyColumnClosure
+		public override string[][] ConstraintOrderedTableKeyColumnClosure
 		{
 			get { return constraintOrderedKeyColumnNames; }
 		}

--- a/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
@@ -422,7 +422,7 @@ namespace NHibernate.Persister.Entity
 			get { return constraintOrderedTableNames; }
 		}
 
-		public override string[][] ContraintOrderedTableKeyColumnClosure
+		public override string[][] ConstraintOrderedTableKeyColumnClosure
 		{
 			get { return constraintOrderedKeyColumnNames; }
 		}

--- a/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
@@ -230,7 +230,7 @@ namespace NHibernate.Persister.Entity
 			get { return constraintOrderedTableNames; }
 		}
 
-		public override string[][] ContraintOrderedTableKeyColumnClosure
+		public override string[][] ConstraintOrderedTableKeyColumnClosure
 		{
 			get { return constraintOrderedKeyColumnNames; }
 		}


### PR DESCRIPTION
I found a misspelled word (ContraintOrderedTableKeyColumnClosure) when I was inspecting an object and I wanted to correct it.

Thanks,
Michael
