### PR TITLE
NH-3754 - Exception "System.ArgumentNullException" when using ICriteria with AliasToBeanResultTransformer and SecondLevelCache

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3754/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3754/Fixture.cs
@@ -1,0 +1,55 @@
+using NHibernate.Cache;
+using NHibernate.Cfg;
+using NHibernate.Criterion;
+using NHibernate.Transform;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3754
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		public override string BugNumber
+		{
+			get { return "NH3754"; }
+		}
+
+		private class TestEntity
+		{
+			public string Name { get; set; }
+		}
+
+		protected override void OnSetUp()
+		{
+			base.OnSetUp();
+			cfg.Properties[Environment.CacheProvider] = typeof(HashtableCacheProvider).AssemblyQualifiedName;
+			cfg.Properties[Environment.UseQueryCache] = "true";			
+		}
+
+		[Test]
+		public void SecondLevelCacheWithResultTransformer()
+		{
+			using (ISession session = OpenSession())
+			{
+				using (ITransaction t = session.BeginTransaction())
+				{
+					User user = new User();
+					user.Name = "Test";
+					user.Id = 1;
+					session.Save(user);
+					session.Flush();
+					session.Clear();
+					var list = session.CreateCriteria<User>()
+					                  .SetProjection(Projections.Property<User>(x => x.Name).As("Name")).SetResultTransformer(new AliasToBeanResultTransformer(typeof (TestEntity)))
+					                  .SetCacheable(false)
+					                  .List<TestEntity>();
+					Assert.AreEqual(1, list.Count);
+					Assert.AreEqual("Test", list[0].Name);
+
+					session.Delete("from User");
+					t.Commit();
+				}
+			}
+		}		
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3754/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3754/Mappings.hbm.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?> 
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+				   assembly="NHibernate.Test"
+				   namespace="NHibernate.Test.NHSpecificTest.NH3754"
+				   default-lazy="true">
+
+	<class name="User" table="`user`">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="IsActive" column="is_active" />
+	</class>
+	
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3754/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3754/Model.cs
@@ -1,0 +1,28 @@
+namespace NHibernate.Test.NHSpecificTest.NH3754
+{
+	public class User
+	{
+		private int _id;
+		private string _name;
+		private short _isActive;
+
+		public virtual int Id
+		{
+			get { return _id; }
+			set { _id = value; }
+		}
+
+		public virtual string Name
+		{
+			get { return _name; }
+			set { _name = value; }
+		}
+
+		public virtual short IsActive
+		{
+			get { return _isActive; }
+			set { _isActive = value; }
+		}
+	}
+
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -811,6 +811,8 @@
     <Compile Include="NHSpecificTest\NH3202\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3604\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3604\FixtureByCode.cs" />
+    <Compile Include="NHSpecificTest\NH3754\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3754\Model.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3234\Fixture.cs" />
@@ -3073,6 +3075,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3754\Mappings.hbm.xml" />
     <EmbeddedResource Include="LazyComponentTest\Person.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3570\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3455\Mappings.hbm.xml" />

--- a/src/NHibernate/Loader/Criteria/CriteriaLoader.cs
+++ b/src/NHibernate/Loader/Criteria/CriteriaLoader.cs
@@ -74,7 +74,7 @@ namespace NHibernate.Loader.Criteria
 			get { return resultTypes; }
 		}
 
-		protected string[] ResultRowAliases
+		protected override  string[] ResultRowAliases
 		{
 			get { return userAliases; }
 		}


### PR DESCRIPTION
Exception "System.ArgumentNullException" when using ICriteria with AliasToBeanResultTransformer and SecondLevelCache.

If use the second-level cache in ICriteria, the AliasToBeanResultTransformer gets a null reference to an array of aliases.


Jira issue [NH-3754](https://nhibernate.jira.com/browse/NH-3754).