### PR TITLE
NH-3831 - NullableDictionary does not set _gotNullValue when using Add(TKey, TValue) method

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -1352,6 +1352,7 @@
     <Compile Include="UnionsubclassPolymorphicFormula\Party.cs" />
     <Compile Include="UnionsubclassPolymorphicFormula\Person.cs" />
     <Compile Include="UnionsubclassPolymorphicFormula\UnionSubclassFixture.cs" />
+    <Compile Include="UtilityTest\NullableDictionaryFixture.cs" />
     <Compile Include="UtilityTest\IdentitySetFixture.cs" />
     <Compile Include="UtilityTest\EnumerableExtensionsTests\AnyExtensionTests.cs" />
     <Compile Include="UtilityTest\EnumerableExtensionsTests\FirstExtensionTests.cs" />

--- a/src/NHibernate.Test/UtilityTest/NullableDictionaryFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/NullableDictionaryFixture.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest
+{
+	/// <summary>
+	/// Tests for NullableDictionary.
+	/// </summary>
+	[TestFixture]
+	public class NullableDictionaryFixture
+	{
+		private NullableDictionary<string, string> nullableDictionary;
+
+		private readonly string _itemKey = "key";
+		private readonly string _itemValue = "value";
+
+		private readonly string _nullItemKey = null;
+		private readonly string _nullItemValue = "null value";
+
+		[SetUp]
+		public void SetUp()
+		{
+			nullableDictionary = new NullableDictionary<string, string>();
+		}
+
+		[Test]
+		public void AddKeyValue()
+		{
+			//non-null key
+			nullableDictionary.Add(_itemKey, _itemValue);
+
+			Assert.AreEqual(1, nullableDictionary.Count);
+			Assert.AreEqual(nullableDictionary[_itemKey], _itemValue);
+
+			//null key
+			nullableDictionary.Add(_nullItemKey, _nullItemValue);
+
+			Assert.AreEqual(2, nullableDictionary.Count);
+			Assert.AreEqual(nullableDictionary[_nullItemKey], _nullItemValue);
+		}
+
+		[Test]
+		public void AddUsingIndexer()
+		{
+			//non-null key
+			nullableDictionary[_itemKey] = _itemValue;
+
+			Assert.AreEqual(1, nullableDictionary.Count);
+			Assert.AreEqual(nullableDictionary[_itemKey], _itemValue);
+
+			//null key
+			nullableDictionary[_nullItemKey] = _nullItemValue;
+
+			Assert.AreEqual(2, nullableDictionary.Count);
+			Assert.AreEqual(nullableDictionary[_nullItemKey], _nullItemValue);
+		}
+
+		[Test]
+		public void AddKeyValuePair()
+		{
+			//non-null key
+			nullableDictionary.Add(new KeyValuePair<string, string>(_itemKey, _itemValue));
+
+			Assert.AreEqual(1, nullableDictionary.Count);
+			Assert.AreEqual(nullableDictionary[_itemKey], _itemValue);
+
+			//null key
+			nullableDictionary.Add(new KeyValuePair<string, string>(_nullItemKey, _nullItemValue));
+
+			Assert.AreEqual(2, nullableDictionary.Count);
+			Assert.AreEqual(nullableDictionary[_nullItemKey], _nullItemValue);
+		}
+	}
+}

--- a/src/NHibernate/Util/NullableDictionary.cs
+++ b/src/NHibernate/Util/NullableDictionary.cs
@@ -37,6 +37,7 @@ namespace NHibernate.Util
 			if (key == null)
 			{
 				_nullValue = value;
+				_gotNullValue = true;
 			}
 			else
 			{


### PR DESCRIPTION
[NH-3831](https://nhibernate.jira.com/browse/NH-3831)

Set _gotNullValue when using the NullableDictionary Add(TKey, TValue) method with a null key.
Added unit tests to verify all methods of adding a null key do so correctly.