### PR TITLE
NH-3957 - fix 2nd level query cache bug and test cases

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3957/ResultTransformerEqualityFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3957/ResultTransformerEqualityFixture.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using NHibernate.Transform;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3957
+{
+	[TestFixture]
+	public class ResultTransformerEqualityFixture
+	{
+		/// <summary>
+		/// Allows to simulate a hashcode collision. Issue would be unpractical to test otherwise.
+		/// Hashcode collision must be supported for avoiding unexpected and hard to reproduce failures.
+		/// </summary>
+		private void TweakHashcode(System.Type transformerToTweak, object hasher)
+		{
+			var hasherTargetField = transformerToTweak.GetField("Hasher", BindingFlags.Static | BindingFlags.NonPublic);
+			if (!_hasherBackup.ContainsKey(transformerToTweak))
+				_hasherBackup.Add(transformerToTweak, hasherTargetField.GetValue(null));
+
+			// Though hasher is a readonly field, this works at the time of this writing. If it starts breaking and cannot be fixed,
+			// ignore those tests or throw them away.
+			hasherTargetField.SetValue(null, hasher);
+		}
+
+		private Dictionary<System.Type, object> _hasherBackup = new Dictionary<System.Type, object>();
+
+		[SetUp]
+		public void Setup()
+		{
+			var hasherForAll = typeof(AliasToEntityMapResultTransformer)
+				.GetField("Hasher", BindingFlags.Static | BindingFlags.NonPublic)
+				.GetValue(null);
+			TweakHashcode(typeof(DistinctRootEntityResultTransformer), hasherForAll);
+			TweakHashcode(typeof(PassThroughResultTransformer), hasherForAll);
+			TweakHashcode(typeof(RootEntityResultTransformer), hasherForAll);
+			TweakHashcode(typeof(ToListResultTransformer), hasherForAll);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			// Restore those types hashcode. (Avoid impacting perf of other tests, avoid second level query cache
+			// issues if it was holding cached entries (but would mean some tests have not cleaned up properly).)
+			foreach(var backup in _hasherBackup)
+			{
+				TweakHashcode(backup.Key, backup.Value);
+			}
+		}
+
+		// Non reg test case
+		[Test]
+		public void AliasToEntityMapEquality()
+		{
+			var transf1 = new AliasToEntityMapResultTransformer();
+			var transf2 = new AliasToEntityMapResultTransformer();
+
+			Assert.IsTrue(transf1.Equals(transf2));
+			Assert.IsTrue(transf2.Equals(transf1));
+		}
+
+		[Test]
+		public void AliasToEntityMapAndDistinctRootEntityInequality()
+		{
+			var transf1 = new AliasToEntityMapResultTransformer();
+			var transf2 = new DistinctRootEntityResultTransformer();
+
+			Assert.IsFalse(transf1.Equals(transf2));
+			Assert.IsFalse(transf2.Equals(transf1));
+		}
+
+		// Non reg test case
+		[Test]
+		public void DistinctRootEntityEquality()
+		{
+			var transf1 = new DistinctRootEntityResultTransformer();
+			var transf2 = new DistinctRootEntityResultTransformer();
+
+			Assert.IsTrue(transf1.Equals(transf2));
+			Assert.IsTrue(transf2.Equals(transf1));
+		}
+
+		// Non reg test case
+		[Test]
+		public void PassThroughEquality()
+		{
+			var transf1 = new PassThroughResultTransformer();
+			var transf2 = new PassThroughResultTransformer();
+
+			Assert.IsTrue(transf1.Equals(transf2));
+			Assert.IsTrue(transf2.Equals(transf1));
+		}
+
+		[Test]
+		public void PassThroughAndRootEntityInequality()
+		{
+			var transf1 = new PassThroughResultTransformer();
+			var transf2 = new RootEntityResultTransformer();
+			
+			Assert.IsFalse(transf1.Equals(transf2));
+			Assert.IsFalse(transf2.Equals(transf1));
+		}
+
+		// Non reg test case
+		[Test]
+		public void RootEntityEquality()
+		{
+			var transf1 = new RootEntityResultTransformer();
+			var transf2 = new RootEntityResultTransformer();
+
+			Assert.IsTrue(transf1.Equals(transf2));
+			Assert.IsTrue(transf2.Equals(transf1));
+		}
+
+		[Test]
+		public void RootEntityAndToListInequality()
+		{
+			var transf1 = new RootEntityResultTransformer();
+			var transf2 = new ToListResultTransformer();
+			
+			Assert.IsFalse(transf1.Equals(transf2));
+			Assert.IsFalse(transf2.Equals(transf1));
+		}
+
+		// Non reg test case
+		[Test]
+		public void ToListEquality()
+		{
+			var transf1 = new ToListResultTransformer();
+			var transf2 = new ToListResultTransformer();
+
+			Assert.IsTrue(transf1.Equals(transf2));
+			Assert.IsTrue(transf2.Equals(transf1));
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -940,6 +940,7 @@
     <Compile Include="NHSpecificTest\NH3874\Two.cs" />
     <Compile Include="NHSpecificTest\NH3909\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3909\FixtureByCode.cs" />
+    <Compile Include="NHSpecificTest\NH3957\ResultTransformerEqualityFixture.cs" />
     <Compile Include="NHSpecificTest\NH646\Domain.cs" />
     <Compile Include="NHSpecificTest\NH646\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3234\Fixture.cs" />

--- a/src/NHibernate/Transform/AliasToEntityMapResultTransformer.cs
+++ b/src/NHibernate/Transform/AliasToEntityMapResultTransformer.cs
@@ -30,18 +30,20 @@ namespace NHibernate.Transform
 		}
 
 
-		public override bool IsTransformedValueATupleElement(String[] aliases, int tupleLength)
+		public override bool IsTransformedValueATupleElement(string[] aliases, int tupleLength)
 		{
 			return false;
 		}
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null)
+			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
 			{
 				return false;
 			}
-			return obj.GetHashCode() == Hasher.GetHashCode();
+			// NH-3957: do not rely on hashcode alone.
+			// Must be the exact same type
+			return obj.GetType() == typeof(AliasToEntityMapResultTransformer);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Transform/DistinctRootEntityResultTransformer.cs
+++ b/src/NHibernate/Transform/DistinctRootEntityResultTransformer.cs
@@ -78,11 +78,13 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null)
+			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
 			{
 				return false;
 			}
-			return obj.GetHashCode() == Hasher.GetHashCode();
+			// NH-3957: do not rely on hashcode alone.
+			// Must be the exact same type
+			return obj.GetType() == typeof(DistinctRootEntityResultTransformer);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Transform/PassThroughResultTransformer.cs
+++ b/src/NHibernate/Transform/PassThroughResultTransformer.cs
@@ -61,11 +61,13 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null)
+			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
 			{
 				return false;
 			}
-			return obj.GetHashCode() == Hasher.GetHashCode();
+			// NH-3957: do not rely on hashcode alone.
+			// Must be the exact same type
+			return obj.GetType() == typeof(PassThroughResultTransformer);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Transform/RootEntityResultTransformer.cs
+++ b/src/NHibernate/Transform/RootEntityResultTransformer.cs
@@ -43,11 +43,13 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null)
+			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
 			{
 				return false;
 			}
-			return obj.GetHashCode() == Hasher.GetHashCode();
+			// NH-3957: do not rely on hashcode alone.
+			// Must be the exact same type
+			return obj.GetType() == typeof(RootEntityResultTransformer);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Transform/ToListResultTransformer.cs
+++ b/src/NHibernate/Transform/ToListResultTransformer.cs
@@ -25,11 +25,13 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null)
+			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
 			{
 				return false;
 			}
-			return obj.GetHashCode() == Hasher.GetHashCode();
+			// NH-3957: do not rely on hashcode alone.
+			// Must be the exact same type
+			return obj.GetType() == typeof(ToListResultTransformer);
 		}
 
 		public override int GetHashCode()


### PR DESCRIPTION
Test cases and fix for [NH-3957](https://nhibernate.jira.com/browse/NH-3957): `Equals` overrides vulnerable to hashcode collisions have been added in a bunch of result transformers classes.  
This causes the second level query cache to be unreliable: we may get a wrong cached query result from it. Granted, due to the way those hashcode are calculated, is it very unlikely, but still possible. This cause a dire situation where an application thoroughly tested may starts failing till restarted, without much possibilities of reproducing the issue afterward.

Test cases only test `Equality`, they do not showcase second level query cache failures which may result from those `Equality` failures, contrary to those of NH-3954 for the proxy cache. But there is no reason the second level query cache would not have been affected by those `Equals` failures.