### PR TITLE
NH-3912 Oracle IBatcher impl instance is not reusable after failed operation.

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3912/BatcherLovingEntity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3912/BatcherLovingEntity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3912
+{
+	class BatcherLovingEntity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3912/ReusableBatcherFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3912/ReusableBatcherFixture.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Linq;
+using NHibernate.AdoNet;
+using NHibernate.Cfg;
+using NHibernate.Cfg.MappingSchema;
+using NHibernate.Driver;
+using NHibernate.Engine;
+using NHibernate.Linq;
+using NHibernate.Mapping.ByCode;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3912
+{
+	public class ReusableBatcherFixture : TestCaseMappingByCode
+	{
+		protected override bool AppliesTo(ISessionFactoryImplementor factory)
+		{
+			var driver = factory.ConnectionProvider.Driver;
+			return driver is OracleDataClientDriver ||
+			       driver is OracleLiteDataClientDriver ||
+			       driver is OracleManagedDataClientDriver;
+		}
+
+		protected override HbmMapping GetMappings()
+		{
+			var mapper = new ModelMapper();
+			mapper.Class<BatcherLovingEntity>(rc =>
+			{
+				rc.Id(x => x.Id, m => m.Generator(Generators.GuidComb));
+				rc.Property(x => x.Name, m => m.Unique(true));
+			});
+
+			return mapper.CompileMappingForAllExplicitlyAddedEntities();
+		}
+
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.SetProperty(Cfg.Environment.BatchStrategy,
+			                          typeof(OracleDataClientBatchingBatcherFactory).AssemblyQualifiedName);
+		}
+
+		protected override void OnSetUp()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var e1 = new BatcherLovingEntity { Name = "Bob" };
+				session.Save(e1);
+
+				var e2 = new BatcherLovingEntity { Name = "Sally" };
+				session.Save(e2);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		/// <summary> Batch operations with the same IBatcher instance fail on expect rows count after single failed operation.  </summary>
+		[Test]
+		public void Test_Batcher_Is_Reusable_After_Failed_Operation()
+		{
+			using (var session = OpenSession())
+			{
+				try
+				{
+					using (session.BeginTransaction())
+					{
+						var valid = new BatcherLovingEntity { Name = "Bill" };
+						session.Save(valid);
+
+						Assert.That(() => session.Query<BatcherLovingEntity>().Count(x => x.Name == "Bob"), Is.EqualTo(1));
+						var bob = new BatcherLovingEntity { Name = "Bob" };
+						session.Save(bob);
+
+						// Should fail on unique constraint violation
+						// Expected behavior
+						session.Flush();
+					}
+				}
+				catch (Exception)
+				{
+					// Opening next transaction in the same session after rollback
+					// to log the problem, for instance.
+					// Executing in the same session with the same instance of IBatcher
+					using (session.BeginTransaction())
+					{
+						// Inserting any valid entity will fail on expected rows count assert in batcher
+						var e1 = new BatcherLovingEntity { Name = "Robert (because Bob already exists)" };
+						session.Save(e1);
+						// Batch update returned unexpected row count from update; actual row count: 1; expected: 2
+						session.Flush();
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -733,6 +733,8 @@
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
     <Compile Include="NHSpecificTest\NH2204\Model.cs" />
     <Compile Include="NHSpecificTest\NH2204\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3912\BatcherLovingEntity.cs" />
+    <Compile Include="NHSpecificTest\NH3912\ReusableBatcherFixture.cs" />
     <Compile Include="NHSpecificTest\NH3414\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3414\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH2218\Fixture.cs" />


### PR DESCRIPTION
Batch operations with the same IBatcher instance fail on expected rows count after single failed operation.
Also, passed DbException message for oracle batcher to outer message.

This issue regards OracleDataClientBatchingBatcher. It seems that in the scenario where two batch commands are performed using the same instance of OracleDataClientBatchingBatcher, second batch command will nearly always fail on expected rows count assert. This will only happen if first batch command failed before the second one (any error will do). The reason is that internal counter _totalExpectedRowsAffected isn't reset after first failed batch command.
Example:
BATCH1:
_totalExpectedRowsAffected += 1 (now 1, was 0)
Insert into table and fail on unique constaint violation for instance
_totalExpectedRowsAffected is not reset.
BATCH2:
_totalExpectedRowsAffected += 1 (now 2, was 1)
Insert into table and succeed
Assert Expectations.VerifyOutcomeBatched fails because _totalExpectedRowsAffected and only one row was actually affected.
Every consecutive batch command will also fail.

Pull requests contains following changes:
- _totalExpectedRowsAffected is reset now regardless of the batch query execution outcome (in finally block)
- DbException.Message is passed to the AdoExceptionHelper, so diagnostic information will be included in the exception propagated to user code.
