### PR TITLE
Test case and fix to NH-3898

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ hibernate.cfg.xml
 available-test-configurations
 current-test-configuration
 NHibernate.VisualState.xml
+/.project

--- a/src/NHibernate.Test/NHSpecificTest/NH3898/DomainClasses.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3898/DomainClasses.cs
@@ -1,0 +1,31 @@
+﻿
+
+using System;
+using System.Collections.Generic;
+namespace NHibernate.Test.NHSpecificTest.NH3898
+{
+    public class Employee
+    {
+        private Int32 id;
+        public virtual Int32 Id
+        {
+            get { return id; }
+            set { id = value; }
+        }
+
+        private String name;
+        public virtual String Name
+        {
+            get { return name; }
+            set { name = value; }
+        }
+
+        private Int32 promotionCount;
+
+        public virtual Int32 PromotionCount
+        {
+            get { return promotionCount; }
+            set { promotionCount = value; }
+        }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3898/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3898/Fixture.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using NHibernate.Dialect;
+using NUnit.Framework;
+using NHibernate.Test.NHSpecificTest;
+using Iesi.Collections.Generic;
+using NHibernate;
+using System.Data;
+using NHibernate.Criterion;
+
+namespace NHibernate.Test.NHSpecificTest.NH3898
+{
+    /// <summary>
+    /// <para>
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    public class Fixture : BugTestCase
+    {
+        protected override void Configure(NHibernate.Cfg.Configuration configuration)
+        {
+            #region removing possible second-level-cache configs
+            configuration.Properties.Remove(NHibernate.Cfg.Environment.CacheProvider);
+            configuration.Properties.Remove(NHibernate.Cfg.Environment.UseQueryCache);
+            configuration.Properties.Add(NHibernate.Cfg.Environment.UseQueryCache, "true");
+            configuration.Properties.Remove(NHibernate.Cfg.Environment.UseSecondLevelCache); 
+            #endregion
+
+            base.Configure(configuration);
+        }
+
+        protected override void OnTearDown()
+        {
+            base.OnTearDown();
+            using (ISession s = OpenSession())
+            {
+                int countUpdate = 0;
+
+                countUpdate =
+                    s
+                        .CreateSQLQuery("DELETE FROM T_EMPLOYEE")
+                        .ExecuteUpdate();
+                Assert.AreEqual(1, countUpdate);
+
+                s.Flush();
+            }
+        }
+
+        protected override void OnSetUp()
+        {
+            base.OnSetUp();
+        }
+
+        protected override bool AppliesTo(global::NHibernate.Dialect.Dialect dialect)
+        {
+            //return dialect as MsSql2005Dialect != null;
+            return base.AppliesTo(dialect);
+        }
+
+        /// <summary>
+        /// Test that reproduces the problem.
+        /// </summary>
+        [Test]
+        public void GeneratedInsertUpdateTrue()
+        {
+            using (ISession session = this.OpenSession())
+            {
+                using (ITransaction tx = session.BeginTransaction())
+                {
+                    Employee employee = new Employee();
+                    employee.Id = 1;
+                    employee.Name = "Employee 1";
+                    employee.PromotionCount = 9999999;
+                    session.Save(employee);
+                    Assert.AreEqual(0, employee.PromotionCount);
+                    tx.Commit();
+                }
+            }
+
+            using (ISession session = this.OpenSession())
+            {
+                using (ITransaction tx = session.BeginTransaction())
+                {
+                    Employee employee = session.Get<Employee>(1);
+                    employee.Name = "Employee 1 changed";
+                    employee.PromotionCount++;
+                    Assert.AreEqual(1, employee.PromotionCount);
+                    tx.Commit();
+                }
+            }
+
+            using (ISession session = this.OpenSession())
+            {
+                Employee employee = session.Get<Employee>(1);
+                Assert.AreEqual("Employee 1 changed", employee.Name);
+                Assert.AreEqual(1, employee.PromotionCount);
+            }
+        }
+    }
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3898/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3898/Mappings.hbm.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.NH3898" default-access="field.camelcase"
+                   default-lazy="true" default-cascade="none">
+
+  <class name="Employee" table="T_EMPLOYEE" mutable="true">
+    <id name="Id" column="C_E_ID">
+      <generator class="native" />
+    </id>
+    <property name="Name" column="C_E_NAME"/>
+    <property name="PromotionCount" insert="false" generated="insert">
+      <column name="C_E_PROMOTION_COUNT" default="0"/>
+    </property>
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -1065,6 +1065,8 @@
     <Compile Include="MappingByCode\IntegrationTests\NH3105\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3436\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3795\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3898\DomainClasses.cs" />
+    <Compile Include="NHSpecificTest\NH3898\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH941\Domain.cs" />
     <Compile Include="NHSpecificTest\NH941\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH941\FixtureUsingList.cs" />
@@ -2930,6 +2932,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3898\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3401\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2049\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH1863\Mappings.hbm.xml" />

--- a/src/NHibernate/Cfg/XmlHbmBinding/PropertiesBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/PropertiesBinder.cs
@@ -297,7 +297,8 @@ namespace NHibernate.Cfg.XmlHbmBinding
 					throw new MappingException("cannot specify both update=\"true\" and generated=\"" + generation
 					                           + "\" for property: " + propertyMapping.Name);
 				}
-				else
+                //Fix for NH-3898
+                else if (generation == PropertyGeneration.Always)
 				{
 					property.IsUpdateable = false;
 				}


### PR DESCRIPTION
Test case and fix to [NH-3898](https://nhibernate.jira.com/browse/NH-3898)
Configuring a property with generated="insert" it makes
"Property.IsUpdatable" "false" even using update="true" in the xml
mapping file.
Please consider keep this issue as Critical, as it does not break the
application, it makes the applications migrated from NHibernate version
2 to 3 or 4 generates inconsistent data within the database.
