### PR TITLE
Additional check if child session has already been closed.

### DIFF
--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -306,7 +306,12 @@ namespace NHibernate.Engine
 		/// </returns>
 		bool IsClosed { get; }
 
-		void Flush();
+        /// <summary>
+        /// Close the session and release all resources.
+        /// </summary>
+        IDbConnection Close();
+
+        void Flush();
 
 		/// <summary> 
 		/// Does this <tt>Session</tt> have an active Hibernate transaction

--- a/src/NHibernate/IStatelessSession.cs
+++ b/src/NHibernate/IStatelessSession.cs
@@ -60,7 +60,7 @@ namespace NHibernate
 		ISessionImplementor GetSessionImplementation();
 
 		/// <summary>Close the stateless session and release the ADO.NET connection.</summary>
-		void Close();
+		IDbConnection Close();
 
 		/// <summary>Insert an entity.</summary>
 		/// <param name="entity">A new transient instance</param>

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -298,7 +298,9 @@ namespace NHibernate.Impl
 			get { return closed; }
 		}
 
-		protected internal virtual void CheckAndUpdateSessionStatus()
+	    public abstract IDbConnection Close();
+
+	    protected internal virtual void CheckAndUpdateSessionStatus()
 		{
 			ErrorIfClosed();
 			EnlistInAmbientTransactionIfNeeded();

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -78,7 +78,7 @@ namespace NHibernate.Impl
 		private readonly ISession rootSession;
 
 		[NonSerialized]
-		private IDictionary<EntityMode, ISession> childSessionsByEntityMode;
+        private IDictionary<EntityMode, SessionImpl> childSessionsByEntityMode;
 
 		[NonSerialized]
 		private readonly bool flushBeforeCompletionEnabled;
@@ -372,9 +372,12 @@ namespace NHibernate.Impl
 					{
 						if (childSessionsByEntityMode != null)
 						{
-							foreach (KeyValuePair<EntityMode, ISession> pair in childSessionsByEntityMode)
+							foreach (KeyValuePair<EntityMode, SessionImpl> pair in childSessionsByEntityMode)
 							{
-								pair.Value.Close();
+							    if (!pair.Value.IsClosed)
+							    {
+								    pair.Value.Close();
+							    }
 							}
 						}
 					}
@@ -2243,10 +2246,10 @@ namespace NHibernate.Impl
 
 				CheckAndUpdateSessionStatus();
 
-				ISession rtn = null;
+				SessionImpl rtn = null;
 				if (childSessionsByEntityMode == null)
 				{
-					childSessionsByEntityMode = new Dictionary<EntityMode, ISession>();
+                    childSessionsByEntityMode = new Dictionary<EntityMode, SessionImpl>();
 				}
 				else
 				{

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -78,7 +78,7 @@ namespace NHibernate.Impl
 		private readonly ISession rootSession;
 
 		[NonSerialized]
-        private IDictionary<EntityMode, SessionImpl> childSessionsByEntityMode;
+        private IDictionary<EntityMode, ISessionImplementor> childSessionsByEntityMode;
 
 		[NonSerialized]
 		private readonly bool flushBeforeCompletionEnabled;
@@ -351,7 +351,7 @@ namespace NHibernate.Impl
 		/// Close() is not aware of distributed transactions
 		/// </remarks>
 		/// </summary>
-		public IDbConnection Close()
+		public override IDbConnection Close()
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
@@ -372,7 +372,7 @@ namespace NHibernate.Impl
 					{
 						if (childSessionsByEntityMode != null)
 						{
-							foreach (KeyValuePair<EntityMode, SessionImpl> pair in childSessionsByEntityMode)
+							foreach (KeyValuePair<EntityMode, ISessionImplementor> pair in childSessionsByEntityMode)
 							{
 							    if (!pair.Value.IsClosed)
 							    {
@@ -2246,10 +2246,10 @@ namespace NHibernate.Impl
 
 				CheckAndUpdateSessionStatus();
 
-				SessionImpl rtn = null;
+                ISessionImplementor rtn = null;
 				if (childSessionsByEntityMode == null)
 				{
-                    childSessionsByEntityMode = new Dictionary<EntityMode, SessionImpl>();
+                    childSessionsByEntityMode = new Dictionary<EntityMode, ISessionImplementor>();
 				}
 				else
 				{
@@ -2263,7 +2263,7 @@ namespace NHibernate.Impl
 					childSessionsByEntityMode.Add(entityMode, rtn);
 				}
 
-				return rtn;
+				return (ISession)rtn;
 			}
 		}
 

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -439,15 +439,15 @@ namespace NHibernate.Impl
 		}
 
 		/// <summary> Close the stateless session and release the ADO.NET connection.</summary>
-		public void Close()
+		public override IDbConnection Close()
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				ManagedClose();
+				return ManagedClose();
 			}
 		}
 
-		public void ManagedClose()
+		public IDbConnection ManagedClose()
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
@@ -455,8 +455,9 @@ namespace NHibernate.Impl
 				{
 					throw new SessionException("Session was already closed!");
 				}
-				ConnectionManager.Close();
+				var dbConection = ConnectionManager.Close();
 				SetClosed();
+			    return dbConection;
 			}
 		}
 


### PR DESCRIPTION
This simple fix prevents unnecessary `SessionException("Session was already closed")` throw when both parent session and child session are closed separately (order does not matter). Before invoking close on child session (during parent session close) we should check if child session has not been closed already. Unfortunately to check if session was closed we have to use `SessionImpl` class instead of `ISession` interface, so we changed `SessionImpl`’s `childSessionsByEntityMode` private field type `IDictionary<EntityMode, ISession>` into `IDictionary<EntityMode, SessionImpl>`.
