### PR TITLE
NH-3951 - support of .All as query result. Test cases, fix and refactoring

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3951/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3951/Entity.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3951
+{
+	class Entity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Guid? RelatedId { get; set; }
+
+		public virtual ISet<Entity> Related { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3951/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3951/Fixture.cs
@@ -1,0 +1,105 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3951
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var e1 = new Entity {Name = "Bob"};
+				session.Save(e1);
+
+				var e2 = new Entity {Name = "Sally"};
+				session.Save(e2);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void AllNamedBob()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.All(e => e.Name == "Bob");
+
+				Assert.AreEqual(false, result);
+			}
+		}
+
+		[Test]
+		public void AllNamedWithAtLeast3Char()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.All(e => e.Name.Length > 2);
+
+				Assert.AreEqual(true, result);
+			}
+		}
+
+		[Test]
+		public void AllNamedBobWorkaround()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = !session.Query<Entity>()
+					.Any(e => e.Name != "Bob");
+
+				Assert.AreEqual(false, result);
+			}
+		}
+
+		[Test]
+		public void AllNamedWithAtLeast3CharWorkaround()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = !session.Query<Entity>()
+					.Any(e => e.Name.Length < 3);
+
+				Assert.AreEqual(true, result);
+			}
+		}
+
+		[Test]
+		public void AnyAndAllInSubQueries()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Select(e => new { e.Id, hasRelated = e.Related.Any(), allBobRelated = e.Related.All(r => r.Name == "Bob") })
+					.ToList();
+
+				Assert.AreEqual(false, result[0].hasRelated);
+				Assert.AreEqual(true, result[0].allBobRelated);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3951/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3951/Mappings.hbm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3951">
+
+	<class name="Entity">
+		<id name="Id" generator="guid.comb" />
+		<property name="Name" />
+		<property name="RelatedId" />
+		<set name="Related">
+			<key column="RelatedId"/>
+			<one-to-many class="Entity" />
+		</set>
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -749,6 +749,8 @@
     <Compile Include="NHSpecificTest\NH3950\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3952\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3952\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3951\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3951\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2204\Model.cs" />
     <Compile Include="NHSpecificTest\NH2204\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3912\BatcherLovingEntity.cs" />
@@ -3227,6 +3229,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH3963\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3950\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3952\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\NH3951\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2204\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3874\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Mappings.hbm.xml" />

--- a/src/NHibernate/Linq/IntermediateHqlTree.cs
+++ b/src/NHibernate/Linq/IntermediateHqlTree.cs
@@ -30,6 +30,14 @@ namespace NHibernate.Linq
 		private HqlTreeNode _root;
 		private HqlOrderBy _orderBy;
 
+		public bool IsRoot
+		{
+			get
+			{
+				return _isRoot;
+			}
+		}
+
 		public HqlTreeNode Root
 		{
 			get
@@ -53,11 +61,6 @@ namespace NHibernate.Linq
 
 		public ExpressionToHqlTranslationResults GetTranslation()
 		{
-			if (_isRoot)
-			{
-				DetectOuterExists();
-			}
-
 			return new ExpressionToHqlTranslationResults(Root,
 														 _itemTransformers,
 														 _listTransformers,
@@ -198,19 +201,6 @@ namespace NHibernate.Linq
 
 				_hqlHaving.ClearChildren();
 				_hqlHaving.AddChild(TreeBuilder.BooleanAnd(currentClause, where));
-			}
-		}
-
-		private void DetectOuterExists()
-		{
-			if (_root is HqlExists)
-			{
-				_takeCount = TreeBuilder.Constant(1);
-				_root = Root.Children.First();
-
-				Expression<Func<IEnumerable<object>, bool>> x = l => l.Any();
-
-				_listTransformers.Add(x);
 			}
 		}
 

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAll.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAll.cs
@@ -1,17 +1,31 @@
-﻿using NHibernate.Hql.Ast;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NHibernate.Hql.Ast;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
-    public class ProcessAll : IResultOperatorProcessor<AllResultOperator>
-    {
-        public void Process(AllResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
-        {
-            tree.AddWhereClause(tree.TreeBuilder.BooleanNot(
-                               HqlGeneratorExpressionTreeVisitor.Visit(resultOperator.Predicate, queryModelVisitor.VisitorParameters).
-                                   ToBooleanExpression()));
+	public class ProcessAll : IResultOperatorProcessor<AllResultOperator>
+	{
+		public void Process(AllResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+		{
+			tree.AddWhereClause(tree.TreeBuilder.BooleanNot(
+				HqlGeneratorExpressionTreeVisitor.Visit(resultOperator.Predicate, queryModelVisitor.VisitorParameters).
+					ToBooleanExpression()));
 
-            tree.SetRoot(tree.TreeBuilder.BooleanNot(tree.TreeBuilder.Exists((HqlQuery) tree.Root)));
-        }
-    }
+			if (tree.IsRoot)
+			{
+				tree.AddTakeClause(tree.TreeBuilder.Constant(1));
+
+				Expression<Func<IEnumerable<object>, bool>> x = l => !l.Any();
+				tree.AddListTransformer(x);
+			}
+			else
+			{
+				tree.SetRoot(tree.TreeBuilder.BooleanNot(tree.TreeBuilder.Exists((HqlQuery)tree.Root)));
+			}
+		}
+	}
 }

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAny.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAny.cs
@@ -1,13 +1,27 @@
-﻿using NHibernate.Hql.Ast;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NHibernate.Hql.Ast;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
-    public class ProcessAny : IResultOperatorProcessor<AnyResultOperator>
-    {
-        public void Process(AnyResultOperator anyOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
-        {
-            tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery) tree.Root));
-        }
-    }
+	public class ProcessAny : IResultOperatorProcessor<AnyResultOperator>
+	{
+		public void Process(AnyResultOperator anyOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+		{
+			if (tree.IsRoot)
+			{
+				tree.AddTakeClause(tree.TreeBuilder.Constant(1));
+
+				Expression<Func<IEnumerable<object>, bool>> x = l => l.Any();
+				tree.AddListTransformer(x);
+			}
+			else
+			{
+				tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery)tree.Root));
+			}
+		}
+	}
 }


### PR DESCRIPTION
Implements [NH-3951](https://nhibernate.jira.com/browse/NH-3951).

This allows calls such as `session.Query<Entity>().All(e => someCondition))`, instead of having to work-around with `!session.Query<Entity>().Any(e => !someCondition))`.

Support of the `Any` case was using some "after-thought" tree inspection, I have simplified it by handling it in the `ProcessAny` result operator processor. This has required exposing the `_isRoot` member of `IntermediateHqlTree` through an `IsRoot` getter, in order to avoid compromising usages of `Any|All` as sub-queries.

Of course, all test cases continue to pass. (Excepted the `DtcFailuresFixture.Can_roll_back_transaction` which has an unrelated `TearDown` issue (not closing its connection), which occurs on my setup without my changes too.)

I would like to be able to go on fixing [NH-3850](https://nhibernate.jira.com/browse/NH-3850) with changes done by this NH-3951.