### PR TITLE
NH-4022 - Patch for Deletion of SQL Server Sequences

### DIFF
--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Dialect
 
 		public override string GetDropSequenceString(string sequenceName)
 		{
-			string dropSequence = "IF EXISTS (select * from sys.sequences where name = N'{0}') DROP SEQUENCE {0}";
+			string dropSequence = "if object_id('{0}') is not null drop sequence {0}";
 
 			return string.Format(dropSequence, sequenceName);
 		}

--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Dialect
 
 		public override string GetDropSequenceString(string sequenceName)
 		{
-			string dropSequence = "if object_id('{0}') is not null drop sequence {0}";
+			string dropSequence = "if object_id(N'{0}') is not null drop sequence {0}";
 
 			return string.Format(dropSequence, sequenceName);
 		}


### PR DESCRIPTION
[NH-4022](https://nhibernate.jira.com/browse/NH-4022) - Deletion of a sequence fails if the sequence does not reside in the default schema, since schema and name are stored in different columns of sys.sequences.