### PR TITLE
NH-3811 Added [ThreadStatic] to table counter 

### DIFF
--- a/src/NHibernate.Test/MappingTest/TableFixture.cs
+++ b/src/NHibernate.Test/MappingTest/TableFixture.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Threading;
 using NHibernate.Dialect;
 using NHibernate.Mapping;
 using NUnit.Framework;
@@ -59,5 +61,44 @@ namespace NHibernate.Test.MappingTest
 
 			Assert.AreEqual("[schema].name", tbl.GetQualifiedName(dialect));
 		}
-	}
+
+	    [Test]
+	    public void TablesUniquelyNamed()
+	    {
+            Table tbl1 = new Table();
+            Table tbl2 = new Table();
+
+            Assert.AreEqual(tbl1.UniqueInteger + 1, tbl2.UniqueInteger);
+	    }
+
+        [Test]
+        public void TablesUniquelyNamedOnlyWithinThread()
+        {
+            var uniqueIntegerList = new System.Collections.Concurrent.ConcurrentBag<int>();
+            var method = new ThreadStart(() =>
+            {
+                Table tbl1 = new Table();
+                Table tbl2 = new Table();
+
+                // Store these values for later comparison
+                uniqueIntegerList.Add(tbl1.UniqueInteger);
+                uniqueIntegerList.Add(tbl2.UniqueInteger);
+
+                // Ensure that within a thread we have unique integers
+                Assert.AreEqual(tbl1.UniqueInteger + 1, tbl2.UniqueInteger);
+            });
+
+            var thread1 = new Thread(method);
+            var thread2 = new Thread(method);
+
+            thread1.Start();
+            thread2.Start();
+
+            thread1.Join();
+            thread2.Join();
+
+            Assert.AreEqual(4, uniqueIntegerList.Count);
+            Assert.AreEqual(2, uniqueIntegerList.Distinct().Count());
+        }
+    }
 }

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -25,7 +25,9 @@ namespace NHibernate.Mapping
 	[Serializable]
 	public class Table : IRelationalModel
 	{
+        [ThreadStatic]
 		private static int tableCounter;
+
 		private readonly List<string> checkConstraints = new List<string>();
 		private readonly LinkedHashMap<string, Column> columns = new LinkedHashMap<string, Column>();
 		private readonly Dictionary<ForeignKeyKey, ForeignKey> foreignKeys = new Dictionary<ForeignKeyKey, ForeignKey>();


### PR DESCRIPTION
so that table aliases can be generated consistently in a multi thread environment.
