### PR TITLE
Fix for NH-3795

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
@@ -4,80 +4,76 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3795
 {
-    /// <summary>
-    /// Tests in this class only failed when the code was build with the Roslyn compiler which is included in Visual Studio 2015
-    /// </summary>
-    [TestFixture]
-    public class Fixture : TestCase
-    {
-        protected Child childAliasField = null;
-        protected A aAliasField = null;
-
-        protected override IList Mappings
-        {
-            get
-            {
-                return new[] { "ParentChild.hbm.xml", "ABC.hbm.xml" };
-            }
-        }
-
-
-        [Test]
-        public void TestAliasInQueryOver()
-        {
-            using (var s = sessions.OpenSession())
-            {
-                A rowalias = null;
-                s.QueryOver(() => aAliasField)
-                    .SelectList(list => list
-                        .Select(() => aAliasField.Id).WithAlias(() => rowalias.Id)
-                    )
-                    .List();
-            }
-        }
-
-        [Test]
-        public void TestAliasInQueryOverWithConversion()
-        {
-            using (var s = sessions.OpenSession())
-            {
-                B rowalias = null;
-                s.QueryOver(() => aAliasField)
-                    .SelectList(list => list
-                        .Select(() => ((B)aAliasField).Count).WithAlias(() => rowalias.Count)
-                    )
-                    .List();
-            }
-        }
-
-        [Test]
-        public void TestAliasInJoinAlias()
-        {
-            using (var s = sessions.OpenSession())
-            {
-                Child rowalias = null;
-                s.QueryOver<Parent>()
-                    .JoinAlias(p => p.Child, () => childAliasField)
-                    .SelectList(list => list
-                        .Select(() => childAliasField.Id).WithAlias(() => rowalias.Id)
-                    )
-                    .List();
-            }
-        }
-
-        [Test]
-        public void TestAliasInJoinQueryOver()
-        {
-            using (var s = sessions.OpenSession())
-            {
-                Child rowalias = null;
-                s.QueryOver<Parent>()
-                    .JoinQueryOver(p => p.Child, () => childAliasField)
-                    .SelectList(list => list
-                        .Select(() => childAliasField.Id).WithAlias(() => rowalias.Id)
-                    )
-                    .List();
-            }
-        }
-    }
+	/// <summary>
+	/// Tests in this class only failed when the code was build with the Roslyn compiler which is included in Visual Studio 2015
+	/// </summary>
+	[TestFixture]
+	public class Fixture : TestCase
+	{
+		protected Child childAliasField = null;
+		protected A aAliasField = null;
+		
+		protected override IList Mappings
+		{
+			get
+			{
+				return new[] { "ParentChild.hbm.xml", "ABC.hbm.xml" };
+			}
+		}
+		
+		
+		[Test]
+		public void TestAliasInQueryOver()
+		{
+			using (var s = sessions.OpenSession())
+			{
+				A rowalias = null;
+				s.QueryOver(() => aAliasField)
+					.SelectList(list => list
+						.Select(() => aAliasField.Id).WithAlias(() => rowalias.Id))
+					.List();
+			}
+		}
+		
+		[Test]
+		public void TestAliasInQueryOverWithConversion()
+		{
+			using (var s = sessions.OpenSession())
+			{
+				B rowalias = null;
+				s.QueryOver(() => aAliasField)
+					.SelectList(list => list
+						.Select(() => ((B)aAliasField).Count).WithAlias(() => rowalias.Count))
+					.List();
+			}
+		}
+		
+		[Test]
+		public void TestAliasInJoinAlias()
+		{
+			using (var s = sessions.OpenSession())
+			{
+					Child rowalias = null;
+					s.QueryOver<Parent>()
+						.JoinAlias(p => p.Child, () => childAliasField)
+						.SelectList(list => list
+							.Select(() => childAliasField.Id).WithAlias(() => rowalias.Id))
+						.List();
+			}
+		}
+		
+		[Test]
+		public void TestAliasInJoinQueryOver()
+		{
+			using (var s = sessions.OpenSession())
+			{
+				Child rowalias = null;
+				s.QueryOver<Parent>()
+					.JoinQueryOver(p => p.Child, () => childAliasField)
+					.SelectList(list => list
+						.Select(() => childAliasField.Id).WithAlias(() => rowalias.Id))
+				.List();
+			}
+		}
+	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		{
 			using (var s = sessions.OpenSession())
 			{
-				A rowalias = null;
+			A rowalias = null;
 				s.QueryOver(() => aAliasField)
 					.SelectList(list => list
 						.Select(() => aAliasField.Id).WithAlias(() => rowalias.Id))
@@ -53,12 +53,12 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		{
 			using (var s = sessions.OpenSession())
 			{
-			    Child rowalias = null;
-			    s.QueryOver<Parent>()
-			    	.JoinAlias(p => p.Child, () => childAliasField)
-			    	.SelectList(list => list
-			    		.Select(() => childAliasField.Id).WithAlias(() => rowalias.Id))
-			    	.List();
+				Child rowalias = null;
+				s.QueryOver<Parent>()
+					.JoinAlias(p => p.Child, () => childAliasField)
+					.SelectList(list => list
+						.Select(() => childAliasField.Id).WithAlias(() => rowalias.Id))
+					.List();
 			}
 		}
 		

--- a/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
@@ -14,14 +14,14 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
         protected A aAliasField = null;
 
         protected override IList Mappings
-		{
-			get
-			{
-				return new [] { "ParentChild.hbm.xml", "ABC.hbm.xml" };
-			}
-		}
+        {
+            get
+            {
+                return new[] { "ParentChild.hbm.xml", "ABC.hbm.xml" };
+            }
+        }
 
-        
+
         [Test]
         public void TestAliasInQueryOver()
         {

--- a/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
@@ -53,12 +53,12 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		{
 			using (var s = sessions.OpenSession())
 			{
-					Child rowalias = null;
-					s.QueryOver<Parent>()
-						.JoinAlias(p => p.Child, () => childAliasField)
-						.SelectList(list => list
-							.Select(() => childAliasField.Id).WithAlias(() => rowalias.Id))
-						.List();
+			    Child rowalias = null;
+			    s.QueryOver<Parent>()
+			    	.JoinAlias(p => p.Child, () => childAliasField)
+			    	.SelectList(list => list
+			    		.Select(() => childAliasField.Id).WithAlias(() => rowalias.Id))
+			    	.List();
 			}
 		}
 		

--- a/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections;
+using NHibernate.DomainModel;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3795
+{
+    /// <summary>
+    /// Tests in this class only failed when the code was build with the Roslyn compiler which is included in Visual Studio 2015
+    /// </summary>
+    [TestFixture]
+    public class Fixture : TestCase
+    {
+        protected Child childAliasField = null;
+        protected A aAliasField = null;
+
+        protected override IList Mappings
+		{
+			get
+			{
+				return new [] { "ParentChild.hbm.xml", "ABC.hbm.xml" };
+			}
+		}
+
+        
+        [Test]
+        public void TestAliasInQueryOver()
+        {
+            using (var s = sessions.OpenSession())
+            {
+                A rowalias = null;
+                s.QueryOver(() => aAliasField)
+                    .SelectList(list => list
+                        .Select(() => aAliasField.Id).WithAlias(() => rowalias.Id)
+                    )
+                    .List();
+            }
+        }
+
+        [Test]
+        public void TestAliasInQueryOverWithConversion()
+        {
+            using (var s = sessions.OpenSession())
+            {
+                B rowalias = null;
+                s.QueryOver(() => aAliasField)
+                    .SelectList(list => list
+                        .Select(() => ((B)aAliasField).Count).WithAlias(() => rowalias.Count)
+                    )
+                    .List();
+            }
+        }
+
+        [Test]
+        public void TestAliasInJoinAlias()
+        {
+            using (var s = sessions.OpenSession())
+            {
+                Child rowalias = null;
+                s.QueryOver<Parent>()
+                    .JoinAlias(p => p.Child, () => childAliasField)
+                    .SelectList(list => list
+                        .Select(() => childAliasField.Id).WithAlias(() => rowalias.Id)
+                    )
+                    .List();
+            }
+        }
+
+        [Test]
+        public void TestAliasInJoinQueryOver()
+        {
+            using (var s = sessions.OpenSession())
+            {
+                Child rowalias = null;
+                s.QueryOver<Parent>()
+                    .JoinQueryOver(p => p.Child, () => childAliasField)
+                    .SelectList(list => list
+                        .Select(() => childAliasField.Id).WithAlias(() => rowalias.Id)
+                    )
+                    .List();
+            }
+        }
+    }
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -810,6 +810,7 @@
     <Compile Include="NHSpecificTest\NH3202\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3604\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3604\FixtureByCode.cs" />
+    <Compile Include="NHSpecificTest\NH3795\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3234\Fixture.cs" />

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -321,7 +321,7 @@ namespace NHibernate.Impl
 						// it's a Nullable<T>, so ignore any .Value
 						if (memberExpression.Member.Name == "Value")
 							return FindMemberExpression(memberExpression.Expression);
-					}
+                    }
 
                     if (IsMemberExpressionOfCompilerGeneratedClass(memberExpression.Expression))
                     {

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -290,12 +290,13 @@ namespace NHibernate.Impl
 			return ProjectionInfo.ForProperty(FindMemberExpression(expression));
 		}
 
-		private static bool IsMemberExpressionOfCompilerGeneratedClass(Expression expression)
+		private static bool IsCompilerGeneratedMemberExpressionOfCompilerGeneratedClass(Expression expression)
 		{
 			var memberExpression = expression as MemberExpression;
 			if (memberExpression != null && memberExpression.Member.DeclaringType != null)
 			{
-				return Attribute.GetCustomAttribute(memberExpression.Member.DeclaringType, typeof(CompilerGeneratedAttribute)) != null;
+				return Attribute.GetCustomAttribute(memberExpression.Member.DeclaringType, typeof(CompilerGeneratedAttribute)) != null 
+                    && memberExpression.Member.Name.StartsWith("<"); // Is there another way to check for a compiler generated member?
 			}
 
 			return false;
@@ -322,7 +323,7 @@ namespace NHibernate.Impl
 							return FindMemberExpression(memberExpression.Expression);
 					}
 
-					if (IsMemberExpressionOfCompilerGeneratedClass(memberExpression.Expression))
+					if (IsCompilerGeneratedMemberExpressionOfCompilerGeneratedClass(memberExpression.Expression))
 					{
 						return memberExpression.Member.Name;
 					}

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -296,7 +296,7 @@ namespace NHibernate.Impl
 			if (memberExpression != null && memberExpression.Member.DeclaringType != null)
 			{
 				return Attribute.GetCustomAttribute(memberExpression.Member.DeclaringType, typeof(CompilerGeneratedAttribute)) != null 
-                    && memberExpression.Member.Name.StartsWith("<"); // Is there another way to check for a compiler generated member?
+					&& memberExpression.Member.Name.StartsWith("<"); // Is there another way to check for a compiler generated member?
 			}
 
 			return false;

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -322,10 +322,10 @@ namespace NHibernate.Impl
 							return FindMemberExpression(memberExpression.Expression);
 					}
 
-                    if (IsMemberExpressionOfCompilerGeneratedClass(memberExpression.Expression))
-                    {
-                        return memberExpression.Member.Name;
-                    }
+					if (IsMemberExpressionOfCompilerGeneratedClass(memberExpression.Expression))
+					{
+						return memberExpression.Member.Name;
+					}
 
 					return FindMemberExpression(memberExpression.Expression) + "." + memberExpression.Member.Name;
 				}

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -290,17 +290,16 @@ namespace NHibernate.Impl
 			return ProjectionInfo.ForProperty(FindMemberExpression(expression));
 		}
 
+		private static bool IsMemberExpressionOfCompilerGeneratedClass(Expression expression)
+		{
+			var memberExpression = expression as MemberExpression;
+			if (memberExpression != null && memberExpression.Member.DeclaringType != null)
+			{
+				return Attribute.GetCustomAttribute(memberExpression.Member.DeclaringType, typeof(CompilerGeneratedAttribute)) != null;
+			}
 
-        private static bool IsMemberExpressionOfCompilerGeneratedClass(Expression expression)
-        {
-            var memberExpression = expression as MemberExpression;
-            if (memberExpression != null && memberExpression.Member.DeclaringType != null)
-            {
-                return Attribute.GetCustomAttribute(memberExpression.Member.DeclaringType, typeof(CompilerGeneratedAttribute)) != null;
-            }
-
-            return false;
-        }
+			return false;
+		}
 
 		/// <summary>
 		/// Retrieves the name of the property from a member expression
@@ -321,7 +320,7 @@ namespace NHibernate.Impl
 						// it's a Nullable<T>, so ignore any .Value
 						if (memberExpression.Member.Name == "Value")
 							return FindMemberExpression(memberExpression.Expression);
-                    }
+					}
 
                     if (IsMemberExpressionOfCompilerGeneratedClass(memberExpression.Expression))
                     {


### PR DESCRIPTION
Compiling query over queries with the Roslyn compiler of Visual Studio breaks resolving alias names because Roslyn compiles lambda's differently. It now sometimes generates a compiler generated class. This compiler generated class has a member of the type of the class declaring the alias. The ExpressionProcessor is recursively searching for members and does not stop at the alias field but also returns the member of the compiler generated class. Members of compiler generated classes can never be used in a query over so they should never be returned 