### PR TITLE
NH-3874 - Fix NullReferenceException

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3874/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3874/Fixture.cs
@@ -1,0 +1,50 @@
+using System;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3874
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		object _id;
+
+		protected override void OnSetUp()
+		{
+			using (var session = OpenSession())
+			using (var tx = session.BeginTransaction())
+			{
+				var one = new One();
+				var two = new Two { One = one };
+				two.One.Twos = new[] { two };
+				_id = session.Save(one);
+				 session.Save(two);
+
+				tx.Commit();
+			}
+		}
+
+		[Test]
+		public void EvictShallNotThrowWhenLoggingIsEnabled()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var one = session.Get<One>(_id);
+
+				session.Evict(one);
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var tx = session.BeginTransaction())
+			{
+				session.Delete("from Two");
+				session.Delete("from One");
+
+				tx.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3874/IntWrapper.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3874/IntWrapper.cs
@@ -1,0 +1,12 @@
+﻿namespace NHibernate.Test.NHSpecificTest.NH3874
+{
+	public class IntWrapper
+	{
+		public IntWrapper(int id)
+		{
+			Id = id;
+		}
+
+		public int Id { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3874/IntWrapperType.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3874/IntWrapperType.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Data;
+using NHibernate.SqlTypes;
+using NHibernate.Type;
+using NHibernate.UserTypes;
+
+namespace NHibernate.Test.NHSpecificTest.NH3874
+{
+	public class IntWrapperType : IUserType
+	{
+		public SqlType[] SqlTypes
+		{
+			get { return new[] { NHNullableType.SqlType }; }
+		}
+
+		public System.Type ReturnedType { get { return typeof(object); } }
+
+		public new bool Equals(object x, object y)
+		{
+			if (ReferenceEquals(x, y)) return true;
+			if (x == null || y == null) return false;
+			return x.Equals(y);
+		}
+
+		public object DeepCopy(object value) { return value; }
+
+		public bool IsMutable { get { return false; } }
+
+		protected NullableType NHNullableType
+		{
+			get { return NHibernateUtil.Int32; }
+		}
+
+		public object NullSafeGet(IDataReader dr, string[] names, object owner)
+		{
+			object obj = NHNullableType.NullSafeGet(dr, names[0]);
+			if (obj == null) return null;
+			return new IntWrapper((int)obj);
+		}
+
+		public void NullSafeSet(IDbCommand cmd, object obj, int index)
+		{
+			if (obj == null)
+			{
+				((IDataParameter)cmd.Parameters[index]).Value = DBNull.Value;
+			}
+			else
+			{
+				IntWrapper id = (IntWrapper)obj;
+				((IDataParameter)cmd.Parameters[index]).Value = id.Id;
+			}
+		}
+
+		public int GetHashCode(object x)
+		{
+			return x.GetHashCode();
+		}
+
+		public object Replace(object original, object target, object owner)
+		{
+			return original;
+		}
+
+		public object Assemble(object cached, object owner)
+		{
+			return cached;
+		}
+
+		public object Disassemble(object value)
+		{
+			return value;
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3874/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3874/Mappings.hbm.xml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+	assembly="NHibernate.Test"
+	namespace="NHibernate.Test.NHSpecificTest.NH3874"
+	default-lazy="false">
+
+  <class name="One" lazy="true">
+    <id name="Id" column="Zzzz" type="IntWrapperType">
+      <generator class="identity"/>
+    </id>
+
+    <bag name="Twos" cascade="all-delete-orphan" inverse="true" lazy="true">
+      <key column="WeirdId"/>
+      <one-to-many class="Two"/>
+    </bag>
+  </class>
+
+  <class name="Two" lazy="true">
+    <id name="Id" column="WeirdId" type="IntWrapperType">
+      <generator class="foreign">
+        <param name="property">One</param>
+      </generator>
+    </id>
+
+    <one-to-one name="One" class="One" constrained="true"/>
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH3874/One.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3874/One.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3874
+{
+	public class One
+	{
+		public virtual IntWrapper Id { get; set; }
+
+		public virtual IList<Two> Twos { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3874/Two.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3874/Two.cs
@@ -1,0 +1,9 @@
+namespace NHibernate.Test.NHSpecificTest.NH3874
+{
+	public class Two
+	{
+		public virtual IntWrapper Id { get; set; }
+
+		public virtual One One { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -896,6 +896,11 @@
     <Compile Include="NHSpecificTest\NH3844\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3818\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3818\MyLovelyCat.cs" />
+    <Compile Include="NHSpecificTest\NH3874\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3874\IntWrapper.cs" />
+    <Compile Include="NHSpecificTest\NH3874\IntWrapperType.cs" />
+    <Compile Include="NHSpecificTest\NH3874\One.cs" />
+    <Compile Include="NHSpecificTest\NH3874\Two.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3234\Fixture.cs" />
@@ -3169,6 +3174,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3874\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2218\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3046\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3518\Mappings.hbm.xml" />

--- a/src/NHibernate/Impl/MessageHelper.cs
+++ b/src/NHibernate/Impl/MessageHelper.cs
@@ -297,7 +297,7 @@ namespace NHibernate.Impl
 				object ownerKey;
 				// TODO: Is it redundant to attempt to use the collectionKey,
 				// or is always using the owner id sufficient?
-				if (collectionKey.GetType().IsAssignableFrom(ownerIdentifierType.ReturnedClass))
+				if (ownerIdentifierType.ReturnedClass.IsInstanceOfType(collectionKey))
 				{
 					ownerKey = collectionKey;
 				}
@@ -369,7 +369,7 @@ namespace NHibernate.Impl
 			// the given ID.  Due to property-ref keys, the collection key
 			// may not be the owner key.
 			IType ownerIdentifierType = persister.OwnerEntityPersister.IdentifierType;
-			if (id.GetType().IsAssignableFrom(ownerIdentifierType.ReturnedClass))
+			if (ownerIdentifierType.ReturnedClass.IsInstanceOfType(id))
 			{
 				s.Append(ownerIdentifierType.ToLoggableString(id, factory));
 			}


### PR DESCRIPTION
If user was trying to remove or evict a collection which key is of `IUserType` when the `ReturnedType` property of the `IUserType` implementation returns a base type of an actually persisted type (eg. `object`) the `MessageHelper.CollectionInfoString` could throw an `NullReferenceException` due to incorrect type check.

Replaces #492 