### PR TITLE
NH-3950: failure of FutureValue on First/Single result operator. Fix and test cases

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3950/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3950/Entity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3950
+{
+	class Entity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3950/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3950/Fixture.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3950
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var e1 = new Entity {Name = "Bob"};
+				session.Save(e1);
+
+				var e2 = new Entity {Name = "Sally"};
+				session.Save(e2);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void FirstFutureValue()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.OrderBy(e => e.Name)
+					.ToFutureValue(q => q.First());
+
+				Assert.AreEqual("Bob", result.Value.Name);
+			}
+		}
+
+		[Test]
+		public void FirstOrDefaultFutureValue()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Select(e => e.Name)
+					.OrderBy(n => n)
+					.ToFutureValue(q => q.FirstOrDefault());
+
+				Assert.AreEqual("Bob", result.Value);
+			}
+		}
+
+		[Test]
+		public void SingleFutureValue()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Where(e => e.Name == "Bob")
+					.ToFutureValue(q => q.Single());
+
+				Assert.AreEqual("Bob", result.Value.Name);
+			}
+		}
+
+		[Test]
+		public void SingleOrDefaultFutureValue()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Select(e => e.Name)
+					.Where(n => n == "Bob")
+					.ToFutureValue(q => q.SingleOrDefault());
+
+				Assert.AreEqual("Bob", result.Value);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3950/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3950/Mappings.hbm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3950">
+
+	<class name="Entity">
+		<id name="Id" generator="guid.comb" />
+		<property name="Name" />
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -736,6 +736,8 @@
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Fixture.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\FooExample.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
+    <Compile Include="NHSpecificTest\NH3950\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3950\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2204\Model.cs" />
     <Compile Include="NHSpecificTest\NH2204\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3912\BatcherLovingEntity.cs" />
@@ -3201,6 +3203,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3950\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2204\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3874\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Mappings.hbm.xml" />

--- a/src/NHibernate/Impl/FutureValue.cs
+++ b/src/NHibernate/Impl/FutureValue.cs
@@ -1,47 +1,44 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Impl
 {
-    internal class FutureValue<T> : IFutureValue<T>, IDelayedValue
-    {
-        public delegate IEnumerable<T> GetResult();
+	internal class FutureValue<T> : IFutureValue<T>, IDelayedValue
+	{
+		public delegate IEnumerable<T> GetResult();
 
-        private readonly GetResult getResult;
+		private readonly GetResult getResult;
 
-        public FutureValue(GetResult result)
-        {
-            getResult = result;
-        }
+		public FutureValue(GetResult result)
+		{
+			getResult = result;
+		}
 
-        public T Value
-        {
-            get
-            {
-                var result = getResult();
+		public T Value
+		{
+			get
+			{
+				var result = getResult();
+				if (ExecuteOnEval != null)
+					// When not null, ExecuteOnEval is fetched with PostExecuteTransformer from IntermediateHqlTree
+					// through ExpressionToHqlTranslationResults, which requires a IQueryable as input and directly
+					// yields the scalar result when the query is scalar.
+					return (T)ExecuteOnEval.DynamicInvoke(result.AsQueryable());
+
 				var enumerator = result.GetEnumerator();
 
 				if (!enumerator.MoveNext())
-				{
-				    var defVal = default(T);
-                    if (ExecuteOnEval != null)
-                        defVal = (T)ExecuteOnEval.DynamicInvoke(defVal);
-				    return defVal;
-				}
+					return default(T);
 
-                var val = enumerator.Current;
+				return enumerator.Current;
+			}
+		}
 
-                if (ExecuteOnEval != null)
-                    val = (T)ExecuteOnEval.DynamicInvoke(val);
-				    
-                return val;
-            }
-        }
-
-        public Delegate ExecuteOnEval
-        {
-            get; set;
-        }
-    }
+		public Delegate ExecuteOnEval
+		{
+			get; set;
+		}
+	}
 }


### PR DESCRIPTION
Test cases and fix for [NH-3950](https://nhibernate.jira.com/browse/NH-3950): failure of FutureValue on First/Single result operator.
All test cases, using SQLServer, pass. (Excepted DtcFailuresFixture.Can_roll_back_transaction which fails to cleanup (connection closed: False) whatever I do, even without my changes.)

I consider this to be a prerequisite for [NH-3850](https://nhibernate.jira.com/browse/NH-3850).

FuturValue.cs diff looks ugly due to previous indentation: it was using spaces instead of tabs, contrary to guidlines. Relevant changes are in `Value` getter.