### PR TITLE
Fix for NH-3904

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/BarExample.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/BarExample.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	[Serializable]
+	public class BarExample : IExample
+	{
+		public string Value { get; set; }
+		public override string ToString()
+		{
+			return string.Format("Bar:{0}", Value);
+		}
+		public bool IsEquivalentTo(IExample that)
+		{
+			return this.Value == that.Value;
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypeProperty.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypeProperty.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	public class EntityWithUserTypeProperty
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual IExample Example { get; set; }
+	}
+
+
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyGeneratorsRegistry.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyGeneratorsRegistry.cs
@@ -1,0 +1,14 @@
+using NHibernate.Linq;
+using NHibernate.Linq.Functions;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	public class EntityWithUserTypePropertyGeneratorsRegistry : DefaultLinqToHqlGeneratorsRegistry
+	{
+		public EntityWithUserTypePropertyGeneratorsRegistry() : base()
+		{
+			RegisterGenerator(ReflectionHelper.GetMethod((IExample e) => e.IsEquivalentTo(null)),
+							new EntityWithUserTypePropertyIsEquivelentGenerator());
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyIsEquivelentGenerator.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyIsEquivelentGenerator.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using NHibernate.Hql.Ast;
+using NHibernate.Linq;
+using NHibernate.Linq.Functions;
+using NHibernate.Linq.Visitors;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	public class EntityWithUserTypePropertyIsEquivelentGenerator : BaseHqlGeneratorForMethod
+	{
+		public EntityWithUserTypePropertyIsEquivelentGenerator() : base()
+		{
+			SupportedMethods = new[] { ReflectionHelper.GetMethodDefinition((IExample e) => e.IsEquivalentTo(null)) };
+		}
+		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
+		{
+			var left = treeBuilder.Cast(visitor.Visit(targetObject).AsExpression(), typeof(string));
+			var right = treeBuilder.Cast(visitor.Visit(arguments.Cast<Expression>().First()).AsExpression(),
+										 typeof(string));
+
+
+
+			var leftSubstring = treeBuilder.MethodCall("substring", left, treeBuilder.Constant(4));
+			var rightSubstring = treeBuilder.MethodCall("substring", right, treeBuilder.Constant(4));
+			var equals = treeBuilder.Equality(leftSubstring, rightSubstring);
+			return equals;
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/ExampleUserType.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/ExampleUserType.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using NHibernate.SqlTypes;
+using NHibernate.UserTypes;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	public class ExampleUserType : IUserType
+	{
+		public new bool Equals(object a, object b)
+		{
+			IExample ga = a as IExample;
+			IExample gb = b as IExample;
+			if (ga == null && gb == null)
+			{
+				return true;
+			}
+			if (ga != null && gb != null && (ga.GetType() == gb.GetType()))
+			{
+				return ga.Value == gb.Value;
+			}
+			return false;
+		}
+
+		public int GetHashCode(object x)
+		{
+			return ((IExample)x).Value.GetHashCode();
+		}
+
+		public object DeepCopy(object value)
+		{
+			if (value == null) return null;
+			if (value.GetType() == typeof(BarExample))
+			{
+				return new BarExample { Value = ((IExample)value).Value };
+			}
+			return new FooExample { Value = ((IExample)value).Value };
+		}
+
+		public object Replace(object original, object target, object owner)
+		{
+			return original;
+		}
+
+		public object Assemble(object cached, object owner)
+		{
+			return cached;
+		}
+
+		public object Disassemble(object value)
+		{
+			return value;
+		}
+
+		public SqlType[] SqlTypes { get { return new[] { SqlTypeFactory.GetString(255) }; } }
+
+		public System.Type ReturnedType { get { return typeof(IExample); } }
+		public bool IsMutable { get { return true; } }
+
+		public void NullSafeSet(IDbCommand cmd, object value, int index)
+		{
+			var dataParameter = (IDataParameter)cmd.Parameters[index];
+			var example = (IExample)value;
+			dataParameter.DbType = DbType.String;
+			if (value == null || example.Value == null)
+			{
+				dataParameter.Value = DBNull.Value;
+			}
+			else
+			{
+				dataParameter.Value = example.ToString();
+			}
+		}
+
+		public object NullSafeGet(IDataReader rs, string[] names, object owner)
+		{
+			var index = rs.GetOrdinal(names[0]);
+			if (rs.IsDBNull(index))
+			{
+				return null;
+			}
+			var val = rs.GetString(index);
+
+			var parts = val.Split(':');
+			if (parts[0] == "Bar")
+			{
+				return new BarExample { Value = parts[1] };
+			}
+			return new FooExample { Value = parts[1] };
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/Fixture.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using NHibernate.Cfg;
+using NHibernate.Dialect;
+using NHibernate.Linq;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Test.NHSpecificTest.FileStreamSql2008;
+using NUnit.Framework;
+
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+
+	[TestFixture]
+	public class Fixture : TestCase
+	{
+		protected override IList Mappings
+		{
+			get { return new[] { "NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators.Mappings.hbm.xml" }; }
+		}
+
+		protected override string MappingsAssembly
+		{
+			get { return "NHibernate.Test"; }
+		}
+
+		protected override bool AppliesTo(Dialect.Dialect dialect)
+		{
+			return true;
+		}
+
+		protected override void Configure(Configuration cfg)
+		{
+
+			base.Configure(cfg);
+			cfg.LinqToHqlGeneratorsRegistry<EntityWithUserTypePropertyGeneratorsRegistry>();
+		}
+
+		protected override void OnSetUp()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var e1 = new EntityWithUserTypeProperty
+				{
+					Id = 1,
+					Name = "Bob",
+					Example = new BarExample
+					{
+						Value = "Larry"
+					}
+				};
+				session.Save(e1);
+
+				var e2 = new EntityWithUserTypeProperty
+				{
+					Id = 2,
+					Name = "Sally",
+					Example = new FooExample
+					{
+						Value = "Larry"
+					}
+				};
+				session.Save(e2);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Delete("from EntityWithUserTypeProperty");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+
+		[Test]
+		public void EqualityWorksForUserType()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var newItem = new BarExample { Value = "Larry" };
+				var entities = session.Query<EntityWithUserTypeProperty>()
+					.Where(x=>x.Example == newItem)
+					.ToList();
+
+				Assert.AreEqual(1, entities.Count);
+			}
+		}
+
+		[Test]
+		public void LinqMethodWorksForUserType()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var newItem = new BarExample { Value = "Larry" };
+				var entities = session.Query<EntityWithUserTypeProperty>()
+					.Where(x => x.Example.IsEquivalentTo(newItem))
+					.ToList();
+
+				Assert.AreEqual(2, entities.Count);
+			}
+		}
+		[Test]
+		public void CanQueryWithHQL()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var newItem = new BarExample { Value = "Larry" };
+				var q = session.CreateQuery("from EntityWithUserTypeProperty e where e.Example = :exampleItem");
+				q.SetParameter("exampleItem", newItem);
+				var entities = q.List<EntityWithUserTypeProperty>();
+
+				Assert.AreEqual(1, entities.Count);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/FooExample.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/FooExample.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	[Serializable]
+	public class FooExample : IExample
+	{
+		public string Value { get; set; }
+		public bool IsEquivalentTo(IExample that)
+		{
+			return this.Value == that.Value;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("Foo:{0}", Value);
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/IExample.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/IExample.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
+{
+	
+	public interface IExample
+	{
+		string Value { get; set; }
+		bool IsEquivalentTo(IExample that);
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/Mappings.hbm.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<hibernate-mapping xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" namespace="NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators" assembly="NHibernate.Test, Version=4.1.0.1001, Culture=neutral, PublicKeyToken=null" xmlns="urn:nhibernate-mapping-2.2">
+  <class name="EntityWithUserTypeProperty">
+	<id name="Id" type="Int32">
+	  <generator class="assigned" />
+	</id>
+	<property name="Name" />
+	<property name="Example" type="NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators.ExampleUserType, NHibernate.Test" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -723,6 +723,14 @@
     <Compile Include="NHSpecificTest\BagWithLazyExtraAndFilter\Fixture.cs" />
     <Compile Include="Linq\ByMethod\DistinctTests.cs" />
     <Compile Include="Component\Basic\ComponentWithUniqueConstraintTests.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\BarExample.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\EntityWithUserTypeProperty.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\EntityWithUserTypePropertyIsEquivelentGenerator.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\EntityWithUserTypePropertyGeneratorsRegistry.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\ExampleUserType.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Fixture.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\FooExample.cs" />
+    <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
     <Compile Include="NHSpecificTest\NH3414\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3414\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH2218\Fixture.cs" />
@@ -3177,6 +3185,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="NHSpecificTest\NH3874\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2218\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3046\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3518\Mappings.hbm.xml" />


### PR DESCRIPTION
Fixes custom types not being properly detected during linq expression tree translation to IASTNode.
