### PR TITLE
NH-3900 - Prework for NUnit 3, but still on NUnit 2.x

### DIFF
--- a/src/NHibernate.Test/CfgTest/AccessorsSerializableTest.cs
+++ b/src/NHibernate.Test/CfgTest/AccessorsSerializableTest.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Test.CfgTest
 	{
 		private static System.Type[] accessors = typeof (IPropertyAccessor).Assembly.GetTypes().Where(t => t.Namespace == typeof (IPropertyAccessor).Namespace && t.GetInterfaces().Contains(typeof (IPropertyAccessor))).ToArray();
 
-		[Test, TestCaseSource("accessors")]
+		[Test, TestCaseSource(nameof(accessors))]
 		public void AllAccessorsAreMarkedAsSerializable(System.Type concreteAccessor)
 		{
 			Assert.That(concreteAccessor, Has.Attribute<SerializableAttribute>());
@@ -17,7 +17,7 @@ namespace NHibernate.Test.CfgTest
 
 		private static System.Type[] setters = typeof(ISetter).Assembly.GetTypes().Where(t => t.Namespace == typeof(ISetter).Namespace && t.GetInterfaces().Contains(typeof(ISetter))).ToArray();
 
-		[Test, TestCaseSource("setters")]
+		[Test, TestCaseSource(nameof(setters))]
 		public void AllSettersAreMarkedAsSerializable(System.Type concreteAccessor)
 		{
 			Assert.That(concreteAccessor, Has.Attribute<SerializableAttribute>());
@@ -25,7 +25,7 @@ namespace NHibernate.Test.CfgTest
 
 		private static System.Type[] getters = typeof(IGetter).Assembly.GetTypes().Where(t => t.Namespace == typeof(IGetter).Namespace && t.GetInterfaces().Contains(typeof(IGetter))).ToArray();
 
-		[Test, TestCaseSource("getters")]
+		[Test, TestCaseSource(nameof(getters))]
 		public void AllGettersAreMarkedAsSerializable(System.Type concreteAccessor)
 		{
 			Assert.That(concreteAccessor, Has.Attribute<SerializableAttribute>());

--- a/src/NHibernate.Test/CfgTest/ConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/ConfigurationFixture.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.CfgTest
 		public void ReadCfgXmlFromDefaultFile()
 		{
 			Configuration cfg = new Configuration();
-			cfg.Configure("TestEnbeddedConfig.cfg.xml");
+			cfg.Configure(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestEnbeddedConfig.cfg.xml"));
 
 			Assert.IsTrue(cfg.Properties.ContainsKey(Environment.ShowSql));
 			Assert.IsTrue(cfg.Properties.ContainsKey(Environment.UseQueryCache));
@@ -91,7 +91,7 @@ namespace NHibernate.Test.CfgTest
 		public void InvalidXmlInCfgFile()
 		{
 			XmlDocument cfgXml = new XmlDocument();
-			cfgXml.Load("TestEnbeddedConfig.cfg.xml");
+			cfgXml.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestEnbeddedConfig.cfg.xml"));
 
 			// this should put us at the first <property> element
 			XmlElement propElement = cfgXml.DocumentElement.GetElementsByTagName("property")[0] as XmlElement;
@@ -99,8 +99,8 @@ namespace NHibernate.Test.CfgTest
 			// removing this will cause it not to validate
 			propElement.RemoveAttribute("name");
 
-			const string FileNameForInvalidCfg = "hibernate.invalid.cfg.xml";
-      cfgXml.Save(FileNameForInvalidCfg);
+			string FileNameForInvalidCfg = Path.Combine(TestContext.CurrentContext.TestDirectory, "hibernate.invalid.cfg.xml");
+			cfgXml.Save(FileNameForInvalidCfg);
 
 			Configuration cfg = new Configuration();
 			try
@@ -222,7 +222,7 @@ namespace NHibernate.Test.CfgTest
 		[Test]
 		public void InvalidXmlInHbmFile()
 		{
-			string filename = "invalid.hbm.xml";
+			string filename = Path.Combine(TestContext.CurrentContext.TestDirectory, "invalid.hbm.xml");
 			// it's missing the class name - won't validate
 			string hbm =
 				@"<?xml version='1.0' encoding='utf-8' ?> 
@@ -432,7 +432,7 @@ namespace NHibernate.Test.CfgTest
 		public void NH2890Standard()
 		{
 			var cfg = new Configuration();
-			cfg.Configure("TestEnbeddedConfig.cfg.xml")
+			cfg.Configure(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestEnbeddedConfig.cfg.xml"))
 				.LinqQueryProvider<SampleQueryProvider>()
 				.SetDefaultAssembly("NHibernate.DomainModel")
 				.SetDefaultNamespace("NHibernate.DomainModel");
@@ -451,7 +451,7 @@ namespace NHibernate.Test.CfgTest
 		public void NH2890Xml()
 		{
 			var cfg = new Configuration();
-			cfg.Configure("TestEnbeddedConfig.cfg.xml")
+			cfg.Configure(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestEnbeddedConfig.cfg.xml"))
 				.SetDefaultAssembly("NHibernate.DomainModel")
 				.SetDefaultNamespace("NHibernate.DomainModel");
 

--- a/src/NHibernate.Test/CfgTest/DefaultNsAssmFixture.cs
+++ b/src/NHibernate.Test/CfgTest/DefaultNsAssmFixture.cs
@@ -97,33 +97,33 @@ namespace NHibernate.Test.CfgTest
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			dir_ = Directory.GetCurrentDirectory();
+			dir_ = TestContext.CurrentContext.TestDirectory;
 
 			// Create hbm files (ideally, we could just embed them directly into the
 			// assembly - same as VS does when 'Build Action' = 'Embedded Resource' - but
 			// I could not find a way to do this, so we use files instead)
 
-			StreamWriter aw = new StreamWriter("A1.hbm.xml");
+			StreamWriter aw = new StreamWriter(Path.Combine(dir_, "A1.hbm.xml"));
 			aw.Write(aJoinedHbmXml);
 			aw.Close();
 
-			StreamWriter bw = new StreamWriter("B1.hbm.xml");
+			StreamWriter bw = new StreamWriter(Path.Combine(dir_, "B1.hbm.xml"));
 			bw.Write(bJoinedHbmXml);
 			bw.Close();
 
-			StreamWriter cw = new StreamWriter("C1.hbm.xml");
+			StreamWriter cw = new StreamWriter(Path.Combine(dir_, "C1.hbm.xml"));
 			cw.Write(cJoinedHbmXml);
 			cw.Close();
 
-			StreamWriter asw = new StreamWriter("A1.subclass.hbm.xml");
+			StreamWriter asw = new StreamWriter(Path.Combine(dir_, "A1.subclass.hbm.xml"));
 			asw.Write(aJoinedHbmXml);
 			asw.Close();
 
-			StreamWriter bsw = new StreamWriter("B1.subclass.hbm.xml");
+			StreamWriter bsw = new StreamWriter(Path.Combine(dir_, "B1.subclass.hbm.xml"));
 			bsw.Write(bJoinedHbmXml);
 			bsw.Close();
 
-			StreamWriter csw = new StreamWriter("C1.subclass.hbm.xml");
+			StreamWriter csw = new StreamWriter(Path.Combine(dir_, "C1.subclass.hbm.xml"));
 			csw.Write(cJoinedHbmXml);
 			csw.Close();
 		}
@@ -151,7 +151,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestA1.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("A.hbm.xml", "A1.hbm.xml");
 			assemblyBuilder.AddResourceFile("B.hbm.xml", "B1.hbm.xml");
@@ -159,7 +159,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 
@@ -169,7 +169,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestB1.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("C.hbm.xml", "C1.hbm.xml");
 			assemblyBuilder.AddResourceFile("B.hbm.xml", "B1.hbm.xml");
@@ -177,7 +177,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 
@@ -187,7 +187,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestC1.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("B.hbm.xml", "B1.hbm.xml");
 			assemblyBuilder.AddResourceFile("A.hbm.xml", "A1.hbm.xml");
@@ -195,7 +195,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 
@@ -205,7 +205,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestCSubclass1.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("B.subclass.hbm.xml", "B1.hbm.xml");
 			assemblyBuilder.AddResourceFile("A.subclass.hbm.xml", "A1.hbm.xml");
@@ -213,7 +213,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 	}

--- a/src/NHibernate.Test/CfgTest/HbmOrderingFixture.cs
+++ b/src/NHibernate.Test/CfgTest/HbmOrderingFixture.cs
@@ -135,33 +135,33 @@ namespace NHibernate.Test.CfgTest
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			dir_ = Directory.GetCurrentDirectory();
+			dir_ = TestContext.CurrentContext.TestDirectory;
 
 			// Create hbm files (ideally, we could just embed them directly into the
 			// assembly - same as VS does when 'Build Action' = 'Embedded Resource' - but
 			// I could not find a way to do this, so we use files instead)
 
-			StreamWriter aw = new StreamWriter("A.hbm.xml");
+			StreamWriter aw = new StreamWriter(Path.Combine(dir_, "A.hbm.xml"));
 			aw.Write(aJoinedHbmXml);
 			aw.Close();
 
-			StreamWriter bw = new StreamWriter("B.hbm.xml");
+			StreamWriter bw = new StreamWriter(Path.Combine(dir_, "B.hbm.xml"));
 			bw.Write(bJoinedHbmXml);
 			bw.Close();
 
-			StreamWriter cw = new StreamWriter("C.hbm.xml");
+			StreamWriter cw = new StreamWriter(Path.Combine(dir_, "C.hbm.xml"));
 			cw.Write(cJoinedHbmXml);
 			cw.Close();
 
-			StreamWriter asw = new StreamWriter("A.subclass.hbm.xml");
+			StreamWriter asw = new StreamWriter(Path.Combine(dir_, "A.subclass.hbm.xml"));
 			asw.Write(aJoinedHbmXml);
 			asw.Close();
 
-			StreamWriter bsw = new StreamWriter("B.subclass.hbm.xml");
+			StreamWriter bsw = new StreamWriter(Path.Combine(dir_, "B.subclass.hbm.xml"));
 			bsw.Write(bJoinedHbmXml);
 			bsw.Close();
 
-			StreamWriter csw = new StreamWriter("C.subclass.hbm.xml");
+			StreamWriter csw = new StreamWriter(Path.Combine(dir_, "C.subclass.hbm.xml"));
 			csw.Write(cJoinedHbmXml);
 			csw.Close();
 		}
@@ -189,7 +189,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestA.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("A.hbm.xml", "A.hbm.xml");
 			assemblyBuilder.AddResourceFile("B.hbm.xml", "B.hbm.xml");
@@ -197,7 +197,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 
@@ -207,7 +207,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestB.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("C.hbm.xml", "C.hbm.xml");
 			assemblyBuilder.AddResourceFile("B.hbm.xml", "B.hbm.xml");
@@ -215,7 +215,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 
@@ -225,7 +225,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestC.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("B.hbm.xml", "B.hbm.xml");
 			assemblyBuilder.AddResourceFile("A.hbm.xml", "A.hbm.xml");
@@ -233,7 +233,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 
@@ -243,7 +243,7 @@ namespace NHibernate.Test.CfgTest
 			AssemblyName assemblyName = new AssemblyName();
 			assemblyName.Name = "MyTestCSubclass.dll";
 			AssemblyBuilder assemblyBuilder =
-				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+				AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave, dir_);
 			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyName.Name, true);
 			assemblyBuilder.AddResourceFile("B.subclass.hbm.xml", "B.hbm.xml");
 			assemblyBuilder.AddResourceFile("A.subclass.hbm.xml", "A.hbm.xml");
@@ -251,7 +251,7 @@ namespace NHibernate.Test.CfgTest
 			assemblyBuilder.Save(assemblyName.Name);
 
 			Configuration cfg = new Configuration();
-			cfg.AddAssembly(Assembly.LoadFile(dir_ + "/" + assemblyName.Name));
+			cfg.AddAssembly(Assembly.LoadFile(Path.Combine(dir_, assemblyName.Name)));
 			// if no exception, success
 		}
 	}

--- a/src/NHibernate.Test/CfgTest/Loquacious/ConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/Loquacious/ConfigurationFixture.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.SqlClient;
+using System.IO;
 using NHibernate.AdoNet;
 using NHibernate.Bytecode;
 using NHibernate.Cache;
@@ -130,7 +131,7 @@ namespace NHibernate.Test.CfgTest.Loquacious
 		public void NH2890Loquacious()
 		{
 			var cfg = new Configuration();
-			cfg.Configure("TestEnbeddedConfig.cfg.xml")
+			cfg.Configure(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestEnbeddedConfig.cfg.xml"))
 				.SetDefaultAssembly("NHibernate.DomainModel")
 				.SetDefaultNamespace("NHibernate.DomainModel")
 				.SessionFactory()

--- a/src/NHibernate.Test/CfgTest/MappingDocumentAggregatorTests.cs
+++ b/src/NHibernate.Test/CfgTest/MappingDocumentAggregatorTests.cs
@@ -65,7 +65,7 @@ namespace NHibernate.Test.CfgTest
 
 			for (int i = 0; i < 5; i++)
 			{
-				FileInfo tempFile = new FileInfo(Guid.NewGuid() + ".hbm.binary");
+				FileInfo tempFile = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, Guid.NewGuid() + ".hbm.binary"));
 
 				// Load the embedded xml mappings (and time it)
 				Stopwatch stopwatch1 = Stopwatch.StartNew();

--- a/src/NHibernate.Test/DialectTest/FunctionTests/SequenceSupportFixture.cs
+++ b/src/NHibernate.Test/DialectTest/FunctionTests/SequenceSupportFixture.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Test.DialectTest.FunctionTests
 		/// <summary>
 		/// Test case data source for DialectSupportingSequencesMustFullfillSequenceContract().
 		/// </summary>
-		private IEnumerable<System.Type> GetAllDialectTypes()
+		private static IEnumerable<System.Type> GetAllDialectTypes()
 		{
 			var dialectBaseType = typeof(NHibernate.Dialect.Dialect);
 
@@ -26,7 +26,7 @@ namespace NHibernate.Test.DialectTest.FunctionTests
 		}
 
 
-		[TestCaseSource("GetAllDialectTypes")]
+		[TestCaseSource(nameof(GetAllDialectTypes))]
 		public void DialectSupportingSequencesMustFullfillSequenceContract(System.Type dialectType)
 		{
 			var dialect = (NHibernate.Dialect.Dialect)Activator.CreateInstance(dialectType);

--- a/src/NHibernate.Test/DialectTest/FunctionTests/SubstringSupportFixture.cs
+++ b/src/NHibernate.Test/DialectTest/FunctionTests/SubstringSupportFixture.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.DialectTest.FunctionTests
 		/// <summary>
 		/// Test case data source for DialectShouldUseCorrectSubstringImplementation().
 		/// </summary>
-		private IEnumerable<System.Type> GetAllDialectTypes()
+		private static IEnumerable<System.Type> GetAllDialectTypes()
 		{
 			var dialectBaseType = typeof(NHibernate.Dialect.Dialect);
 
@@ -24,7 +24,7 @@ namespace NHibernate.Test.DialectTest.FunctionTests
 		}
 
 
-		[TestCaseSource("GetAllDialectTypes")]
+		[TestCaseSource(nameof(GetAllDialectTypes))]
 		public void DialectShouldUseCorrectSubstringImplementation(System.Type dialectType)
 		{
 			var dialect = (NHibernate.Dialect.Dialect)Activator.CreateInstance(dialectType);

--- a/src/NHibernate.Test/DynamicProxyTests/PeVerifier.cs
+++ b/src/NHibernate.Test/DynamicProxyTests/PeVerifier.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.DynamicProxyTests
 
 		public PeVerifier(string assemblyFileName)
 		{
-			var assemblyLocation = Path.Combine(Environment.CurrentDirectory, assemblyFileName);
+			var assemblyLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, assemblyFileName);
 
 			if (!File.Exists(assemblyLocation))
 				throw new ArgumentException(string.Format("Could not locate assembly {0}", assemblyLocation), "assemblyLocation");

--- a/src/NHibernate.Test/DynamicProxyTests/PeVerifyFixture.cs
+++ b/src/NHibernate.Test/DynamicProxyTests/PeVerifyFixture.cs
@@ -124,7 +124,7 @@ namespace NHibernate.Test.DynamicProxyTests
 			public AssemblyBuilder DefineDynamicAssembly(AppDomain appDomain, AssemblyName name)
 			{
 				AssemblyBuilderAccess access = AssemblyBuilderAccess.RunAndSave;
-				return appDomain.DefineDynamicAssembly(new AssemblyName(assemblyName), access);
+				return appDomain.DefineDynamicAssembly(new AssemblyName(assemblyName), access, TestContext.CurrentContext.TestDirectory);
 			}
 
 			public ModuleBuilder DefineDynamicModule(AssemblyBuilder assemblyBuilder, string moduleName)

--- a/src/NHibernate.Test/Linq/LinqReadonlyTestsContext.cs
+++ b/src/NHibernate.Test/Linq/LinqReadonlyTestsContext.cs
@@ -103,7 +103,7 @@ namespace NHibernate.Test.Linq
 		private string GetScripFileName(Configuration configuration,string postFix)
 		{
 			var dialect = Dialect.Dialect.GetDialect(configuration.Properties);
-			return Path.Combine("DbScripts", dialect.GetType().Name + postFix + ".sql");
+			return Path.Combine(TestContext.CurrentContext.TestDirectory, "DbScripts", dialect.GetType().Name + postFix + ".sql");
 		}
 
 		private Configuration Configure()

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -759,7 +759,7 @@ namespace NHibernate.Test.Linq
 
 
 		[Test(Description = "NH-3366")]
-		[TestCaseSource(typeof(WhereTests), "CanUseCompareInQueryDataSource")]
+		[TestCaseSource(typeof(WhereTests), nameof(CanUseCompareInQueryDataSource))]
 		public void CanUseCompareInQuery(Expression<Func<Product, bool>> expression, int expectedCount, bool expectCase)
 		{
 			using (var ls = new SqlLogSpy())
@@ -774,7 +774,7 @@ namespace NHibernate.Test.Linq
 		}
 
 
-		private List<object[]> CanUseCompareInQueryDataSource()
+		private static List<object[]> CanUseCompareInQueryDataSource()
 		{
 			return new List<object[]>
 				{

--- a/src/NHibernate.Test/NHSpecificTest/NH2188/AppDomainWithMultipleSearchPath.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2188/AppDomainWithMultipleSearchPath.cs
@@ -14,14 +14,19 @@ namespace NHibernate.Test.NHSpecificTest.NH2188
 				return GetDefaultConfigurationFilePath();
 			}
 		}
+
 		[Test]
 		public void WhenSerchInMultiplePathsThenNotThrows()
 		{
+			// NUnit 3 sets PrivateBinPath when using an NUnit project, so we need to reset back to the correct setting when done.
+			var privatePath = AppDomain.CurrentDomain.SetupInformation.PrivateBinPath;
+
 			string binPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin");
 			var expected = Path.Combine(binPath, Configuration.DefaultHibernateCfgFileName);
 
 			try
 			{
+				AppDomain.CurrentDomain.ClearPrivatePath();
 				AppDomain.CurrentDomain.AppendPrivatePath("bin");
 				AppDomain.CurrentDomain.AppendPrivatePath("DbScripts");
 				var configuration = new MyNhConfiguration();
@@ -30,6 +35,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2188
 			finally
 			{
 				AppDomain.CurrentDomain.ClearPrivatePath();
+				if (privatePath != null) AppDomain.CurrentDomain.AppendPrivatePath(privatePath);
 			}
 		}
 	}


### PR DESCRIPTION
I have another pull request, #508 for updating to NUnit 3 for [NH-3900](https://nhibernate.jira.com/browse/NH-3900), this is as much pre-changes that can be done without updating all the way to NUnit 3.

I am going to push the Linq tests split after the build server starts so that there is a baseline without the split, because a bunch of stuff will be "new" failures because it's in a different place.