### PR TITLE
NH-3665 - Use result type override if present

### DIFF
--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -795,6 +795,19 @@ namespace NHibernate.Test.Linq
 		}
 
 
+		[Test(Description = "NH-3665")]
+		public void SelectOnCollectionReturnsResult()
+		{
+			var result = db.Animals.Select(x => new
+			{
+				x.Children
+			}).FirstOrDefault();
+
+			Assert.That(result, Is.Not.Null);
+			Assert.That(result.Children, Is.Not.Empty);
+		}
+
+
 		private static List<object[]> CanUseCompareInQueryDataSource()
 		{
 			return new List<object[]>

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFirstOrSingleBase.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFirstOrSingleBase.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 	{
 		protected static void AddClientSideEval(MethodInfo target, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{
-			var type = queryModelVisitor.Model.SelectClause.Selector.Type;
+			var type = queryModelVisitor.Model.ResultTypeOverride ?? queryModelVisitor.Model.SelectClause.Selector.Type;
 			target = target.MakeGenericMethod(type);
 
 			var parameter = Expression.Parameter(typeof(IQueryable<>).MakeGenericType(type), null);


### PR DESCRIPTION
Fixes [NH-3665](https://nhibernate.jira.com/browse/NH-3665).

Would this qualify for a back port to 4.1.X (or maybe even 3.4.X)?
