### PR TITLE
NH-2520 - update documentation for including new TimestampUtc type.

### DIFF
--- a/doc/reference/modules/basic_mapping.xml
+++ b/doc/reference/modules/basic_mapping.xml
@@ -52,14 +52,12 @@
 </hibernate-mapping>]]></programlisting>
 
         <para>
-             We will now discuss the content of the mapping document. We will only describe the 
-             document elements and attributes that are used by NHibernate at runtime. The mapping 
-             document also contains some extra optional attributes and elements that affect the 
+             We will now discuss the content of the mapping document. We will only describe the
+             document elements and attributes that are used by NHibernate at runtime. The mapping
+             document also contains some extra optional attributes and elements that affect the
              database schemas exported by the schema export tool. (For example the <literal>
              not-null</literal> attribute.)
         </para>
-
-
 
         <sect2 id="mapping-declaration-xmlns">
             <title>XML Namespace</title>
@@ -69,7 +67,7 @@
                 may be found in the <literal>src\nhibernate-mapping.xsd</literal> file in the
                 NHibernate distribution.
             </para>
-            
+
             <para><emphasis>
                 Tip: to enable IntelliSense for mapping and configuration files, copy the appropriate
                 <literal>.xsd</literal> files as part of any project in your solution,
@@ -79,7 +77,7 @@
               with different version of the xsd for different versions of NHibernate.
             </emphasis>
             </para>
-            
+
         </sect2>
 
         <sect2 id="mapping-declaration-mapping">
@@ -90,7 +88,7 @@
                 specifies that tables referred to by this mapping belong to the named schema. If specified, 
                 table names will be qualified by the given schema name. If missing, table names will be 
                 unqualified. The <literal>default-cascade</literal> attribute specifies what cascade style
-                should be assumed for properties and collections which do not specify a 
+                should be assumed for properties and collections which do not specify a
                 <literal>cascade</literal> attribute. The <literal>auto-import</literal> attribute lets us
                 use unqualified class names in the query language, by default. The <literal>assembly</literal>
                 and <literal>namespace</literal> attributes specify the assembly where persistent classes
@@ -125,7 +123,7 @@
                      </callout>
                      <callout arearefs="hm2">
                          <para>
-                             <literal>default-cascade</literal> (optional - defaults to <literal>none</literal>): 
+                             <literal>default-cascade</literal> (optional - defaults to <literal>none</literal>):
                              A default cascade style.
                          </para>
                      </callout>
@@ -145,7 +143,7 @@
                      </callout>
                    <callout arearefs="hm6">
                      <para>
-                       <literal>default-access</literal> (optional - defaults to property): 
+                       <literal>default-access</literal> (optional - defaults to property):
                        The strategy NHibernate should use for accessing a property value
                      </para>
                    </callout>
@@ -157,7 +155,7 @@
                    </callout>
                  </calloutlist>
              </programlistingco>
-             
+
              <para>
                  If you are not using <literal>assembly</literal> and <literal>namespace</literal>
                  attributes, you have to specify fully-qualified class names, including the name
@@ -165,7 +163,7 @@
              </para>
 
              <para>
-                 If you have two persistent classes with the same (unqualified) name, you should set 
+                 If you have two persistent classes with the same (unqualified) name, you should set
                  <literal>auto-import="false"</literal>. NHibernate will throw an exception if you attempt
                  to assign two classes to the same "imported" name.
              </para>
@@ -177,7 +175,7 @@
             <para>
                 You may declare a persistent class using the <literal>class</literal> element:
             </para>
-            
+
             <programlistingco>
                 <areaspec>
                     <area id="class1" coords="2 55"/>
@@ -196,7 +194,7 @@
                     <area id="class14" coords="15 55"/>
                     <area id="class15" coords="16 55"/>
                     <area id="class16" coords="17 55"/>
-                </areaspec>   
+                </areaspec>
                 <programlisting><![CDATA[<class
         name="ClassName"
         table="tableName"
@@ -218,7 +216,7 @@
                 <calloutlist>
                     <callout arearefs="class1">
                         <para>
-                            <literal>name</literal>: The fully qualified .NET class name of the persistent class 
+                            <literal>name</literal>: The fully qualified .NET class name of the persistent class
                             (or interface), including its assembly name.
                         </para>
                     </callout>
@@ -236,72 +234,72 @@
                     </callout>
                     <callout arearefs="class4">
                         <para>
-                            <literal>mutable</literal> (optional, defaults to <literal>true</literal>): Specifies 
+                            <literal>mutable</literal> (optional, defaults to <literal>true</literal>): Specifies
                             that instances of the class are (not) mutable.
                         </para>
-                    </callout>    
+                    </callout>
                     <callout arearefs="class5">
                         <para>
                             <literal>schema</literal> (optional): Override the schema name specified by
                             the root <literal>&lt;hibernate-mapping&gt;</literal> element.
                         </para>
-                    </callout>                
+                    </callout>
                     <callout arearefs="class6">
                         <para>
                             <literal>proxy</literal> (optional): Specifies an interface to use for lazy
                             initializing proxies. You may specify the name of the class itself.
                         </para>
-                    </callout>    
+                    </callout>
                     <callout arearefs="class7">
                         <para>
-                            <literal>dynamic-update</literal> (optional, defaults to <literal>false</literal>): 
+                            <literal>dynamic-update</literal> (optional, defaults to <literal>false</literal>):
                             Specifies that <literal>UPDATE</literal> SQL should be generated at runtime and 
                             contain only those columns whose values have changed.
                         </para>
-                    </callout>    
+                    </callout>
                     <callout arearefs="class8">
                         <para>
-                            <literal>dynamic-insert</literal> (optional, defaults to <literal>false</literal>): 
+                            <literal>dynamic-insert</literal> (optional, defaults to <literal>false</literal>):
                             Specifies that <literal>INSERT</literal> SQL should be generated at runtime and 
                             contain only the columns whose values are not null.
                         </para>
-                    </callout>    
+                    </callout>
                     <callout arearefs="class9">
                         <para>
-                            <literal>select-before-update</literal> (optional, defaults to <literal>false</literal>): 
-                            Specifies that NHibernate should <emphasis>never</emphasis> perform an SQL <literal>UPDATE</literal> 
+                            <literal>select-before-update</literal> (optional, defaults to <literal>false</literal>):
+                            Specifies that NHibernate should <emphasis>never</emphasis> perform an SQL <literal>UPDATE</literal>
                             unless it is certain that an object is actually modified. In certain cases (actually, only
                             when a transient object has been associated with a new session using <literal>update()</literal>),
                             this means that NHibernate will perform an extra SQL <literal>SELECT</literal> to determine
                             if an <literal>UPDATE</literal> is actually required.
                         </para>
-                    </callout>    
+                    </callout>
                     <callout arearefs="class10">
                         <para>
-                            <literal>polymorphism</literal> (optional, defaults to <literal>implicit</literal>): 
+                            <literal>polymorphism</literal> (optional, defaults to <literal>implicit</literal>):
                             Determines whether implicit or explicit query polymorphism is used.
                         </para>
-                    </callout>    
+                    </callout>
                     <callout arearefs="class11">
                         <para>
-                            <literal>where</literal> (optional) specify an arbitrary SQL <literal>WHERE</literal> 
+                            <literal>where</literal> (optional) specify an arbitrary SQL <literal>WHERE</literal>
                             condition to be used when retrieving objects of this class
                         </para>
-                    </callout>                 
+                    </callout>
                     <callout arearefs="class12">
                         <para>
                             <literal>persister</literal> (optional): Specifies a custom <literal>IClassPersister</literal>.
                         </para>
-                    </callout>                 
+                    </callout>
                     <callout arearefs="class13">
                         <para>
-                            <literal>batch-size</literal> (optional, defaults to <literal>1</literal>) specify a "batch size" 
+                            <literal>batch-size</literal> (optional, defaults to <literal>1</literal>) specify a "batch size"
                             for fetching instances of this class by identifier.
                         </para>
-                    </callout>                 
+                    </callout>
                    <callout arearefs="class14">
                         <para>
-                            <literal>optimistic-lock</literal> (optional, defaults to <literal>version</literal>): 
+                            <literal>optimistic-lock</literal> (optional, defaults to <literal>version</literal>):
                             Determines the optimistic locking strategy.
                         </para>
                     </callout>    
@@ -319,7 +317,7 @@
                     </callout>
                 </calloutlist>
             </programlistingco>
-            
+
             <para>
                 It is perfectly acceptable for the named persistent class to be an interface. You would then
                 declare implementing classes of that interface using the <literal>&lt;subclass&gt;</literal>
@@ -327,22 +325,22 @@
                 class name using the standard form ie. <literal>Eg.Foo+Bar, Eg</literal>.
                 Due to an HQL parser limitation inner classes can not be used in queries in NHibernate 1.0.
             </para>
-            
+
             <para>
                 Changes to immutable classes, <literal>mutable="false"</literal>, will not be
                 persisted. This allows NHibernate to make some minor performance optimizations.
             </para>
-            
+
             <para>
                 The optional <literal>proxy</literal> attribute enables lazy initialization of persistent
-                instances of the class. NHibernate will initially return proxies which implement 
-                the named interface. The actual persistent object will be loaded when a method of the 
+                instances of the class. NHibernate will initially return proxies which implement
+                the named interface. The actual persistent object will be loaded when a method of the
                 proxy is invoked. See "Proxies for Lazy Initialization" below.
             </para>
-            
+
             <para><emphasis>Implicit</emphasis> polymorphism means that instances of the class will be returned
                 by a query that names any superclass or implemented interface or the class and that instances
-                of any subclass of the class will be returned by a query that names the class itself. 
+                of any subclass of the class will be returned by a query that names the class itself.
                 <emphasis>Explicit</emphasis> polymorphism means that class instances will be returned only
                 be queries that explicitly name that class and that queries that name the class will return
                 only instances of subclasses mapped inside this <literal>&lt;class&gt;</literal> declaration
@@ -351,31 +349,31 @@
                 Explicit polymorphism is useful when two different classes are mapped to the same table
                 (this allows a "lightweight" class that contains a subset of the table columns).
             </para>
-            
+
             <para>
                 The <literal>persister</literal> attribute lets you customize the persistence strategy used for
-                the class. You may, for example, specify your own subclass of 
+                the class. You may, for example, specify your own subclass of
                 <literal>NHibernate.Persister.EntityPersister</literal> or you might even provide a
-                completely new implementation of the interface 
+                completely new implementation of the interface
                 <literal>NHibernate.Persister.IClassPersister</literal> that implements persistence via,
                 for example, stored procedure calls, serialization to flat files or LDAP. See
                 <literal>NHibernate.DomainModel.CustomPersister</literal> for a simple example (of "persistence"
                 to a <literal>Hashtable</literal>).
             </para>
-            
+
             <para>
                 Note that the <literal>dynamic-update</literal> and <literal>dynamic-insert</literal>
                 settings are not inherited by subclasses and so may also be specified on the
-                <literal>&lt;subclass&gt;</literal> or <literal>&lt;joined-subclass&gt;</literal> elements. 
-                These settings may increase performance in some cases, but might actually decrease 
+                <literal>&lt;subclass&gt;</literal> or <literal>&lt;joined-subclass&gt;</literal> elements.
+                These settings may increase performance in some cases, but might actually decrease
                 performance in others. Use judiciously.
             </para>
-            
+
             <para>
                 Use of <literal>select-before-update</literal> will usually decrease performance. It is very
                 useful to prevent a database update trigger being called unnecessarily.
             </para>
-            
+
             <para>
                 If you enable <literal>dynamic-update</literal>, you will have a choice of optimistic
                 locking strategies:
@@ -423,8 +421,8 @@
             <title>id</title>
 
             <para>
-                Mapped classes <emphasis>must</emphasis> declare the primary key column of the database 
-                table. Most classes will also have a property holding the unique identifier 
+                Mapped classes <emphasis>must</emphasis> declare the primary key column of the database
+                table. Most classes will also have a property holding the unique identifier
                 of an instance. The <literal>&lt;id&gt;</literal> element defines the mapping from that
                 property to the primary key column.
             </para>
@@ -481,10 +479,10 @@
             </programlistingco>
             
             <para>
-                If the <literal>name</literal> attribute is missing, it is assumed that the class has no 
+                If the <literal>name</literal> attribute is missing, it is assumed that the class has no
                 identifier property.
             </para>
-            
+
             <para>
                 The <literal>unsaved-value</literal> attribute is almost never needed in NHibernate 1.0.
             </para>
@@ -493,18 +491,18 @@
                 There is an alternative <literal>&lt;composite-id&gt;</literal> declaration to allow access to
                 legacy data with composite keys. We strongly discourage its use for anything else.
             </para>
-            
+
             <sect3 id="mapping-declaration-id-generator">
                 <title>generator</title>
 
                 <para>
                     The required <literal>generator</literal> names a .NET class used to generate unique identifiers
-					for instances of the persistent class.
-				</para>
-				<para>
-					The generator can be declared using the <literal>&lt;generator&gt;</literal> child element. If 
-					any parameters are required to configure or initialize the generator instance, they are passed 
-					using <literal>&lt;param&gt;</literal> elements.
+                    for instances of the persistent class.
+                </para>
+                <para>
+                  The generator can be declared using the <literal>&lt;generator&gt;</literal> child element. If
+                  any parameters are required to configure or initialize the generator instance, they are passed
+                  using <literal>&lt;param&gt;</literal> elements.
                 </para>
 
                 <programlisting><![CDATA[<id name="Id" type="Int64" column="uid" unsaved-value="0">
@@ -516,8 +514,8 @@
 
                 <para>
                     If no parameters are required, the generator can be declared using a <literal>generator</literal>
-					attribute directly on the <literal>&lt;id&gt;</literal> element, as follows:
-                 </para>
+                    attribute directly on the <literal>&lt;id&gt;</literal> element, as follows:
+                </para>
 
                 <programlisting><![CDATA[<id name="Id" type="Int64" column="uid" unsaved-value="0" generator="native" />]]></programlisting>
 
@@ -708,7 +706,7 @@
             <sect3 id="mapping-declaration-id-uuid-string">
                 <title>UUID String Algorithm</title>
                 <para>
-                    The UUID is generated by calling <literal>Guid.NewGuid().ToByteArray()</literal> and 
+                    The UUID is generated by calling <literal>Guid.NewGuid().ToByteArray()</literal> and
                     then converting the <literal>byte[]</literal> into a <literal>char[]</literal>.  The
                     <literal>char[]</literal> is returned as a <literal>String</literal> consisting of
                     16 characters.
@@ -720,7 +718,7 @@
                 <para>
                     The <literal>guid</literal> identifier is generated by calling <literal>Guid.NewGuid()</literal>.
                     To address some of the performance concerns with using Guids as primary keys, foreign keys, and
-                    as part of indexes with MS SQL the <literal>guid.comb</literal> can be used.  The benefit of using  
+                    as part of indexes with MS SQL the <literal>guid.comb</literal> can be used.  The benefit of using
                     the <literal>guid.comb</literal> with other databases that support GUIDs has not been measured.
                 </para>
             </sect3>
@@ -769,9 +767,9 @@
                     <literal>Save()</literal> or <literal>Update()</literal> method of the ISession.
                 </para>
             </sect3>
-            
-			<sect3 id="mapping-declaration-id-enhanced">
-			    <title>Enhanced identifier generators</title>
+
+            <sect3 id="mapping-declaration-id-enhanced">
+                <title>Enhanced identifier generators</title>
 
                 <para>Starting with NHibernate release 3.3.0, there are 2 new generators which
                 represent a re-thinking of 2 different aspects of identifier
@@ -781,10 +779,10 @@
                 generators are intended to take the place of some of the named
                 generators described above, starting in 3.3.x. However, they are
                 included in the current releases and can be referenced by FQN.</para>
-        
+
                 <para>The first of these new generators is
                 <literal>NHibernate.Id.Enhanced.SequenceStyleGenerator</literal>
-				(short name <literal>enhanced-sequence</literal>)
+                (short name <literal>enhanced-sequence</literal>)
                 which is intended, firstly, as a replacement for the
                 <literal>sequence</literal> generator and, secondly, as a better
                 portability generator than <literal>native</literal>. This is because
@@ -806,14 +804,14 @@
                       <literal>hibernate_sequence</literal>): the name of the sequence
                       or table to be used.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>initial_value</literal> (optional, defaults to
                       <literal>1</literal>): the initial value to be retrieved from
                       the sequence/table. In sequence creation terms, this is
                       analogous to the clause typically named "STARTS WITH".</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>increment_size</literal> (optional - defaults to
                       <literal>1</literal>): the value by which subsequent calls to
@@ -821,41 +819,41 @@
                       this is analogous to the clause typically named "INCREMENT
                       BY".</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>force_table_use</literal> (optional - defaults to
                       <literal>false</literal>): should we force the use of a table as
                       the backing structure even though the dialect might support
                       sequence?</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>value_column</literal> (optional - defaults to
                       <literal>next_val</literal>): only relevant for table
                       structures, it is the name of the column on the table which is
                       used to hold the value.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>prefer_sequence_per_entity</literal> (optional -
                       defaults to <literal>false</literal>): should we create
                       separate sequence for each entity that share current generator
                       based on its name?</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>sequence_per_entity_suffix</literal> (optional -
                       defaults to <literal>_SEQ</literal>): suffix added to the name
                       of a dedicated sequence.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>optimizer</literal> (optional - defaults to
                       <literal>none</literal>): See <xref
                       linkend="mapping-declaration-id-enhanced-optimizers" /></para>
                     </listitem>
                   </itemizedlist></para>
-        
+
                 <para>The second of these new generators is
                 <literal>NHibernate.Id.Enhanced.TableGenerator</literal> (short name <literal>enhanced-table</literal>), which is
                 intended, firstly, as a replacement for the <literal>table</literal>
@@ -873,13 +871,13 @@
                       <literal>hibernate_sequences</literal>): the name of the table
                       to be used.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>value_column_name</literal> (optional - defaults
                       to <literal>next_val</literal>): the name of the column on the
                       table that is used to hold the value.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>segment_column_name</literal> (optional -
                       defaults to <literal>sequence_name</literal>): the name of the
@@ -887,42 +885,42 @@
                       is the value which identifies which increment value to
                       use.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>segment_value</literal> (optional - defaults to
                       <literal>default</literal>): The "segment key" value for the
                       segment from which we want to pull increment values for this
                       generator.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>segment_value_length</literal> (optional -
                       defaults to <literal>255</literal>): Used for schema generation;
                       the column size to create this segment key column.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>initial_value</literal> (optional - defaults to
                       <literal>1</literal>): The initial value to be retrieved from
                       the table.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>increment_size</literal> (optional - defaults to
                       <literal>1</literal>): The value by which subsequent calls to
                       the table should differ.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>optimizer</literal> (optional - defaults to
                       <literal>??</literal>): See <xref
                       linkend="mapping-declaration-id-enhanced-optimizers" />.</para>
                     </listitem>
                   </itemizedlist></para>
-        
+
                 <sect4 id="mapping-declaration-id-enhanced-optimizers">
                   <title>Identifier generator optimization</title>
-        
+
                   <para>For identifier generators that store values in the database,
                   it is inefficient for them to hit the database on each and every
                   call to generate a new identifier value. Instead, you can group a
@@ -931,7 +929,7 @@
                   pluggable optimizers. Currently only the two enhanced generators
                   (<xref linkend="mapping-declaration-id-enhanced" /> support this
                   operation.</para>
-        
+
                   <itemizedlist spacing="compact">
                     <listitem>
                       <para><literal>none</literal> (generally this is the default if
@@ -939,7 +937,7 @@
                       optimizations and hit the database for each and every
                       request.</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>hilo</literal>: applies a hi/lo algorithm around
                       the database retrieved values. The values from the database for
@@ -949,7 +947,7 @@
                       <literal>increment_size</literal> is multiplied by that value in
                       memory to define a group "hi value".</para>
                     </listitem>
-        
+
                     <listitem>
                       <para><literal>pooled</literal>: as with the case of
                       <literal>hilo</literal>, this optimizer attempts to minimize the
@@ -960,19 +958,19 @@
                       <literal>increment_size</literal> refers to the values coming
                       from the database.</para>
                     </listitem>
-					
+
                     <listitem>
                       <para><literal>pooled-lo</literal>: similar to
                       <literal>pooled</literal>, except that it's the starting value of
-					  the "current group" that is stored into the database structure.
-					  Here,
+                      the "current group" that is stored into the database structure.
+                      Here,
                       <literal>increment_size</literal> refers to the values coming
                       from the database.</para>
                     </listitem>
                   </itemizedlist>
                 </sect4>
             </sect3>
-	  
+
         </sect2>
 
         <sect2 id="mapping-declaration-compositeid">
@@ -995,7 +993,7 @@
                 accepts <literal>&lt;key-property&gt;</literal> property mappings and
                 <literal>&lt;key-many-to-one&gt;</literal> mappings as child elements.
             </para>
-            
+
             <programlisting><![CDATA[<composite-id>
         <key-property name="MedicareNumber"/>
         <key-property name="Dependent"/>
@@ -1008,9 +1006,9 @@
             </para>
 
             <para>
-                Unfortunately, this approach to composite identifiers means that a persistent object 
-                is its own identifier. There is no convenient "handle" other than the object itself. 
-                You must instantiate an instance of the persistent class itself and populate its 
+                Unfortunately, this approach to composite identifiers means that a persistent object
+                is its own identifier. There is no convenient "handle" other than the object itself.
+                You must instantiate an instance of the persistent class itself and populate its
                 identifier properties before you can <literal>load()</literal> the persistent state
                 associated with a composite key. We will describe a much more
                 convenient approach where the composite identifier is implemented as a separate class
@@ -1038,22 +1036,22 @@
                     </para>
                 </listitem>
             </itemizedlist>
-            
+
         </sect2>
-        
+
         <sect2 id="mapping-declaration-discriminator" revision="1">
             <title>discriminator</title>
 
             <para>
-                The <literal>&lt;discriminator&gt;</literal> element is required for polymorphic persistence 
-                using the table-per-class-hierarchy mapping strategy and declares a discriminator column of the 
-                table. The discriminator column contains marker values that tell the persistence layer what 
-                subclass to instantiate for a particular row. A restricted set of types may be used: 
-                <literal>String</literal>, <literal>Char</literal>, <literal>Int32</literal>, 
-                <literal>Byte</literal>, <literal>Short</literal>, <literal>Boolean</literal>, 
+                The <literal>&lt;discriminator&gt;</literal> element is required for polymorphic persistence
+                using the table-per-class-hierarchy mapping strategy and declares a discriminator column of the
+                table. The discriminator column contains marker values that tell the persistence layer what
+                subclass to instantiate for a particular row. A restricted set of types may be used:
+                <literal>String</literal>, <literal>Char</literal>, <literal>Int32</literal>,
+                <literal>Byte</literal>, <literal>Short</literal>, <literal>Boolean</literal>,
                 <literal>YesNo</literal>, <literal>TrueFalse</literal>.
             </para>
-            
+
             <programlistingco>
                 <areaspec>
                     <area id="discriminator1" coords="2 40"/>
@@ -1081,10 +1079,10 @@
                             <literal>type</literal> (optional - defaults to <literal>String</literal>) a
                             name that indicates the NHibernate type
                         </para>
-                    </callout>          
+                    </callout>
                     <callout arearefs="discriminator3">
                         <para>
-                            <literal>force</literal> (optional - defaults to <literal>false</literal>) 
+                            <literal>force</literal> (optional - defaults to <literal>false</literal>)
                             "force" NHibernate to specify allowed discriminator values even when retrieving 
                             all instances of the root class.
                         </para>
@@ -1098,7 +1096,7 @@
                     </callout>
                     <callout arearefs="discriminator5">
                         <para>
-                            <literal>formula</literal> (optional) an arbitrary SQL expression that is 
+                            <literal>formula</literal> (optional) an arbitrary SQL expression that is
                             executed when a type has to be evaluated. Allows content-based discrimination.
                         </para>
                     </callout>
@@ -1159,7 +1157,7 @@
                             <literal>column</literal> (optional - defaults to the property name): The name
                             of the column holding the version number.
                         </para>
-                    </callout>          
+                    </callout>
                     <callout arearefs="version2">
                         <para>
                             <literal>name</literal>: The name of a property  of the persistent class.
@@ -1167,7 +1165,7 @@
                     </callout>
                     <callout arearefs="version3">
                         <para>
-                            <literal>type</literal> (optional - defaults to <literal>Int32</literal>): 
+                            <literal>type</literal> (optional - defaults to <literal>Int32</literal>):
                             The type of the version number.
                         </para>
                     </callout>
@@ -1179,7 +1177,7 @@
                     </callout>
                    <callout arearefs="version5">
                         <para>
-                            <literal>unsaved-value</literal> (optional - defaults to a "sensible" value): 
+                            <literal>unsaved-value</literal> (optional - defaults to a "sensible" value):
                             A version property value that indicates that an instance is newly instantiated
                             (unsaved), distinguishing it from transient instances that were saved or loaded
                             in a previous session. (<literal>undefined</literal> specifies that the identifier
@@ -1195,10 +1193,10 @@
                     </callout>
                 </calloutlist>
             </programlistingco>
-            
+
             <para>
                 Version numbers may be of type <literal>Int64</literal>, <literal>Int32</literal>,
-                <literal>Int16</literal>, <literal>Ticks</literal>, <literal>Timestamp</literal>, 
+                <literal>Int16</literal>, <literal>Ticks</literal>, <literal>Timestamp</literal>,
                 or <literal>TimeSpan</literal> (or their nullable counterparts in .NET 2.0).
             </para>
 
@@ -1213,7 +1211,7 @@
                 a less safe implementation of optimistic locking. However, sometimes the application might
                 use the timestamps in other ways.
             </para>
-            
+
             <programlistingco>
                 <areaspec>
                     <area id="timestamp1" coords="2 45"/>
@@ -1235,7 +1233,7 @@
                             <literal>column</literal> (optional - defaults to the property name): The name
                             of a column holding the timestamp.
                         </para>
-                    </callout>                   
+                    </callout>
                     <callout arearefs="timestamp2">
                         <para>
                             <literal>name</literal>: The name of a property of .NET type
@@ -1250,7 +1248,7 @@
                     </callout>
                    <callout arearefs="timestamp4">
                         <para>
-                            <literal>unsaved-value</literal> (optional - defaults to <literal>null</literal>): 
+                            <literal>unsaved-value</literal> (optional - defaults to <literal>null</literal>):
                             A timestamp property value that indicates that an instance is newly instantiated
                             (unsaved), distinguishing it from transient instances that were saved or loaded
                             in a previous session. (<literal>undefined</literal> specifies that the identifier
@@ -1268,7 +1266,7 @@
             </programlistingco>
             
             <para>
-                Note that <literal>&lt;timestamp&gt;</literal> is equivalent to 
+                Note that <literal>&lt;timestamp&gt;</literal> is equivalent to
                 <literal>&lt;version type="timestamp"&gt;</literal>.
             </para>
         </sect2>
@@ -1314,7 +1312,7 @@
                         <para>
                             <literal>name</literal>: the name of the property of your class.
                         </para>
-                    </callout>                   
+                    </callout>
                     <callout arearefs="property2">
                         <para>
                             <literal>column</literal> (optional - defaults to the property name): the name
@@ -1329,7 +1327,7 @@
                     <callout arearefs="property4-5">
                         <para>
                             <literal>update, insert</literal> (optional - defaults to <literal>true</literal>) :
-                            specifies that the mapped columns should be included in SQL <literal>UPDATE</literal> 
+                            specifies that the mapped columns should be included in SQL <literal>UPDATE</literal>
                             and/or <literal>INSERT</literal> statements. Setting both to <literal>false</literal>
                             allows a pure "derived" property whose value is initialized from some other
                             property that maps to the same column(s) or by a trigger or other application.
@@ -1350,7 +1348,7 @@
                     </callout>
                     <callout arearefs="property8">
                         <para>
-                            <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>): 
+                            <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>):
                             Specifies that updates to this property do or do not require acquisition of the
                             optimistic lock. In other words, determines if a version increment should occur when 
                             this property is dirty.
@@ -1436,7 +1434,7 @@
             <para>
                 The <literal>access</literal> attribute lets you control how NHibernate will access
                 the value of the property at runtime.  The value of the <literal>access</literal> attribute should
-                be text formatted as <literal>access-strategy.naming-strategy</literal>.  The 
+                be text formatted as <literal>access-strategy.naming-strategy</literal>.  The
                 <literal>.naming-strategy</literal> is not always required.
                 <table>
                     <title>Access Strategies</title>
@@ -1472,7 +1470,7 @@
                                         is needed.
                                     </para>
                                 </entry>
-                            </row>	
+                            </row>
                             <row>
                                 <entry><literal>nosetter</literal></entry>
                                 <entry>
@@ -1481,11 +1479,11 @@
                                         Property when getting the value.  This can be used when a property only exposes
                                         a get accessor because the consumers of your API can't change the value directly.
                                         A naming strategy is required because NHibernate uses the value of the
-                                        <literal>name</literal> attribute as the property name and needs to 
+                                        <literal>name</literal> attribute as the property name and needs to
                                         be told what the name of the field is.
                                     </para>
                                 </entry>
-                            </row>	
+                            </row>
                             <row>
                                 <entry><literal>ClassName</literal></entry>
                                 <entry>
@@ -1493,7 +1491,7 @@
                                         If NHibernate's built in access strategies are not what is needed for your situation
                                         then you can build your own by implementing the interface 
                                         <literal>NHibernate.Property.IPropertyAccessor</literal>.  The value of the 
-                                        <literal>access</literal> attribute should be an assembly-qualified name that can be 
+                                        <literal>access</literal> attribute should be an assembly-qualified name that can be
                                         loaded with <literal>Activator.CreateInstance(string assemblyQualifiedName)</literal>.
                                     </para>
                                 </entry>
@@ -1532,7 +1530,7 @@
                                         <literal>&lt;property name="FooBar" ... &gt;</literal> uses the field <literal>_fooBar</literal>.
                                     </para>
                                 </entry>
-                            </row>	
+                            </row>
                             <row>
                                 <entry><literal>camelcase-m-underscore</literal></entry>
                                 <entry>
@@ -1551,7 +1549,7 @@
                                         <literal>&lt;property name="FooBar" ... &gt;</literal> uses the field <literal>foobar</literal>.
                                     </para>
                                 </entry>
-                            </row>	
+                            </row>
                             <row>
                                 <entry><literal>lowercase-underscore</literal></entry>
                                 <entry>
@@ -1642,12 +1640,12 @@
                     <callout arearefs="manytoone1">
                         <para>
                             <literal>name</literal>: The name of the property.
-                        </para>                    
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="manytoone2">
                         <para>
                             <literal>column</literal> (optional): The name of the column.
-                        </para>                    
+                        </para>
                     </callout>
                     <callout arearefs="manytoone3">
                         <para>
@@ -1663,7 +1661,7 @@
                     </callout>
                     <callout arearefs="manytoone5">
                         <para>
-                            <literal>fetch</literal> (optional - defaults to <literal>select</literal>): 
+                            <literal>fetch</literal> (optional - defaults to <literal>select</literal>):
                             Chooses between outer-join fetching or sequential select fetching.
                         </para>
                     </callout>
@@ -1678,7 +1676,7 @@
                     </callout>
                     <callout arearefs="manytoone8">
                         <para>
-                            <literal>property-ref</literal>: (optional) The name of a property of the associated 
+                            <literal>property-ref</literal>: (optional) The name of a property of the associated
                             class that is joined to this foreign key. If not specified, the primary key of
                             the associated class is used.
                         </para>
@@ -1697,9 +1695,9 @@
                     </callout>
                     <callout arearefs="manytoone11">
                         <para>
-                            <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>): 
+                            <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>):
                             Specifies that updates to this property do or do not require acquisition of the
-                            optimistic lock. In other words, determines if a version increment should occur when 
+                            optimistic lock. In other words, determines if a version increment should occur when
                             this property is dirty.
                         </para>
                     </callout>
@@ -1720,11 +1718,11 @@
                 will propagate certain operations to the associated (child) object.
                 See "Lifecycle Objects" below.
             </para>
-            
+
             <para>
                 The <literal>fetch</literal> attribute accepts two different values:
             </para>
-            
+
             <itemizedlist spacing="compact">
                 <listitem>
                     <para>
@@ -1737,7 +1735,7 @@
                     </para>
                 </listitem>
             </itemizedlist>
-            
+
             <para>
                 A typical <literal>many-to-one</literal> declaration looks as simple as
             </para>
@@ -1748,30 +1746,30 @@
                 The <literal>property-ref</literal> attribute should only be used for mapping legacy
                 data where a foreign key refers to a unique key of the associated table other than
                 the primary key. This is an ugly relational model. For example, suppose the 
-                <literal>Product</literal> class had a unique serial number, that is not the primary 
+                <literal>Product</literal> class had a unique serial number, that is not the primary
                 key. (The <literal>unique</literal> attribute controls NHibernate's DDL generation with
                 the SchemaExport tool.)
             </para>
-            
+
             <programlisting><![CDATA[<property name="serialNumber" unique="true" type="string" column="SERIAL_NUMBER"/>]]></programlisting>
-            
+
             <para>
                 Then the mapping for <literal>OrderItem</literal> might use:
             </para>
-            
+
             <programlisting><![CDATA[<many-to-one name="product" property-ref="serialNumber" column="PRODUCT_SERIAL_NUMBER"/>]]></programlisting>
             
             <para>
                 This is certainly not encouraged, however.
             </para>
-            
+
         </sect2>
 
         <sect2 id="mapping-declaration-onetoone">
             <title>one-to-one</title>
 
             <para>
-                A one-to-one association to another persistent class is declared using a 
+                A one-to-one association to another persistent class is declared using a
                 <literal>one-to-one</literal> element.
             </para>
             
@@ -1798,8 +1796,8 @@
                     <callout arearefs="onetoone1">
                         <para>
                             <literal>name</literal>: The name of the property.
-                        </para>                
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="onetoone2">
                         <para>
                             <literal>class</literal> (optional - defaults to the property type
@@ -1823,7 +1821,7 @@
                     </callout>
                     <callout arearefs="onetoone5">
                         <para>
-                            <literal>fetch</literal> (optional - defaults to <literal>select</literal>): 
+                            <literal>fetch</literal> (optional - defaults to <literal>select</literal>):
                             Chooses between outer-join fetching or sequential select fetching.
                         </para>
                     </callout>
@@ -1832,8 +1830,8 @@
                             <literal>property-ref</literal>: (optional) The name of a property of the associated class
                             that is joined to the primary key of this class. If not specified, the primary key of
                             the associated class is used.
-                        </para>                
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="onetoone7">
                         <para>
                             <literal>access</literal> (optional - defaults to <literal>property</literal>): The
@@ -1898,27 +1896,27 @@
                 Alternatively, a foreign key with a unique constraint, from <literal>Employee</literal> to 
                 <literal>Person</literal>, may be expressed as:
             </para>
-            
+
             <programlisting><![CDATA[<many-to-one name="Person" class="Person" column="PERSON_ID" unique="true"/>]]></programlisting>
-            
+
             <para>
                 And this association may be made bidirectional by adding the following to the 
                 <literal>Person</literal> mapping:
             </para>
-            
+
            <programlisting><![CDATA[<one-to-one name="Employee" class="Employee" property-ref="Person"/>]]></programlisting>
 
         </sect2>
-        
+
         <sect2 id="mapping-declaration-naturalid">
             <title>natural-id</title>
-            
+
             <programlisting><![CDATA[<natural-id mutable="true|false"/>
         <property ... />
         <many-to-one ... />
         ......
 </natural-id>]]></programlisting>
-            
+
             <para>
                 Even though we recommend the use of surrogate keys as primary keys, you should still try
                 to identify natural keys for all entities. A natural key is a property or combination of
@@ -1966,7 +1964,7 @@
                     <area id="component4" coords="5 60"/>
                     <area id="component5" coords="6 60"/>
                     <area id="component6" coords="7 60"/>
-                </areaspec>            
+                </areaspec>
                 <programlisting><![CDATA[<component 
         name="PropertyName" 
         class="ClassName"
@@ -1974,7 +1972,7 @@
         upate="true|false"
         access="field|property|nosetter|ClassName"
         optimistic-lock="true|false">
-        
+
         <property ...../>
         <many-to-one .... />
         ........
@@ -1983,26 +1981,26 @@
                     <callout arearefs="component1">
                         <para>
                             <literal>name</literal>: The name of the property.
-                        </para>               
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="component2">
                         <para>
                             <literal>class</literal> (optional - defaults to the property type
                             determined by reflection): The name of the component (child) class.
-                        </para>                 
+                        </para>
                     </callout>
                     <callout arearefs="component3">
                         <para>
-                            <literal>insert</literal>: Do the mapped columns appear in SQL 
+                            <literal>insert</literal>: Do the mapped columns appear in SQL
                             <literal>INSERT</literal>s?
-                        </para>               
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="component4">
                         <para>
-                            <literal>update</literal>: Do the mapped columns appear in SQL 
+                            <literal>update</literal>: Do the mapped columns appear in SQL
                             <literal>UPDATE</literal>s?
-                        </para>               
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="component5">
                         <para>
                             <literal>access</literal> (optional - defaults to <literal>property</literal>): The
@@ -2013,7 +2011,7 @@
                         <para>
                             <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>):
                             Specifies that updates to this component do or do not require acquisition of the
-                            optimistic lock. In other words, determines if a version increment should occur when 
+                            optimistic lock. In other words, determines if a version increment should occur when
                             this property is dirty.
                         </para>
                     </callout>
@@ -2188,7 +2186,7 @@
                     </callout>
                     <callout arearefs="subclass3">
                         <para>
-                            <literal>proxy</literal> (optional): Specifies a class or interface to use for 
+                            <literal>proxy</literal> (optional): Specifies a class or interface to use for
                             lazy initializing proxies.
                         </para>
                     </callout>
@@ -2219,7 +2217,7 @@
             <title>joined-subclass</title>
 
             <para>
-                Alternatively, a subclass that is persisted to its own table (table-per-subclass 
+                Alternatively, a subclass that is persisted to its own table (table-per-subclass
                 mapping strategy) is declared using a <literal>&lt;joined-subclass&gt;</literal>
                 element.
             </para>
@@ -2517,13 +2515,13 @@
                         <para>
                             <literal>class</literal>: The fully qualified class name of any .NET class, including
                             its assembly name.
-                        </para>              
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="import2">
                         <para>
                             <literal>rename</literal> (optional - defaults to the unqualified class name):
                             A name that may be used in the query language.
-                        </para>               
+                        </para>
                     </callout>
                 </calloutlist>
             </programlistingco>
@@ -2581,9 +2579,9 @@
             <title>Basic value types</title>
 
             <para>
-                The <emphasis>basic types</emphasis> may be roughly categorized into three groups - <literal>System.ValueType</literal> 
+                The <emphasis>basic types</emphasis> may be roughly categorized into three groups - <literal>System.ValueType</literal>
                 types, <literal>System.Object</literal> types, and <literal>System.Object</literal> types for large objects.  Just like
-                the .NET Types, columns for System.ValueType types <emphasis>can not</emphasis> store <literal>null</literal> values 
+                the .NET Types, columns for System.ValueType types <emphasis>can not</emphasis> store <literal>null</literal> values
                 and System.Object types	<emphasis>can</emphasis> store <literal>null</literal> values.
             </para>
             <table>
@@ -2594,7 +2592,7 @@
                             <entry>NHibernate Type</entry>
                             <entry>.NET Type</entry>
                             <entry>Database Type</entry>
-                            <entry>Remarks</entry>	
+                            <entry>Remarks</entry>
                         </row>
                     </thead>	
                     <tbody>
@@ -2602,7 +2600,7 @@
                             <entry><literal>AnsiChar</literal></entry>
                             <entry><literal>System.Char</literal></entry>
                             <entry><literal>DbType.AnsiStringFixedLength - 1 char</literal></entry>
-                            <entry></entry>
+                            <entry><literal>type="AnsiChar"</literal> must be specified.</entry>
                         </row>
                         <row>
                             <entry><literal>Boolean</literal></entry>
@@ -2656,19 +2654,8 @@
                             <entry><literal>DbTimestamp</literal></entry>
                             <entry><literal>System.DateTime</literal></entry>
                             <entry><literal>DbType.DateTime</literal> - as specific as database supports.</entry>
-                            <entry><literal>type="DbTimestamp"</literal> must be specified.  When used as a <literal>version</literal> field, uses the database's current time rather than the client's current time.</entry>
-                        </row>
-                        <row>
-                          <entry><literal>LocalDateTime</literal></entry>
-                          <entry><literal>System.DateTime</literal></entry>
-                          <entry><literal>DbType.DateTime</literal> - ignores the milliseconds</entry>
-                          <entry>Ensures the <literal>DateTimeKind</literal> is set to <literal>DateTimeKind.Local</literal></entry>
-                        </row>
-                        <row>
-                          <entry><literal>UtcDateTime</literal></entry>
-                          <entry><literal>System.DateTime</literal></entry>
-                          <entry><literal>DbType.DateTime</literal> - ignores the milliseconds</entry>
-                          <entry>Ensures the <literal>DateTimeKind</literal> is set to <literal>DateTimeKind.Utc</literal></entry>
+                            <entry><literal>type="DbTimestamp"</literal> must be specified.  When used as a <literal>version</literal>
+                            field, uses the database's current time rather than the client's current time.</entry>
                         </row>
                         <row>
                             <entry><literal>Decimal</literal></entry>
@@ -2705,6 +2692,13 @@
                             <entry><literal>System.Int64</literal></entry>
                             <entry><literal>DbType.Int64</literal></entry>
                             <entry>Default when no <literal>type</literal> attribute specified.</entry>
+                        </row>
+                        <row>
+                            <entry><literal>LocalDateTime</literal></entry>
+                            <entry><literal>System.DateTime</literal></entry>
+                            <entry><literal>DbType.DateTime</literal> - ignores the milliseconds</entry>
+                            <entry><literal>type="LocalDateTime"</literal> must be specified.  Ensures the
+                            <literal>DateTimeKind</literal> is set to <literal>DateTimeKind.Local</literal></entry>
                         </row>
                         <row>
                             <entry><literal>PersistentEnum</literal></entry>
@@ -2757,6 +2751,13 @@
                             <entry><literal>type="Timestamp"</literal> must be specified.</entry>
                         </row>
                         <row>
+                            <entry><literal>TimestampUtc</literal></entry>
+                            <entry><literal>System.DateTime</literal></entry>
+                            <entry><literal>DbType.DateTime</literal> - as specific as database supports.</entry>
+                            <entry><literal>type="TimestampUtc"</literal> must be specified.  Ensures the
+                            <literal>DateTimeKind</literal> is set to <literal>DateTimeKind.Utc</literal></entry>
+                        </row>
+                        <row>
                             <entry><literal>TrueFalse</literal></entry>
                             <entry><literal>System.Boolean</literal></entry>
                             <entry><literal>DbType.AnsiStringFixedLength</literal> - 1 char either 'T' or 'F'</entry>
@@ -2781,15 +2782,21 @@
                             <entry>Default when no <literal>type</literal> attribute specified.</entry>
                         </row>
                         <row>
+                            <entry><literal>UtcDateTime</literal></entry>
+                            <entry><literal>System.DateTime</literal></entry>
+                            <entry><literal>DbType.DateTime</literal> - ignores the milliseconds</entry>
+                            <entry>Ensures the <literal>DateTimeKind</literal> is set to <literal>DateTimeKind.Utc</literal></entry>
+                        </row>
+                        <row>
                             <entry><literal>YesNo</literal></entry>
                             <entry><literal>System.Boolean</literal></entry>
                             <entry><literal>DbType.AnsiStringFixedLength</literal> - 1 char either 'Y' or 'N'</entry>
                             <entry><literal>type="YesNo"</literal> must be specified.</entry>
                         </row>
                     </tbody>
-                </tgroup>	
+                </tgroup>
             </table>
-            
+
             <table>
                 <title>System.Object Mapping Types</title>
                 <tgroup cols="4">
@@ -2800,7 +2807,7 @@
                             <entry>Database Type</entry>
                             <entry>Remarks</entry>	
                         </row>
-                    </thead>	
+                    </thead>
                     <tbody>
                         <row>
                             <entry><literal>AnsiString</literal></entry>
@@ -2840,8 +2847,8 @@
                         </row>
                     </tbody>
                 </tgroup>
-            </table>	
-            
+            </table>
+
             <table>
                 <title>Large Object Mapping Types</title>
                 <tgroup cols="4">
@@ -2849,10 +2856,10 @@
                         <row>
                             <entry>NHibernate Type</entry>
                             <entry>.NET Type</entry>
-                            <entry>Database Type</entry>	
+                            <entry>Database Type</entry>
                             <entry>Remarks</entry>
                         </row>
-                    </thead>	
+                    </thead>
                     <tbody>
                         <row>
                             <entry><literal>StringClob</literal></entry>
@@ -2887,15 +2894,15 @@
                         </row>
                     </tbody>
                 </tgroup>
-            </table>	
-            
+            </table>
+
             <para>
                 NHibernate supports some additional type names for compatibility with Java's Hibernate (useful for those coming over from
                 Hibernate or using some of the tools to generate <literal>hbm.xml</literal> files).
                 A <literal>type="integer"</literal> or <literal>type="int"</literal> will map to an <literal>Int32</literal>
                 NHibernate type, <literal>type="short"</literal> to an <literal>Int16</literal> NHibernateType.
                 To see all of the conversions you can view the source of static constructor of the class
-                <literal>NHibernate.Type.TypeFactory</literal>. 
+                <literal>NHibernate.Type.TypeFactory</literal>.
             </para>
 
         </sect2>
@@ -2906,19 +2913,19 @@
             <para>
                 It is relatively easy for developers to create their own value types. For example,
                 you might want to persist properties of type <literal>Int64</literal>
-                to <literal>VARCHAR</literal> columns. NHibernate does not provide a built-in type 
-                for this. But custom types are not limited to mapping a property (or collection element) 
-                to a single table column. So, for example, you might have a property 
+                to <literal>VARCHAR</literal> columns. NHibernate does not provide a built-in type
+                for this. But custom types are not limited to mapping a property (or collection element)
+                to a single table column. So, for example, you might have a property
                 <literal>Name { get; set; }</literal> of type
-                <literal>String</literal> that is persisted to the columns 
-                <literal>FIRST_NAME</literal>, <literal>INITIAL</literal>, <literal>SURNAME</literal>. 
+                <literal>String</literal> that is persisted to the columns
+                <literal>FIRST_NAME</literal>, <literal>INITIAL</literal>, <literal>SURNAME</literal>.
             </para>
             
             <para>
-                To implement a custom type, implement either <literal>NHibernate.UserTypes.IUserType</literal> 
-                or <literal>NHibernate.UserTypes.ICompositeUserType</literal> and declare properties using the 
-                fully qualified name of the type. Check out 
-                <literal>NHibernate.DomainModel.DoubleStringType</literal> to see the kind of things that 
+                To implement a custom type, implement either <literal>NHibernate.UserTypes.IUserType</literal>
+                or <literal>NHibernate.UserTypes.ICompositeUserType</literal> and declare properties using the
+                fully qualified name of the type. Check out
+                <literal>NHibernate.DomainModel.DoubleStringType</literal> to see the kind of things that
                 are possible.
             </para>
 
@@ -2940,10 +2947,10 @@
             </para>
             
             <para>
-                You may even supply parameters to an <literal>IUserType</literal> in the mapping file. To 
-                do this, your <literal>IUserType</literal> must implement the 
-                <literal>NHibernate.UserTypes.IParameterizedType</literal> interface. To supply parameters 
-                to your custom type, you can use the <literal>&lt;type&gt;</literal> element in your mapping 
+                You may even supply parameters to an <literal>IUserType</literal> in the mapping file. To
+                do this, your <literal>IUserType</literal> must implement the
+                <literal>NHibernate.UserTypes.IParameterizedType</literal> interface. To supply parameters
+                to your custom type, you can use the <literal>&lt;type&gt;</literal> element in your mapping
                 files.
             </para>
             
@@ -2963,40 +2970,40 @@
                 Typedefs assign a name to a custom type, and may also contain a list of default
                 parameter values if the type is parameterized.
             </para>
-            
+
             <programlisting><![CDATA[<typedef class="MyCompany.UserTypes.DefaultValueIntegerType" name="default_zero">
     <param name="default">0</param>
 </typedef>]]></programlisting>
-            
+
             <programlisting><![CDATA[<property name="priority" type="default_zero"/>]]></programlisting>
             
             <para>
                 It is also possible to override the parameters supplied in a typedef on a case-by-case basis
                 by using type parameters on the property mapping.
             </para>
-            
+
             <para>
                 Even though NHibernate's rich range of built-in types and support for components means you
                 will very rarely <emphasis>need</emphasis> to use a custom type, it is nevertheless
                 considered good form to use custom types for (non-entity) classes that occur frequently
                 in your application. For example, a <literal>MonetaryAmount</literal> class is a good
-                candidate for an <literal>ICompositeUserType</literal>, even though it could easily be mapped 
-                as a component. One motivation for this is abstraction. With a custom type, your mapping 
-                documents would be future-proofed against possible changes in your way of representing 
+                candidate for an <literal>ICompositeUserType</literal>, even though it could easily be mapped
+                as a component. One motivation for this is abstraction. With a custom type, your mapping
+                documents would be future-proofed against possible changes in your way of representing
                 monetary values.
             </para>
 
         </sect2>
-        
+
         <sect2 id="mapping-types-anymapping">
             <title>Any type mappings</title>
-            
+
             <para>
-                There is one further type of property mapping. The <literal>&lt;any&gt;</literal> mapping element 
+                There is one further type of property mapping. The <literal>&lt;any&gt;</literal> mapping element
                 defines a polymorphic association to classes from multiple tables. This type of mapping always
-                requires more than one column. The first column holds the type of the associated entity. 
+                requires more than one column. The first column holds the type of the associated entity.
                 The remaining columns hold the identifier. It is impossible to specify a foreign key constraint
-                for this kind of association, so this is most certainly not meant as the usual way of mapping 
+                for this kind of association, so this is most certainly not meant as the usual way of mapping
                 (polymorphic) associations. You should use this only in very special cases (eg. audit logs,
                 user session data, etc).
             </para>
@@ -3007,9 +3014,9 @@
 </any>]]></programlisting>
 
             <para>
-                 The <literal>meta-type</literal> attribute lets the application specify a custom type that 
-                 maps database column values to persistent classes which have identifier properties of the 
-                 type specified by <literal>id-type</literal>. If the meta-type returns instances of 
+                 The <literal>meta-type</literal> attribute lets the application specify a custom type that
+                 maps database column values to persistent classes which have identifier properties of the
+                 type specified by <literal>id-type</literal>. If the meta-type returns instances of
                  <literal>System.Type</literal>, nothing else is required. On the other hand, if it is
                  a basic type like <literal>String</literal> or <literal>Char</literal>, you must
                  specify the mapping from values to classes.
@@ -3051,26 +3058,26 @@
                     <callout arearefs="any1">
                         <para>
                             <literal>name</literal>: the property name.
-                        </para>            
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="any2">
                         <para>
                             <literal>id-type</literal>: the identifier type.
-                        </para>            
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="any3">
                         <para>
-                            <literal>meta-type</literal> (optional - defaults to <literal>Type</literal>): 
+                            <literal>meta-type</literal> (optional - defaults to <literal>Type</literal>):
                             a type that maps <literal>System.Type</literal> to a single database column
                             or, alternatively, a type that is allowed for a discriminator mapping.
-                        </para>            
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="any4">
                         <para>
-                            <literal>cascade</literal> (optional - defaults to <literal>none</literal>): 
+                            <literal>cascade</literal> (optional - defaults to <literal>none</literal>):
                             the cascade style.
-                        </para>            
-                    </callout>                   
+                        </para>
+                    </callout>
                     <callout arearefs="any5">
                         <para>
                             <literal>access</literal> (optional - defaults to <literal>property</literal>): The
@@ -3079,7 +3086,7 @@
                     </callout>
                     <callout arearefs="any6">
                         <para>
-                            <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>): 
+                            <literal>optimistic-lock</literal> (optional - defaults to <literal>true</literal>):
                             Specifies that updates to this property do or do not require acquisition of the
                             optimistic lock. In other words, define if a version increment should occur if this
                             property is dirty.
@@ -3088,20 +3095,20 @@
                 </calloutlist>
             </programlistingco>
 
-      </sect2>
+        </sect2>
 
     </sect1>
-    
-    <sect1 id="mapping-quotedidentifiers">
-            <title>SQL quoted identifiers</title>
-            <para>
-                You may force NHibernate to quote an identifier in the generated SQL by enclosing the table or
-                column name in back-ticks in the mapping document. NHibernate will use the correct quotation
-                style for the SQL <literal>Dialect</literal> (usually double quotes, but brackets for SQL
-                Server and back-ticks for MySQL).
-            </para>
 
-            <programlisting><![CDATA[<class name="LineItem" table="`Line Item`">
+    <sect1 id="mapping-quotedidentifiers">
+        <title>SQL quoted identifiers</title>
+        <para>
+            You may force NHibernate to quote an identifier in the generated SQL by enclosing the table or
+            column name in back-ticks in the mapping document. NHibernate will use the correct quotation
+            style for the SQL <literal>Dialect</literal> (usually double quotes, but brackets for SQL
+            Server and back-ticks for MySQL).
+        </para>
+
+        <programlisting><![CDATA[<class name="LineItem" table="`Line Item`">
     <id name="Id" column="`Item Id`"/><generator class="assigned"/></id>
     <property name="ItemNumber" column="`Item #`"/>
     ...
@@ -3118,7 +3125,7 @@
             specify an <literal>extends</literal> attribute in the subclass mapping, naming a previously
             mapped superclass. Use of this feature makes the ordering of the mapping documents important!
         </para>
-    
+
         <programlisting><![CDATA[
 <hibernate-mapping>
         <subclass name="Eg.Subclass.DomesticCat, Eg"
@@ -3228,4 +3235,3 @@
     </sect1>
 
 </chapter>
-


### PR DESCRIPTION
NH-2520 follow up for updating documentation in order to include new `TimestampUtc` type.

I find its name a bit unfortunate, in regard to already existing `UtcDateTime`. It should have been named `UtcTimestamp`, or we should obsolete `UtcDateTime` and replace it with a `DateTimeUtc`.

Let me know if agreeing with my viewpoint, I would then add some commit to this PR for renaming this new type.

Otherwise I will probably merge this tomorrow.

Done some cleanup on documentation. Non white-space changes range from line 2603 to 2790.