### PR TITLE
NH-3964 - Refactor reflection patterns

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3964/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3964/Fixture.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3964
+{
+	[TestFixture]
+	public class Fixture
+	{
+		[Test(Description = "Test for removal of a workaround for an old Fx bug (<v4)")]
+		public void AddingNullToNonGenericListShouldNotThrow()
+		{
+			var a1 = new ArrayList { null };
+			var a2 = new ArrayList();
+			Assert.DoesNotThrow(() => ArrayHelper.AddAll(a2, a1));
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -742,6 +742,7 @@
     <Compile Include="NHSpecificTest\NH3961\DateParametersComparedTo.cs" />
     <Compile Include="NHSpecificTest\NH3963\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3963\MappedAsFixture.cs" />
+    <Compile Include="NHSpecificTest\NH3964\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3950\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3950\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3952\Entity.cs" />

--- a/src/NHibernate/Bytecode/EmitUtil.cs
+++ b/src/NHibernate/Bytecode/EmitUtil.cs
@@ -188,25 +188,25 @@ namespace NHibernate.Bytecode
 			il.Emit(OpCodes.Call, typeof(System.Type).GetMethod("GetTypeFromHandle"));
 		}
 
+		private static readonly MethodInfo GetMethodFromHandle = typeof(MethodBase).GetMethod(
+			"GetMethodFromHandle", new System.Type[] { typeof(RuntimeMethodHandle) });
+
 		public static void EmitLoadMethodInfo(ILGenerator il, MethodInfo methodInfo)
 		{
 			il.Emit(OpCodes.Ldtoken, methodInfo);
-			il.Emit(
-				OpCodes.Call,
-				typeof(MethodBase).GetMethod(
-					"GetMethodFromHandle", new System.Type[] {typeof(RuntimeMethodHandle)}));
+			il.Emit(OpCodes.Call, GetMethodFromHandle);
 			il.Emit(OpCodes.Castclass, typeof(MethodInfo));
 		}
 
+		private static readonly MethodInfo CreateDelegate = typeof(Delegate).GetMethod(
+				"CreateDelegate", BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
+				new System.Type[] { typeof(System.Type), typeof(MethodInfo) }, null);
+
 		public static void EmitCreateDelegateInstance(ILGenerator il, System.Type delegateType, MethodInfo methodInfo)
 		{
-			MethodInfo createDelegate = typeof(Delegate).GetMethod(
-				"CreateDelegate", BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
-				new System.Type[] {typeof(System.Type), typeof(MethodInfo)}, null);
-
 			EmitLoadType(il, delegateType);
 			EmitLoadMethodInfo(il, methodInfo);
-			il.EmitCall(OpCodes.Call, createDelegate, null);
+			il.EmitCall(OpCodes.Call, CreateDelegate, null);
 			il.Emit(OpCodes.Castclass, delegateType);
 		}
 	}

--- a/src/NHibernate/Bytecode/EmitUtil.cs
+++ b/src/NHibernate/Bytecode/EmitUtil.cs
@@ -2,6 +2,8 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Collections.Generic;
+using NHibernate.Linq;
+using NHibernate.Util;
 
 namespace NHibernate.Bytecode
 {
@@ -185,22 +187,18 @@ namespace NHibernate.Bytecode
 		public static void EmitLoadType(ILGenerator il, System.Type type)
 		{
 			il.Emit(OpCodes.Ldtoken, type);
-			il.Emit(OpCodes.Call, typeof(System.Type).GetMethod("GetTypeFromHandle"));
+			il.Emit(OpCodes.Call, ReflectionCache.TypeMethods.GetTypeFromHandle);
 		}
-
-		private static readonly MethodInfo GetMethodFromHandle = typeof(MethodBase).GetMethod(
-			"GetMethodFromHandle", new System.Type[] { typeof(RuntimeMethodHandle) });
 
 		public static void EmitLoadMethodInfo(ILGenerator il, MethodInfo methodInfo)
 		{
 			il.Emit(OpCodes.Ldtoken, methodInfo);
-			il.Emit(OpCodes.Call, GetMethodFromHandle);
+			il.Emit(OpCodes.Call, ReflectionCache.MethodBaseMethods.GetMethodFromHandle);
 			il.Emit(OpCodes.Castclass, typeof(MethodInfo));
 		}
 
-		private static readonly MethodInfo CreateDelegate = typeof(Delegate).GetMethod(
-				"CreateDelegate", BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
-				new System.Type[] { typeof(System.Type), typeof(MethodInfo) }, null);
+		private static readonly MethodInfo CreateDelegate = ReflectionHelper.GetMethod(
+			() => Delegate.CreateDelegate(null, null));
 
 		public static void EmitCreateDelegateInstance(ILGenerator il, System.Type delegateType, MethodInfo methodInfo)
 		{

--- a/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
+++ b/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
@@ -118,6 +118,9 @@ namespace NHibernate.Bytecode.Lightweight
 			}
 		}
 
+		private static readonly MethodInfo GetterCallbackInvoke = typeof (GetterCallback).GetMethod(
+			"Invoke", new[] { typeof (object), typeof (int) });
+
 		/// <summary>
 		/// Generates a dynamic method on the given type.
 		/// </summary>
@@ -163,8 +166,7 @@ namespace NHibernate.Bytecode.Lightweight
 				else
 				{
 					// using the getter itself via a callback
-					MethodInfo invokeMethod = typeof (GetterCallback).GetMethod("Invoke",
-					                                                            new[] {typeof (object), typeof (int)});
+					MethodInfo invokeMethod = GetterCallbackInvoke;
 					il.Emit(OpCodes.Ldarg_1);
 					il.Emit(OpCodes.Ldarg_0);
 					il.Emit(OpCodes.Ldc_I4, i);
@@ -181,6 +183,9 @@ namespace NHibernate.Bytecode.Lightweight
 
 			return (GetPropertyValuesInvoker) method.CreateDelegate(typeof (GetPropertyValuesInvoker));
 		}
+
+		private static readonly MethodInfo SetterCallbackInvoke = typeof(SetterCallback).GetMethod(
+			"Invoke", new[] { typeof(object), typeof(int), typeof(object) });
 
 		/// <summary>
 		/// Generates a dynamic method on the given type.
@@ -224,8 +229,7 @@ namespace NHibernate.Bytecode.Lightweight
 				else
 				{
 					// using the setter itself via a callback
-					MethodInfo invokeMethod = typeof (SetterCallback).GetMethod("Invoke",
-					                                                            new[] {typeof (object), typeof (int), typeof (object)});
+					MethodInfo invokeMethod = SetterCallbackInvoke;
 					il.Emit(OpCodes.Ldarg_2);
 					il.Emit(OpCodes.Ldarg_0);
 					il.Emit(OpCodes.Ldc_I4, i);

--- a/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
+++ b/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Security;
 using System.Security.Permissions;
+using NHibernate.Linq;
 using NHibernate.Properties;
 using NHibernate.Util;
 
@@ -118,8 +119,8 @@ namespace NHibernate.Bytecode.Lightweight
 			}
 		}
 
-		private static readonly MethodInfo GetterCallbackInvoke = typeof (GetterCallback).GetMethod(
-			"Invoke", new[] { typeof (object), typeof (int) });
+		private static readonly MethodInfo GetterCallbackInvoke = ReflectionHelper.GetMethod<GetterCallback>(
+			g => g.Invoke(null, 0));
 
 		/// <summary>
 		/// Generates a dynamic method on the given type.
@@ -184,8 +185,8 @@ namespace NHibernate.Bytecode.Lightweight
 			return (GetPropertyValuesInvoker) method.CreateDelegate(typeof (GetPropertyValuesInvoker));
 		}
 
-		private static readonly MethodInfo SetterCallbackInvoke = typeof(SetterCallback).GetMethod(
-			"Invoke", new[] { typeof(object), typeof(int), typeof(object) });
+		private static readonly MethodInfo SetterCallbackInvoke = ReflectionHelper.GetMethod<SetterCallback>(
+			g => g.Invoke(null, 0, null));
 
 		/// <summary>
 		/// Generates a dynamic method on the given type.

--- a/src/NHibernate/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Linq/DefaultQueryProvider.cs
@@ -79,17 +79,13 @@ namespace NHibernate.Linq
 			return nhLinqExpression;
 		}
 
+		private static readonly MethodInfo Future = ReflectionHelper.GetMethodDefinition<IQuery>(q => q.Future<object>());
+		private static readonly MethodInfo FutureValue = ReflectionHelper.GetMethodDefinition<IQuery>(q => q.FutureValue<object>());
+
 		protected virtual object ExecuteFutureQuery(NhLinqExpression nhLinqExpression, IQuery query, NhLinqExpression nhQuery)
 		{
-			MethodInfo method;
-			if (nhLinqExpression.ReturnType == NhLinqExpressionReturnType.Sequence)
-			{
-				method = typeof (IQuery).GetMethod("Future").MakeGenericMethod(nhQuery.Type);
-			}
-			else
-			{
-				method = typeof (IQuery).GetMethod("FutureValue").MakeGenericMethod(nhQuery.Type);
-			}
+			var method = (nhLinqExpression.ReturnType == NhLinqExpressionReturnType.Sequence ? Future : FutureValue)
+				.MakeGenericMethod(nhQuery.Type);
 
 			object result = method.Invoke(query, new object[0]);
 

--- a/src/NHibernate/Linq/NhRelinqQueryParser.cs
+++ b/src/NHibernate/Linq/NhRelinqQueryParser.cs
@@ -53,18 +53,26 @@ namespace NHibernate.Linq
 		{
 			var methodInfoRegistry = new MethodInfoBasedNodeTypeRegistry();
 
-			methodInfoRegistry.Register(new[] { typeof(EagerFetchingExtensionMethods).GetMethod("Fetch") }, typeof(FetchOneExpressionNode));
-			methodInfoRegistry.Register(new[] { typeof(EagerFetchingExtensionMethods).GetMethod("FetchMany") }, typeof(FetchManyExpressionNode));
-			methodInfoRegistry.Register(new[] { typeof(EagerFetchingExtensionMethods).GetMethod("ThenFetch") }, typeof(ThenFetchOneExpressionNode));
-			methodInfoRegistry.Register(new[] { typeof(EagerFetchingExtensionMethods).GetMethod("ThenFetchMany") }, typeof(ThenFetchManyExpressionNode));
+			methodInfoRegistry.Register(
+				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.Fetch<object, object>(null, null)) },
+				typeof(FetchOneExpressionNode));
+			methodInfoRegistry.Register(
+				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.FetchMany<object, object>(null, null)) },
+				typeof(FetchManyExpressionNode));
+			methodInfoRegistry.Register(
+				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetch<object, object, object>(null, null)) },
+				typeof(ThenFetchOneExpressionNode));
+			methodInfoRegistry.Register(
+				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetchMany<object, object, object>(null, null)) },
+				typeof(ThenFetchManyExpressionNode));
 
 			methodInfoRegistry.Register(
 				new[]
-					{
-						typeof(LinqExtensionMethods).GetMethod("Cacheable"),
-						typeof(LinqExtensionMethods).GetMethod("CacheMode"),
-						typeof(LinqExtensionMethods).GetMethod("CacheRegion"),
-					}, typeof(CacheableExpressionNode));
+				{
+					ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.Cacheable<object>(null)),
+					ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.CacheMode<object>(null, CacheMode.Normal)),
+					ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.CacheRegion<object>(null, null)),
+				}, typeof(CacheableExpressionNode));
 
 			methodInfoRegistry.Register(
 				new[]

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -18,12 +18,19 @@ namespace NHibernate.Linq.Visitors
 		private readonly Dictionary<ConstantExpression, NamedParameter> _parameters = new Dictionary<ConstantExpression, NamedParameter>();
 		private readonly ISessionFactoryImplementor _sessionFactory;
 
+		private static readonly MethodInfo QueryableSkipDefinition =
+			ReflectionHelper.GetMethodDefinition(() => Queryable.Skip<object>(null, 0));
+		private static readonly MethodInfo QueryableTakeDefinition =
+			ReflectionHelper.GetMethodDefinition(() => Queryable.Take<object>(null, 0));
+		private static readonly MethodInfo EnumerableSkipDefinition =
+			ReflectionHelper.GetMethodDefinition(() => Enumerable.Skip<object>(null, 0));
+		private static readonly MethodInfo EnumerableTakeDefinition =
+			ReflectionHelper.GetMethodDefinition(() => Enumerable.Take<object>(null, 0));
+
 		private readonly ICollection<MethodBase> _pagingMethods = new HashSet<MethodBase>
 			{
-				ReflectionHelper.GetMethodDefinition(() => Queryable.Skip<object>(null, 0)),
-				ReflectionHelper.GetMethodDefinition(() => Queryable.Take<object>(null, 0)),
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Skip<object>(null, 0)),
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Take<object>(null, 0)),
+				QueryableSkipDefinition, QueryableTakeDefinition,
+				EnumerableSkipDefinition, EnumerableTakeDefinition
 			};
 
 		public ExpressionParameterVisitor(ISessionFactoryImplementor sessionFactory)

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFirst.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFirst.cs
@@ -1,19 +1,23 @@
 using System.Linq;
+using System.Reflection;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
-    public class ProcessFirst : ProcessFirstOrSingleBase, IResultOperatorProcessor<FirstResultOperator>
-    {
-        public void Process(FirstResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
-        {
-            var firstMethod = resultOperator.ReturnDefaultWhenEmpty
-                                  ? ReflectionHelper.GetMethodDefinition(() => Queryable.FirstOrDefault<object>(null))
-                                  : ReflectionHelper.GetMethodDefinition(() => Queryable.First<object>(null));
+	public class ProcessFirst : ProcessFirstOrSingleBase, IResultOperatorProcessor<FirstResultOperator>
+	{
+		private static readonly MethodInfo FirstOrDefault =
+			ReflectionHelper.GetMethodDefinition(() => Queryable.FirstOrDefault<object>(null));
+		private static readonly MethodInfo First =
+			ReflectionHelper.GetMethodDefinition(() => Queryable.First<object>(null));
 
-            AddClientSideEval(firstMethod, queryModelVisitor, tree);
+		public void Process(FirstResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+		{
+			var firstMethod = resultOperator.ReturnDefaultWhenEmpty ? FirstOrDefault : First;
 
-						tree.AddTakeClause(tree.TreeBuilder.Constant(1));
-        }
-    }
+			AddClientSideEval(firstMethod, queryModelVisitor, tree);
+
+			tree.AddTakeClause(tree.TreeBuilder.Constant(1));
+		}
+	}
 }

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessSingle.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessSingle.cs
@@ -1,17 +1,21 @@
 using System.Linq;
+using System.Reflection;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 {
-    public class ProcessSingle : ProcessFirstOrSingleBase, IResultOperatorProcessor<SingleResultOperator>
-    {
-        public void Process(SingleResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
-        {
-            var firstMethod = resultOperator.ReturnDefaultWhenEmpty
-                                  ? ReflectionHelper.GetMethodDefinition(() => Queryable.SingleOrDefault<object>(null))
-                                  : ReflectionHelper.GetMethodDefinition(() => Queryable.Single<object>(null));
+	public class ProcessSingle : ProcessFirstOrSingleBase, IResultOperatorProcessor<SingleResultOperator>
+	{
+		private static readonly MethodInfo SingleOrDefault =
+			ReflectionHelper.GetMethodDefinition(() => Queryable.SingleOrDefault<object>(null));
+		private static readonly MethodInfo Single =
+			ReflectionHelper.GetMethodDefinition(() => Queryable.Single<object>(null));
 
-            AddClientSideEval(firstMethod, queryModelVisitor, tree);
-        }
-    }
+		public void Process(SingleResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
+		{
+			var firstMethod = resultOperator.ReturnDefaultWhenEmpty ? SingleOrDefault : Single;
+
+			AddClientSideEval(firstMethod, queryModelVisitor, tree);
+		}
+	}
 }

--- a/src/NHibernate/Proxy/DynamicProxy/DefaultMethodEmitter.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/DefaultMethodEmitter.cs
@@ -24,6 +24,7 @@ namespace NHibernate.Proxy.DynamicProxy
 		private static readonly MethodInfo getMethodFromHandle = typeof (MethodBase).GetMethod("GetMethodFromHandle", new[] {typeof (RuntimeMethodHandle)});
 		private static readonly MethodInfo getTypeFromHandle = typeof(System.Type).GetMethod("GetTypeFromHandle");
 		private static readonly MethodInfo handlerMethod = typeof (IInterceptor).GetMethod("Intercept");
+		private static readonly MethodInfo getArguments = typeof(InvocationInfo).GetMethod("get_Arguments");
 
 		private static readonly ConstructorInfo infoConstructor = typeof (InvocationInfo).GetConstructor(new[]
 			{
@@ -118,7 +119,6 @@ namespace NHibernate.Proxy.DynamicProxy
 		private static void SaveRefArguments(ILGenerator IL, ParameterInfo[] parameters)
 		{
 			// Save the arguments returned from the handler method
-			MethodInfo getArguments = typeof (InvocationInfo).GetMethod("get_Arguments");
 			IL.Emit(OpCodes.Ldloc_1);
 			IL.Emit(OpCodes.Call, getArguments);
 			IL.Emit(OpCodes.Stloc_0);

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
@@ -12,21 +12,21 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.Serialization;
+using NHibernate.Linq;
+using NHibernate.Util;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	public sealed class ProxyFactory
 	{
 		private static readonly ConstructorInfo defaultBaseConstructor = typeof(object).GetConstructor(new System.Type[0]);
-		private static readonly MethodInfo getTypeFromHandle = typeof(System.Type).GetMethod("GetTypeFromHandle");
 
-		private static readonly MethodInfo getValue = typeof (SerializationInfo).GetMethod("GetValue", BindingFlags.Public | BindingFlags.Instance, null,
-																																											 new[] { typeof(string), typeof(System.Type) }, null);
-
-		private static readonly MethodInfo setType = typeof(SerializationInfo).GetMethod("SetType", BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(System.Type) }, null);
-
-		private static readonly MethodInfo addValue = typeof (SerializationInfo).GetMethod("AddValue", BindingFlags.Public | BindingFlags.Instance, null,
-																						   new[] {typeof (string), typeof (object)}, null);
+		private static readonly MethodInfo getValue = ReflectionHelper.GetMethod<SerializationInfo>(
+			si => si.GetValue(null, null));
+		private static readonly MethodInfo setType = ReflectionHelper.GetMethod<SerializationInfo>(
+			si => si.SetType(null));
+		private static readonly MethodInfo addValue = ReflectionHelper.GetMethod<SerializationInfo>(
+			si => si.AddValue(null, null));
 
 		public ProxyFactory()
 			: this(new DefaultyProxyMethodBuilder()) {}
@@ -221,7 +221,7 @@ namespace NHibernate.Proxy.DynamicProxy
 			// info.SetType(typeof(ProxyObjectReference));
 			IL.Emit(OpCodes.Ldarg_1);
 			IL.Emit(OpCodes.Ldtoken, typeof (ProxyObjectReference));
-			IL.Emit(OpCodes.Call, getTypeFromHandle);
+			IL.Emit(OpCodes.Call, ReflectionCache.TypeMethods.GetTypeFromHandle);
 			IL.Emit(OpCodes.Callvirt, setType);
 
 			// info.AddValue("__interceptor", __interceptor);
@@ -276,7 +276,7 @@ namespace NHibernate.Proxy.DynamicProxy
 
 
 			IL.Emit(OpCodes.Ldtoken, typeof (IInterceptor));
-			IL.Emit(OpCodes.Call, getTypeFromHandle);
+			IL.Emit(OpCodes.Call, ReflectionCache.TypeMethods.GetTypeFromHandle);
 			IL.Emit(OpCodes.Stloc, interceptorType);
 
 			IL.Emit(OpCodes.Ldarg_0);

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyImplementor.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyImplementor.cs
@@ -18,6 +18,9 @@ namespace NHibernate.Proxy.DynamicProxy
 		                                                  MethodAttributes.SpecialName | MethodAttributes.NewSlot |
 		                                                  MethodAttributes.Virtual;
 
+		private static readonly MethodInfo OriginalSetter = typeof(IProxy).GetMethod("set_Interceptor");
+		private static readonly MethodInfo OriginalGetter = typeof(IProxy).GetMethod("get_Interceptor");
+
 		private FieldBuilder field;
 
 		public FieldBuilder InterceptorField
@@ -54,11 +57,8 @@ namespace NHibernate.Proxy.DynamicProxy
 			IL.Emit(OpCodes.Stfld, field);
 			IL.Emit(OpCodes.Ret);
 
-			MethodInfo originalSetter = typeof (IProxy).GetMethod("set_Interceptor");
-			MethodInfo originalGetter = typeof (IProxy).GetMethod("get_Interceptor");
-
-			typeBuilder.DefineMethodOverride(setterMethod, originalSetter);
-			typeBuilder.DefineMethodOverride(getterMethod, originalGetter);
+			typeBuilder.DefineMethodOverride(setterMethod, OriginalSetter);
+			typeBuilder.DefineMethodOverride(getterMethod, OriginalGetter);
 		}
 	}
 }

--- a/src/NHibernate/Util/ArrayHelper.cs
+++ b/src/NHibernate/Util/ArrayHelper.cs
@@ -95,40 +95,9 @@ namespace NHibernate.Util
 		/// <param name="from"></param>
 		public static void AddAll(IList to, IList from)
 		{
-			System.Action addNull = null;
 			foreach (object obj in from)
 			{
-				// There is bug in .NET, before version 4, where adding null to a List<Nullable<T>> through the non-generic IList interface throws an exception.
-				// TODO: Everything but the to.Add(obj) should be conditionally compiled only for versions of .NET earlier than 4.
-				if (obj == null)
-				{
-					if (addNull == null)
-					{
-						var toType = to.GetType();
-						if (toType.IsGenericType &&
-							toType.GetGenericTypeDefinition() == typeof(List<>) &&
-							toType.GetGenericArguments()[0].IsNullable())
-						{
-							MethodInfo addMethod = toType.GetMethod("Add");
-							var addMethodCall =	System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression.Constant(to),
-																		addMethod,
-																		System.Linq.Expressions.Expression.Constant(null, toType.GetGenericArguments()[0]));
-							System.Linq.Expressions.LambdaExpression addLambda =
-								System.Linq.Expressions.Expression.Lambda(addMethodCall);
-
-							addNull = (System.Action)addLambda.Compile();
-						}
-						else
-						{
-							addNull = () => to.Add(null);
-						}
-					}
-					addNull();
-				}
-				else
-				{
-					to.Add(obj);
-				}
+				to.Add(obj);
 			}
 		}
 

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -565,6 +565,7 @@ namespace NHibernate.Util
 			return null;
 		}
 
+		[Obsolete("Please use Linq.ReflectionHelper instead")]
 		public static MethodInfo GetGenericMethodFrom<T>(string methodName, System.Type[] genericArgs, System.Type[] signature)
 		{
 			MethodInfo result = null;

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -16,6 +16,7 @@ namespace NHibernate.Util
 		//  - If the method is generic, suffix it with "On" followed by its generic parameter type names.
 		// Avoid caching here narrow cases, such as those using specific types and unlikely to be used by many classes.
 		// Cache them instead in classes using them.
+
 		internal static class EnumerableMethods
 		{
 			internal static readonly MethodInfo AggregateDefinition =
@@ -39,6 +40,20 @@ namespace NHibernate.Util
 
 			internal static readonly MethodInfo ToListDefinition =
 				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
+		}
+
+		internal static class MethodBaseMethods
+		{
+			internal static readonly MethodInfo GetMethodFromHandle =
+				ReflectionHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle()));
+			internal static readonly MethodInfo GetMethodFromHandleWithDeclaringType =
+				ReflectionHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle(), new RuntimeTypeHandle()));
+		}
+
+		internal static class TypeMethods
+		{
+			internal static readonly MethodInfo GetTypeFromHandle =
+				ReflectionHelper.GetMethod(() => System.Type.GetTypeFromHandle(new RuntimeTypeHandle()));
 		}
 	}
 }


### PR DESCRIPTION
[NH-3964](https://nhibernate.jira.com/browse/NH-3964) - This is a sort of follow up to NH-3952: remove usage of `EnumerableHelper`.
They were replaced by `ReflectionHelper`, and additionally cached whenever possible and useful.
This improvement aims at similarly caching other `MethodInfo`/`PropertyInfo` reflected through older `ReflectionHelper` usages (impacts `Linq` namespace), or any other means (most other NHibernate namespaces). 
If adequate, those other means of reflecting should be replaced by `ReflectionHelper`.