### PR TITLE
Add tests for NH-3755 - Proxy exception for multiple joined-subclass

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3755/Circle.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/Circle.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public class Circle : Shape, ICircle
+	{
+        public override string Property2 { get; set; }
+        public virtual string Property3 { get; set; }                
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/Fixture.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var c = new Circle { Property1 = "Circle1", Property2 = "Circle2", Property3 = "Circle3"};
+				session.Save(c);
+
+                var s = new Square { Property1 = "Square1", Property2 = "Square2", Property3 = "Square3" };
+                session.Save(c); session.Save(s);
+
+			    var sc1 = new ShapeContainer {Name = "Circle", Shape = c};
+                var sc2 = new ShapeContainer { Name = "Square", Shape = s };
+
+			    session.Save(sc1);
+			    session.Save(sc2);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+        [Test, KnownBug("NH-3755")]
+		public void TestCompositeProxy()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result1 = (from e in session.Query<ShapeContainer>()
+							 where e.Name == "Circle"
+							 select e).ToList();
+
+                var result2 = (from e in session.Query<ShapeContainer>()
+                               where e.Name == "Square"
+                               select e).ToList();
+
+			    var circle = (ICircle) result1[0].Shape;
+			    var square = (ISquare) result2[0].Shape;
+
+                Assert.IsNotNull(circle.Property1);
+                Assert.IsNotNull(circle.Property2);
+                Assert.IsNotNull(circle.Property3);
+
+                Assert.IsNotNull(square.Property1);
+                Assert.IsNotNull(square.Property2);
+                Assert.IsNotNull(square.Property3);
+
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/ICircle.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/ICircle.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public interface ICircle : IShape
+    {
+        string Property2 { get; set; }
+        string Property3 { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/IShape.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/IShape.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public interface IShape
+    {
+        Guid Id { get; set; }
+        string Property1 { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/IShapeContainer.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/IShapeContainer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public interface IShapeContainer
+    {
+        Guid Id { get; set; }
+        string Name { get; set; }
+        IShape Shape { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/ISquare.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/ISquare.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public interface ISquare : IShape
+    {
+        string Property2 { get; set; }
+        string Property3 { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/Mappings.hbm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" default-lazy="true" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3755">
+
+	<class name="Shape" proxy="IShape">
+    <id name="Id">
+      <generator class="guid.comb" />
+    </id> 
+		<property name="Property1" />
+	</class>
+
+  <joined-subclass proxy="ISquare" extends="Shape" name="Square">
+    <key column="ShapeId" />
+    <property name="Property2"/>
+    <property name="Property3"/>
+  </joined-subclass>
+
+  <joined-subclass proxy="ICircle" extends="Shape" name="Circle">
+    <key column="ShapeId" />
+    <property name="Property2"/>
+    <property name="Property3"/>
+  </joined-subclass>
+  
+  <class name="ShapeContainer" proxy="IShapeContainer">
+    <id name="Id">
+      <generator class="guid.comb" />
+    </id>
+    <property name="Name" />
+    <many-to-one name="Shape" class="Shape" />
+  </class>
+  
+  
+
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/Shape.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/Shape.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public abstract class Shape : IShape
+    {
+        public virtual Guid Id { get; set; }
+        public string Property1 { get; set; }
+        public abstract string Property2 { get; set; }
+     }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/ShapeContainer.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/ShapeContainer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public class ShapeContainer : IShapeContainer
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public IShape Shape { get; set; }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3755/Square.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3755/Square.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3755
+{
+    public class Square : Shape, ISquare
+    {
+        
+        public override string Property2 { get; set; }
+        public virtual string Property3 { get; set; }  
+    }
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -811,6 +811,15 @@
     <Compile Include="NHSpecificTest\NH3202\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3604\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3604\FixtureByCode.cs" />
+    <Compile Include="NHSpecificTest\NH3755\Circle.cs" />
+    <Compile Include="NHSpecificTest\NH3755\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3755\ICircle.cs" />
+    <Compile Include="NHSpecificTest\NH3755\IShape.cs" />
+    <Compile Include="NHSpecificTest\NH3755\IShapeContainer.cs" />
+    <Compile Include="NHSpecificTest\NH3755\ISquare.cs" />
+    <Compile Include="NHSpecificTest\NH3755\Shape.cs" />
+    <Compile Include="NHSpecificTest\NH3755\ShapeContainer.cs" />
+    <Compile Include="NHSpecificTest\NH3755\Square.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3234\Fixture.cs" />
@@ -3073,6 +3082,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3755\Mappings.hbm.xml" />
     <EmbeddedResource Include="LazyComponentTest\Person.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3570\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3455\Mappings.hbm.xml" />


### PR DESCRIPTION
Created unit test to reproduce exception after swapping proxy factory due to upgrade from NH 3.2 to 4.0 
ProxyFactory:
from _NHibernate.ByteCode.Castle.ProxyFactoryFactory, NHibernate.ByteCode.Castle_
to _NHibernate.Bytecode.DefaultProxyFactoryFactory, NHibernate_

https://nhibernate.jira.com/browse/NH-3755
