### PR TITLE
Fix false positive warning about non-serializable interfaces

### DIFF
--- a/src/NHibernate/Type/CompositeCustomType.cs
+++ b/src/NHibernate/Type/CompositeCustomType.cs
@@ -49,7 +49,7 @@ namespace NHibernate.Type
 				throw new MappingException(name + " must implement NHibernate.UserTypes.ICompositeUserType", ice);
 			}
 			TypeFactory.InjectParameters(userType, parameters);
-			if (!userType.ReturnedClass.IsSerializable)
+			if (!userType.ReturnedClass.IsInterface && !userType.ReturnedClass.IsAbstract && !userType.ReturnedClass.IsSerializable)
 			{
 				LoggerProvider.LoggerFor(typeof(CustomType)).WarnFormat("the custom composite class '{0}' handled by '{1}' is not Serializable: ", userType.ReturnedClass, userTypeClass);
 			}

--- a/src/NHibernate/Type/CustomType.cs
+++ b/src/NHibernate/Type/CustomType.cs
@@ -64,7 +64,7 @@ namespace NHibernate.Type
 			}
 			TypeFactory.InjectParameters(userType, parameters);
 			sqlTypes = userType.SqlTypes;
-			if (!userType.ReturnedType.IsSerializable)
+			if (!userType.ReturnedType.IsInterface && !userType.ReturnedType.IsAbstract && !userType.ReturnedType.IsSerializable)
 			{
 				LoggerProvider.LoggerFor(typeof(CustomType)).WarnFormat("the custom type '{0}' handled by '{1}' is not Serializable: ", userType.ReturnedType, userTypeClass);
 			}


### PR DESCRIPTION
See this issue in NHibernate.Spatial: https://github.com/nhibernate/NHibernate.Spatial/issues/9.
Also see this discussion on StackOverflow: http://stackoverflow.com/q/35983333/5311735.

All geometry types return IGeometry interface as their ReturnedType, and they cannot do otherwise, because there are several concrete types which implement this interface. This produces a false positive warning about IGeometry type being not serializable, which floods the logs. It seems there is no need to produce non-serializable warning for interface and abstract types, because they cannot be serializable anyway.