### PR TITLE
NH-3793: Set ReferencedEntityName from keyManyToOneSchema

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3793/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3793/Entity.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3793
+{
+	[Serializable]
+	public class ParentEntityKey : IEquatable<ParentEntityKey>
+	{
+		public ParentEntityKey()
+		{
+		}
+
+		public virtual int Number { get; set; }
+		public virtual string StringKey { get; set; }
+
+		public bool Equals(ParentEntityKey other)
+		{
+			if (other == null)
+			{
+				return false;
+			}
+			return Number.Equals(other.Number) &&
+				(StringKey ?? String.Empty).Equals(other.StringKey ?? String.Empty);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+			{
+				return false;
+			}
+			var other = obj as ParentEntityKey;
+			if (other != null)
+			{
+				return Equals(other);
+			}
+			return base.Equals(obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return (Number * 19) + (StringKey ?? String.Empty).GetHashCode();
+			}
+		}
+	}
+
+	[Serializable]
+	public class ParentEntity
+	{
+		public ParentEntity()
+		{
+		}
+
+		public virtual ParentEntityKey ParentEntityKey { get; set; }
+		public virtual int Number { get; set; }
+		public virtual string StringKey { get; set; }
+		public virtual string OtherInformationOne { get; set; }
+		public virtual string OtherInformationTwo { get; set; }
+		public virtual ISet<ChildEntity> Children { get; set; }
+	}
+
+	[Serializable]
+	public class ChildEntityKey : IEquatable<ChildEntityKey>
+	{
+		public ChildEntityKey()
+		{
+		}
+
+		public virtual ParentEntity ParentEntity { get; set; }
+		public virtual string ChildIdentifier { get; set; }
+
+		public virtual bool Equals(ChildEntityKey other)
+		{
+			if (other == null)
+			{
+				return false;
+			}
+			if (ParentEntity == null && other.ParentEntity == null)
+			{
+				return ChildIdentifier == other.ChildIdentifier;
+			}
+			if (ParentEntity == null || other.ParentEntity == null)
+			{
+				return false;
+			}
+			if (ParentEntity.ParentEntityKey == null && other.ParentEntity.ParentEntityKey == null)
+			{
+				return ChildIdentifier == other.ChildIdentifier;
+			}
+			if (ParentEntity.ParentEntityKey == null || other.ParentEntity.ParentEntityKey == null)
+			{
+				return false;
+			}
+			return ParentEntity.ParentEntityKey.Equals(other.ParentEntity.ParentEntityKey) &&
+				ChildIdentifier == other.ChildIdentifier;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+			{
+				return false;
+			}
+			var other = obj as ChildEntityKey;
+			if (other != null)
+			{
+				return Equals(other);
+			}
+			return base.Equals(obj);
+		}
+
+		public override int GetHashCode()
+		{
+			if (ChildIdentifier == null)
+			{
+				return Int32.MinValue;
+			}
+			return ChildIdentifier.GetHashCode();
+		}
+	}
+
+	[Serializable]
+	public class ChildEntity
+	{
+		public ChildEntity()
+		{
+		}
+
+		public virtual ChildEntityKey ChildEntityKey { get; set; }
+		public virtual string ChildIdentifier { get; set; }
+		public virtual string SomeOtherProperty { get; set; }
+	}
+
+	[Serializable]
+	public class ObjectWithBothEntityNames
+	{
+		public ObjectWithBothEntityNames()
+		{
+		}
+
+		public virtual int ObjectWithBothEntityNamesId { get; set; }
+
+		public virtual ISet<ParentEntity> ParentEntityOneSet { get; set; }
+		public virtual ISet<ParentEntity> ParentEntityTwoSet { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3793/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3793/Fixture.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3793
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			// No-op
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void CompositeIdWithKeyManyToOneUsesEntityName()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				session.Query<ObjectWithBothEntityNames>()
+					   .SelectMany(o => o.ParentEntityOneSet.Select(p => p.Children));
+
+				// Previously, there would have been an exception before reaching this point.
+				Assert.IsTrue(true);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3793/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3793/Mappings.hbm.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3793">
+
+	<class name="ParentEntity" entity-name="ParentEntityOne" table="AAPARN">
+		<composite-id name="ParentEntityKey">
+			<key-property name="Number" column="AAPNUM" />
+			<key-property name="StringKey" column="AAPKEY" />
+		</composite-id>
+		<property name="OtherInformationOne" column="AAOINF" />
+		<set name="Children" inverse="true">
+			<key>
+				<column name="BBPNUM" />
+				<column name="BBPKEY" />
+			</key>
+			<one-to-many class="ChildEntity" entity-name="ChildEntityOne"/>
+		</set>
+	</class>
+
+	<class name="ChildEntity" entity-name="ChildEntityOne" table="AACHLD">
+		<composite-id name="ChildEntityKey">
+			<key-many-to-one name="ParentEntity" entity-name="ParentEntityOne">
+				<column name="AAPNUM" />
+				<column name="AAPKEY" />
+			</key-many-to-one>
+			<key-property name="ChildIdentifier" column="BBCHID" />
+		</composite-id>
+		<property name="ChildIdentifier" column="BBCHID" />
+		<property name="SomeOtherProperty" column="BBZZZZ" />
+	</class>
+
+	<class name="ParentEntity" entity-name="ParentEntityTwo" table="CCPARN">
+		<composite-id name="ParentEntityKey">
+			<key-property name="Number" column="AAPNUM" />
+			<key-property name="StringKey" column="AAPKEY" />
+		</composite-id>
+		<property name="OtherInformationTwo" column="AAOINF" />
+		<set name="Children" inverse="true">
+			<key>
+				<column name="BBPNUM" />
+				<column name="BBPKEY" />
+			</key>
+			<one-to-many class="ChildEntity" entity-name="ChildEntityTwo"/>
+		</set>
+	</class>
+
+	<class name="ChildEntity" entity-name="ChildEntityTwo" table="CCCHLD">
+		<composite-id name="ChildEntityKey">
+			<key-many-to-one name="ParentEntity" class="ParentEntity" entity-name="ParentEntityTwo">
+				<column name="AAPNUM" />
+				<column name="AAPKEY" />
+			</key-many-to-one>
+			<key-property name="ChildIdentifier" column="BBCHID" />
+		</composite-id>
+		<property name="ChildIdentifier" column="BBCHID" />
+		<property name="SomeOtherProperty" column="BBZZZZ" />
+	</class>
+
+	<class name="ObjectWithBothEntityNames" table="OWBOTH">
+		<id name="ObjectWithBothEntityNamesId" column="OWBTID" generator="assigned" />
+		<set name="ParentEntityOneSet">
+			<key column="AAPNUM" />
+			<one-to-many class="ParentEntity" entity-name="ParentEntityOne"/>
+		</set>
+		<set name="ParentEntityTwoSet">
+			<key column="AAPTNM" />
+			<one-to-many class="ParentEntity" entity-name="ParentEntityTwo"/>
+		</set>
+	</class>
+	
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -718,6 +718,8 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Linq\ByMethod\DistinctTests.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3793\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3793\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2839\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH3564\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH3583\Entity.cs" />
@@ -3142,6 +3144,9 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3793\Mappings.hbm.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="NHSpecificTest\NH3666\Mappings.hbm.xml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -3379,7 +3384,9 @@
     <EmbeddedResource Include="TypesTest\UriClass.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\EntityNameWithFullName\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2361\Mappings.hbm.xml" />
-    <EmbeddedResource Include="NHSpecificTest\EntityNameAndCompositeId\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\EntityNameAndCompositeId\Mappings.hbm.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PolymorphicGetAndLoad\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2331\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2324\Mappings.hbm.xml" />

--- a/src/NHibernate/Cfg/XmlHbmBinding/ClassCompositeIdBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/ClassCompositeIdBinder.cs
@@ -174,7 +174,11 @@ namespace NHibernate.Cfg.XmlHbmBinding
 			                   	: keyManyToOneSchema.lazy == HbmRestrictedLaziness.Proxy;
 
 			string typeNode = keyManyToOneSchema.@class;
-			if (typeNode != null)
+			if (keyManyToOneSchema.EntityName != null)
+			{
+				manyToOne.ReferencedEntityName = keyManyToOneSchema.EntityName;
+			}
+			else if (typeNode != null)
 			{
 				manyToOne.ReferencedEntityName = GetClassName(typeNode, mappings);
 			}


### PR DESCRIPTION
Includes test case and fix for [NH-3793](https://nhibernate.jira.com/browse/NH-3793), "Attribute entity-name on <key-many-to-one> is ignored, causing mapping exception".
