### PR TITLE
NH-3845, NH-3946 - Fix Linq queries with `.OfType<T>()` and `where is T`, where T is a mapped base type

### DIFF
--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -662,6 +662,14 @@ namespace NHibernate.Test.Linq
 			Assert.That(query.Count, Is.EqualTo(3));
 		}
 
+		[Test(Description = "NH-3845")]
+		public void PolymorphicSearchOnObjectTypeWithOfType()
+		{
+			var query = session.Query<Animal>().OfType<Mammal>().ToList();
+
+			Assert.That(query.Count, Is.EqualTo(3));
+		}
+
 		[Test]
 		public void BitwiseQuery()
 		{

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -652,6 +652,16 @@ namespace NHibernate.Test.Linq
 			Assert.That(query.Count, Is.EqualTo(2));
 		}
 
+		[Test(Description = "NH-3946")]
+		public void PolymorphicSearchOnObjectTypeWithIsKeyword()
+		{
+			var query = (from o in session.Query<Animal>()
+						 where o is Mammal
+						 select o).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(3));
+		}
+
 		[Test]
 		public void BitwiseQuery()
 		{

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessOfType.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessOfType.cs
@@ -1,24 +1,17 @@
-﻿using System.Linq.Expressions;
-using NHibernate.Hql.Ast;
-using Remotion.Linq.Clauses.ResultOperators;
+﻿using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
 	public class ProcessOfType : IResultOperatorProcessor<OfTypeResultOperator>
 	{
-		#region IResultOperatorProcessor<OfTypeResultOperator> Members
-
 		public void Process(OfTypeResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{
-		    Expression source = queryModelVisitor.Model.SelectClause.GetOutputDataInfo().ItemExpression;
+			var source = queryModelVisitor.Model.SelectClause.GetOutputDataInfo().ItemExpression;
 
-			tree.AddWhereClause(tree.TreeBuilder.Equality(
-				tree.TreeBuilder.Dot(
-					HqlGeneratorExpressionTreeVisitor.Visit(source, queryModelVisitor.VisitorParameters).AsExpression(),
-					tree.TreeBuilder.Class()),
-				tree.TreeBuilder.Ident(resultOperator.SearchedItemType.FullName)));
+			var expression = new HqlGeneratorExpressionTreeVisitor(queryModelVisitor.VisitorParameters)
+				.BuildOfType(source, resultOperator.SearchedItemType);
+
+			tree.AddWhereClause(expression);
 		}
-
-		#endregion
 	}
 }

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1013,6 +1013,7 @@ namespace NHibernate.Persister.Entity
 		public abstract string[] ConstraintOrderedTableNameClosure { get;}
 		public abstract string DiscriminatorSQLValue { get;}
 		public abstract object DiscriminatorValue { get;}
+		public abstract string[] SubclassClosure { get; }
 		public abstract string[] PropertySpaces { get;}
 
 		protected virtual void AddDiscriminatorToInsert(SqlInsertBuilder insert) { }

--- a/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
@@ -345,6 +345,11 @@ namespace NHibernate.Persister.Entity
 			get { return discriminatorValue; }
 		}
 
+		public override string[] SubclassClosure
+		{
+			get { return subclassClosure; }
+		}
+
 		public override string[] PropertySpaces
 		{
 			get

--- a/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
@@ -424,7 +424,7 @@ namespace NHibernate.Persister.Entity
 			get { return discriminatorValue; }
 		}
 
-		public virtual string[] SubclassClosure
+		public override string[] SubclassClosure
 		{
 			get { return subclassClosure; }
 		}
@@ -618,7 +618,7 @@ namespace NHibernate.Persister.Entity
 @"The class {0} can't be instatiated and does not have mapped subclasses; 
 possible solutions:
 - don't map the abstract class
-- map the its subclasses.";
+- map its subclasses.";
 
 			if (NeedsDiscriminator)
 			{

--- a/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
@@ -186,7 +186,7 @@ namespace NHibernate.Persister.Entity
 			get { return discriminatorValue; }
 		}
 
-		public string[] SubclassClosure
+		public override string[] SubclassClosure
 		{
 			get { return subclassClosure; }
 		}


### PR DESCRIPTION
Patch allows queries like `session.Query<Animal>().Where(x => x is Mammal)` and `session.Query<Animal>().OfType<Mammal>()` to get all dogs and cats, for example.