### PR TITLE
Make OfType work better with polymorphic mappings

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/MainEntity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/MainEntity.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Concrete
+{
+	public class MainEntity : IMainEntity
+	{
+		public virtual int MainEntityId { get; set; }
+		public virtual string Text { get; set; }
+		public virtual ISet<IPropertyEntityBase> Properties { get; protected set; } = new HashSet<IPropertyEntityBase>();
+		public virtual ISet<ISeparateEntity> SeparateEntities { get; protected set; } = new HashSet<ISeparateEntity>();
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityA.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityA.cs
@@ -1,0 +1,9 @@
+﻿using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Concrete
+{
+	public class PropertyEntityA : PropertyEntityBase, IPropertyEntityA
+	{
+		public virtual int SerialNumber { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityB.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityB.cs
@@ -1,0 +1,10 @@
+﻿using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Concrete
+{
+	public class PropertyEntityB : PropertyEntityBase, IPropertyEntityB
+	{
+		public virtual string Description { get; set; }
+		public virtual string AnotherString { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityBase.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityBase.cs
@@ -1,0 +1,12 @@
+﻿using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Concrete
+{
+	public abstract class PropertyEntityBase : IPropertyEntityBase
+	{
+		public virtual int PropertyEntityBaseId { get; set; }
+		public virtual string Name { get; set; }
+		public virtual string SharedValue { get; set; }
+		public virtual IMainEntity MainEntity { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityC.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/PropertyEntityC.cs
@@ -1,0 +1,10 @@
+﻿using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Concrete
+{
+	public class PropertyEntityC : PropertyEntityBase, IPropertyEntityC
+	{
+		public virtual string Description { get; set; }
+		public virtual int AnotherNumber { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/SeparateEntity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Concrete/SeparateEntity.cs
@@ -1,0 +1,11 @@
+﻿using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Concrete
+{
+	public class SeparateEntity : ISeparateEntity
+	{
+		public virtual int SeparateEntityId { get; set; }
+		public virtual IMainEntity MainEntity { get; set; }
+		public virtual int SeparateEntityValue { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Fixture.cs
@@ -1,0 +1,159 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NHibernate.Test.NHSpecificTest.NH3845.Concrete;
+using NHibernate.Test.NHSpecificTest.NH3845.Interfaces;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var entityA = new PropertyEntityA()
+				{
+					Name = "Name A",
+					SerialNumber = 4321,
+					SharedValue = "Some Value"
+				};
+				var entityB = new PropertyEntityB()
+				{
+					Name = "Name B",
+					Description = "Some Description",
+					SharedValue = "Another Value",
+					AnotherString = "Another String"
+				};
+				var entityC = new PropertyEntityC()
+				{
+					Name = "Name C",
+					Description = "Has Description",
+					SharedValue = "Value",
+					AnotherNumber = 42
+				};
+
+				var separateEntity = new SeparateEntity()
+				{
+					SeparateEntityValue = 5432
+				};
+
+				var mainEntity = new MainEntity()
+				{
+					Text = "Main Entity Text"
+				};
+				var secondMainEntity = new MainEntity()
+				{
+					Text = "Second Entity Text"
+				};
+				session.Save(mainEntity);
+				session.Save(secondMainEntity);
+				entityA.MainEntity = mainEntity;
+				entityB.MainEntity = mainEntity;
+				entityC.MainEntity = secondMainEntity;
+				separateEntity.MainEntity = secondMainEntity;
+				session.Save(entityA);
+				session.Save(entityB);
+				session.Save(entityC);
+				session.Save(separateEntity);
+
+				//mainEntity.Properties.Add(entityA);
+				//mainEntity.Properties.Add(entityB);
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void OfTypeWorksWithSingleEntityInterface()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var entityQuery = session.Query<IMainEntity>();
+				var result =
+					entityQuery.Where(m => m.Properties.OfType<IPropertyEntityB>().Any()).ToList();
+				Assert.AreEqual(1, result.Count);
+			}
+		}
+
+		[Test]
+		public void OfTypeWorksWithUnrelatedInterface()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var entityQuery = session.Query<IMainEntity>();
+				var result =
+					entityQuery.Where(m => m.Properties.OfType<IHasDescription>().Any()).ToList();
+				Assert.AreEqual(2, result.Count);
+			}
+		}
+
+		[Test]
+		public void CanQueryOfTypePropertyWithUnrelatedInterface()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var entityQuery = session.Query<IMainEntity>();
+				var result =
+					entityQuery.Where(m => m.Properties.OfType<IHasDescription>().Any(d => d.Description == "Has Description"))
+								.ToList();
+				Assert.AreEqual(1, result.Count);
+			}
+		}
+
+		[Test]
+		public void ImpossibleOfTypeReturnsNoResults()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var entityQuery = session.Query<IMainEntity>();
+				var result =
+					entityQuery.Where(m => m.Properties.OfType<ISession>().Any()).ToList();
+				Assert.IsEmpty(result);
+			}
+		}
+
+		[Test]
+		public void ImpossibleMappedOfTypeReturnsNoResults()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var entityQuery = session.Query<IMainEntity>();
+				var result =
+					entityQuery.Where(m => m.Properties.OfType<ISeparateEntity>().Any(se => se.SeparateEntityValue == 5432)).ToList();
+				Assert.IsEmpty(result);
+			}
+		}
+
+		[Test]
+		public void OfTypeAppliedToNonSubclassEntityStillWorks()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var entityQuery = session.Query<IMainEntity>();
+				var result = entityQuery.Where(m => m.SeparateEntities.OfType<SeparateEntity>().Any()).ToList();
+				Assert.AreEqual(1, result.Count);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IHasDescription.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IHasDescription.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface IHasDescription
+	{
+		string Description { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IMainEntity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IMainEntity.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface IMainEntity
+	{
+		int MainEntityId { get; set; }
+		string Text { get; set; }
+		ISet<IPropertyEntityBase> Properties { get; }
+		ISet<ISeparateEntity> SeparateEntities { get; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityA.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityA.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface IPropertyEntityA : IPropertyEntityBase
+	{
+		int SerialNumber { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityB.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityB.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface IPropertyEntityB : IPropertyEntityBase, IHasDescription
+	{
+		string AnotherString { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityBase.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityBase.cs
@@ -1,0 +1,10 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface IPropertyEntityBase
+	{
+		int PropertyEntityBaseId { get; set; }
+		string Name { get; set; }
+		string SharedValue { get; set; }
+		IMainEntity MainEntity { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityC.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/IPropertyEntityC.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface IPropertyEntityC : IPropertyEntityBase, IHasDescription
+	{
+		int AnotherNumber { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/ISeparateEntity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Interfaces/ISeparateEntity.cs
@@ -1,0 +1,9 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3845.Interfaces
+{
+	public interface ISeparateEntity
+	{
+		int SeparateEntityId { get; set; }
+		IMainEntity MainEntity { get; set; }
+		int SeparateEntityValue { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3845/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3845/Mappings.hbm.xml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.NH3845.Concrete">
+  <class name="MainEntity">
+    <id name="MainEntityId" type="Int32">
+      <generator class="native" />
+    </id>
+    <property name="Text" />
+    <set name="Properties" cascade="all" inverse="true" lazy="true">
+      <key column="MainEntityId" />
+      <one-to-many class="PropertyEntityBase" />
+    </set>
+    <set name="SeparateEntities" cascade="all" inverse="true" lazy="true">
+      <key column="MainEntityId" />
+      <one-to-many class="SeparateEntity" />
+    </set>
+  </class>
+  <class name="PropertyEntityBase" abstract="true">
+    <id name="PropertyEntityBaseId" type="Int32">
+      <generator class="enhanced-sequence" />
+    </id>
+    <property name="Name" />
+    <property name="SharedValue" />
+    <many-to-one name="MainEntity" class="MainEntity" cascade="all" column="MainEntityId" />
+    <union-subclass name="PropertyEntityA">
+      <property name="SerialNumber" />
+    </union-subclass>
+    <union-subclass name="PropertyEntityB">
+      <property name="Description" />
+      <property name="AnotherString" />
+    </union-subclass>
+    <union-subclass name="PropertyEntityC">
+      <property name="Description" />
+      <property name="AnotherNumber" />
+    </union-subclass>
+  </class>
+  <class name="SeparateEntity">
+    <id name="SeparateEntityId" type="Int32">
+      <generator class="native" />
+    </id>
+    <many-to-one name="MainEntity" class="MainEntity" cascade="all" column="MainEntityId" />
+    <property name="SeparateEntityValue" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -720,6 +720,13 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Linq\ByMethod\DistinctTests.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Concrete\MainEntity.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Concrete\PropertyEntityA.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Concrete\PropertyEntityB.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Concrete\PropertyEntityBase.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Concrete\PropertyEntityC.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Concrete\SeparateEntity.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2931\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2931\Mappings.cs" />
     <Compile Include="NHSpecificTest\NH2931\Models.cs" />
@@ -1280,6 +1287,13 @@
     <Compile Include="NHSpecificTest\NH3641\TestFixture.cs" />
     <Compile Include="NHSpecificTest\NH3800\Domain.cs" />
     <Compile Include="NHSpecificTest\NH3800\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\IHasDescription.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\IMainEntity.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\IPropertyEntityA.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\IPropertyEntityB.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\IPropertyEntityBase.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\IPropertyEntityC.cs" />
+    <Compile Include="NHSpecificTest\NH3845\Interfaces\ISeparateEntity.cs" />
     <Compile Include="NHSpecificTest\Properties\CompositePropertyRefTest.cs" />
     <Compile Include="NHSpecificTest\Properties\DynamicEntityTest.cs" />
     <Compile Include="NHSpecificTest\Properties\Model.cs" />
@@ -3160,6 +3174,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3845\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3518\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3609\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3818\Mappings.hbm.xml" />

--- a/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
@@ -416,7 +416,7 @@ namespace NHibernate.Hql.Ast
 			return new HqlFalse(_factory);
 		}
 
-		public HqlIn In(HqlExpression itemExpression, HqlTreeNode source)
+		public HqlIn In(HqlExpression itemExpression, params HqlTreeNode[] source)
 		{
 			return new HqlIn(_factory, itemExpression, source);
 		}

--- a/src/NHibernate/Hql/Ast/HqlTreeNode.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeNode.cs
@@ -885,7 +885,7 @@ namespace NHibernate.Hql.Ast
 
 	public class HqlIn : HqlBooleanExpression
 	{
-		public HqlIn(IASTFactory factory, HqlExpression itemExpression, HqlTreeNode source)
+		public HqlIn(IASTFactory factory, HqlExpression itemExpression, params HqlTreeNode[] source)
 			: base(HqlSqlWalker.IN, "in", factory, itemExpression)
 		{
 			AddChild(new HqlInList(factory, source));
@@ -894,7 +894,7 @@ namespace NHibernate.Hql.Ast
 
 	public class HqlInList : HqlTreeNode
 	{
-		public HqlInList(IASTFactory factory, HqlTreeNode source)
+		public HqlInList(IASTFactory factory, params HqlTreeNode[] source)
 			: base(HqlSqlWalker.IN_LIST, "inlist", factory, source)
 		{
 		}

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessOfType.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessOfType.cs
@@ -1,5 +1,10 @@
-﻿using System.Linq.Expressions;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using NHibernate.Hql.Ast;
+using NHibernate.Persister.Entity;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
@@ -8,15 +13,90 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 	{
 		#region IResultOperatorProcessor<OfTypeResultOperator> Members
 
-		public void Process(OfTypeResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+		public void Process(
+			OfTypeResultOperator resultOperator,
+			QueryModelVisitor queryModelVisitor,
+			IntermediateHqlTree tree)
 		{
-		    Expression source = queryModelVisitor.Model.SelectClause.GetOutputDataInfo().ItemExpression;
+			Expression source = queryModelVisitor.Model.SelectClause.GetOutputDataInfo().ItemExpression;
+			var fromItemEnumerableType = queryModelVisitor.Model.MainFromClause.FromExpression.Type;
+			var fromItemType = typeof(object);
+			var asEnumerable =
+				fromItemEnumerableType.GetInterfaces()
+									.FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+			if (asEnumerable != null)
+			{
+				fromItemType = asEnumerable.GetGenericArguments()[0];
+			}
 
-			tree.AddWhereClause(tree.TreeBuilder.Equality(
+			var fromItemImplementorQueue =
+				new Queue<string>(queryModelVisitor.VisitorParameters.SessionFactory.GetImplementors(fromItemType.FullName));
+			var fromItemTypeNamesProcessed = new HashSet<string>();
+			var fromItemTypePersisters = new List<IEntityPersister>();
+			while (fromItemImplementorQueue.Any())
+			{
+				var currentImplementor = fromItemImplementorQueue.Dequeue();
+				if (fromItemTypeNamesProcessed.Add(currentImplementor))
+				{
+					var persister = queryModelVisitor.VisitorParameters.SessionFactory.TryGetEntityPersister(currentImplementor);
+					if (persister != null)
+					{
+						fromItemTypePersisters.Add(persister);
+						persister.EntityMetamodel.SubclassEntityNames.ToList().ForEach(fromItemImplementorQueue.Enqueue);
+					}
+				}
+			}
+
+			// Which of the mapped types are assignable to both the source -- meaning that the property could actually
+			// be of the mapped type -- and to the searched item type?
+			var persistersToUse =
+				fromItemTypePersisters.Where(
+					p =>
+					{
+						var mappedClass = p.GetMappedClass(EntityMode.Poco);
+						return fromItemType.IsAssignableFrom(mappedClass) && resultOperator.SearchedItemType.IsAssignableFrom(mappedClass);
+					}).ToList();
+
+			// If the persisters are not among the subclass persister types, there will be no class property, so the query would fail
+			// if we tried to include the class literal in the query anyway.  Also, if there are no applicable persisters, no results
+			// can be returned, so add "WHERE 1 = 0" in those cases.
+			if (persistersToUse.Count == 0)
+			{
+				tree.AddWhereClause(tree.TreeBuilder.Equality(tree.TreeBuilder.Constant(1), tree.TreeBuilder.Constant(0)));
+				// Because the rest of the query may be invalid (e.g., by referencing properties that do not exist),
+				// delete any remaining body clauses.
+				queryModelVisitor.Model.BodyClauses.Clear();
+				return;
+			}
+			if (!persistersToUse.Any(p => p.EntityMetamodel.HasSubclasses || p.EntityMetamodel.SuperclassType != null))
+			{
+				// All results should be returned, so no point adding a where clause
+				return;
+			}
+
+			var classesToUse =
+				fromItemTypePersisters.Select(p => p.GetMappedClass(EntityMode.Poco))
+									.Where(t => fromItemType.IsAssignableFrom(t) && resultOperator.SearchedItemType.IsAssignableFrom(t))
+									.Select(t => t.FullName)
+									.ToList();
+
+			var dotNode =
 				tree.TreeBuilder.Dot(
 					HqlGeneratorExpressionTreeVisitor.Visit(source, queryModelVisitor.VisitorParameters).AsExpression(),
-					tree.TreeBuilder.Class()),
-				tree.TreeBuilder.Ident(resultOperator.SearchedItemType.FullName)));
+					tree.TreeBuilder.Class());
+
+			// For now, use the name of the persisted class as a literal identifier.  The string value containing
+			// the full class name is translated to a discriminator column value in
+			// NHibernate.Hql.Ast.ANTLR.Util.LiteralProcessor.ProcessConstant(SqlNode, bool).
+			if (classesToUse.Count == 1)
+			{
+				tree.AddWhereClause(tree.TreeBuilder.Equality(dotNode, tree.TreeBuilder.Ident(classesToUse[0])));
+			}
+			else
+			{
+				var implementorNodes = classesToUse.Select(tree.TreeBuilder.Ident).OfType<HqlTreeNode>().ToArray();
+				tree.AddWhereClause(tree.TreeBuilder.In(dotNode, implementorNodes));
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
Addresses NH-3845.  The ProcessOfType Linq visitor class now handles interfaces and base classes by checking which mapped types that could be in the result set implement the class, then filtering accordingly.  If no results are possible, any remaining filters are removed from the query tree to avoid problems with invalid property names.

Because the HQL tree for OfType can now mimic the ".class IN" construct, the In method of HqlTreeBuilder was inadequate to express the tree.  Allowing an array of nodes to be passed as the source solves this problem.