### PR TITLE
NH-3966 - Missing command set dispose in batchers

### DIFF
--- a/src/NHibernate/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/AdoNet/AbstractBatcher.cs
@@ -265,7 +265,7 @@ namespace NHibernate.AdoNet
 			}
 		}
 
-		public void CloseCommands()
+		public virtual void CloseCommands()
 		{
 			_releasing = true;
 			try

--- a/src/NHibernate/AdoNet/MySqlClientBatchingBatcher.cs
+++ b/src/NHibernate/AdoNet/MySqlClientBatchingBatcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data.Common;
 using System.Text;
 using NHibernate.AdoNet.Util;
@@ -96,6 +97,22 @@ namespace NHibernate.AdoNet
 		private MySqlClientSqlCommandSet CreateConfiguredBatch()
 		{
 			return new MySqlClientSqlCommandSet(batchSize);
+		}
+
+		public override void CloseCommands()
+		{
+			base.CloseCommands();
+
+			try
+			{
+				currentBatch.Dispose();
+			}
+			catch (Exception e)
+			{
+				// Prevent exceptions when closing the batch from hiding any original exception
+				// (We do not know here if this batch closing occurs after a failure or not.)
+				Log.Warn("Exception closing batcher", e);
+			}
 		}
 	}
 }

--- a/src/NHibernate/AdoNet/SqlClientBatchingBatcher.cs
+++ b/src/NHibernate/AdoNet/SqlClientBatchingBatcher.cs
@@ -117,5 +117,21 @@ namespace NHibernate.AdoNet
 
 			return result;
 		}
+
+		public override void CloseCommands()
+		{
+			base.CloseCommands();
+
+			try
+			{
+				_currentBatch.Dispose();
+			}
+			catch (Exception e)
+			{
+				// Prevent exceptions when closing the batch from hiding any original exception
+				// (We do not know here if this batch closing occurs after a failure or not.)
+				Log.Warn("Exception closing batcher", e);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fix for [NH-3966](https://nhibernate.jira.com/browse/NH-3966) - Missing command set dispose in batchers.

Spotted while working on NH-3931, in `SqlClientBatchingBatcher` and `MySqlClientBatchingBatcher`. They do dispose their `currentBatch` after execution, but immediately instantiate a new one. And on their dispose, they do nothing, leaving the last `currentBatch` un-disposed.

