### PR TITLE
Test & fix for NH-3917

### DIFF
--- a/src/NHibernate.Test/DialectTest/SQLiteDialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/SQLiteDialectFixture.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using NHibernate.Dialect.Function;
 using NHibernate.Mapping;
 
 namespace NHibernate.Test.DialectTest
@@ -10,17 +12,35 @@ namespace NHibernate.Test.DialectTest
     public class SQLiteDialectFixture
     {
         private SQLiteDialect dialect;
+        private SQLFunctionRegistry registry;
 
         [SetUp]
         public void SetUp()
         {
             dialect = new SQLiteDialect();
+            registry = new SQLFunctionRegistry(dialect, new Dictionary<string, ISQLFunction>());
         }
 
         [Test]
         public void SupportsSubSelect()
         {
             Assert.IsTrue(dialect.SupportsSubSelects);
+        }
+
+        [TestCase("int"), TestCase("integer"), TestCase("tinyint"), TestCase("smallint"), TestCase("bigint")]
+        [TestCase("numeric"), TestCase("decimal"), TestCase("bit"), TestCase("money"), TestCase("smallmoney")]
+        [TestCase("float"), TestCase("real"), TestCase("date"), TestCase("datetime"), TestCase("smalldatetime")]
+        [TestCase("char"), TestCase("varchar"), TestCase("text"), TestCase("nvarchar"), TestCase("ntext")]
+        [TestCase("binary"), TestCase("varbinary"), TestCase("image")]
+        [TestCase("cursor"), TestCase("timestamp"), TestCase("uniqueidentifier"), TestCase("sql_variant")]
+        public void WhereStringTemplate(string type)
+        {
+            if (!type.EndsWith(")"))
+                WhereStringTemplate(type + "(1)");
+
+            const string value = "1";
+            string sql = "(CAST(" + value + " AS " + type + "))";
+            Assert.AreEqual(sql, Template.RenderWhereStringTemplate(sql, dialect, registry));
         }
 
         [Test]

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -91,6 +91,32 @@ namespace NHibernate.Dialect
 		protected virtual void RegisterKeywords()
 		{
 			RegisterKeyword("int"); // Used in our function templates.
+			RegisterKeyword("integer"); // a commonly-used alias for 'int'
+			RegisterKeyword("tinyint");
+			RegisterKeyword("smallint");
+			RegisterKeyword("bigint");
+			RegisterKeyword("numeric");
+			RegisterKeyword("decimal");
+			RegisterKeyword("bit");
+			RegisterKeyword("money");
+			RegisterKeyword("smallmoney");
+			RegisterKeyword("float");
+			RegisterKeyword("real");
+			RegisterKeyword("datetime");
+			RegisterKeyword("smalldatetime");
+			RegisterKeyword("char");
+			RegisterKeyword("varchar");
+			RegisterKeyword("text");
+			RegisterKeyword("nchar");
+			RegisterKeyword("nvarchar");
+			RegisterKeyword("ntext");
+			RegisterKeyword("binary");
+			RegisterKeyword("varbinary");
+			RegisterKeyword("image");
+			RegisterKeyword("cursor");
+			RegisterKeyword("timestamp");
+			RegisterKeyword("uniqueidentifier");
+			RegisterKeyword("sql_variant");
 		}
 
 		protected virtual void RegisterDefaultProperties()


### PR DESCRIPTION
https://nhibernate.jira.com/browse/NH-3917

SQLiteDialect only defines 'int' as keyword and as such Template.RenderWhereStringTemplate generates incorrect SQL. As this is used in Formula mapping, it's impossible to use cast in Formulas. Also reported here: http://stackoverflow.com/q/9174356
