### PR TITLE
NH-3370: Remove warning about "NHibernate.Type.CustomType -- the custom type * is not serializable"

### DIFF
--- a/src/NHibernate/Type/CustomType.cs
+++ b/src/NHibernate/Type/CustomType.cs
@@ -64,10 +64,6 @@ namespace NHibernate.Type
 			}
 			TypeFactory.InjectParameters(userType, parameters);
 			sqlTypes = userType.SqlTypes;
-			if (!userType.ReturnedType.IsSerializable)
-			{
-				LoggerProvider.LoggerFor(typeof(CustomType)).WarnFormat("the custom type '{0}' handled by '{1}' is not Serializable: ", userType.ReturnedType, userTypeClass);
-			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
The serializable check for custom types is not needed. If the type is not serializable, it will fill the log files with warnings. e.g. When you have a custom type, that returns the type IEnumerable<T>.