### PR TITLE
Team City

### DIFF
--- a/build-common/common-project.xml
+++ b/build-common/common-project.xml
@@ -99,7 +99,7 @@
 	<target name="common.run-tests"
 		description="Run NUnit tests">
 		<call target="common.find-nunit" unless="${property::exists('nunit.found')}" />
-		<property name="common.run-tests.failonerror" value="${not property::exists(project::get-name() + '.IgnoreFail')}"/>
+		<property name="common.run-tests.failonerror" value="${not property::exists(test.file + '.IgnoreFail')}"/>
 		<exec program="${nunit-console}" failonerror="${common.run-tests.failonerror}">
 			<arg line="${bin.dir}/${test.file}.dll /xml:${testresults.dir}/${test.file}.dll-results.xml /framework:${framework::get-target-framework()}" />
 		</exec>

--- a/default.build
+++ b/default.build
@@ -46,7 +46,7 @@
 	<target name="test" depends="init build" description="Runs all NHibernate tests for the current framework" unless="${skip.tests}">
 		<property name="testfiles.all" value="NHibernate.TestDatabaseSetup NHibernate.Test NHibernate.Test.VisualBasic" />
 		<foreach item="String" in="${testfiles.all}" delim=" " property="test.file">
-			<call target="common.run-database-tests" failonerror="false"/>
+			<call target="common.run-database-tests"/>
 		</foreach>
 	</target>
 	

--- a/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
+++ b/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
@@ -143,7 +143,7 @@ namespace NHibernate.Test.Criteria
 
 			DetachedCriteria criteria = DetachedCriteria.For<Course>("c");
 			criteria.SetProjection(Projections.Count("id"));
-			criteria.Add(Expression.Or(Subqueries.Le(5, subcriteria), Subqueries.IsNull(subcriteria)));
+			criteria.Add(Expression.Or(Subqueries.Le(5D, subcriteria), Subqueries.IsNull(subcriteria)));
 
 			object o = criteria.GetExecutableCriteria(session).UniqueResult();
 			Assert.AreEqual(1, o);

--- a/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
+++ b/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
@@ -619,8 +619,8 @@ namespace NHibernate.Test.Hql.Ast
 
 			count =
 				s.CreateQuery("update Animal set bodyWeight = bodyWeight + :w1 + :w2")
-				.SetDouble("w1", 1)
-				.SetDouble("w2", 2)
+				.SetSingle("w1", 1)
+				.SetSingle("w2", 2)
 				.ExecuteUpdate();
 			Assert.That(count, Is.EqualTo(6), "incorrect count on 'complex' update assignment");
 
@@ -649,7 +649,7 @@ namespace NHibernate.Test.Hql.Ast
 					s.CreateQuery("update Animal set description = :newDesc, bodyWeight = :w1 where description = :desc")
 						.SetString("desc", data.Polliwog.Description)
 						.SetString("newDesc", "Tadpole")
-						.SetDouble("w1", 3)
+						.SetSingle("w1", 3)
 						.ExecuteUpdate();
 				
 				Assert.That(count, Is.EqualTo(1));

--- a/teamcity.build
+++ b/teamcity.build
@@ -12,7 +12,17 @@
 
 	<property name="build.number" value="${CCNetLabel}" if="${property::exists('CCNetLabel')}" />
 
-	<target name="clean-configure-test" depends="cleanall init copy-teamcity-configuration binaries test verify-test-results binaries-zip" />
+	<target name="clean-configure-test" depends="cleanall init copy-nunitaddin copy-teamcity-configuration binaries test verify-test-results binaries-zip" />
+
+	<target name="copy-nunitaddin" depends="init">
+		<if test="${property::exists('teamcity.dotnet.nunitaddin')}">
+			<copy todir="${tools.dir}/NUnit/addins">
+				<fileset>
+					<include name="${teamcity.dotnet.nunitaddin}-2.6.1.*" />
+				</fileset>
+			</copy>
+		</if>
+	</target>
 
 	<target name="copy-teamcity-configuration">
 		<copy file="build-common/teamcity-hibernate.cfg.xml" tofile="${bin.dir}/hibernate.cfg.xml" />
@@ -71,8 +81,8 @@
 	</target>
 
 	<target name="setup-teamcity-firebird32">
-		<property name="nhibernate.connection.driver_class"				value="NHibernate.Driver.FirebirdClientDriver" />
-		<property name="nhibernate.dialect"												value="NHibernate.Dialect.FirebirdDialect" />
+		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.FirebirdClientDriver" />
+		<property name="nhibernate.dialect"							value="NHibernate.Dialect.FirebirdDialect" />
 		<property name="nhibernate.connection.connection_string"	value="Database=NHibernate.fdb;ServerType=1;UserID=SYSDBA" />
 		<copy todir="${bin.dir}">
 			<fileset basedir="${root.dir}/lib/teamcity/firebird/x86">
@@ -87,8 +97,8 @@
 	<target name="setup-teamcity-firebird64">
 		<property name="nunit-console" value="${tools.dir}/NUnit/nunit-console.exe" />
 		<property name="nunit.found" value="true" />
-		<property name="nhibernate.connection.driver_class"				value="NHibernate.Driver.FirebirdClientDriver" />
-		<property name="nhibernate.dialect"												value="NHibernate.Dialect.FirebirdDialect" />
+		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.FirebirdClientDriver" />
+		<property name="nhibernate.dialect"							value="NHibernate.Dialect.FirebirdDialect" />
 		<property name="nhibernate.connection.connection_string"	value="Database=NHibernate.fdb;ServerType=1;UserID=SYSDBA" />
 		<copy todir="${bin.dir}">
 			<fileset basedir="${root.dir}/lib/teamcity/firebird/x64">


### PR DESCRIPTION
- Previously the Postgres build was treated as successfully finished, even if there were failing tests
- Use TeamCity NUnit AddIn to track tests online
- Fix tests for PostgreSQL
 - The BulkManipulation.UpdateMultiplePropertyOnAnimal and BulkManipulation.UpdateOnAnimal tests were using Double parameter types to update the Single column. It seems that now Npgsql calculates parameter types according to the columns they touches and fails to set the parameters in this case.
 - The CriteriaQueryTest.TestSubcriteriaBeingNull were using the Int32 parameter type instead of expected Double.