### PR TITLE
AbstractCollectionPersister: Include the table when generating column…

### DIFF
--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -239,7 +239,7 @@ namespace NHibernate.Persister.Collection
 				foreach (Column col in collection.Key.ColumnIterator)
 				{
 					keyColumnNames[k] = col.GetQuotedName(dialect);
-					keyColumnAliases[k] = col.GetAlias(dialect);
+					keyColumnAliases[k] = col.GetAlias(dialect, table);
 					k++;
 				}
 				joinColumnNames = keyColumnNames;
@@ -306,7 +306,7 @@ namespace NHibernate.Persister.Collection
 			int j = 0;
 			foreach (ISelectable selectable in element.ColumnIterator)
 			{
-				elementColumnAliases[j] = selectable.GetAlias(dialect);
+				elementColumnAliases[j] = selectable.GetAlias(dialect, table);
 				if (selectable.IsFormula)
 				{
 					Formula form = (Formula) selectable;


### PR DESCRIPTION
… aliases.

This modifies the calls to Column.GetAlias() in two places to also include
the table parameter, so that the generated alias will be unique in more cases.
It matches what is currently used in Hibernate code.

This fixes the failure of SubselectFetchFixture.ManyToManyCriteriaJoin on
SqlServerCe that was introduced by the modifications to Column.GetAlias()
done in 013b5da27301.