### PR TITLE
NH-3885 - Replace ThreadSafeDictionary wrapper with Framework's ConcurrentDictionary.

### DIFF
--- a/src/NHibernate.Test/UtilityTest/ThreadSafeDictionaryFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/ThreadSafeDictionaryFixture.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using log4net;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.UtilityTest
@@ -23,42 +23,36 @@ namespace NHibernate.Test.UtilityTest
 		[Test, Explicit]
 		public void MultiThreadAccess()
 		{
-			MultiThreadRunner<IDictionary<int, int>>.ExecuteAction[] actions =
-				new MultiThreadRunner<IDictionary<int, int>>.ExecuteAction[]
+			MultiThreadRunner<ConcurrentDictionary<int, int>>.ExecuteAction[] actions =
+				new MultiThreadRunner<ConcurrentDictionary<int, int>>.ExecuteAction[]
 					{
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 							{
-								try
-								{
-									log.DebugFormat("T{0} Add", Thread.CurrentThread.Name);
-									write++;
-									d.Add(rnd.Next(), rnd.Next());
-								}
-								catch (ArgumentException)
-								{
-									// duplicated key
-								}
+								log.DebugFormat("T{0} Add", Thread.CurrentThread.Name);
+								write++;
+								d.TryAdd(rnd.Next(), rnd.Next());
 							}, 
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 						 	{
 								log.DebugFormat("T{0} ContainsKey", Thread.CurrentThread.Name);
 					   		read++;
 					   		d.ContainsKey(rnd.Next());
 					   	}, 
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 			   	   	{
 								log.DebugFormat("T{0} Remove", Thread.CurrentThread.Name);
 			   	   		write++;
-			   	   		d.Remove(rnd.Next());
+			   	   		int value;
+			   	   		d.TryRemove(rnd.Next(), out value);
 			   	   	}, 
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 	   	   	   	{
 								log.DebugFormat("T{0} TryGetValue", Thread.CurrentThread.Name);
 	   	   	   		read++;
 	   	   	   		int val;
 	   	   	   		d.TryGetValue(rnd.Next(), out val);
 	   	   	   	}, 
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
  	   	   	   	{
  	   	   	   		try
  	   	   	   		{
@@ -71,25 +65,25 @@ namespace NHibernate.Test.UtilityTest
  	   	   	   			// not foud key
  	   	   	   		}
  	   	   	   	}, 
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
  	   	   	   	{
 								log.DebugFormat("T{0} set_this[]", Thread.CurrentThread.Name);
  	   	   	   		write++;
  	   	   	   		d[rnd.Next()] = rnd.Next();
  	   	   	   	},
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 							{
 								log.DebugFormat("T{0} Keys", Thread.CurrentThread.Name);
 								read++;
 								IEnumerable<int> e = d.Keys;
 							},
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 					   	{
 								log.DebugFormat("T{0} Values", Thread.CurrentThread.Name);
 					   		read++;
 					   		IEnumerable<int> e = d.Values;
 					   	}, 
-						delegate(IDictionary<int, int> d)
+						delegate(ConcurrentDictionary<int, int> d)
 			   	   	{
 								log.DebugFormat("T{0} GetEnumerator", Thread.CurrentThread.Name);
 			   	   		read++;
@@ -99,8 +93,8 @@ namespace NHibernate.Test.UtilityTest
 			   	   		}
 			   	   	},
 					};
-			MultiThreadRunner<IDictionary<int, int>> mtr = new MultiThreadRunner<IDictionary<int, int>>(20, actions);
-			IDictionary<int, int> wrapper = new ThreadSafeDictionary<int, int>(new Dictionary<int, int>());
+			MultiThreadRunner<ConcurrentDictionary<int, int>> mtr = new MultiThreadRunner<ConcurrentDictionary<int, int>>(20, actions);
+			ConcurrentDictionary<int, int> wrapper = new ConcurrentDictionary<int, int>();
 			mtr.EndTimeout = 2000;
 			mtr.Run(wrapper);
 			log.DebugFormat("{0} reads, {1} writes -- elements {2}", read, write, wrapper.Count);

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -93,8 +94,8 @@ namespace NHibernate.Impl
 		private static readonly IIdentifierGenerator UuidGenerator = new UUIDHexGenerator();
 
 		[NonSerialized]
-		private readonly ThreadSafeDictionary<string, ICache> allCacheRegions =
-			new ThreadSafeDictionary<string, ICache>(new Dictionary<string, ICache>());
+		private readonly ConcurrentDictionary<string, ICache> allCacheRegions =
+			new ConcurrentDictionary<string, ICache>();
 
 		[NonSerialized]
 		private readonly IDictionary<string, IClassMetadata> classMetadata;
@@ -147,7 +148,7 @@ namespace NHibernate.Impl
 		private readonly IQueryCache queryCache;
 
 		[NonSerialized]
-		private readonly IDictionary<string, IQueryCache> queryCaches;
+		private readonly ConcurrentDictionary<string, IQueryCache> queryCaches;
 		[NonSerialized]
 		private readonly SchemaExport schemaExport;
 		[NonSerialized]
@@ -160,7 +161,7 @@ namespace NHibernate.Impl
 		[NonSerialized]
 		private readonly UpdateTimestampsCache updateTimestampsCache;
 		[NonSerialized]
-		private readonly IDictionary<string, string[]> entityNameImplementorsMap = new ThreadSafeDictionary<string, string[]>(new Dictionary<string, string[]>(100));
+		private readonly IDictionary<string, string[]> entityNameImplementorsMap = new ConcurrentDictionary<string, string[]>(4 * System.Environment.ProcessorCount, 100);
 		private readonly string uuid;
 		private bool disposed;
 
@@ -247,7 +248,10 @@ namespace NHibernate.Impl
 					if (cache != null)
 					{
 						caches.Add(cacheRegion, cache);
-						allCacheRegions.Add(cache.RegionName, cache.Cache);
+						if (!allCacheRegions.TryAdd(cache.RegionName, cache.Cache))
+						{
+							throw new HibernateException("An item with the same key has already been added to allCacheRegions.");
+						}
 					}
 				}
 				IEntityPersister cp = PersisterFactory.CreateClassPersister(model, cache, this, mapping);
@@ -375,7 +379,7 @@ namespace NHibernate.Impl
 			{
 				updateTimestampsCache = new UpdateTimestampsCache(settings, properties);
 				queryCache = settings.QueryCacheFactory.GetQueryCache(null, updateTimestampsCache, settings, properties);
-				queryCaches = new ThreadSafeDictionary<string, IQueryCache>(new Dictionary<string, IQueryCache>());
+				queryCaches = new ConcurrentDictionary<string, IQueryCache>();
 			}
 			else
 			{
@@ -967,10 +971,8 @@ namespace NHibernate.Impl
 
 		public IDictionary<string, ICache> GetAllSecondLevelCacheRegions()
 		{
-			lock (allCacheRegions.SyncRoot)
-			{
-				return new Dictionary<string, ICache>(allCacheRegions);
-			}
+			// ToArray creates a moment in time snapshot
+			return allCacheRegions.ToArray().ToDictionary(kv => kv.Key, kv => kv.Value);
 		}
 
 		public ICache GetSecondLevelCacheRegion(string regionName)
@@ -1002,18 +1004,14 @@ namespace NHibernate.Impl
 				return null;
 			}
 
-			lock (allCacheRegions.SyncRoot)
-			{
-				IQueryCache currentQueryCache;
-				if (!queryCaches.TryGetValue(cacheRegion, out currentQueryCache))
+			return queryCaches.GetOrAdd(
+				cacheRegion,
+				cr =>
 				{
-					currentQueryCache =
-						settings.QueryCacheFactory.GetQueryCache(cacheRegion, updateTimestampsCache, settings, properties);
-					queryCaches[cacheRegion] = currentQueryCache;
+					IQueryCache currentQueryCache = settings.QueryCacheFactory.GetQueryCache(cacheRegion, updateTimestampsCache, settings, properties);
 					allCacheRegions[currentQueryCache.RegionName] = currentQueryCache.Cache;
-				}
-				return currentQueryCache;
-			}
+					return currentQueryCache;
+				});
 		}
 
 		public void EvictQueries()

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyCache.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyCache.cs
@@ -6,14 +6,13 @@
 
 #endregion
 
-using System.Collections.Generic;
-using NHibernate.Util;
+using System.Collections.Concurrent;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	public class ProxyCache : IProxyCache
 	{
-		private static readonly IDictionary<ProxyCacheEntry, System.Type> cache = new ThreadSafeDictionary<ProxyCacheEntry, System.Type>(new Dictionary<ProxyCacheEntry, System.Type>());
+		private static readonly ConcurrentDictionary<ProxyCacheEntry, System.Type> cache = new ConcurrentDictionary<ProxyCacheEntry, System.Type>();
 
 		#region IProxyCache Members
 

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -7,7 +7,6 @@ using System.Xml;
 using System.Xml.Linq;
 using NHibernate.Bytecode;
 using NHibernate.Classic;
-using NHibernate.Engine;
 using NHibernate.SqlTypes;
 using NHibernate.UserTypes;
 using NHibernate.Util;
@@ -60,14 +59,14 @@ namespace NHibernate.Type
 		 * "System.String(l)" -> instance of StringType with specified l
 		 */
 
-		private static readonly IDictionary<string, IType> typeByTypeOfName =
-			new ThreadSafeDictionary<string, IType>(new Dictionary<string, IType>());
+		private static readonly ConcurrentDictionary<string, IType> typeByTypeOfName =
+			new ConcurrentDictionary<string, IType>();
 
-		private static readonly IDictionary<string, GetNullableTypeWithLength> getTypeDelegatesWithLength =
-			new ThreadSafeDictionary<string, GetNullableTypeWithLength>(new Dictionary<string, GetNullableTypeWithLength>());
+		private static readonly ConcurrentDictionary<string, GetNullableTypeWithLength> getTypeDelegatesWithLength =
+			new ConcurrentDictionary<string, GetNullableTypeWithLength>();
 
-		private static readonly IDictionary<string, GetNullableTypeWithPrecision> getTypeDelegatesWithPrecision =
-			new ThreadSafeDictionary<string, GetNullableTypeWithPrecision>(new Dictionary<string, GetNullableTypeWithPrecision>());
+		private static readonly ConcurrentDictionary<string, GetNullableTypeWithPrecision> getTypeDelegatesWithPrecision =
+			new ConcurrentDictionary<string, GetNullableTypeWithPrecision>();
 
 		private delegate NullableType GetNullableTypeWithLength(int length); // Func<int, NullableType>
 
@@ -133,7 +132,10 @@ namespace NHibernate.Type
 			foreach (var alias in typeAliases)
 			{
 				typeByTypeOfName[alias] = nhibernateType;
-				getTypeDelegatesWithLength.Add(alias, ctorLength);
+				if (!getTypeDelegatesWithLength.TryAdd(alias, ctorLength))
+				{
+					throw new HibernateException("An item with the same key has already been added to getTypeDelegatesWithLength.");
+				}
 			}
 		}
 
@@ -143,7 +145,10 @@ namespace NHibernate.Type
 			foreach (var alias in typeAliases)
 			{
 				typeByTypeOfName[alias] = nhibernateType;
-				getTypeDelegatesWithPrecision.Add(alias, ctorPrecision);
+				if (!getTypeDelegatesWithPrecision.TryAdd(alias, ctorPrecision))
+				{
+					throw new HibernateException("An item with the same key has already been added to getTypeDelegatesWithPrecision.");
+				}
 			}
 		}
 
@@ -402,18 +407,30 @@ namespace NHibernate.Type
 
 		private static void AddToTypeOfName(string key, IType type)
 		{
-			typeByTypeOfName.Add(key, type);
-			typeByTypeOfName.Add(type.Name, type);
+			if (!typeByTypeOfName.TryAdd(key, type))
+			{
+				throw new HibernateException("An item with the same key has already been added to typeByTypeOfName.");
+			}
+			if (!typeByTypeOfName.TryAdd(type.Name, type))
+			{
+				throw new HibernateException("An item with the same key has already been added to typeByTypeOfName.");
+			}
 		}
 
 		private static void AddToTypeOfNameWithLength(string key, IType type)
 		{
-			typeByTypeOfName.Add(key, type);
+			if (!typeByTypeOfName.TryAdd(key, type))
+			{
+				throw new HibernateException("An item with the same key has already been added to typeByTypeOfName.");
+			}
 		}
 
 		private static void AddToTypeOfNameWithPrecision(string key, IType type)
 		{
-			typeByTypeOfName.Add(key, type);
+			if (!typeByTypeOfName.TryAdd(key, type))
+			{
+				throw new HibernateException("An item with the same key has already been added to typeByTypeOfName.");
+			}
 		}
 
 		private static string GetKeyForLengthBased(string name, int length)


### PR DESCRIPTION
Backport of 925a9f0 and e6aa1c4 to 4.1.x. Only difference is that on
the older branch, we leave the ThreadSafeDictionary class to avoid
changing public API. /OB 2016-12-04.