### PR TITLE
NH-3952: removing usages of NHibernate.Linq.EnumerableHelper

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3952/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3952/Entity.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.NHSpecificTest.NH3952
+{
+	class Entity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Guid? ParentId { get; set; }
+		public virtual ISet<Entity> Children { get; set; }
+		public virtual string[] Hobbies { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3952/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3952/Fixture.cs
@@ -1,0 +1,81 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3952
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				var e1 = new Entity { Name = "Bob" };
+				session.Save(e1);
+
+				var e2 = new Entity { Name = "Sally", ParentId = e1.Id, Hobbies = new[] { "Inline skate", "Sailing" } };
+				session.Save(e2);
+
+				var e3 = new Entity { Name = "Max", ParentId = e1.Id };
+				session.Save(e3);
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void SimpleNestedSelect()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Select(e => new { e.Name, children = e.Children.Select(c => c.Name).ToArray() })
+					.OrderBy(e => e.Name)
+					.ToList();
+
+				Assert.AreEqual(3, result.Count);
+				Assert.AreEqual(2, result[0].children.Length);
+				Assert.AreEqual("Bob", result[0].Name);
+				Assert.Contains("Max", result[0].children);
+				Assert.Contains("Sally", result[0].children);
+				Assert.AreEqual(0, result[1].children.Length + result[2].children.Length);
+			}
+		}
+
+		[Test]
+		public void ArraySelect()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Select(e => new { e.Name, e.Hobbies })
+					.OrderBy(e => e.Name)
+					.ToList();
+
+				Assert.AreEqual(3, result.Count);
+				Assert.AreEqual(2, result[2].Hobbies.Length);
+				Assert.AreEqual("Sally", result[2].Name);
+				Assert.Contains("Inline skate", result[2].Hobbies);
+				Assert.Contains("Sailing", result[2].Hobbies);
+				Assert.AreEqual(0, result[0].Hobbies.Length + result[1].Hobbies.Length);
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3952/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3952/Mappings.hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3952">
+
+	<class name="Entity">
+		<id name="Id" generator="guid.comb" />
+		<property name="Name" />
+		<property name="ParentId" />
+		<set name="Children">
+			<key column="ParentId"/>
+			<one-to-many class="Entity" />
+		</set>
+		<array name="Hobbies" table="Hobby">
+			<key column="EntityId" />
+			<index column="`Index`"/>
+			<element type="string" length="50">
+				<column name="Name" />
+			</element>
+		</array>
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -736,6 +736,8 @@
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Fixture.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\FooExample.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
+    <Compile Include="NHSpecificTest\NH3952\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3952\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2204\Model.cs" />
     <Compile Include="NHSpecificTest\NH2204\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3912\BatcherLovingEntity.cs" />
@@ -3201,6 +3203,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH3952\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2204\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3874\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Mappings.hbm.xml" />

--- a/src/NHibernate/Linq/EnumerableHelper.cs
+++ b/src/NHibernate/Linq/EnumerableHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -57,7 +56,7 @@ namespace NHibernate.Linq
 			if (method == null)
 				throw new ArgumentNullException("method");
 
-			return ((MethodCallExpression) method.Body).Method;
+			return ((MethodCallExpression)method.Body).Method;
 		}
 
 		/// <summary>
@@ -91,6 +90,45 @@ namespace NHibernate.Linq
 			}
 
 			return null;
+		}
+	}
+
+	internal static class ReflectionCache
+	{
+		// When adding a method to this cache, please follow the naming convention of those subclasses and fields:
+		//  - Add your method to a subclass named according to the type holding the method, and suffixed with "Methods".
+		//  - Name the field according to the method name.
+		//  - If the method has overloads, suffix it with "With" followed by its parameter names. Do not list parameters
+		//    common to all overloads.
+		//  - If the method is a generic method definition, add "Definition" as final suffix.
+		//  - If the method is generic, suffix it with "On" followed by its generic parameter type names.
+		// Avoid caching here narrow cases, such as those using specific types and unlikely to be used by many classes.
+		// Cache them instead in classes using them.
+		internal static class EnumerableMethods
+		{
+			internal static readonly MethodInfo AggregateDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object>(null, null));
+			internal static readonly MethodInfo AggregateWithSeedDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
+			internal static readonly MethodInfo AggregateWithSeedAndResultSelectorDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
+
+			internal static readonly MethodInfo CastDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
+			internal static readonly MethodInfo CastOnObjectArray =
+				ReflectionHelper.GetMethod(() => Enumerable.Cast<object[]>(null));
+
+			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectionHelper.GetMethodDefinition(
+				() => Enumerable.GroupBy<object, object, object>(null, null, (Func<object, object>)null));
+
+			internal static readonly MethodInfo SelectDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Select<object, object>(null, (Func<object, object>)null));
+
+			internal static readonly MethodInfo ToArrayDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
+
+			internal static readonly MethodInfo ToListDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
 		}
 	}
 	

--- a/src/NHibernate/Linq/EnumerableHelper.cs
+++ b/src/NHibernate/Linq/EnumerableHelper.cs
@@ -93,8 +93,8 @@ namespace NHibernate.Linq
 			return null;
 		}
 	}
-
-	// TODO rename / remove - reflection helper above is better
+	
+	[Obsolete("ReflectionHelper is better")]
 	public static class EnumerableHelper
 	{
 		public static MethodInfo GetMethod(string name, System.Type[] parameterTypes)

--- a/src/NHibernate/Linq/EnumerableHelper.cs
+++ b/src/NHibernate/Linq/EnumerableHelper.cs
@@ -92,45 +92,6 @@ namespace NHibernate.Linq
 			return null;
 		}
 	}
-
-	internal static class ReflectionCache
-	{
-		// When adding a method to this cache, please follow the naming convention of those subclasses and fields:
-		//  - Add your method to a subclass named according to the type holding the method, and suffixed with "Methods".
-		//  - Name the field according to the method name.
-		//  - If the method has overloads, suffix it with "With" followed by its parameter names. Do not list parameters
-		//    common to all overloads.
-		//  - If the method is a generic method definition, add "Definition" as final suffix.
-		//  - If the method is generic, suffix it with "On" followed by its generic parameter type names.
-		// Avoid caching here narrow cases, such as those using specific types and unlikely to be used by many classes.
-		// Cache them instead in classes using them.
-		internal static class EnumerableMethods
-		{
-			internal static readonly MethodInfo AggregateDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object>(null, null));
-			internal static readonly MethodInfo AggregateWithSeedDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
-			internal static readonly MethodInfo AggregateWithSeedAndResultSelectorDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
-
-			internal static readonly MethodInfo CastDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
-			internal static readonly MethodInfo CastOnObjectArray =
-				ReflectionHelper.GetMethod(() => Enumerable.Cast<object[]>(null));
-
-			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectionHelper.GetMethodDefinition(
-				() => Enumerable.GroupBy<object, object, object>(null, null, (Func<object, object>)null));
-
-			internal static readonly MethodInfo SelectDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Select<object, object>(null, (Func<object, object>)null));
-
-			internal static readonly MethodInfo ToArrayDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
-
-			internal static readonly MethodInfo ToListDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
-		}
-	}
 	
 	[Obsolete("Please use ReflectionHelper instead")]
 	public static class EnumerableHelper

--- a/src/NHibernate/Linq/EnumerableHelper.cs
+++ b/src/NHibernate/Linq/EnumerableHelper.cs
@@ -94,7 +94,7 @@ namespace NHibernate.Linq
 		}
 	}
 	
-	[Obsolete("ReflectionHelper is better")]
+	[Obsolete("Please use ReflectionHelper instead")]
 	public static class EnumerableHelper
 	{
 		public static MethodInfo GetMethod(string name, System.Type[] parameterTypes)

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregate.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregate.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using NHibernate.Util;
 using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Clauses.StreamedData;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors;

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregate.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregate.cs
@@ -1,8 +1,5 @@
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Clauses.StreamedData;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors;
@@ -11,11 +8,6 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
 	public class ProcessAggregate : IResultOperatorProcessor<AggregateResultOperator>
 	{
-		private static readonly MethodInfo CastMethodDefinition = ReflectionHelper.GetMethodDefinition(
-			() => Enumerable.Cast<object>(null));
-		private static readonly MethodInfo AggregateMethodDefinition = ReflectionHelper.GetMethodDefinition(
-			() => Enumerable.Aggregate<object>(null, null));
-
 		public void Process(AggregateResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{
 			var inputExpr = ((StreamedSequenceInfo)queryModelVisitor.PreviousEvaluationType).ItemExpression;
@@ -28,10 +20,10 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(typeof(object)), "inputList");
 
-			var castToItem = CastMethodDefinition.MakeGenericMethod(new[] { inputType });
+			var castToItem = ReflectionCache.EnumerableMethods.CastDefinition.MakeGenericMethod(new[] { inputType });
 			var castToItemExpr = Expression.Call(castToItem, inputList);
 
-			var aggregate = AggregateMethodDefinition.MakeGenericMethod(inputType);
+			var aggregate = ReflectionCache.EnumerableMethods.AggregateDefinition.MakeGenericMethod(inputType);
 
 			MethodCallExpression call = Expression.Call(
 				aggregate,

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregateFromSeed.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregateFromSeed.cs
@@ -1,40 +1,44 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using Remotion.Linq.Clauses.ExpressionTreeVisitors;
+using System.Reflection;
 using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Clauses.StreamedData;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
-    public class ProcessAggregateFromSeed : IResultOperatorProcessor<AggregateFromSeedResultOperator>
-    {
-        public void Process(AggregateFromSeedResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
-        {
-        	var inputExpr = ((StreamedSequenceInfo) queryModelVisitor.PreviousEvaluationType).ItemExpression;
+	public class ProcessAggregateFromSeed : IResultOperatorProcessor<AggregateFromSeedResultOperator>
+	{
+		private static readonly MethodInfo CastMethodDefinition = ReflectionHelper.GetMethodDefinition(
+			() => Enumerable.Cast<object>(null));
+		private static readonly MethodInfo AggregateMethodDefinition = ReflectionHelper.GetMethodDefinition(
+			() => Enumerable.Aggregate<object, object>(null, null, null));
+		private static readonly MethodInfo AggregateWithResultOpMethodDefinition = ReflectionHelper.GetMethodDefinition(
+			() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
+
+		public void Process(AggregateFromSeedResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+		{
+			var inputExpr = ((StreamedSequenceInfo)queryModelVisitor.PreviousEvaluationType).ItemExpression;
 			var inputType = inputExpr.Type;
-        	var paramExpr = Expression.Parameter(inputType, "item");
-        	var accumulatorFunc = Expression.Lambda(
+			var paramExpr = Expression.Parameter(inputType, "item");
+			var accumulatorFunc = Expression.Lambda(
 				ReplacingExpressionTreeVisitor.Replace(inputExpr, paramExpr, resultOperator.Func.Body),
 				resultOperator.Func.Parameters[0],
 				paramExpr);
-			
+
 			var accumulatorType = resultOperator.Func.Parameters[0].Type;
 			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(typeof(object)), "inputList");
 
-			var castToItem = EnumerableHelper.GetMethod("Cast", new[] { typeof(IEnumerable) }, new[] { inputType });
+			var castToItem = CastMethodDefinition.MakeGenericMethod(new[] { inputType });
 			var castToItemExpr = Expression.Call(castToItem, inputList);
 
 			MethodCallExpression call;
 
 			if (resultOperator.OptionalResultSelector == null)
 			{
-				var aggregate = ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
-				aggregate = aggregate.GetGenericMethodDefinition().MakeGenericMethod(inputType, accumulatorType);
+				var aggregate = AggregateMethodDefinition.MakeGenericMethod(inputType, accumulatorType);
 
 				call = Expression.Call(
 					aggregate,
@@ -46,8 +50,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 			else
 			{
 				var selectorType = resultOperator.OptionalResultSelector.Type.GetGenericArguments()[2];
-				var aggregate = ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
-				aggregate = aggregate.GetGenericMethodDefinition().MakeGenericMethod(inputType, accumulatorType, selectorType);
+				var aggregate = AggregateWithResultOpMethodDefinition.MakeGenericMethod(inputType, accumulatorType, selectorType);
 
 				call = Expression.Call(
 					aggregate,
@@ -60,5 +63,5 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 			tree.AddListTransformer(Expression.Lambda(call, inputList));
 		}
-    }
+	}
 }

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregateFromSeed.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregateFromSeed.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
+using NHibernate.Util;
 using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Clauses.StreamedData;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors;

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessClientSideSelect.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessClientSideSelect.cs
@@ -1,19 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 using NHibernate.Linq.GroupBy;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
 	public class ProcessClientSideSelect : IResultOperatorProcessor<ClientSideSelect>
 	{
-		private static readonly MethodInfo SelectMethodDefinition = ReflectionHelper.GetMethodDefinition(
-			() => Enumerable.Select<object, object>(null, (Func<object, object>)null));
-		private static readonly MethodInfo ToListMethodDefinition = ReflectionHelper.GetMethodDefinition(
-			() => Enumerable.ToList<object>(null));
-
 		public void Process(ClientSideSelect resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{
 			var inputType = resultOperator.SelectClause.Parameters[0].Type;
@@ -21,8 +13,8 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(inputType), "inputList");
 
-			var selectMethod = SelectMethodDefinition.MakeGenericMethod(new[] { inputType, outputType });
-			var toListMethod = ToListMethodDefinition.MakeGenericMethod(new[] { outputType });
+			var selectMethod = ReflectionCache.EnumerableMethods.SelectDefinition.MakeGenericMethod(new[] { inputType, outputType });
+			var toListMethod = ReflectionCache.EnumerableMethods.ToListDefinition.MakeGenericMethod(new[] { outputType });
 
 			var lambda = Expression.Lambda(
 				Expression.Call(toListMethod,

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessClientSideSelect.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessClientSideSelect.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 using NHibernate.Linq.GroupBy;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessNonAggregatingGroupBy.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessNonAggregatingGroupBy.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using NHibernate.Linq.ResultOperators;
+using NHibernate.Util;
 using Remotion.Linq.Clauses.ExpressionTreeVisitors;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -740,6 +740,7 @@
     <Compile Include="Util\ArrayHelper.cs" />
     <Compile Include="Util\CollectionPrinter.cs" />
     <Compile Include="Util\EnumerableExtensions.cs" />
+    <Compile Include="Util\ReflectionCache.cs" />
     <Compile Include="Util\EnumeratorAdapter.cs" />
     <Compile Include="Util\IdentityMap.cs" />
     <Compile Include="Util\JoinedEnumerable.cs" />

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using NHibernate.Linq;
+
+namespace NHibernate.Util
+{
+	internal static class ReflectionCache
+	{
+		// When adding a method to this cache, please follow the naming convention of those subclasses and fields:
+		//  - Add your method to a subclass named according to the type holding the method, and suffixed with "Methods".
+		//  - Name the field according to the method name.
+		//  - If the method has overloads, suffix it with "With" followed by its parameter names. Do not list parameters
+		//    common to all overloads.
+		//  - If the method is a generic method definition, add "Definition" as final suffix.
+		//  - If the method is generic, suffix it with "On" followed by its generic parameter type names.
+		// Avoid caching here narrow cases, such as those using specific types and unlikely to be used by many classes.
+		// Cache them instead in classes using them.
+		internal static class EnumerableMethods
+		{
+			internal static readonly MethodInfo AggregateDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object>(null, null));
+			internal static readonly MethodInfo AggregateWithSeedDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
+			internal static readonly MethodInfo AggregateWithSeedAndResultSelectorDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
+
+			internal static readonly MethodInfo CastDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
+
+			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectionHelper.GetMethodDefinition(
+				() => Enumerable.GroupBy<object, object, object>(null, null, (Func<object, object>)null));
+
+			internal static readonly MethodInfo SelectDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.Select<object, object>(null, (Func<object, object>)null));
+
+			internal static readonly MethodInfo ToArrayDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
+
+			internal static readonly MethodInfo ToListDefinition =
+				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
+		}
+	}
+}


### PR DESCRIPTION
`NHibernate.Linq.EnumerableHelper` has following comment:

> // TODO rename / remove - reflection helper above is better

Done with this pull request.
It includes some additional test cases for classes impacted by this change which were not already thoroughly tested by existing test cases.
An explicit test for choosing which reflection implementation to choose from the other patterns found in NHibernate has been added too. (Unsurprisingly, caching as a static variable the thread safe `MethodInfo` prove to be the fastest by a wide margin. As it does not look to me as an added code complexity, pattern used in this pull request on each class affected by the removal of `EnumerableHelper`.) 

Tracked under [Jira task NH-3952](https://nhibernate.jira.com/browse/NH-3952).

`EnumerableHelper` is not removed but just marked as `Obsolete`, since it is publicly exposed and may be directly referenced by NHibernate users.