### PR TITLE
Rename connection.provider_class to connection.provider

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -203,7 +203,7 @@ ISession session = sessions.OpenSession(conn);
             <tbody>
             <row>
                 <entry>
-                    <literal>connection.provider_class</literal>
+                    <literal>connection.provider</literal>
                 </entry>
                 <entry>
                     The type of a custom <literal>IConnectionProvider</literal>.
@@ -346,7 +346,7 @@ ISession session = sessions.OpenSession(conn);
         <para>
             You may define your own plugin strategy for obtaining ADO.NET connections by implementing the
             interface <literal>NHibernate.Connection.IConnectionProvider</literal>. You may select
-            a custom implementation by setting <literal>connection.provider_class</literal>.
+            a custom implementation by setting <literal>connection.provider</literal>.
         </para>
 
     </sect1>


### PR DESCRIPTION
The documentation refers to "connection.provider_class" but the example shows "connection.provider". On the system I have been working on it is "connection.provider" that works.