### PR TITLE
Bug fix for NH-3634

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3634/CachedPerson.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/CachedPerson.cs
@@ -1,0 +1,9 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3634
+{
+	class CachedPerson
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Connection Connection { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/CachedPersonMapper.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/CachedPersonMapper.cs
@@ -1,0 +1,26 @@
+﻿using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+
+namespace NHibernate.Test.NHSpecificTest.NH3634
+{
+	class CachedPersonMapper : ClassMapping<CachedPerson>
+	{
+		public CachedPersonMapper()
+		{
+			Id(p => p.Id, m => m.Generator(Generators.Identity));
+			Lazy(false);
+			Cache(m => m.Usage(CacheUsage.ReadWrite));
+			Table("cachedpeople");
+			Property(p => p.Name);
+			Component(
+				p => p.Connection,
+				m =>
+				{
+					m.Class<Connection>();
+					m.Property(c => c.ConnectionType, mapper => mapper.NotNullable(true)); 
+					m.Property(c => c.Address, mapper => mapper.NotNullable(false));
+					m.Property(c => c.PortName, mapper => mapper.NotNullable(false));
+				});
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/Connection.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/Connection.cs
@@ -1,0 +1,9 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3634
+{
+	class Connection
+	{
+		public virtual string ConnectionType { get; set; }
+		public virtual string Address { get; set; }
+		public virtual string PortName { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/FixtureByCode.cs
@@ -1,0 +1,345 @@
+﻿using NHibernate.Cfg.MappingSchema;
+using NHibernate.Criterion;
+using NHibernate.Mapping.ByCode;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3634
+{
+	public class ByCodeFixture : TestCaseMappingByCode
+	{
+		protected override HbmMapping GetMappings()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping<PersonMapper>();
+			mapper.AddMapping<CachedPersonMapper>();
+
+			return mapper.CompileMappingForAllExplicitlyAddedEntities();
+		}
+
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var bobsConnection = new Connection
+					{
+						Address = "test.com",
+						ConnectionType = "http",
+						PortName = "80"
+					};
+				var e1 = new Person
+					{
+						Name = "Bob", 
+						Connection = bobsConnection
+					};
+				session.Save(e1);
+
+				var sallysConnection = new Connection
+					{
+						Address = "test.com",
+						ConnectionType = "http",
+					};
+				var e2 = new Person
+					{
+						Name = "Sally", 
+						Connection = sallysConnection
+					};
+				session.Save(e2);
+
+				var cachedNullConnection = new Connection
+				{
+					Address = "test.com",
+					ConnectionType = "http",
+				};
+				var cachedNullConnectionPerson = new CachedPerson
+				{
+					Name = "CachedNull",
+					Connection = cachedNullConnection
+				};
+				var cachedNotNullConnection = new Connection
+				{
+					Address = "test.com",
+					ConnectionType = "http",
+					PortName = "port"
+				};
+				var cachedNotNullConnectionPerson = new CachedPerson
+				{
+					Name = "CachedNotNull",
+					Connection = cachedNotNullConnection
+				};
+				session.Save(cachedNullConnectionPerson);
+				session.Save(cachedNotNullConnectionPerson);
+
+				session.Flush();
+				transaction.Commit();
+				session.Evict(typeof(CachedPerson));
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void QueryOverComponentWithANullProperty()
+		{
+//			Broken at the time NH3634 was reported
+//			Generates the following Rpc(exec sp_executesql)
+//			SELECT this_.Id as Id0_0_, 
+//				   this_.Name as Name0_0_, 
+//				   this_.ConnectionType as Connecti3_0_0_, 
+//				   this_.Address as Address0_0_, 
+//				   this_.PortName as PortName0_0_ 
+//			  FROM people this_ 
+//			 WHERE this_.ConnectionType = @p0 
+//			   and this_.Address = @p1 
+//			   and this_.PortName = @p2
+//
+//			@p0=N'http',@p1=N'test.com',@p2=NULL
+
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var componentToCompare = new Connection
+					{
+						ConnectionType = "http",
+						Address = "test.com", 
+						PortName = null
+					};
+				var sally = session.QueryOver<Person>()
+								   .Where(p => p.Connection == componentToCompare)
+								   .SingleOrDefault<Person>();
+
+				Assert.That(sally.Name, Is.EqualTo("Sally"));
+				Assert.That(sally.Connection.PortName, Is.Null);
+			}
+		}
+
+		[Test]
+		public void QueryAgainstComponentWithANullPropertyUsingCriteria()
+		{
+//			Broken at the time NH3634 was reported
+//			Generates the following Rpc(exec sp_executesql)
+//			SELECT this_.Id as Id0_0_, 
+//				   this_.Name as Name0_0_, 
+//				   this_.ConnectionType as Connecti3_0_0_, 
+//				   this_.Address as Address0_0_, 
+//				   this_.PortName as PortName0_0_ 
+//			  FROM people this_ 
+//			 WHERE this_.ConnectionType = @p0 
+//			   and this_.Address = @p1 
+//			   and this_.PortName = @p2
+//
+//			@p0=N'http',@p1=N'test.com',@p2=NULL
+
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var componentToCompare = new Connection
+				{
+					ConnectionType = "http",
+					Address = "test.com",
+					PortName = null
+				};
+				var sally = session.CreateCriteria<Person>()
+				                   .Add(Restrictions.Eq("Connection", componentToCompare))
+				                   .UniqueResult<Person>();
+
+				Assert.That(sally.Name, Is.EqualTo("Sally"));
+				Assert.That(sally.Connection.PortName, Is.Null);
+			}
+		}
+
+		[Test]
+		public void CachedQueryMissesWithDifferentNotNullComponent()
+		{
+			var componentToCompare = new Connection
+				{
+					ConnectionType = "http",
+					Address = "test.com",
+					PortName = null
+				};
+
+			using (ISession session = OpenSession())
+			using (ITransaction tx = session.BeginTransaction())
+			{
+				var cached = session.CreateCriteria<CachedPerson>()
+								   .Add(Restrictions.Eq("Connection", componentToCompare))
+								   .SetCacheable(true)
+								   .UniqueResult<CachedPerson>();
+
+				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
+				Assert.That(cached.Connection.PortName, Is.Null);
+
+				using (var dbCommand = session.Connection.CreateCommand())
+				{
+					dbCommand.CommandText = "DELETE FROM cachedpeople";
+					tx.Enlist(dbCommand);
+					dbCommand.ExecuteNonQuery();
+				}
+
+				tx.Commit();
+			}
+
+			componentToCompare.PortName = "port";
+			using (ISession session = OpenSession())
+			using (ITransaction tx = session.BeginTransaction())
+			{
+				//Cache should not return cached entity, because it no longer matches criteria
+				var cachedPeople = session.CreateCriteria<CachedPerson>()
+				                          .Add(Restrictions.Eq("Connection", componentToCompare))
+				                          .SetCacheable(true)
+				                          .List<CachedPerson>();
+
+				Assert.That(cachedPeople, Is.Empty);
+
+				tx.Commit();
+			}
+		}
+
+		[Test]
+		public void CachedQueryMissesWithDifferentNullComponent()
+		{
+			var componentToCompare = new Connection
+				{
+					ConnectionType = "http",
+					Address = "test.com",
+					PortName = "port"
+				};
+
+			using (ISession session = OpenSession())
+			using (ITransaction tx = session.BeginTransaction())
+			{
+				var cached = session.CreateCriteria<CachedPerson>()
+								   .Add(Restrictions.Eq("Connection", componentToCompare))
+								   .SetCacheable(true)
+								   .UniqueResult<CachedPerson>();
+
+				Assert.That(cached.Name, Is.EqualTo("CachedNotNull"));
+				Assert.That(cached.Connection.PortName, Is.Not.Null);
+
+				using (var dbCommand = session.Connection.CreateCommand())
+				{
+					dbCommand.CommandText = "DELETE FROM cachedpeople";
+					tx.Enlist(dbCommand);
+					dbCommand.ExecuteNonQuery();
+				}
+
+				tx.Commit();
+			}
+
+			componentToCompare.PortName = null;
+			using (ISession session = OpenSession())
+			using (ITransaction tx = session.BeginTransaction())
+			{
+				//Cache should not return cached entity, because it no longer matches criteria
+				var cachedPeople = session.CreateCriteria<CachedPerson>()
+				                          .Add(Restrictions.Eq("Connection", componentToCompare))
+				                          .SetCacheable(true)
+				                          .List<CachedPerson>();
+
+				Assert.That(cachedPeople, Is.Empty);
+
+				tx.Commit();
+			}
+		}
+
+		[Test]
+		public void CachedQueryAgainstComponentWithANullPropertyUsingCriteria()
+		{
+			var componentToCompare = new Connection
+				{
+					ConnectionType = "http",
+					Address = "test.com",
+					PortName = null
+				};
+
+			using (ISession session = OpenSession())
+			using (ITransaction tx = session.BeginTransaction())
+			{
+				var cached = session.CreateCriteria<CachedPerson>()
+								   .Add(Restrictions.Eq("Connection", componentToCompare))
+								   .SetCacheable(true)
+								   .UniqueResult<CachedPerson>();
+
+				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
+				Assert.That(cached.Connection.PortName, Is.Null);
+
+				using (var dbCommand = session.Connection.CreateCommand())
+				{
+					dbCommand.CommandText = "DELETE FROM cachedpeople";
+					tx.Enlist(dbCommand);
+					dbCommand.ExecuteNonQuery();
+				}
+
+				tx.Commit();
+			}
+
+			using (ISession session = OpenSession())
+			using (ITransaction tx = session.BeginTransaction())
+			{
+				//Should retreive from cache since we deleted directly from database.
+				var cached = session.CreateCriteria<CachedPerson>()
+								   .Add(Restrictions.Eq("Connection", componentToCompare))
+								   .SetCacheable(true)
+								   .UniqueResult<CachedPerson>();
+
+				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
+				Assert.That(cached.Connection.PortName, Is.Null);
+
+				tx.Commit();
+			}
+		}
+
+		[Test]
+		public void QueryOverANullComponentProperty()
+		{
+//          Works at the time NH3634 was reported 
+//			Generates the following SqlBatch:			
+//			SELECT this_.Id as Id0_0_, 
+//				   this_.Name as Name0_0_, 
+//				   this_.ConnectionType as Connecti3_0_0_, 
+//				   this_.Address as Address0_0_, 
+//				   this_.PortName as PortName0_0_ 
+//			  FROM people this_ 
+//			 WHERE this_.PortName is null
+
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var sally = session.QueryOver<Person>()
+				                   .Where(p => p.Connection.PortName == null)
+				                   .And(p => p.Connection.Address == "test.com")
+				                   .And(p => p.Connection.ConnectionType == "http")
+				                   .SingleOrDefault<Person>();
+
+				Assert.That(sally.Name, Is.EqualTo("Sally"));
+				Assert.That(sally.Connection.PortName, Is.Null);
+			}
+		}
+
+		[Test]
+		public void QueryAgainstANullComponentPropertyUsingCriteriaApi()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var sally = session.CreateCriteria<Person>()
+				                   .Add(Restrictions.Eq("Connection.PortName", null))
+				                   .Add(Restrictions.Eq("Connection.Address", "test.com"))
+				                   .Add(Restrictions.Eq("Connection.ConnectionType", "http"))
+				                   .UniqueResult<Person>();
+
+				Assert.That(sally.Name, Is.EqualTo("Sally"));
+				Assert.That(sally.Connection.PortName, Is.Null);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/Person.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/Person.cs
@@ -1,0 +1,9 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3634
+{
+	class Person
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Connection Connection { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/PersonMapper.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/PersonMapper.cs
@@ -1,0 +1,25 @@
+﻿using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+
+namespace NHibernate.Test.NHSpecificTest.NH3634
+{
+	class PersonMapper : ClassMapping<Person>
+	{
+		public PersonMapper()
+		{
+			Id(p => p.Id, m => m.Generator(Generators.Identity));
+			Lazy(false);
+			Table("people");
+			Property(p => p.Name);
+			Component(
+				p => p.Connection,
+				m =>
+				{
+					m.Class<Connection>();
+					m.Property(c => c.ConnectionType, mapper => mapper.NotNullable(true)); 
+					m.Property(c => c.Address, mapper => mapper.NotNullable(false));
+					m.Property(c => c.PortName, mapper => mapper.NotNullable(false));
+				});
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -728,6 +728,8 @@
     <Compile Include="NHSpecificTest\NH3453\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3480\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3480\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3634\Connection.cs" />
+    <Compile Include="NHSpecificTest\NH3634\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH3487\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3487\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3567\DomainClass.cs" />
@@ -863,6 +865,10 @@
     <Compile Include="NHSpecificTest\NH3604\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH3754\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3754\Model.cs" />
+    <Compile Include="NHSpecificTest\NH3634\Person.cs" />
+    <Compile Include="NHSpecificTest\NH3634\CachedPerson.cs" />
+    <Compile Include="NHSpecificTest\NH3634\CachedPersonMapper.cs" />
+    <Compile Include="NHSpecificTest\NH3634\PersonMapper.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3234\Fixture.cs" />

--- a/src/NHibernate/SqlCommand/SqlCommandImpl.cs
+++ b/src/NHibernate/SqlCommand/SqlCommandImpl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -105,7 +106,7 @@ namespace NHibernate.SqlCommand
 			}
 
 			// due to IType.NullSafeSet(System.Data.IDbCommand , object, int, ISessionImplementor) the SqlType[] is supposed to be in a certain sequence.
-			// this mean that found the first location of a parameter for the IType span, the others are in secuence
+			// this mean that found the first location of a parameter for the IType span, the others are in sequence
 			foreach (IParameterSpecification specification in Specifications)
 			{
 				string firstParameterId = specification.GetIdsForBackTrack(factory).First();
@@ -115,7 +116,7 @@ namespace NHibernate.SqlCommand
 					int firstParamNameIndex = effectiveParameterLocations[0] + singleSqlParametersOffset;
 					foreach (int location in effectiveParameterLocations)
 					{
-						int parameterSpan = specification.ExpectedType.GetColumnSpan(factory);
+						int parameterSpan = Math.Min(specification.ExpectedType.GetColumnSpan(factory), SqlQueryParametersList.Count);
 						for (int j = 0; j < parameterSpan; j++)
 						{
 							sqlQueryParametersList[location + j].ParameterPosition = firstParamNameIndex + j;

--- a/src/NHibernate/Type/MetaType.cs
+++ b/src/NHibernate/Type/MetaType.cs
@@ -109,7 +109,7 @@ namespace NHibernate.Type
 
 		public override bool[] ToColumnNullness(object value, IMapping mapping)
 		{
-			throw new NotSupportedException();
+			return baseType.ToColumnNullness(value, mapping);
 		}
 
 		public string ToXMLString(object value, ISessionFactoryImplementor factory)


### PR DESCRIPTION
:orange_book:  **Ready for code review**

#### Description
Test case and fix for [NH-3634](https://nhibernate.jira.com/browse/NH-3634). 

Please do a thorough code review. I'm new to the NHB code base, and I'm not entirely sure that this was the best place to make the fix.

#### Todo
- [x] ~~Add test where component only has one property and case is ignored. If fails, fix (in SimpleExpression).~~ This case is broken, but not related to NH-3634.
- [x] Verify it is ok to implement `MetaType.ToColumnNullness`
- [x] Fix ignored test: `AnyIs_QueryOver`
- [x] Fix ignored test: `EachEmbeddedBasicTypeIsSerializable`

#### Code Review Questions
* The `if (ignoreCase)` code path in `SimpleExpression.ToSqlString` seems broken. What if this is applied to a component with a single property. Because of `object icvalue = ignoreCase ? value.ToString().ToLower() : value;` in `GetParameterTypedValue` the compared value will be changed from the component object to a string. This is broken. Maybe it doesn't matter, because it's a edge case, but it might be indicitive of a larger problem around handling case insensitivity for `SimpleExpression`. I won't attempt to fix as part of this pull request unless asked to.
* Is it ok to implement `MetaType.ToColumnNullness` here? I couldn't see any reason not to, and it didn't fail any tests.