### PR TITLE
NH-3046 Potential Memory leak

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3046/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3046/Fixture.cs
@@ -1,0 +1,60 @@
+
+using System;
+using NUnit.Framework;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Cfg;
+
+namespace NHibernate.Test.NHSpecificTest.NH3046
+{
+	[TestFixture]
+    public class Fixture : BugTestCase
+	{
+		[Test]
+		public void MemoryLeak()
+		{
+
+            long initialMemory = GC.GetTotalMemory(true);
+            long nextId = 1;
+            long nextIdChild = 1;
+
+            using (ISession session = OpenSession())
+            using (session.BeginTransaction())
+            {
+                // We try to insert 100.000 entities, cleaning the sessions
+                // every 1000.
+                // We keep track of memory, that should be increasing forever.
+                // We took a maximum of 250000 that can change to greater number but
+                // not increase forever.
+                for (int i = 0; i < 100; i++)
+                {
+                    GC.Collect();
+                    long currentMemory = GC.GetTotalMemory(true);
+                    long memoryIncrease = currentMemory - initialMemory;
+
+                    Assert.Less(memoryIncrease, 300000);
+                    // Console.WriteLine(memoryIncrease);
+                    for (int j = 0; j < 1000; j++)
+                    {
+                        Parent a = new Parent();
+                        a.Id = nextId++;
+
+                        Child c = new Child();
+                        c.Id = nextIdChild++;
+
+                        a.Childs.Add(c);
+
+                        session.Save(c);
+                        session.Save(a);
+                    }
+                    session.Flush();
+                    session.Clear();
+                }
+            }
+		}
+
+        protected override string CacheConcurrencyStrategy
+        {
+            get { return null; }
+        }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3046/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3046/Mappings.hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping
+	xmlns="urn:nhibernate-mapping-2.2"
+	assembly="NHibernate.Test"
+	namespace="NHibernate.Test.NHSpecificTest.NH3046">
+
+  <class name="Parent">
+    <id name="Id"/>
+
+    <bag name="Childs" lazy="true" inverse="true" cascade="all">
+      <key column="parent_id" />
+      <one-to-many class="Child" />
+    </bag>
+
+  </class>
+
+  <class name="Child">
+    <id name="Id"/>
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3046/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3046/Model.cs
@@ -1,0 +1,21 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3010
+{
+	using System;
+	using System.Collections.Generic;
+
+	public class Parent
+	{
+		public Parent()
+		{
+			Childs = new List<Child>();
+		}
+
+		public virtual Guid Id { get; set; }
+		public virtual IList<Child> Childs { get; set; }
+	}
+
+	public class Child
+	{
+		public virtual Guid Id { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3046/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3046/Model.cs
@@ -1,4 +1,4 @@
-﻿namespace NHibernate.Test.NHSpecificTest.NH3010
+﻿namespace NHibernate.Test.NHSpecificTest.NH3046
 {
 	using System;
 	using System.Collections.Generic;
@@ -10,12 +10,12 @@
 			Childs = new List<Child>();
 		}
 
-		public virtual Guid Id { get; set; }
+		public virtual long Id { get; set; }
 		public virtual IList<Child> Childs { get; set; }
 	}
 
 	public class Child
 	{
-		public virtual Guid Id { get; set; }
+		public virtual long Id { get; set; }
 	}
 }

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -723,6 +723,8 @@
     <Compile Include="NHSpecificTest\NH2931\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2931\Mappings.cs" />
     <Compile Include="NHSpecificTest\NH2931\Models.cs" />
+    <Compile Include="NHSpecificTest\NH3046\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3046\Model.cs" />
     <Compile Include="NHSpecificTest\NH3518\ClassWithXmlMember.cs" />
     <Compile Include="NHSpecificTest\NH3518\XmlColumnTest.cs" />
     <Compile Include="NHSpecificTest\NH3609\MappingEntity.cs" />
@@ -3160,6 +3162,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3046\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3518\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3609\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3818\Mappings.hbm.xml" />

--- a/src/NHibernate/Action/CollectionAction.cs
+++ b/src/NHibernate/Action/CollectionAction.cs
@@ -114,16 +114,19 @@ namespace NHibernate.Action
 
 		public virtual AfterTransactionCompletionProcessDelegate AfterTransactionCompletionProcess
 		{
+
 			get
 			{
-				return new AfterTransactionCompletionProcessDelegate((success) =>
-				{
-					if (persister.HasCache)
-					{
-						CacheKey ck = Session.GenerateCacheKey(key, persister.KeyType, persister.Role);
-						persister.Cache.Release(ck, softLock);
-					}
-				});
+                // Only make sense to add the delegate if there is a cache.
+                if (persister.HasCache)
+                {
+                    return new AfterTransactionCompletionProcessDelegate((success) =>
+                    {
+                        CacheKey ck = new CacheKey(key, persister.KeyType, persister.Role, Session.EntityMode, Session.Factory);
+                        persister.Cache.Release(ck, softLock);
+                    });
+                }
+                return null; 
 			}
 		}
 		

--- a/src/NHibernate/Action/CollectionUpdateAction.cs
+++ b/src/NHibernate/Action/CollectionUpdateAction.cs
@@ -125,35 +125,38 @@ namespace NHibernate.Action
 		{
 			get
 			{
-				return new AfterTransactionCompletionProcessDelegate((success) =>
-				{
-					// NH Different behavior: to support unlocking collections from the cache.(r3260)
-					if (Persister.HasCache)
-					{
-						CacheKey ck = Session.GenerateCacheKey(Key, Persister.KeyType, Persister.Role);
+                // Only make sense to add the delegate if there is a cache.
+                if (Persister.HasCache)
+                {
+                    // NH Different behavior: to support unlocking collections from the cache.(r3260)
+                    return new AfterTransactionCompletionProcessDelegate((success) =>
+                    {
+                        CacheKey ck = Session.GenerateCacheKey(Key, Persister.KeyType, Persister.Role);
 
-						if (success)
-						{
-							// we can't disassemble a collection if it was uninitialized 
-							// or detached from the session
-							if (Collection.WasInitialized && Session.PersistenceContext.ContainsCollection(Collection))
-							{
-								CollectionCacheEntry entry = new CollectionCacheEntry(Collection, Persister);
-								bool put = Persister.Cache.AfterUpdate(ck, entry, null, Lock);
-		
-								if (put && Session.Factory.Statistics.IsStatisticsEnabled)
-								{
-									Session.Factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
-								}
-							}
-						}
-						else
-						{
-							Persister.Cache.Release(ck, Lock);
-						}
-					}
-				});
-			}
+                        if (success)
+                        {
+                            // we can't disassemble a collection if it was uninitialized 
+                            // or detached from the session
+                            if (Collection.WasInitialized && Session.PersistenceContext.ContainsCollection(Collection))
+                            {
+                                CollectionCacheEntry entry = new CollectionCacheEntry(Collection, Persister);
+                                bool put = Persister.Cache.AfterUpdate(ck, entry, null, Lock);
+
+                                if (put && Session.Factory.Statistics.IsStatisticsEnabled)
+                                {
+                                    Session.Factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            Persister.Cache.Release(ck, Lock);
+                        }
+                    });
+                }
+                else
+                    return null;
+            }
 		}
 	}
 }

--- a/src/NHibernate/Action/EntityAction.cs
+++ b/src/NHibernate/Action/EntityAction.cs
@@ -106,7 +106,9 @@ namespace NHibernate.Action
 		{
 			get
 			{
-				return new BeforeTransactionCompletionProcessDelegate(BeforeTransactionCompletionProcessImpl);
+                return NeedsBeforeTransactionCompletion()
+                    ? new BeforeTransactionCompletionProcessDelegate(BeforeTransactionCompletionProcessImpl)
+                    : null;
 			}
 		}
 		
@@ -120,10 +122,17 @@ namespace NHibernate.Action
 			}
 		}
 		
-		private bool NeedsAfterTransactionCompletion()
+		protected virtual bool NeedsAfterTransactionCompletion()
 		{
 			return persister.HasCache || HasPostCommitEventListeners;
 		}
+
+        protected virtual bool NeedsBeforeTransactionCompletion()
+        {
+            // At the moment, there is no need to add the delegate, 
+            // Subclasses can override this method and add the delegate if needed.
+            return false;
+        }
 		
 		protected virtual void BeforeTransactionCompletionProcessImpl()
 		{


### PR DESCRIPTION
Found a potential kind of memory leak.

Memory used by entities is not released when Session.Clean is called. This is due a reference that is kept from delegates used in before/after commit. 

This delegates are necessary in case we are using cache's but totally unnecessary in other escenarios.

The proposed solution is simple, is just not create this delegates when not needed. 

In our environment, we needed a long running transaction... we discover the issue when the process took 8Gb of memmory and 4 hours of processing. After the change, it took 200mb and 15 minutes...

We add a test case where we can detect the issue when delegates are always created.

https://nhibernate.jira.com/browse/NH-3046