### PR TITLE
NH-3918 - Nominate equality expressions in SELECT clauses

### DIFF
--- a/src/NHibernate.Test/Linq/SelectionTests.cs
+++ b/src/NHibernate.Test/Linq/SelectionTests.cs
@@ -451,6 +451,35 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void CanSelectConditionalEntityWithCast()
+		{
+			var fatherInsteadOfChild = db.Mammals.Select(a => a.Father.SerialNumber == "5678" ? (object)a.Father : (object)a).ToList();
+			Assert.That(fatherInsteadOfChild, Has.Exactly(2).With.Property("SerialNumber").EqualTo("5678"));
+		}
+
+		[Test]
+		public void CanSelectConditionalEntityValue()
+		{
+			var fatherInsteadOfChild = db.Animals.Select(a => a.Father.SerialNumber == "5678" ? a.Father.SerialNumber : a.SerialNumber).ToList();
+			Assert.That(fatherInsteadOfChild, Has.Exactly(2).EqualTo("5678"));
+		}
+
+		[Test]
+		public void CanSelectConditionalEntityValueWithEntityComparison()
+		{
+			var father = db.Animals.Single(a => a.SerialNumber == "5678");
+			var fatherInsteadOfChild = db.Animals.Select(a => a.Father == father ? a.Father.SerialNumber : a.SerialNumber).ToList();
+			Assert.That(fatherInsteadOfChild, Has.Exactly(2).EqualTo("5678"));
+		}
+
+		[Test]
+		public void CanSelectConditionalEntityValueWithEntityComparisonRepeat()
+		{
+			// Check again in the same ISessionFactory to ensure caching doesn't cause failures
+			CanSelectConditionalEntityValueWithEntityComparison();
+		}
+
+		[Test]
 		public void CanSelectConditionalObject()
 		{
 			var fatherIsKnown = db.Animals.Select(a => new { a.SerialNumber, Superior = a.Father.SerialNumber, FatherIsKnown = a.Father.SerialNumber == "5678" ? (object)true : (object)false }).ToList();

--- a/src/NHibernate.Test/NHSpecificTest/NH3918/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3918/FixtureByCode.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using NHibernate.Cfg.MappingSchema;
+using NHibernate.Linq;
+using NHibernate.Mapping.ByCode;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3918
+{
+	public class ByCodeFixture : TestCaseMappingByCode
+	{
+		protected override HbmMapping GetMappings()
+		{
+			var mapper = new ModelMapper();
+			mapper.Class<Owner>(rc =>
+			{
+				rc.Id(x => x.Id, m => m.Generator(Generators.GuidComb));
+				rc.Property(x => x.Name);
+			});
+			mapper.Class<Entity>(rc =>
+			{
+				rc.Id(x => x.Id, m => m.Generator(Generators.GuidComb));
+				rc.Property(x => x.Name);
+				rc.ManyToOne(m => m.Owner, m =>
+				{
+					m.Column("OwnerId");
+				});
+			});
+
+			return mapper.CompileMappingForAllExplicitlyAddedEntities();
+		}
+
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var bob =  CreateOwner(session, "Bob");
+				var carl = CreateOwner(session, "Carl");
+				var doug = CreateOwner(session, "Doug");
+
+				CreateEntity(session, "Test 1", bob);
+				CreateEntity(session, "Test 2", carl);
+				CreateEntity(session, "Test 3", doug);
+				CreateEntity(session, "Test 4", bob);
+				CreateEntity(session, "Test 5", carl);
+				CreateEntity(session, "Test 6", doug);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected Owner CreateOwner(ISession session, string name)
+		{
+			var t = new Owner { Name = name };
+			session.Save(t);
+			return t;
+		}
+
+		protected void CreateEntity(ISession session, string name, Owner owner)
+		{
+			var t = new Entity
+			{
+				Name = name,
+				Owner = owner,
+			};
+			session.Save(t);
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from Entity");
+				session.Delete("from Owner");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void EntityComparisonTest()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var bob = session.Query<Owner>().Single(o => o.Name == "Bob");
+
+				var queryWithWhere = session.Query<Entity>()
+										.Where(WhereExpression(bob))
+										.Select(e => e.Name);
+				var queryWithSelect = session.Query<Entity>()
+										.Select(SelectExpression(bob));
+
+				var resultsFromWhere = queryWithWhere.ToList();
+				var resultsFromSelect = queryWithSelect.ToList();
+
+				Assert.That(resultsFromSelect.Where(x => (bool)x[1]).Select(x => (string)x[0]), Is.EquivalentTo(resultsFromWhere));
+			}
+		}
+
+		[Test]
+		public void EntityComparisonTestAgain()
+		{
+			// When the entire fixture is run this will execute the test again within the same ISessionFactory which will test caching
+			EntityComparisonTest();
+		}
+
+		protected Expression<Func<Entity, bool>> WhereExpression(Owner owner)
+		{
+			return e => e.Owner == owner;
+		}
+
+		protected Expression<Func<Entity, object[]>> SelectExpression(Owner owner)
+		{
+			return e => new object[]
+			{
+				e.Name,
+				e.Owner == owner
+			};
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3918/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3918/Model.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3918
+{
+	public interface IModelObject
+	{
+		Guid Id { get; set; }
+		string Name { get; set; }
+	}
+
+	public class Entity : IModelObject
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+
+		public virtual Owner Owner { get; set; }
+	}
+
+	public class Owner : IModelObject
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -735,6 +735,8 @@
     <Compile Include="NHSpecificTest\NH2204\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3912\BatcherLovingEntity.cs" />
     <Compile Include="NHSpecificTest\NH3912\ReusableBatcherFixture.cs" />
+    <Compile Include="NHSpecificTest\NH3918\Model.cs" />
+    <Compile Include="NHSpecificTest\NH3918\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH3414\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3414\FixtureByCode.cs" />
     <Compile Include="NHSpecificTest\NH2218\Fixture.cs" />


### PR DESCRIPTION
with constants in them

* Allow for entity equality to be correctly translated to HQL
* Prevents unneeded joins and caching of entities in the query plan