### PR TITLE
Adding some prerequisites for having tests passing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ Since you now have a failing test case, it should be straight-forward to step in
 
 Once you've made changes to the NHibernate code base, you'll want to ensure that you haven't caused any previously passing tests to fail. The easiest way to check this is to select option D from the build menu, ensure the root tree node is selected, then press run to have all the tests run. 
 
+Please note that some tests assume a case insensitive accent sensitive database when performing string comparison. Some tests assume SQL user locales to be en-US. They will fail otherwise. With SQL Server, collation with supplementary characters (\_SC suffix on collation name) are no supported by legacy tests on "text" types.
+
 ## Submit a Pull Request
 
 Be sure to link to the JIRA issue in your GitHub pull request. Also, go back to your JIRA issue and link to the pull request. 

--- a/Contributor Guide.html
+++ b/Contributor Guide.html
@@ -132,8 +132,12 @@ When you commit, please include the issue number in your commit message.  This w
 Since you now have a failing test case, it should be straight-forward to step into NHibernate to attempt to ascertain what the problem is.  While this may seem daunting at first, feel free to give it a go.  It's just code afterall. :)
 
 <h3>Ensure All Tests Pass</h3>
-
-Once you've made changes to the NHibernate code base, you'll want to ensure that you haven't caused any previously passing tests to fail.  The easiest way to check this is to select option D from the build menu, ensure the root tree node is selected, then press run to have all the tests run.
+<p>
+    Once you've made changes to the NHibernate code base, you'll want to ensure that you haven't caused any previously passing tests to fail.  The easiest way to check this is to select option D from the build menu, ensure the root tree node is selected, then press run to have all the tests run.
+</p>
+<p>
+    Please note that some tests assume a case insensitive accent sensitive database when performing string comparison.  Some tests assume SQL user locales to be en-US.  They will fail otherwise.  With SQL Server, collation with supplementary characters (_SC suffix on collation name) are no supported by legacy tests on "text" types.
+</p>
 
 <h2>Submit a Pull Request</h2>
 


### PR DESCRIPTION
I had some difficulties getting all tests supposed to pass actually passing, due to some mismatch in my SQL server configuration with what some tests assume.

So to help other wannabe contributors having those tests passing, I would like to add a note on those sql configuration assumption.

- Case insensitive accent sensitive string matching. (My default test SQL Server collation is `Latin1_General_100_CI_AI_SC`...)
- en-US SQL user locales. Some tests causes dates to be converted from string to date on db side, and fails with locales such as fr-FR. Other tests expect the db to raise some error message, and check it matches some English words, which fails if the error message was emitted in another language. (My SQL user was using French.)
- With SQL Server, supplementary characters collations (\_SC suffix) cause some tests on legacy types such as `text` and `ntext` to fail.

I had difficulties having the DTC tests passing too. But that was a trouble of DTC sort of "not fully enabled". (I had to follow http://stackoverflow.com/a/30959127/1178314.) It will not fit well in those contributors guides I think. (And I keep having some DTC failures, but it looks related to some glitches in current NHibernate DTC implementation, as said [there](https://groups.google.com/forum/#!topic/nhibernate-development/cGLRZxfTzGI).)

I have not written a Jira for those changes.
Should I? Or should I add a Jira only for changes impacting the deliverable?