### PR TITLE
Flush child sessions when parent is flushed.

### DIFF
--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -1462,6 +1462,15 @@ namespace NHibernate.Impl
 				{
 					flushEventListener[i].OnFlush(new FlushEvent(this));
 				}
+				
+				// Flush children when parent is flushed.
+				if (childSessionsByEntityMode != null)
+				{
+					foreach (var childSession in childSessionsByEntityMode)
+					{
+						childSession.Value.Flush();
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
For years I used GeneratedBy.Assigned() with a incremental PK for audit logging.  As soon as Save is called it issues an INSERT to the database, so it didn't matter if Flush was called on the child session.  I switched to guid.comb and now Save does not issue an INSERT (which is the correct behavior) but since the child session isn't flushed my audit record is never written.
