### PR TITLE
Fix failure of NH1756 test case on ODBC with MS SQL Server 2016.

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH1756/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH1756/Mappings.hbm.xml
@@ -11,8 +11,10 @@
 
 		<discriminator column="subclass" />
 
-		<version	name="Version"	column="version_column" type="Timestamp" generated="always" />
-		<property name="Name"			column="name_column"																				/>
+		<version	name="Version" type="Timestamp" generated="always">
+      <column name="version_column" sql-type="datetime2(3)" />
+    </version>
+		<property name="Name" column="name_column" />
 
 		<bag name="Pages">
 			<key column="book_id" />
@@ -37,8 +39,10 @@
 
 		<discriminator column="subclass" />
 
-		<version	name="Version"	column="version_column" type="Timestamp" generated="never"	/>
-		<property name="Name"			column="name_column"																				/>
+    <version	name="Version" type="Timestamp" generated="never">
+      <column name="version_column" sql-type="datetime2(3)" />
+    </version>
+		<property name="Name" column="name_column"																				/>
 
 		<bag name="Pages">
 			<key column="book_id" />


### PR DESCRIPTION
MS SQL Server 2016 changed rounding rules for the datetime type.

The datetime type is only accurate to 1/300th of a second.

On MSSQL 2014 and earlier, a datetime casted to a datetime2 with precision 4 or
more will return a value that ends in .nn0, .nn3 or .nn7, because the stored
datetime value will be rounded to three fractional second digits before being
converted to datetime2.

Since MSSQL 2016, the datetime will not be rounded before being converted to
datetime2, so a result of such a cast may return values such as .nn333, or
.nn667, for precision 5.

This is a problem for the NH1756 test case because the generated datetime-based
version will be returned .Net with precision 3, (.nn0, .nn3 or .nn7). When
we later pass that value over ODBC, the SQL server (or ODBC library, not sure)
will interpret the parameter as of type datetime2(7). When SQL server converts
the value to the stored version of type datetime, the stored version will
first be converted to a datetime2(7) - this may include additional fractional
digits and it might end of comparing e.g. .nn33333 to .nn3. Since this is
obviously different, there will be not match and eventually this leads to
a StaleObjectException.

Fixing this by letting the testcase use the datetime2 column type, which works
the same since MSSQL2008. Not sure if there is a more proper fix that could be
done, but ODBC for MSSQL server should be a quite narrow use case, and also
MS recommends to use the datetime2 type for new work.