### PR TITLE
NH-3812 - GuidCombGenerator using DateTime.UtcNow

### DIFF
--- a/src/NHibernate/Id/GuidCombGenerator.cs
+++ b/src/NHibernate/Id/GuidCombGenerator.cs
@@ -24,6 +24,8 @@ namespace NHibernate.Id
 	/// </remarks>
 	public class GuidCombGenerator : IIdentifierGenerator
 	{
+		private static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;
+
 		#region IIdentifierGenerator Members
 
 		/// <summary>
@@ -44,11 +46,10 @@ namespace NHibernate.Id
 		{
 			byte[] guidArray = Guid.NewGuid().ToByteArray();
 
-			DateTime baseDate = new DateTime(1900, 1, 1);
-			DateTime now = DateTime.Now;
+			DateTime now = DateTime.UtcNow;
 
 			// Get the days and milliseconds which will be used to build the byte string 
-			TimeSpan days = new TimeSpan(now.Ticks - baseDate.Ticks);
+			TimeSpan days = new TimeSpan(now.Ticks - BaseDateTicks);
 			TimeSpan msecs = now.TimeOfDay;
 
 			// Convert to a byte array 


### PR DESCRIPTION
GuidCombGenerator using `DateTime.UtcNow` instead of `DateTime.Now` as **.Now is affected by daylight saving time (DST) changes**. This results in once a year the keys to not be sequential to previous keys.

* `DateTime.Now` is also much slower than `DateTime.UtcNow` as `.Now` needs to apply timezone offsets to the time.
* Also a small optimisation as the base value does not need to be generated each time a value is generated.