### PR TITLE
uuid.hex id generator fix in mapping by code. Parameters added and retur...

### DIFF
--- a/src/NHibernate/Mapping/ByCode/Generators.cs
+++ b/src/NHibernate/Mapping/ByCode/Generators.cs
@@ -91,6 +91,28 @@ namespace NHibernate.Mapping.ByCode
 	{
 		#region Implementation of IGeneratorDef
 
+		private readonly object param;
+
+		public UUIDHexGeneratorDef()
+		{
+		}
+
+		public UUIDHexGeneratorDef(string format)
+		{
+			if (format == null)
+				throw new ArgumentNullException("format");
+			param = new { format = format };
+		}
+
+		public UUIDHexGeneratorDef(string format, string separator)
+		{
+			if (format == null)
+				throw new ArgumentNullException("format");
+			if (separator == null)
+				throw new ArgumentNullException("separator");
+			param = new { format = format, seperator = separator };
+		}
+
 		public string Class
 		{
 			get { return "uuid.hex"; }
@@ -98,12 +120,12 @@ namespace NHibernate.Mapping.ByCode
 
 		public object Params
 		{
-			get { return null; }
+			get { return param; }
 		}
 
 		public System.Type DefaultReturnType
 		{
-			get { return typeof(Guid); }
+			get { return typeof(string); }
 		}
 
 		public bool SupportedAsCollectionElementId


### PR DESCRIPTION
We use uuid.hex in the NHibernate.AspNet.Identity project. Right now a custom mapper is implemented in the project. It could be avoided with this fix.