### PR TITLE
NH-3963 - More explicit error on MappedAs invalid usage.

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3963/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3963/Entity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3963
+{
+	class Entity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3963/MappedAsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3963/MappedAsFixture.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+using NHibernate.Type;
+using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3963
+{
+	[TestFixture]
+	public class MappedAsFixture : BugTestCase
+	{
+		[Test]
+		public void ShouldThrowExplicitErrorOnInvalidUsage()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Where(e => e.Name.MappedAs(NHibernateUtil.AnsiString) == "Bob");
+
+				Assert.Throws<HibernateException>(() => { result.ToList(); });
+			}
+		}
+
+		[Test]
+		public void ShouldThrowExplicitErrorOnUnsupportedTypeUsage()
+		{
+			using (ISession session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = session.Query<Entity>()
+					.Where(e => e.Name == "Bob".MappedAs(e.Id == Guid.Empty ? (IType)NHibernateUtil.AnsiString : NHibernateUtil.StringClob));
+
+				Assert.Throws<HibernateException>(() => { result.ToList(); });
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3963/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3963/Mappings.hbm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3963">
+
+	<class name="Entity">
+		<id name="Id" generator="guid.comb" />
+		<property name="Name" />
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -741,6 +741,8 @@
     <Compile Include="NHSpecificTest\NH3386\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3961\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3961\DateParametersComparedTo.cs" />
+    <Compile Include="NHSpecificTest\NH3963\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3963\MappedAsFixture.cs" />
     <Compile Include="NHSpecificTest\NH3950\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3950\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3952\Entity.cs" />
@@ -3214,6 +3216,7 @@
   <ItemGroup>
     <EmbeddedResource Include="NHSpecificTest\NH3386\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3961\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\NH3963\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3950\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3952\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2204\Mappings.hbm.xml" />


### PR DESCRIPTION
Test cases and implementation of [NH-3963](https://nhibernate.jira.com/browse/NH-3963): More explicit error on MappedAs invalid usage.

Juste a small improvement. `MappedAs` was implemented assuming it will ever be called on `ConstantExpression`, resulting otherwise in an invalid cast exception when executing the query. I think it is better raising a more explicit message.