### PR TITLE
NH-3877 Backtrack to target .Net 4.6.1 since we don't need any 4.6.2 API. 

### DIFF
--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -196,7 +196,7 @@
 		<property name="link.sdkdoc.version" value="SDK_v1_1" />
 		<!-- merge should work with 4.0 when compiling for 4.0 -->
 		<property name="merge.targetplatform" value="v4" />
-		<property name="referenceassemblies.dir" value="${environment::get-folder-path('ProgramFiles')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2" />
+		<property name="referenceassemblies.dir" value="${environment::get-folder-path('ProgramFiles')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1" />
 	</target>
 	
 	<target name="set-net-3.5-framework-configuration">

--- a/src/NHibernate.DomainModel/NHibernate.DomainModel.csproj
+++ b/src/NHibernate.DomainModel/NHibernate.DomainModel.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/src/NHibernate.Everything.sln
+++ b/src/NHibernate.Everything.sln
@@ -67,7 +67,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Test", "NHiberna
 EndProject
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "NHibernate.Example.Web", "NHibernate.Example.Web\", "{C5D6EE68-1760-4F97-AD31-42343593D8C1}"
 	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
+		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.6.1"
 		ProjectReferences = "{5909BFE7-93CF-4E5F-BE22-6293368AF01D}|NHibernate.dll;"
 		Debug.AspNetCompiler.VirtualPath = "/NHibernate.Example.Web"
 		Debug.AspNetCompiler.PhysicalPath = "NHibernate.Example.Web\"

--- a/src/NHibernate.Example.Web/Web.Config
+++ b/src/NHibernate.Example.Web/Web.Config
@@ -23,7 +23,7 @@
             affects performance, set this value to true only 
             during development.
         -->
-    <compilation debug="true" targetFramework="4.0"/>
+    <compilation debug="true" targetFramework="4.6.1"/>
     <!--
             The <authentication> section enables configuration 
             of the security authentication mode used by 
@@ -49,7 +49,9 @@
     </httpModules>
   </system.web>
   <hibernate-configuration xmlns="urn:nhibernate-configuration-2.2">
-    <bytecode-provider type="null"/><!-- Important under Medium Trust -->
+    <!-- Important under Medium Trust -->
+    <bytecode-provider type="null"/>
+
     <session-factory>
       <property name="connection.provider">NHibernate.Connection.DriverConnectionProvider, NHibernate</property>
       <property name="connection.connection_string">

--- a/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
+++ b/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>NHibernate.Test.VisualBasic</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <StartAction>Program</StartAction>
     <StartProgram>$(MSBuildProjectDirectory)\..\..\Tools\nunit\nunit-x86.exe</StartProgram>

--- a/src/NHibernate.Test/App.config
+++ b/src/NHibernate.Test/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	
 	<configSections>
@@ -98,7 +98,7 @@
 
 	</log4net>
 
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/src/NHibernate.TestDatabaseSetup/App.config
+++ b/src/NHibernate.TestDatabaseSetup/App.config
@@ -13,4 +13,4 @@
       </property>
     </session-factory>
   </hibernate-configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/src/NHibernate.TestDatabaseSetup/NHibernate.TestDatabaseSetup.csproj
+++ b/src/NHibernate.TestDatabaseSetup/NHibernate.TestDatabaseSetup.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHibernate.TestDatabaseSetup</RootNamespace>
     <AssemblyName>NHibernate.TestDatabaseSetup</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartupObject>
     </StartupObject>

--- a/src/NHibernate.Tool.HbmXsd/NHibernate.Tool.HbmXsd.csproj
+++ b/src/NHibernate.Tool.HbmXsd/NHibernate.Tool.HbmXsd.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/src/NHibernate.Tool.HbmXsd/app.config
+++ b/src/NHibernate.Tool.HbmXsd/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>


### PR DESCRIPTION
With .Net 4.6.2 being very new, .Net 4.6.1 currently has greater adoption.
Since we don't actually plan to use any of the new API in .Net 4.6.2, we
might as well target the older version.