### PR TITLE
Made RuleSetMappingDefinition immutable

### DIFF
--- a/src/NHibernate/Cache/QueryKey.cs
+++ b/src/NHibernate/Cache/QueryKey.cs
@@ -137,11 +137,11 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			if (!CollectionHelper.CollectionEquals<int>(_multiQueriesFirstRows, that._multiQueriesFirstRows))
+			if (!CollectionHelper.CollectionEquals((ICollection<int>)_multiQueriesFirstRows, that._multiQueriesFirstRows))
 			{
 				return false;
 			}
-			if (!CollectionHelper.CollectionEquals<int>(_multiQueriesMaxRows, that._multiQueriesMaxRows))
+			if (!CollectionHelper.CollectionEquals((ICollection<int>)_multiQueriesMaxRows, that._multiQueriesMaxRows))
 			{
 				return false;
 			}

--- a/src/NHibernate/Cfg/XmlHbmBinding/NamedSQLQueryBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/NamedSQLQueryBinder.cs
@@ -43,7 +43,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 							new ResultSetMappingBinder(Mappings).Create(querySchema);
 
 						namedQuery = new NamedSQLQueryDefinition(queryText,
-							definition.GetQueryReturns(), synchronizedTables, cacheable, region, timeout,
+							definition.QueryReturns, synchronizedTables, cacheable, region, timeout,
 							fetchSize, flushMode, cacheMode, readOnly, comment, parameterTypes, callable);
 					}
 					else

--- a/src/NHibernate/Cfg/XmlHbmBinding/ResultSetMappingBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/ResultSetMappingBinder.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Engine;
 using NHibernate.Engine.Query.Sql;
@@ -29,19 +31,12 @@ namespace NHibernate.Cfg.XmlHbmBinding
 
 		private ResultSetMappingDefinition Create(string name, object[] items)
 		{
-			ResultSetMappingDefinition definition = new ResultSetMappingDefinition(name);
+			var itemsNullSafe = items ?? new object[0];
+			var returns = itemsNullSafe.Select(CreateQueryReturn)
+																 .Where(x => x != null)
+																 .ToArray();
 
-			int count = 0;
-			foreach (object item in items ?? new object[0])
-			{
-				count += 1;
-				INativeSQLQueryReturn queryReturn = CreateQueryReturn(item, count);
-
-				if (queryReturn != null)
-					definition.AddQueryReturn(queryReturn);
-			}
-
-			return definition;
+			return new ResultSetMappingDefinition(name, returns);
 		}
 
 		private INativeSQLQueryReturn CreateQueryReturn(object item, int count)

--- a/src/NHibernate/Engine/NamedSQLQueryDefinition.cs
+++ b/src/NHibernate/Engine/NamedSQLQueryDefinition.cs
@@ -11,8 +11,8 @@ namespace NHibernate.Engine
 	[Serializable]
 	public class NamedSQLQueryDefinition : NamedQueryDefinition
 	{
-		private readonly ReadOnlyCollection<INativeSQLQueryReturn> queryReturns;
-		private readonly ReadOnlyCollection<string> querySpaces;
+		private readonly IReadOnlyList<INativeSQLQueryReturn> queryReturns;
+		private readonly IReadOnlyList<string> querySpaces;
 		private readonly bool callable;
 		private readonly string resultSetRef;
 
@@ -48,45 +48,45 @@ namespace NHibernate.Engine
 			this.callable = callable;
 		}
 
-		public NamedSQLQueryDefinition(
-			string query,
-			string resultSetRef,
-			IList<string> querySpaces,
-			bool cacheable,
-			string cacheRegion,
-			int timeout,
-			int fetchSize,
-			FlushMode flushMode,
-			CacheMode? cacheMode,
-			bool readOnly,
-			string comment,
-			IDictionary<string, string> parameterTypes,
-			bool callable)
-			: base(
-				query.Trim(), /* trim done to workaround stupid oracle bug that cant handle whitespaces before a { in a sp */
-				cacheable,
-				cacheRegion,
-				timeout,
-				fetchSize,
-				flushMode,
-				cacheMode,
-				readOnly,
-				comment,
-				parameterTypes
-				)
-		{
-		    this.queryReturns = ReadOnlyCollectionHelper.EmptyQueryReturns;
-            this.resultSetRef = resultSetRef;
-			this.querySpaces = new ReadOnlyCollection<string>(querySpaces);
-			this.callable = callable;
-		}
+	  public NamedSQLQueryDefinition(
+	    string query,
+	    string resultSetRef,
+	    IList<string> querySpaces,
+	    bool cacheable,
+	    string cacheRegion,
+	    int timeout,
+	    int fetchSize,
+	    FlushMode flushMode,
+	    CacheMode? cacheMode,
+	    bool readOnly,
+	    string comment,
+	    IDictionary<string, string> parameterTypes,
+	    bool callable)
+	    : base(query.Trim(),
+	           /* trim done to workaround stupid oracle bug that cant handle whitespaces before a { in a sp */
+	           cacheable,
+	           cacheRegion,
+	           timeout,
+	           fetchSize,
+	           flushMode,
+	           cacheMode,
+	           readOnly,
+	           comment,
+	           parameterTypes
+	          )
+	  {
+	    this.queryReturns = ReadOnlyCollectionHelper.EmptyQueryReturns;
+	    this.resultSetRef = resultSetRef;
+	    this.querySpaces = new ReadOnlyCollection<string>(querySpaces);
+	    this.callable = callable;
+	  }
 
-		public ReadOnlyCollection<INativeSQLQueryReturn> QueryReturns
+	  public IReadOnlyList<INativeSQLQueryReturn> QueryReturns
 		{
 			get { return queryReturns; }
 		}
 
-		public ReadOnlyCollection<string> QuerySpaces
+		public IReadOnlyList<string> QuerySpaces
 		{
 			get { return querySpaces; }
 		}

--- a/src/NHibernate/Engine/NamedSQLQueryDefinition.cs
+++ b/src/NHibernate/Engine/NamedSQLQueryDefinition.cs
@@ -1,21 +1,24 @@
 using System;
-using System.Collections;
-using NHibernate.Engine.Query.Sql;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+using NHibernate.Engine.Query.Sql;
+using NHibernate.Util;
+
 
 namespace NHibernate.Engine
 {
 	[Serializable]
 	public class NamedSQLQueryDefinition : NamedQueryDefinition
 	{
-		private readonly INativeSQLQueryReturn[] queryReturns;
-		private readonly IList<string> querySpaces;
+		private readonly ReadOnlyCollection<INativeSQLQueryReturn> queryReturns;
+		private readonly ReadOnlyCollection<string> querySpaces;
 		private readonly bool callable;
 		private readonly string resultSetRef;
 
 		public NamedSQLQueryDefinition(
 			string query,
-			INativeSQLQueryReturn[] queryReturns,
+			IList<INativeSQLQueryReturn> queryReturns,
 			IList<string> querySpaces,
 			bool cacheable,
 			string cacheRegion,
@@ -40,8 +43,8 @@ namespace NHibernate.Engine
 				parameterTypes
 				)
 		{
-			this.queryReturns = queryReturns;
-			this.querySpaces = querySpaces;
+			this.queryReturns = new ReadOnlyCollection<INativeSQLQueryReturn>(queryReturns);
+			this.querySpaces = new ReadOnlyCollection<string>(querySpaces);
 			this.callable = callable;
 		}
 
@@ -72,17 +75,18 @@ namespace NHibernate.Engine
 				parameterTypes
 				)
 		{
-			this.resultSetRef = resultSetRef;
-			this.querySpaces = querySpaces;
+		    this.queryReturns = ReadOnlyCollectionHelper.EmptyQueryReturns;
+            this.resultSetRef = resultSetRef;
+			this.querySpaces = new ReadOnlyCollection<string>(querySpaces);
 			this.callable = callable;
 		}
 
-		public INativeSQLQueryReturn[] QueryReturns
+		public ReadOnlyCollection<INativeSQLQueryReturn> QueryReturns
 		{
 			get { return queryReturns; }
 		}
 
-		public IList<string> QuerySpaces
+		public ReadOnlyCollection<string> QuerySpaces
 		{
 			get { return querySpaces; }
 		}

--- a/src/NHibernate/Engine/Query/Sql/NativeSQLQuerySpecification.cs
+++ b/src/NHibernate/Engine/Query/Sql/NativeSQLQuerySpecification.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
 using NHibernate.Util;
 
 namespace NHibernate.Engine.Query.Sql
@@ -6,47 +8,46 @@ namespace NHibernate.Engine.Query.Sql
 	public class NativeSQLQuerySpecification
 	{
 		private readonly string queryString;
-		private readonly INativeSQLQueryReturn[] sqlQueryReturns;
-		private readonly ISet<string> querySpaces;
+		private readonly ReadOnlyCollection<INativeSQLQueryReturn> sqlQueryReturns;
+		private readonly ReadOnlyCollection<string> querySpaces;
 		private readonly int hashCode;
 
-		public NativeSQLQuerySpecification(
-			string queryString,
-			INativeSQLQueryReturn[] sqlQueryReturns,
-			ICollection<string> querySpaces)
-		{
-			this.queryString = queryString;
-			this.sqlQueryReturns = sqlQueryReturns;
+	    public NativeSQLQuerySpecification(
+	        string queryString,
+	        IList<INativeSQLQueryReturn> sqlQueryReturns,
+	        IList<string> querySpaces)
+	    {
+	        this.queryString = queryString;
+	        this.sqlQueryReturns = new ReadOnlyCollection<INativeSQLQueryReturn>(sqlQueryReturns);
+	        this.querySpaces = new ReadOnlyCollection<string>(querySpaces ?? new string[0]);
 
-			this.querySpaces = new HashSet<string>();
-			if (querySpaces != null)
-				this.querySpaces.UnionWith(querySpaces);
+	        // pre-determine and cache the hashcode
+	        int hCode = queryString.GetHashCode();
 
-			// pre-determine and cache the hashcode
-			int hCode = queryString.GetHashCode();
-			unchecked
-			{
-				hCode = 29 * hCode + CollectionHelper.GetHashCode(this.querySpaces);
-				if (this.sqlQueryReturns != null)
-				{
-					hCode = 29 * hCode + CollectionHelper.GetHashCode(this.sqlQueryReturns);
-				}
-			}
+	        unchecked
+	        {
+	            hCode = 29*hCode + CollectionHelper.GetHashCode(this.querySpaces);
 
-			hashCode = hCode;
-		}
+                if (this.sqlQueryReturns.Count > 0)
+	            {
+	                hCode = 29*hCode + CollectionHelper.GetHashCode(this.sqlQueryReturns);
+	            }
+	        }
 
-		public string QueryString
+	        hashCode = hCode;
+	    }
+
+	    public string QueryString
 		{
 			get { return queryString; }
 		}
 
-		public INativeSQLQueryReturn[] SqlQueryReturns
+		public ReadOnlyCollection<INativeSQLQueryReturn> SqlQueryReturns
 		{
 			get { return sqlQueryReturns; }
 		}
 
-		public ISet<string> QuerySpaces
+		public ReadOnlyCollection<string> QuerySpaces
 		{
 			get { return querySpaces; }
 		}

--- a/src/NHibernate/Engine/Query/Sql/NativeSQLQuerySpecification.cs
+++ b/src/NHibernate/Engine/Query/Sql/NativeSQLQuerySpecification.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 using NHibernate.Util;
 
@@ -8,18 +7,18 @@ namespace NHibernate.Engine.Query.Sql
 	public class NativeSQLQuerySpecification
 	{
 		private readonly string queryString;
-		private readonly ReadOnlyCollection<INativeSQLQueryReturn> sqlQueryReturns;
-		private readonly ReadOnlyCollection<string> querySpaces;
+		private readonly IReadOnlyList<INativeSQLQueryReturn> sqlQueryReturns;
+		private readonly IReadOnlyList<string> querySpaces;
 		private readonly int hashCode;
 
 	    public NativeSQLQuerySpecification(
 	        string queryString,
-	        IList<INativeSQLQueryReturn> sqlQueryReturns,
-	        IList<string> querySpaces)
+	        IEnumerable<INativeSQLQueryReturn> sqlQueryReturns,
+					IEnumerable<string> querySpaces)
 	    {
 	        this.queryString = queryString;
-	        this.sqlQueryReturns = new ReadOnlyCollection<INativeSQLQueryReturn>(sqlQueryReturns);
-	        this.querySpaces = new ReadOnlyCollection<string>(querySpaces ?? new string[0]);
+	        this.sqlQueryReturns = new List<INativeSQLQueryReturn>(sqlQueryReturns).AsReadOnly();
+	        this.querySpaces = new List<string>(querySpaces ?? new string[0]).AsReadOnly();
 
 	        // pre-determine and cache the hashcode
 	        int hCode = queryString.GetHashCode();
@@ -42,12 +41,12 @@ namespace NHibernate.Engine.Query.Sql
 			get { return queryString; }
 		}
 
-		public ReadOnlyCollection<INativeSQLQueryReturn> SqlQueryReturns
+		public IReadOnlyList<INativeSQLQueryReturn> SqlQueryReturns
 		{
 			get { return sqlQueryReturns; }
 		}
 
-		public ReadOnlyCollection<string> QuerySpaces
+		public IReadOnlyList<string> QuerySpaces
 		{
 			get { return querySpaces; }
 		}
@@ -67,7 +66,7 @@ namespace NHibernate.Engine.Query.Sql
 			return hashCode == that.hashCode &&
 				queryString.Equals(that.queryString) &&
 				CollectionHelper.CollectionEquals(querySpaces, that.querySpaces) &&
-				CollectionHelper.CollectionEquals<INativeSQLQueryReturn>(sqlQueryReturns, that.sqlQueryReturns);
+				CollectionHelper.CollectionEquals(sqlQueryReturns, that.sqlQueryReturns);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Engine/ResultSetMappingDefinition.cs
+++ b/src/NHibernate/Engine/ResultSetMappingDefinition.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
-using NHibernate.Engine.Query.Sql;
 using System;
+using System.Collections.ObjectModel;
+using NHibernate.Engine.Query.Sql;
+
 
 namespace NHibernate.Engine
 {
@@ -9,11 +9,17 @@ namespace NHibernate.Engine
 	public class ResultSetMappingDefinition
 	{
 		private readonly string name;
-		private readonly List<INativeSQLQueryReturn> queryReturns = new List<INativeSQLQueryReturn>();
+		private readonly ReadOnlyCollection<INativeSQLQueryReturn> queryReturns;
 
-		public ResultSetMappingDefinition(string name)
+		public ResultSetMappingDefinition(string name, INativeSQLQueryReturn[] queryReturns)
 		{
+			if (queryReturns == null)
+			{
+				throw new ArgumentNullException(nameof(queryReturns));
+			}
+
 			this.name = name;
+			this.queryReturns = new ReadOnlyCollection<INativeSQLQueryReturn>(queryReturns);
 		}
 
 		public string Name
@@ -21,17 +27,9 @@ namespace NHibernate.Engine
 			get { return name; }
 		}
 
-		public void AddQueryReturn(INativeSQLQueryReturn queryReturn)
+		public ReadOnlyCollection<INativeSQLQueryReturn> QueryReturns
 		{
-			if (queryReturn != null)
-			{
-				queryReturns.Add(queryReturn);
-			}
-		}
-
-		public INativeSQLQueryReturn[] GetQueryReturns()
-		{
-			return queryReturns.ToArray();
+			get { return queryReturns; }
 		}
 	}
 }

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1180,7 +1180,7 @@ namespace NHibernate.Impl
 						{
 							throw new MappingException("Unable to find resultset-ref definition: " + qd.ResultSetRef);
 						}
-						spec = new NativeSQLQuerySpecification(qd.QueryString, definition.GetQueryReturns(), qd.QuerySpaces);
+						spec = new NativeSQLQuerySpecification(qd.QueryString, definition.QueryReturns, qd.QuerySpaces);
 					}
 					else
 					{

--- a/src/NHibernate/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Impl/SqlQueryImpl.cs
@@ -26,10 +26,10 @@ namespace NHibernate.Impl
 	/// </example>
 	public class SqlQueryImpl : AbstractQueryImpl, ISQLQuery
 	{
-		private readonly ReadOnlyCollection<string> querySpaces;
+		private readonly IReadOnlyList<string> querySpaces;
 		private readonly bool callable;
-        private ReadOnlyCollection<INativeSQLQueryReturn> queryReturns;
-        private bool autoDiscoverTypes;
+	  private IReadOnlyList<INativeSQLQueryReturn> queryReturns;
+	  private bool autoDiscoverTypes;
 
 		/// <summary> Constructs a SQLQueryImpl given a sql query defined in the mappings. </summary>
 		/// <param name="queryDef">The representation of the defined sql-query. </param>
@@ -73,7 +73,7 @@ namespace NHibernate.Impl
 			}
 		}
 
-	    private ReadOnlyCollection<INativeSQLQueryReturn> GetQueryReturns()
+	    private IReadOnlyList<INativeSQLQueryReturn> GetQueryReturns()
 	    {
 	        return queryReturns;
 	    }

--- a/src/NHibernate/Loader/Collection/OneToManyJoinWalker.cs
+++ b/src/NHibernate/Loader/Collection/OneToManyJoinWalker.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Loader.Collection
 		{
 			//disable a join back to this same association
 			bool isSameJoin = oneToManyPersister.TableName.Equals(foreignKeyTable)
-			                  && CollectionHelper.CollectionEquals<string>(foreignKeyColumns, oneToManyPersister.KeyColumnNames);
+			                  && CollectionHelper.CollectionEquals((ICollection<string>)foreignKeyColumns, oneToManyPersister.KeyColumnNames);
 			return isSameJoin || base.IsDuplicateAssociation(foreignKeyTable, foreignKeyColumns);
 		}
 

--- a/src/NHibernate/Loader/Custom/Sql/SQLCustomQuery.cs
+++ b/src/NHibernate/Loader/Custom/Sql/SQLCustomQuery.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Loader.Custom.Sql
 		private readonly SqlString sql;
 		private readonly List<IParameterSpecification> parametersSpecifications;
 
-		public SQLCustomQuery(INativeSQLQueryReturn[] queryReturns, string sqlQuery, ICollection<string> additionalQuerySpaces,
+		public SQLCustomQuery(IList<INativeSQLQueryReturn> queryReturns, string sqlQuery, ICollection<string> additionalQuerySpaces,
 		                      ISessionFactoryImplementor factory)
 		{
 			log.Debug("starting processing of sql query [" + sqlQuery + "]");

--- a/src/NHibernate/Loader/Custom/Sql/SQLCustomQuery.cs
+++ b/src/NHibernate/Loader/Custom/Sql/SQLCustomQuery.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Loader.Custom.Sql
 		private readonly SqlString sql;
 		private readonly List<IParameterSpecification> parametersSpecifications;
 
-		public SQLCustomQuery(IList<INativeSQLQueryReturn> queryReturns, string sqlQuery, ICollection<string> additionalQuerySpaces,
+		public SQLCustomQuery(IEnumerable<INativeSQLQueryReturn> queryReturns, string sqlQuery, IEnumerable<string> additionalQuerySpaces,
 		                      ISessionFactoryImplementor factory)
 		{
 			log.Debug("starting processing of sql query [" + sqlQuery + "]");

--- a/src/NHibernate/Loader/Custom/Sql/SQLQueryReturnProcessor.cs
+++ b/src/NHibernate/Loader/Custom/Sql/SQLQueryReturnProcessor.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 using NHibernate.Engine;
 using NHibernate.Engine.Query.Sql;
@@ -14,7 +13,7 @@ namespace NHibernate.Loader.Custom.Sql
 	{
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof (SQLQueryReturnProcessor));
 
-		private readonly ReadOnlyCollection<INativeSQLQueryReturn> queryReturns;
+		private readonly IReadOnlyList<INativeSQLQueryReturn> queryReturns;
 
 		private readonly Dictionary<string, INativeSQLQueryReturn> alias2Return =
 			new Dictionary<string, INativeSQLQueryReturn>();
@@ -45,9 +44,9 @@ namespace NHibernate.Loader.Custom.Sql
 			get { return factory; }
 		}
 
-		public SQLQueryReturnProcessor(IList<INativeSQLQueryReturn> queryReturns, ISessionFactoryImplementor factory)
+		public SQLQueryReturnProcessor(IEnumerable<INativeSQLQueryReturn> queryReturns, ISessionFactoryImplementor factory)
 		{
-			this.queryReturns = new ReadOnlyCollection<INativeSQLQueryReturn>(queryReturns);
+			this.queryReturns = new List<INativeSQLQueryReturn>(queryReturns).AsReadOnly();
 			this.factory = factory;
 		}
 

--- a/src/NHibernate/Loader/Custom/Sql/SQLQueryReturnProcessor.cs
+++ b/src/NHibernate/Loader/Custom/Sql/SQLQueryReturnProcessor.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 using NHibernate.Engine;
 using NHibernate.Engine.Query.Sql;
@@ -13,7 +14,7 @@ namespace NHibernate.Loader.Custom.Sql
 	{
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof (SQLQueryReturnProcessor));
 
-		private readonly INativeSQLQueryReturn[] queryReturns;
+		private readonly ReadOnlyCollection<INativeSQLQueryReturn> queryReturns;
 
 		private readonly Dictionary<string, INativeSQLQueryReturn> alias2Return =
 			new Dictionary<string, INativeSQLQueryReturn>();
@@ -44,9 +45,9 @@ namespace NHibernate.Loader.Custom.Sql
 			get { return factory; }
 		}
 
-		public SQLQueryReturnProcessor(INativeSQLQueryReturn[] queryReturns, ISessionFactoryImplementor factory)
+		public SQLQueryReturnProcessor(IList<INativeSQLQueryReturn> queryReturns, ISessionFactoryImplementor factory)
 		{
-			this.queryReturns = queryReturns;
+			this.queryReturns = new ReadOnlyCollection<INativeSQLQueryReturn>(queryReturns);
 			this.factory = factory;
 		}
 
@@ -116,7 +117,7 @@ namespace NHibernate.Loader.Custom.Sql
 		{
 			// first, break down the returns into maps keyed by alias
 			// so that role returns can be more easily resolved to their owners
-			for (int i = 0; i < queryReturns.Length; i++)
+			for (int i = 0; i < queryReturns.Count; i++)
 			{
 				var rtn = queryReturns[i] as NativeSQLQueryNonScalarReturn;
 				if (rtn != null)
@@ -131,7 +132,7 @@ namespace NHibernate.Loader.Custom.Sql
 			}
 
 			// Now, process the returns
-			for (int i = 0; i < queryReturns.Length; i++)
+			for (int i = 0; i < queryReturns.Count; i++)
 			{
 				ProcessReturn(queryReturns[i]);
 			}
@@ -288,7 +289,7 @@ namespace NHibernate.Loader.Custom.Sql
 		{
 			IList customReturns = new List<object>();
 			IDictionary<string, object> customReturnsByAlias = new Dictionary<string, object>();
-			for (int i = 0; i < queryReturns.Length; i++)
+			for (int i = 0; i < queryReturns.Count; i++)
 			{
 				if (queryReturns[i] is NativeSQLQueryScalarReturn)
 				{

--- a/src/NHibernate/Loader/JoinWalker.cs
+++ b/src/NHibernate/Loader/JoinWalker.cs
@@ -573,7 +573,7 @@ namespace NHibernate.Loader
 				if (that == null)
 					return false;
 
-				return that.table.Equals(table) && CollectionHelper.CollectionEquals<string>(columns, that.columns);
+			  return that.table.Equals(table) && CollectionHelper.CollectionEquals((ICollection<string>) columns, that.columns);
 			}
 
 			public override int GetHashCode()

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -1007,21 +1007,22 @@ namespace NHibernate.Mapping
 		[Serializable]
 		internal class ForeignKeyKey : IEqualityComparer<ForeignKeyKey>
 		{
-			internal List<Column> columns;
+			internal IReadOnlyList<Column> columns;
 			internal string referencedClassName;
-			internal List<Column> referencedColumns;
+			internal IReadOnlyList<Column> referencedColumns;
 
 			internal ForeignKeyKey(IEnumerable<Column> columns, string referencedClassName, IEnumerable<Column> referencedColumns)
 			{
 				this.referencedClassName = referencedClassName;
-				this.columns = new List<Column>(columns);
+				this.columns = new List<Column>(columns).AsReadOnly();
+
 				if (referencedColumns != null)
 				{
-					this.referencedColumns = new List<Column>(referencedColumns);
+					this.referencedColumns = new List<Column>(referencedColumns).AsReadOnly();
 				}
 				else
 				{
-					this.referencedColumns = new List<Column>();
+					this.referencedColumns = new List<Column>(0);
 				}
 			}
 

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -746,6 +746,7 @@
     <Compile Include="Util\JoinedEnumerable.cs" />
     <Compile Include="Util\ObjectHelpers.cs" />
     <Compile Include="Util\PropertiesHelper.cs" />
+    <Compile Include="Util\ReadOnlyCollectionHelper.cs" />
     <Compile Include="Util\ReflectHelper.cs" />
     <Compile Include="Util\SequencedHashMap.cs" />
     <Compile Include="Util\StringHelper.cs" />

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using Iesi.Collections;
 using System.Collections.Generic;
 
 namespace NHibernate.Util
@@ -131,105 +130,25 @@ namespace NHibernate.Util
 				return emptyEnumerator;
 			}
 		}
-
-		[Serializable]
-		private class EmptyListClass : IList
-		{
-			public int Add(object value)
-			{
-				throw new NotImplementedException();
-			}
-
-			public bool Contains(object value)
-			{
-				return false;
-			}
-
-			public void Clear()
-			{
-				throw new NotImplementedException();
-			}
-
-			public int IndexOf(object value)
-			{
-				return -1;
-			}
-
-			public void Insert(int index, object value)
-			{
-				throw new NotImplementedException();
-			}
-
-			public void Remove(object value)
-			{
-				throw new NotImplementedException();
-			}
-
-			public void RemoveAt(int index)
-			{
-				throw new NotImplementedException();
-			}
-
-			public object this[int index]
-			{
-				get { throw new IndexOutOfRangeException(); }
-				set { throw new IndexOutOfRangeException(); }
-			}
-
-			public bool IsReadOnly
-			{
-				get { return true; }
-			}
-
-			public bool IsFixedSize
-			{
-				get { return true; }
-			}
-
-			public void CopyTo(Array array, int index)
-			{
-			}
-
-			public int Count
-			{
-				get { return 0; }
-			}
-
-			public object SyncRoot
-			{
-				get { return this; }
-			}
-
-			public bool IsSynchronized
-			{
-				get { return false; }
-			}
-
-			public IEnumerator GetEnumerator()
-			{
-				return new EmptyEnumerator();
-			}
-		}
-
+		
 		public static readonly IEnumerable EmptyEnumerable = new EmptyEnumerableClass();
 		public static readonly IDictionary EmptyMap = new EmptyMapClass();
 		public static readonly ICollection EmptyCollection = EmptyMap;
-		public static readonly IList EmptyList = new EmptyListClass();
-
+		
 		/// <summary>
 		/// Determines if two collections have equals elements, with the same ordering.
 		/// </summary>
 		/// <param name="c1">The first collection.</param>
 		/// <param name="c2">The second collection.</param>
 		/// <returns><c>true</c> if collection are equals, <c>false</c> otherwise.</returns>
-		public static bool CollectionEquals(ICollection c1, ICollection c2)
+		public static bool CollectionEquals<T>(IReadOnlyCollection<T> c1, IReadOnlyCollection<T> c2)
 		{
 			if (c1 == c2)
 			{
 				return true;
 			}
 
-			if(c1==null || c2==null)
+			if (c1 == null || c2 == null)
 			{
 				return false;
 			}
@@ -239,22 +158,27 @@ namespace NHibernate.Util
 				return false;
 			}
 
-			IEnumerator e1 = c1.GetEnumerator();
-			IEnumerator e2 = c2.GetEnumerator();
-
-			while (e1.MoveNext())
-			{
-				e2.MoveNext();
-				if (!Equals(e1.Current, e2.Current))
-				{
-					return false;
-				}
-			}
-
-			return true;
+			return InternalCompareCollections(c1, c2);
 		}
 
-		public static bool DictionaryEquals(IDictionary a, IDictionary b)
+		private static bool InternalCompareCollections(IEnumerable c1, IEnumerable c2)
+	  {
+	    IEnumerator e1 = c1.GetEnumerator();
+	    IEnumerator e2 = c2.GetEnumerator();
+
+	    while (e1.MoveNext())
+	    {
+	      e2.MoveNext();
+	      if (!Equals(e1.Current, e2.Current))
+	      {
+	        return false;
+	      }
+	    }
+
+	    return true;
+	  }
+
+	  public static bool DictionaryEquals(IDictionary a, IDictionary b)
 		{
 			if (Equals(a, b))
 			{
@@ -650,19 +574,7 @@ namespace NHibernate.Util
 				return false;
 			}
 
-			IEnumerator e1 = c1.GetEnumerator();
-			IEnumerator e2 = c2.GetEnumerator();
-
-			while (e1.MoveNext())
-			{
-				e2.MoveNext();
-				if (!Equals(e1.Current, e2.Current))
-				{
-					return false;
-				}
-			}
-
-			return true;
+			return InternalCompareCollections(c1, c2);
 		}
 
 	}

--- a/src/NHibernate/Util/ReadOnlyCollectionHelper.cs
+++ b/src/NHibernate/Util/ReadOnlyCollectionHelper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+using NHibernate.Engine.Query.Sql;
+
+
+namespace NHibernate.Util
+{
+  public static class ReadOnlyCollectionHelper
+  {
+    internal static readonly ReadOnlyCollection<INativeSQLQueryReturn> EmptyQueryReturns =
+      new ReadOnlyCollection<INativeSQLQueryReturn>(new INativeSQLQueryReturn[0]);
+
+    public static ReadOnlyCollection<T> ImmutableAdd<T>(this ReadOnlyCollection<T> collection, T value)
+    {
+      if (collection == null)
+      {
+        throw new ArgumentNullException("collection");
+      }
+
+      T[] tmp = new T[collection.Count + 1];
+
+      collection.CopyTo(tmp, 0);
+
+      tmp[tmp.Length - 1] = value;
+
+      return new ReadOnlyCollection<T>(tmp);
+    }
+
+    public static ReadOnlyCollection<T> ImmutableAddRange<T>(this ReadOnlyCollection<T> collection, IList<T> values)
+    {
+      if (collection == null)
+      {
+        throw new ArgumentNullException("collection");
+      }
+
+      if (values == null)
+      {
+        throw new ArgumentNullException("values");
+      }
+
+      T[] tmp = new T[collection.Count + values.Count];
+
+      collection.CopyTo(tmp, 0);
+      values.CopyTo(tmp, collection.Count);
+      
+      return new ReadOnlyCollection<T>(tmp);
+    }
+  }
+}

--- a/src/NHibernate/Util/ReadOnlyCollectionHelper.cs
+++ b/src/NHibernate/Util/ReadOnlyCollectionHelper.cs
@@ -12,23 +12,22 @@ namespace NHibernate.Util
     internal static readonly ReadOnlyCollection<INativeSQLQueryReturn> EmptyQueryReturns =
       new ReadOnlyCollection<INativeSQLQueryReturn>(new INativeSQLQueryReturn[0]);
 
-    public static ReadOnlyCollection<T> ImmutableAdd<T>(this ReadOnlyCollection<T> collection, T value)
+    public static IReadOnlyList<T> ImmutableAdd<T>(this IReadOnlyList<T> collection, T value)
     {
       if (collection == null)
       {
         throw new ArgumentNullException("collection");
       }
 
-      T[] tmp = new T[collection.Count + 1];
+			var result = new List<T>(collection.Count + 1);
 
-      collection.CopyTo(tmp, 0);
-
-      tmp[tmp.Length - 1] = value;
-
-      return new ReadOnlyCollection<T>(tmp);
+			result.AddRange(collection);
+			result.Add(value);
+			
+      return result.AsReadOnly();
     }
 
-    public static ReadOnlyCollection<T> ImmutableAddRange<T>(this ReadOnlyCollection<T> collection, IList<T> values)
+    public static IReadOnlyList<T> ImmutableAddRange<T>(this IReadOnlyList<T> collection, IList<T> values)
     {
       if (collection == null)
       {
@@ -39,13 +38,13 @@ namespace NHibernate.Util
       {
         throw new ArgumentNullException("values");
       }
+			
+			var result = new List<T>(collection.Count + values.Count);
 
-      T[] tmp = new T[collection.Count + values.Count];
-
-      collection.CopyTo(tmp, 0);
-      values.CopyTo(tmp, collection.Count);
-      
-      return new ReadOnlyCollection<T>(tmp);
+			result.AddRange(collection);
+			result.AddRange(values);
+			
+      return result.AsReadOnly();
     }
   }
 }


### PR DESCRIPTION
Query returns are initialized immediately (as an array) in order to get rid of unnecessary List->Array conversions
