### PR TITLE
NH-3934 Add methods to QueryOver WhereNot and AndNot with ICriterion …

### DIFF
--- a/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
@@ -164,16 +164,19 @@ namespace NHibernate.Test.Criteria.Lambda
 		[Test]
 		public void Negation()
 		{
-			ICriteria expected =
-				CreateTestCriteria(typeof(Person), "personAlias")
-					.Add(Restrictions.Not(Restrictions.Eq("Name", "test name")))
-					.Add(Restrictions.Not(Restrictions.Eq("personAlias.Name", "test name")));
+            ICriteria expected =
+                CreateTestCriteria(typeof(Person), "personAlias")
+                    .Add(Restrictions.Not(Restrictions.Eq("Name", "test name")))
+                    .Add(Restrictions.Not(Restrictions.Eq("personAlias.Name", "test name")))
+					.Add(Restrictions.Not(Restrictions.Eq("Name", "not test name")));
 
-			Person personAlias = null;
+
+            Person personAlias = null;
 			IQueryOver<Person> actual =
 				CreateTestQueryOver<Person>(() => personAlias)
 					.AndNot(p => p.Name == "test name")
-					.AndNot(() => personAlias.Name == "test name");
+					.AndNot(() => personAlias.Name == "test name")
+					.AndNot(Restrictions.Eq("Name", "not test name"));
 
 			AssertCriteriaAreEqual(expected, actual);
 		}
@@ -187,14 +190,16 @@ namespace NHibernate.Test.Criteria.Lambda
 					.And(() => personAlias.Name == "test name")
 					.And(p => p.Name == "test name")
 					.AndNot(() => personAlias.Name == "test name")
-					.AndNot(p => p.Name == "test name");
+                    .AndNot(p => p.Name == "test name")
+					.AndNot(Restrictions.Eq("Name", "not test name"));
 
 			IQueryOver<Person> actual =
 				CreateTestQueryOver<Person>(() => personAlias)
 					.Where(() => personAlias.Name == "test name")
 					.Where(p => p.Name == "test name")
 					.WhereNot(() => personAlias.Name == "test name")
-					.WhereNot(p => p.Name == "test name");
+					.WhereNot(p => p.Name == "test name")
+					.WhereNot(Restrictions.Eq("Name", "not test name"));
 
 			AssertCriteriaAreEqual(expected.UnderlyingCriteria, actual);
 		}

--- a/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
@@ -164,14 +164,14 @@ namespace NHibernate.Test.Criteria.Lambda
 		[Test]
 		public void Negation()
 		{
-            ICriteria expected =
-                CreateTestCriteria(typeof(Person), "personAlias")
-                    .Add(Restrictions.Not(Restrictions.Eq("Name", "test name")))
-                    .Add(Restrictions.Not(Restrictions.Eq("personAlias.Name", "test name")))
+			ICriteria expected =
+				CreateTestCriteria(typeof(Person), "personAlias")
+					.Add(Restrictions.Not(Restrictions.Eq("Name", "test name")))
+					.Add(Restrictions.Not(Restrictions.Eq("personAlias.Name", "test name")))
 					.Add(Restrictions.Not(Restrictions.Eq("Name", "not test name")));
 
 
-            Person personAlias = null;
+			Person personAlias = null;
 			IQueryOver<Person> actual =
 				CreateTestQueryOver<Person>(() => personAlias)
 					.AndNot(p => p.Name == "test name")
@@ -190,7 +190,7 @@ namespace NHibernate.Test.Criteria.Lambda
 					.And(() => personAlias.Name == "test name")
 					.And(p => p.Name == "test name")
 					.AndNot(() => personAlias.Name == "test name")
-                    .AndNot(p => p.Name == "test name")
+					.AndNot(p => p.Name == "test name")
 					.AndNot(Restrictions.Eq("Name", "not test name"));
 
 			IQueryOver<Person> actual =

--- a/src/NHibernate/Criterion/QueryOver.cs
+++ b/src/NHibernate/Criterion/QueryOver.cs
@@ -346,8 +346,8 @@ namespace NHibernate.Criterion
 		{
 			return AddNot(expression);
 		}
-
-        public QueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression)
+		
+		public QueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{
 			return new QueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body));
 		}
@@ -387,7 +387,7 @@ namespace NHibernate.Criterion
 			return AddNot(expression);
 		}
 
-        public QueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
+		public QueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{
 			return new QueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body));
 		}
@@ -784,13 +784,13 @@ namespace NHibernate.Criterion
 			return this;
 		}
 
-        private QueryOver<TRoot, TSubType> AddNot(ICriterion expression)
-        {
-            criteria.Add(Restrictions.Not(expression));
-            return this;
-        }
-
-        IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.And(Expression<Func<TSubType, bool>> expression)
+		private QueryOver<TRoot, TSubType> AddNot(ICriterion expression)
+		{
+			criteria.Add(Restrictions.Not(expression));
+			return this;
+		}
+		
+		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.And(Expression<Func<TSubType, bool>> expression)
 		{ return And(expression); }
 
 		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.And(Expression<Func<bool>> expression)
@@ -802,8 +802,8 @@ namespace NHibernate.Criterion
 		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndNot(Expression<Func<TSubType, bool>> expression)
 		{ return AndNot(expression); }
 
-        IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.AndNot(Expression<Func<bool>> expression)
-        { return AndNot(expression); }
+		IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.AndNot(Expression<Func<bool>> expression)
+		{ return AndNot(expression); }
 
 		IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.AndNot(ICriterion expression)
 		{ return AndNot(expression); }
@@ -832,7 +832,7 @@ namespace NHibernate.Criterion
 		IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.WhereNot(ICriterion expression)
 		{ return WhereNot(expression); }
 
-        IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
+		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{ return new IQueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body)); }
 
 		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereRestrictionOn(Expression<Func<object>> expression)

--- a/src/NHibernate/Criterion/QueryOver.cs
+++ b/src/NHibernate/Criterion/QueryOver.cs
@@ -808,7 +808,7 @@ namespace NHibernate.Criterion
 		IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.AndNot(ICriterion expression)
 		{ return AndNot(expression); }
 
-        IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndRestrictionOn(Expression<Func<TSubType, object>> expression)
+		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{ return new IQueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body)); }
 
 		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndRestrictionOn(Expression<Func<object>> expression)

--- a/src/NHibernate/Criterion/QueryOver.cs
+++ b/src/NHibernate/Criterion/QueryOver.cs
@@ -342,7 +342,12 @@ namespace NHibernate.Criterion
 			return AddNot(expression);
 		}
 
-		public QueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression)
+		public QueryOver<TRoot, TSubType> AndNot(ICriterion expression)
+		{
+			return AddNot(expression);
+		}
+
+        public QueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{
 			return new QueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body));
 		}
@@ -377,7 +382,12 @@ namespace NHibernate.Criterion
 			return AddNot(expression);
 		}
 
-		public QueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
+		public QueryOver<TRoot, TSubType> WhereNot(ICriterion expression)
+		{
+			return AddNot(expression);
+		}
+
+        public QueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{
 			return new QueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body));
 		}
@@ -774,8 +784,13 @@ namespace NHibernate.Criterion
 			return this;
 		}
 
+        private QueryOver<TRoot, TSubType> AddNot(ICriterion expression)
+        {
+            criteria.Add(Restrictions.Not(expression));
+            return this;
+        }
 
-		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.And(Expression<Func<TSubType, bool>> expression)
+        IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.And(Expression<Func<TSubType, bool>> expression)
 		{ return And(expression); }
 
 		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.And(Expression<Func<bool>> expression)
@@ -787,10 +802,13 @@ namespace NHibernate.Criterion
 		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndNot(Expression<Func<TSubType, bool>> expression)
 		{ return AndNot(expression); }
 
-		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndNot(Expression<Func<bool>> expression)
+        IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.AndNot(Expression<Func<bool>> expression)
+        { return AndNot(expression); }
+
+		IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.AndNot(ICriterion expression)
 		{ return AndNot(expression); }
 
-		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndRestrictionOn(Expression<Func<TSubType, object>> expression)
+        IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{ return new IQueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body)); }
 
 		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.AndRestrictionOn(Expression<Func<object>> expression)
@@ -811,7 +829,10 @@ namespace NHibernate.Criterion
 		IQueryOver<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereNot(Expression<Func<bool>> expression)
 		{ return WhereNot(expression); }
 
-		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
+		IQueryOver<TRoot, TSubType> IQueryOver<TRoot, TSubType>.WhereNot(ICriterion expression)
+		{ return WhereNot(expression); }
+
+        IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereRestrictionOn(Expression<Func<TSubType, object>> expression)
 		{ return new IQueryOverRestrictionBuilder<TRoot,TSubType>(this, ExpressionProcessor.FindMemberProjection(expression.Body)); }
 
 		IQueryOverRestrictionBuilder<TRoot,TSubType> IQueryOver<TRoot,TSubType>.WhereRestrictionOn(Expression<Func<object>> expression)

--- a/src/NHibernate/IQueryOver.cs
+++ b/src/NHibernate/IQueryOver.cs
@@ -215,12 +215,12 @@ namespace NHibernate
 		/// </summary>
 		IQueryOver<TRoot, TSubType> AndNot(ICriterion expression);
 
-        /// <summary>
-        /// Add restriction to a property
-        /// </summary>
-        /// <param name="expression">Lambda expression containing path to property</param>
-        /// <returns>criteria instance</returns>
-        IQueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression);
+		/// <summary>
+		/// Add restriction to a property
+		/// </summary>
+		/// <param name="expression">Lambda expression containing path to property</param>
+		/// <returns>criteria instance</returns>
+		IQueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression);
 
 		/// <summary>
 		/// Add restriction to a property
@@ -267,12 +267,12 @@ namespace NHibernate
 		/// </summary>
 		IQueryOver<TRoot, TSubType> WhereNot(ICriterion expression);
 
-        /// <summary>
-        /// Identical semantics to AndRestrictionOn() to allow more readable queries
-        /// </summary>
-        /// <param name="expression">Lambda expression</param>
-        /// <returns>criteria instance</returns>
-        IQueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression);
+		/// <summary>
+		/// Identical semantics to AndRestrictionOn() to allow more readable queries
+		/// </summary>
+		/// <param name="expression">Lambda expression</param>
+		/// <returns>criteria instance</returns>
+		IQueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression);
 
 		/// <summary>
 		/// Identical semantics to AndRestrictionOn() to allow more readable queries

--- a/src/NHibernate/IQueryOver.cs
+++ b/src/NHibernate/IQueryOver.cs
@@ -211,11 +211,16 @@ namespace NHibernate
 		IQueryOver<TRoot,TSubType> AndNot(Expression<Func<bool>> expression);
 
 		/// <summary>
-		/// Add restriction to a property
+		/// Add negation of criterion expressed as ICriterion
 		/// </summary>
-		/// <param name="expression">Lambda expression containing path to property</param>
-		/// <returns>criteria instance</returns>
-		IQueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression);
+		IQueryOver<TRoot, TSubType> AndNot(ICriterion expression);
+
+        /// <summary>
+        /// Add restriction to a property
+        /// </summary>
+        /// <param name="expression">Lambda expression containing path to property</param>
+        /// <returns>criteria instance</returns>
+        IQueryOverRestrictionBuilder<TRoot,TSubType> AndRestrictionOn(Expression<Func<TSubType, object>> expression);
 
 		/// <summary>
 		/// Add restriction to a property
@@ -258,11 +263,16 @@ namespace NHibernate
 		IQueryOver<TRoot,TSubType> WhereNot(Expression<Func<bool>> expression);
 
 		/// <summary>
-		/// Identical semantics to AndRestrictionOn() to allow more readable queries
+		/// Identical semantics to AndNot() to allow more readable queries
 		/// </summary>
-		/// <param name="expression">Lambda expression</param>
-		/// <returns>criteria instance</returns>
-		IQueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression);
+		IQueryOver<TRoot, TSubType> WhereNot(ICriterion expression);
+
+        /// <summary>
+        /// Identical semantics to AndRestrictionOn() to allow more readable queries
+        /// </summary>
+        /// <param name="expression">Lambda expression</param>
+        /// <returns>criteria instance</returns>
+        IQueryOverRestrictionBuilder<TRoot,TSubType> WhereRestrictionOn(Expression<Func<TSubType, object>> expression);
 
 		/// <summary>
 		/// Identical semantics to AndRestrictionOn() to allow more readable queries


### PR DESCRIPTION
QueryOver has methods Where(ICriterion) and And(ICriterion) but hasnt WhereNot(ICriterion) and AndNot(ICriterion). It's usefull for example when work with subqueries