### PR TITLE
NH-3726: Added escape character support in SqlMethods.Like

### DIFF
--- a/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
@@ -356,6 +356,11 @@ namespace NHibernate.Hql.Ast
 			return new HqlLike(_factory, lhs, rhs);
 		}
 
+		public HqlLike Like(HqlExpression lhs, HqlExpression rhs, HqlConstant escapeCharacter)
+		{
+			return new HqlLike(_factory, lhs, rhs, escapeCharacter);
+		}
+
 		public HqlConcat Concat(params HqlExpression[] args)
 		{
 			return new HqlConcat(_factory, args);

--- a/src/NHibernate/Hql/Ast/HqlTreeNode.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeNode.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Hql.Ast
 			AddChildren(children);
 		}
 
-		protected HqlTreeNode(int type, string text, IASTFactory factory, params HqlTreeNode[] children) : this(type, text, factory, (IEnumerable<HqlTreeNode>) children)
+		protected HqlTreeNode(int type, string text, IASTFactory factory, params HqlTreeNode[] children) : this(type, text, factory, (IEnumerable<HqlTreeNode>)children)
 		{
 		}
 
@@ -92,7 +92,7 @@ namespace NHibernate.Hql.Ast
 
 		internal void AddChild(HqlTreeNode child)
 		{
-			if (child is HqlExpressionSubTreeHolder) 
+			if (child is HqlExpressionSubTreeHolder)
 			{
 				AddChildren(child.Children);
 			}
@@ -116,7 +116,7 @@ namespace NHibernate.Hql.Ast
 		{
 			if (node is HqlDot)
 			{
-				return new HqlBooleanDot(node.Factory, (HqlDot) node);
+				return new HqlBooleanDot(node.Factory, (HqlDot)node);
 			}
 
 			// TODO - nice error handling if cast fails
@@ -220,8 +220,8 @@ namespace NHibernate.Hql.Ast
 					}
 					if (type == typeof(DateTimeOffset))
 					{
-					    SetText("datetimeoffset");
-					    break;
+						SetText("datetimeoffset");
+						break;
 					}
 					throw new NotSupportedException(string.Format("Don't currently support idents of type {0}", type.Name));
 			}
@@ -373,7 +373,7 @@ namespace NHibernate.Hql.Ast
 	public class HqlTake : HqlStatement
 	{
 		public HqlTake(IASTFactory factory, HqlExpression parameter)
-			: base(HqlSqlWalker.TAKE, "take", factory, parameter) {}
+			: base(HqlSqlWalker.TAKE, "take", factory, parameter) { }
 	}
 
 	public class HqlConstant : HqlExpression
@@ -690,7 +690,7 @@ namespace NHibernate.Hql.Ast
 			: base(HqlSqlWalker.AGGREGATE, "max", factory, expression)
 		{
 		}
-}
+	}
 
 	public class HqlMin : HqlExpression
 	{
@@ -816,6 +816,19 @@ namespace NHibernate.Hql.Ast
 	{
 		public HqlLike(IASTFactory factory, HqlExpression lhs, HqlExpression rhs)
 			: base(HqlSqlWalker.LIKE, "like", factory, lhs, rhs)
+		{
+		}
+
+		public HqlLike(IASTFactory factory, HqlExpression lhs, HqlExpression rhs, HqlConstant escapeCharacter)
+		: base(HqlSqlWalker.LIKE, "like", factory, lhs, rhs, new HqlEscape(factory, escapeCharacter))
+		{
+		}
+	}
+
+	public class HqlEscape : HqlStatement
+	{
+		public HqlEscape(IASTFactory factory, HqlConstant escapeCharacter)
+			: base(HqlSqlWalker.ESCAPE, "escape", factory, escapeCharacter)
 		{
 		}
 	}

--- a/src/NHibernate/Linq/Functions/StringGenerator.cs
+++ b/src/NHibernate/Linq/Functions/StringGenerator.cs
@@ -18,9 +18,22 @@ namespace NHibernate.Linq.Functions
 		public HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments,
 		                            HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
 		{
-			return treeBuilder.Like(
-				visitor.Visit(arguments[0]).AsExpression(),
-				visitor.Visit(arguments[1]).AsExpression());
+			if (arguments.Count == 2)
+			{
+				return treeBuilder.Like(
+					visitor.Visit(arguments[0]).AsExpression(),
+					visitor.Visit(arguments[1]).AsExpression());
+			}
+			if (arguments[2].NodeType == ExpressionType.Constant)
+			{
+				var escapeCharExpression = (ConstantExpression)arguments[2];
+				return treeBuilder.Like(
+					visitor.Visit(arguments[0]).AsExpression(),
+					visitor.Visit(arguments[1]).AsExpression(),
+					treeBuilder.Constant(escapeCharExpression.Value));
+			}
+			throw new ArgumentException("The escape character must be specified as literal value or a string variable");
+
 		}
 
 		public bool SupportsMethod(MethodInfo method)
@@ -34,8 +47,8 @@ namespace NHibernate.Linq.Functions
 			// to avoid referencing Linq2Sql or Linq2NHibernate, if they so wish.
 
 			return method != null && method.Name == "Like" &&
-			       method.GetParameters().Length == 2 &&
-			       method.DeclaringType != null &&
+			       (method.GetParameters().Length == 2 || method.GetParameters().Length == 3) &&
+				   method.DeclaringType != null &&
 			       method.DeclaringType.FullName.EndsWith("SqlMethods");
 		}
 

--- a/src/NHibernate/Linq/SqlMethods.cs
+++ b/src/NHibernate/Linq/SqlMethods.cs
@@ -5,13 +5,26 @@ namespace NHibernate.Linq
 	public static class SqlMethods
 	{
 		/// <summary>
-		/// Use the SqlMethods.Like() method in a Linq2NHibernate expression to generate
+		/// Use this method in a Linq2NHibernate expression to generate
 		/// an SQL LIKE expression. (If you want to avoid depending on the NHibernate.Linq namespace,
 		/// you can define your own replica of this method. Any 2-argument method named Like in a class named SqlMethods
-		/// will be translated.) This method can only be used in Linq2NHibernate expression, and will throw
+		/// will be translated.) This method can only be used in Linq2NHibernate expressions, and will throw
 		/// if called directly.
 		/// </summary>
 		public static bool Like(this string matchExpression, string sqlLikePattern)
+		{
+			throw new NotSupportedException(
+				"The NHibernate.Linq.SqlMethods.Like(string, string) method can only be used in Linq2NHibernate expressions.");
+		}
+
+		/// <summary>
+		/// Use this method in a Linq2NHibernate expression to generate
+		/// an SQL LIKE expression with an escape character defined. (If you want to avoid depending on the NHibernate.Linq namespace,
+		/// you can define your own replica of this method. Any 3-argument method named Like in a class named SqlMethods
+		/// will be translated.) This method can only be used in Linq2NHibernate expressions, and will throw
+		/// if called directly.
+		/// </summary>
+		public static bool Like(this string matchExpression, string sqlLikePattern, char escapeCharacter)
 		{
 			throw new NotSupportedException(
 				"The NHibernate.Linq.SqlMethods.Like(string, string) method can only be used in Linq2NHibernate expressions.");


### PR DESCRIPTION
Did not yet follow my own suggestion to fix StartsWIth, Contains and EndWith, since that could be considered a breaking change. But it is a bug, IMO.