### PR TITLE
Added generic IResultTransformer interface

### DIFF
--- a/src/NHibernate/Transform/IResultTransformer.cs
+++ b/src/NHibernate/Transform/IResultTransformer.cs
@@ -1,10 +1,9 @@
-using System;
 using System.Collections;
 
 namespace NHibernate.Transform
 {
 	/// <summary>
-	/// Implementors define a strategy for transforming criteria query
+	/// Implementers define a strategy for transforming criteria query
 	/// results into the actual application-visible query result list.
 	/// </summary>
 	/// <seealso cref="NHibernate.ICriteria.SetResultTransformer(IResultTransformer)" />
@@ -25,4 +24,16 @@ namespace NHibernate.Transform
 		/// <returns></returns>
 		IList TransformList(IList collection);
 	}
+
+    /// <summary>
+    /// Implementers define a strategy for transforming a <typeparamref name="T"/>
+    /// specific <see cref="Result"/> for transforming criteria query results into
+    /// the application specific query result list.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IResultTransformer<out T> : IResultTransformer
+        where T : new()
+    {
+        T Result { get; }
+    }
 }


### PR DESCRIPTION
I am also working on a _ResultTransformerBase_ that helps automate ad hoc database queries that would otherwise not require a full mapping, but I see that `ResultTransformer` already has a significant footprint, so I want to tread carefully where that's concerned. Will be content with the interface for now; future direction for this feature is to automate the transformation, whether via delegated `Func`, `Expression`, `Reflection`, or what have you.

Possibly use cases:

``` Sql
SELECT [dbo].[fn_does_my_feature_work](N'blahblahblah',1) AS [Working]
```

And which would respond to the data set including `[Working]`, whether that's a first class object `T Result`, or a simple `System.Boolean`, matters not.

So far it's working well in my situation, and it is **FAST**, which is _CRITICAL_ for this purpose.
