### PR TITLE
NH-3844 - Tests and fix

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
@@ -715,6 +715,20 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));
 		}
 
+		[Test(Description = "NH-3844")]
+		public void GroupByComputedValueFromNestedArraySelect()
+		{
+			var orderGroups = db.OrderLines.Select(o => new object[] { o }).GroupBy(x => new object[] { ((OrderLine)x[0]).Order.Customer == null ? 0 : 1 }).Select(g => new { Key = g.Key, Count = g.Count() }).ToList();
+			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));
+		}
+
+		[Test(Description = "NH-3844")]
+		public void GroupByComputedValueFromNestedObjectSelect()
+		{
+			var orderGroups = db.OrderLines.Select(o => new { OrderLine = (object)o }).GroupBy(x => new object[] { ((OrderLine)x.OrderLine).Order.Customer == null ? 0 : 1 }).Select(g => new { Key = g.Key, Count = g.Count() }).ToList();
+			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));
+		}
+
 		private static void CheckGrouping<TKey, TElement>(IEnumerable<IGrouping<TKey, TElement>> groupedItems, Func<TElement, TKey> groupBy)
 		{
 			var used = new HashSet<object>();

--- a/src/NHibernate.Test/NHSpecificTest/NH3844/Domain.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3844/Domain.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NHibernate.Test.NHSpecificTest.NH3844
+{
+	public class Project
+	{
+		public Project()
+		{
+			Components = new List<Component>();
+		}
+
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual IList<Component> Components { get; set; }
+		public virtual Job Job { get; set; }
+	}
+
+	public class Component
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Project Project { get; set; }
+	}
+
+	public class TimeRecord
+	{
+		public TimeRecord()
+		{
+			Components = new List<Component>();
+		}
+
+		public virtual Guid Id { get; set; }
+		public virtual double TimeInHours { get; set; }
+		public virtual Project Project { get; set; }
+		public virtual IList<Component> Components { get; set; }
+
+	}
+
+	public class Job
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual BillingType BillingType { get; set; }
+	}
+
+	public enum BillingType
+	{
+		None,
+		Hourly,
+		Fixed,
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3844/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3844/Fixture.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using NHibernate.Linq;
+using NHibernate.Test.ExceptionsTest;
+using NHibernate.Test.MappingByCode;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3844
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			var job1 = new Job { Name = "Not a Job", BillingType = BillingType.None };
+			var job2 = new Job { Name = "Contract Job", BillingType = BillingType.Fixed };
+			var job3 = new Job { Name = "Pay as You Go Job", BillingType = BillingType.Hourly };
+
+			var project1 = new Project { Name = "ProjectOne", Job = job1 };
+			var compP1_x = new Component() { Name = "P1x", Project = project1 };
+			var compP1_y = new Component() { Name = "P1y", Project = project1 };
+
+			var project2 = new Project { Name = "ProjectTwo", Job = job2 };
+			var compP2_x = new Component() { Name = "P2x", Project = project2 };
+			var compP2_y = new Component() { Name = "P2y", Project = project2 };
+
+			var project3 = new Project { Name = "ProjectThree", Job = job3 };
+			var compP3_x = new Component() { Name = "P3x", Project = project3 };
+			var compP3_y = new Component() { Name = "P3y", Project = project3 };
+
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Save(job1);
+				session.Save(project1);
+				session.Save(compP1_x);
+				session.Save(compP1_y);
+				session.Save(job2);
+				session.Save(project2);
+				session.Save(compP2_x);
+				session.Save(compP2_y);
+				session.Save(job3);
+				session.Save(project3);
+				session.Save(compP3_x);
+				session.Save(compP3_y);
+
+
+				session.Save(new TimeRecord { TimeInHours = 1, Project = project1, Components = { } });
+				session.Save(new TimeRecord { TimeInHours = 2, Project = project1, Components = { compP1_x } });
+				session.Save(new TimeRecord { TimeInHours = 3, Project = project1, Components = { compP1_y } });
+				session.Save(new TimeRecord { TimeInHours = 4, Project = project1, Components = { compP1_x, compP1_y } });
+
+				session.Save(new TimeRecord { TimeInHours = 5, Project = project2, Components = { } });
+				session.Save(new TimeRecord { TimeInHours = 6, Project = project2, Components = { compP2_x } });
+				session.Save(new TimeRecord { TimeInHours = 7, Project = project2, Components = { compP2_y } });
+				session.Save(new TimeRecord { TimeInHours = 8, Project = project2, Components = { compP2_x, compP2_y } });
+
+				session.Save(new TimeRecord { TimeInHours = 9, Project = project3, Components = { } });
+				session.Save(new TimeRecord { TimeInHours = 10, Project = project3, Components = { compP3_x } });
+				session.Save(new TimeRecord { TimeInHours = 11, Project = project3, Components = { compP3_y } });
+				session.Save(new TimeRecord { TimeInHours = 12, Project = project3, Components = { compP3_x, compP3_y } });
+
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Delete("from TimeRecord");
+				session.Delete("from Component");
+				session.Delete("from Project");
+				session.Delete("from Job");
+
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void ConditionalGroupKeyFromArrayAccess()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var baseQuery = session.Query<TimeRecord>();
+
+				Assert.That(baseQuery.Sum(x => x.TimeInHours), Is.EqualTo(78));
+
+				var query = baseQuery.Select(t => new object[] { t })
+					.GroupBy(j => new object[] { ((TimeRecord)j[0]).Project.Job.BillingType == BillingType.None ? 0 : 1 }, j => (TimeRecord)j[0])
+					.Select(g => new object[] { g.Key, g.Count(), g.Sum(t => (decimal?)t.TimeInHours) });
+
+				var results = query.ToList().OrderBy(x => (int)((object[])x[0])[0]);
+				Assert.That(results.Select(x => x[1]), Is.EquivalentTo(new[] { 4, 8 }));
+				Assert.That(results.Select(x => x[2]), Is.EquivalentTo(new[] { 10, 68 }));
+
+				Assert.That(results.Sum(x => (decimal?)x[2]), Is.EqualTo(78));
+
+				transaction.Rollback();
+			}
+		}
+
+		[Test]
+		public void ConditionalGroupKeyFromSubqueryArrayAccess()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var baseQuery = session.Query<TimeRecord>();
+
+				Assert.That(baseQuery.Sum(x => x.TimeInHours), Is.EqualTo(78));
+
+				var query = baseQuery.Select(t => new object[] { t })
+					.SelectMany(t => ((TimeRecord)t[0]).Components.Select(c => (object)c.Id).DefaultIfEmpty().Select(c => new[] { t[0], c }))
+					.GroupBy(j => new object[] { ((TimeRecord)j[0]).Project.Job.BillingType == BillingType.None ? 0 : 1 }, j => (TimeRecord)j[0])
+					.Select(g => new object[] { g.Key, g.Count(), g.Sum(t => (decimal?)t.TimeInHours) });
+
+				var results = query.ToList().OrderBy(x => (int)((object[])x[0])[0]);
+				Assert.That(results.Select(x => x[1]), Is.EquivalentTo(new[] { 5, 10 }));
+				Assert.That(results.Select(x => x[2]), Is.EquivalentTo(new[] { 14, 88 }));
+
+				Assert.That(results.Sum(x => (decimal?)x[2]), Is.EqualTo(102));
+
+				transaction.Rollback();
+			}
+		}
+
+		[Test]
+		public void ConditionalInComplexGroupKeyFromSubqueryArrayAccess()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var baseQuery = session.Query<TimeRecord>();
+
+				Assert.That(baseQuery.Sum(x => x.TimeInHours), Is.EqualTo(78));
+
+				var query = baseQuery.Select(t => new object[] { t })
+					.SelectMany(t => ((TimeRecord)t[0]).Components.Select(c => (object)c.Id).DefaultIfEmpty().Select(c => new[] { t[0], c }))
+					.GroupBy(j => new object[] { ((TimeRecord)j[0]).Project.Job.BillingType == BillingType.None ? 0 : 1, ((Component)j[1]).Name }, j => (TimeRecord)j[0])
+					.Select(g => new object[] { g.Key, g.Count(), g.Sum(t => (decimal?)t.TimeInHours) });
+
+				var results = query.ToList().OrderBy(x => (int)((object[])x[0])[0]).ThenBy(x => (string)((object[])x[0])[1]);
+				Assert.That(results.Select(x => x[1]), Is.EquivalentTo(new[] { 1, 2, 2, 2, 2, 2, 2, 2 }));
+				Assert.That(results.Select(x => x[2]), Is.EquivalentTo(new[] { 1, 6, 7, 14, 14, 15, 22, 23 }));
+
+				Assert.That(results.Sum(x => (decimal?)x[2]), Is.EqualTo(102));
+
+				transaction.Rollback();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3844/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3844/Mappings.hbm.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+				   namespace="NHibernate.Test.NHSpecificTest.NH3844"
+				   assembly="NHibernate.Test">
+
+  <class name="Project">
+    <id name="Id" column="ProjectId">
+      <generator class="guid.comb"/>
+    </id>
+    <property name="Name" not-null="true"/>
+    <bag name="Components"  inverse="true" lazy="true" fetch="select">
+      <key>
+        <column name="ProjectId" not-null="true" />
+      </key>
+      <one-to-many class="Component" />
+    </bag>
+    <many-to-one name="Job" column="JobId" class="Job" not-null="true"/>
+  </class>
+
+  <class name="Component">
+    <id name="Id" column="ComponentId">
+      <generator class="guid.comb"/>
+    </id>
+    <property name="Name" not-null="true"/>
+    <many-to-one name="Project" column="ProjectId" class="Project" not-null="true"/>
+  </class>
+
+  <class name="TimeRecord">
+    <id name="Id" column="TimeRecordId">
+      <generator class="guid.comb"/>
+    </id>
+    <property name="TimeInHours" not-null="true"/>
+    <many-to-one name="Project" column="ProjectId" class="Project" />
+    <bag name="Components" inverse="false" lazy="true" fetch="select">
+      <key>
+        <column name="TimeRecordId" not-null="true" />
+      </key>
+      <many-to-many class="Component">
+        <column name="ComponentId" not-null="true" />
+      </many-to-many>
+    </bag>
+  </class>
+
+  <class name="Job">
+    <id name="Id" column="JobId">
+      <generator class="guid.comb"/>
+    </id>
+    <property name="Name" not-null="true"/>
+    <property name="BillingType" not-null="true" type="BillingType"/>
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -889,6 +889,8 @@
     <Compile Include="NHSpecificTest\NH3727\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3727\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH3795\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3844\Domain.cs" />
+    <Compile Include="NHSpecificTest\NH3844\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3818\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3818\MyLovelyCat.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
@@ -3166,6 +3168,9 @@
   <ItemGroup>
     <EmbeddedResource Include="NHSpecificTest\NH3046\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3518\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\NH3844\Mappings.hbm.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="NHSpecificTest\NH3609\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3818\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3666\Mappings.hbm.xml">


### PR DESCRIPTION
I found that for some cases we need to flatten array index before we start rewriting the query for group bys and sometimes we need to do it after. Not sure if there is a case where both is required, but running the array flattener twice should have no ill effects on the query.