### PR TITLE
Additional check if child session has already been closed during parent session closing.

### DIFF
--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -370,7 +370,10 @@ namespace NHibernate.Impl
 						{
 							foreach (KeyValuePair<EntityMode, ISession> pair in childSessionsByEntityMode)
 							{
-								pair.Value.Close();
+								if (pair.Value.IsOpen)
+								{
+									pair.Value.Close();
+								}
 							}
 						}
 					}


### PR DESCRIPTION
This simple fix prevents unnecessary SessionException("Session was already closed") throw when both parent session and child session are closed separately (order does not matter). Before invoking close on child session (during parent session close) we should check if child session has not been closed already. 