### PR TITLE
Added IgnoreForDialects and RunForDialects attributes

### DIFF
--- a/src/NHibernate.Test/IgnoreForDialectsAttribute.cs
+++ b/src/NHibernate.Test/IgnoreForDialectsAttribute.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test
+{
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class,
+		AllowMultiple = true)]
+	public class IgnoreForDialectsAttribute : Attribute, ITestAction
+	{
+		private readonly string[] _dialectTypePartialNames;
+		private readonly System.Type[] _dialectTypes;
+
+		public IgnoreForDialectsAttribute(params System.Type[] dialectTypes)
+		{
+			_dialectTypes = dialectTypes;
+		}
+
+		public IgnoreForDialectsAttribute(params string[] dialectTypePartialNames)
+		{
+			_dialectTypePartialNames = dialectTypePartialNames;
+		}
+
+		public string Message { get; set; }
+
+		public void BeforeTest(TestDetails details)
+		{
+			var fixture = details.Fixture as TestCase;
+			if (fixture != null)
+			{
+				var fixtureDialect = fixture.Dialect;
+				if (fixtureDialect == null)
+				{
+					return;
+				}
+				if (_dialectTypes != null && _dialectTypes.Any(x => x.IsInstanceOfType(fixtureDialect)) ||
+					_dialectTypePartialNames != null && _dialectTypePartialNames.Any(x=>fixtureDialect.GetType().Name.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0))
+				{
+					Assert.Ignore(string.Format("Ignored for dialect {0}. {1}", fixture.Dialect.GetType().Name, Message));
+				}
+			}
+		}
+
+		public void AfterTest(TestDetails details)
+		{
+
+		}
+
+		public ActionTargets Targets
+		{
+			get { return ActionTargets.Test; }
+		}
+
+
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -480,6 +480,7 @@
     <Compile Include="IdTest\AssignedClass.cs" />
     <Compile Include="IdTest\AssignedFixture.cs" />
     <Compile Include="IdTest\TableGeneratorFixture.cs" />
+    <Compile Include="IgnoreForDialectsAttribute.cs" />
     <Compile Include="Immutable\Contract.cs" />
     <Compile Include="Immutable\ContractVariation.cs" />
     <Compile Include="Immutable\EntityWithMutableCollection\AbstractEntityWithManyToManyTest.cs" />
@@ -1327,6 +1328,7 @@
     <Compile Include="ReadOnly\StudentDto.cs" />
     <Compile Include="ReadOnly\TextHolder.cs" />
     <Compile Include="ReadOnly\VersionedNode.cs" />
+    <Compile Include="RunForDialectsAttribute.cs" />
     <Compile Include="SqlCommandTest\SqlTokenizerFixture.cs" />
     <Compile Include="RecordingInterceptor.cs" />
     <Compile Include="Stateless\Contact.cs" />
@@ -3754,7 +3756,6 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NHibernate.Test/RunForDialectsAttribute.cs
+++ b/src/NHibernate.Test/RunForDialectsAttribute.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test
+{
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class,
+		AllowMultiple = true)]
+	public class RunForDialectsAttribute : Attribute, ITestAction
+	{
+		private readonly string[] _dialectTypePartialNames;
+		private readonly System.Type[] _dialectTypes;
+
+		public RunForDialectsAttribute(params System.Type[] dialectTypes)
+		{
+			_dialectTypes = dialectTypes;
+		}
+
+		public RunForDialectsAttribute(params string[] dialectTypePartialNames)
+		{
+			_dialectTypePartialNames = dialectTypePartialNames;
+		}
+
+		public string Message { get; set; }
+
+		public void BeforeTest(TestDetails details)
+		{
+			var fixture = details.Fixture as TestCase;
+			if (fixture != null)
+			{
+				var fixtureDialect = fixture.Dialect;
+				if (fixtureDialect == null)
+				{
+					return;
+				}
+				if (_dialectTypes != null && _dialectTypes.Any(x => x.IsInstanceOfType(fixtureDialect)) ||
+					_dialectTypePartialNames != null && _dialectTypePartialNames.Any(x => fixtureDialect.GetType().Name.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0))
+				{
+					return;
+				}
+				Assert.Ignore(string.Format("Ignored for dialect {0}. {1}", fixtureDialect.GetType().Name, Message));
+			}
+		}
+
+		public void AfterTest(TestDetails details)
+		{
+
+		}
+
+		public ActionTargets Targets
+		{
+			get { return ActionTargets.Test; }
+		}
+
+
+	}
+}

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Test
 
 		private static readonly ILog log = LogManager.GetLogger(typeof(TestCase));
 
-		protected Dialect.Dialect Dialect
+		public Dialect.Dialect Dialect
 		{
 			get { return NHibernate.Dialect.Dialect.GetDialect(cfg.Properties); }
 		}


### PR DESCRIPTION
No JIRA case. Just a suggestion.

These attributes should allow cleaner exclusion/inclusion of tests for certain dialects. Just annotate the fixture or the test with [IgnoreForDialects(typeof(SomeDialect))] or [RunForDialect("partialNameOfDialectType")]
