### PR TITLE
NH-3931 - Invalid order of child inserts

### DIFF
--- a/src/NHibernate.Test/Insertordering/AnimalModel/Animal.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/Animal.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class Animal
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Person Owner { get; set; }
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/Cat.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/Cat.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class Cat : Animal
+	{
+		public virtual string EyeColor { get; set; }
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/Dog.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/Dog.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class Dog : Animal
+	{
+		public virtual string Country { get; set; }
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/Fixture.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/Fixture.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using NHibernate.Cfg;
+using NUnit.Framework;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	[TestFixture]
+	public class Fixture : TestCase
+	{
+		protected override IList Mappings
+		{
+			get { return new[] { "Insertordering.AnimalModel.Mappings.hbm.xml" }; }
+		}
+
+		protected override string MappingsAssembly
+		{
+			get { return "NHibernate.Test"; }
+		}
+
+		protected override void Configure(Configuration configuration)
+		{
+			configuration.DataBaseIntegration(x =>
+			{
+				x.BatchSize = 10;
+				x.OrderInserts = true;
+			});
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Delete("from Animal");
+				session.Delete("from Person");
+				tran.Commit();
+			}
+		}
+
+		[Test]
+		public void ElaboratedModel()
+		{
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var personWithAnimals = new PersonWithAnimals { Name = "fabio" };
+				var personWithCats = new PersonWithCats { Name = "dario" };
+				var personWithSivasKangals = new PersonWithSivasKangals { Name = "tuna" };
+				var personWithDogs = new PersonWithDogs { Name = "davy" };
+
+				var animalForAnimals = new Animal { Name = "Pasha", Owner = personWithAnimals };
+				var dogForAnimals = new Dog { Name = "Efe", Country = "Turkey", Owner = personWithAnimals };
+				var catForAnimals = new Cat { Name = "Tekir", EyeColor = "green", Owner = personWithAnimals };
+				var sivasKangalForAnimals = new SivasKangal { Name = "Karabas", Country = "Turkey", HouseAddress = "Atakoy", Owner = personWithAnimals };
+
+				personWithAnimals.AnimalsGeneric.Add(animalForAnimals);
+				personWithAnimals.AnimalsGeneric.Add(dogForAnimals);
+				personWithAnimals.AnimalsGeneric.Add(catForAnimals);
+				personWithAnimals.AnimalsGeneric.Add(sivasKangalForAnimals);
+
+				var animalForCats = new Animal { Name = "Pasha2", Owner = personWithCats };
+				var catForCats = new Cat { Name = "Tekir2", EyeColor = "green", Owner = personWithCats };
+				var dogForCats = new Dog { Name = "Efe2", Country = "Turkey", Owner = personWithCats };
+				personWithCats.AnimalsGeneric.Add(catForCats);
+
+				var catForDogs = new Cat { Name = "Tekir3", EyeColor = "blue", Owner = personWithDogs };
+				var dogForDogs = new Dog { Name = "Efe3", Country = "Turkey", Owner = personWithDogs };
+				var sivasKangalForDogs = new SivasKangal { Name = "Karabas3", Country = "Turkey", HouseAddress = "Atakoy", Owner = personWithDogs };
+				personWithDogs.AnimalsGeneric.Add(dogForDogs);
+				personWithDogs.AnimalsGeneric.Add(sivasKangalForDogs);
+
+				var animalForSivasKangals = new Animal { Name = "Pasha4", Owner = personWithSivasKangals };
+				var dogForSivasKangals = new Dog { Name = "Efe4", Country = "Turkey", Owner = personWithSivasKangals };
+				var catForSivasKangals = new Cat { EyeColor = "red", Name = "Tekir4", Owner = personWithSivasKangals };
+				var sivasKangalForSivasKangals = new SivasKangal { Name = "Karabas4", Country = "Turkey", HouseAddress = "Atakoy", Owner = personWithSivasKangals };
+				personWithSivasKangals.AnimalsGeneric.Add(sivasKangalForSivasKangals);
+
+				session.Save(animalForCats);
+				session.Save(dogForCats);
+
+				session.Save(catForDogs);
+
+				session.Save(animalForSivasKangals);
+				session.Save(dogForSivasKangals);
+				session.Save(catForSivasKangals);
+
+				session.Save(personWithAnimals);
+				session.Save(personWithCats);
+				session.Save(personWithDogs);
+				session.Save(personWithSivasKangals);
+
+				Assert.DoesNotThrow(() => { tran.Commit(); });
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/Mappings.hbm.xml
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/Mappings.hbm.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+									 assembly="NHibernate.Test"
+									 namespace="NHibernate.Test.Insertordering.AnimalModel">
+
+  <class name="Animal" discriminator-value="0">
+    <id name="Id" generator="guid.comb" />
+    <discriminator column="AnimalType" type="int" force="true"/>
+    <property name="Name"	type="string"/>
+    <many-to-one name="Owner" class="Person" column="OwnerId"/>
+    <subclass name="Cat" discriminator-value="1"/>
+    <subclass name="Dog" discriminator-value="2">
+      <property name="Country"/>
+      <subclass name="SivasKangal" discriminator-value="3">
+        <property name="HouseAddress"></property>
+      </subclass>
+    </subclass>
+  </class>
+  <class name="Person" discriminator-value="0">
+    <id name="Id" generator="guid.comb" />
+
+    <discriminator column="PersonType" type="int"/>
+    <property name="Name"/>
+    <bag name="AnimalsGeneric" lazy="true" inverse="true" cascade="save-update">
+      <key column="OwnerId" />
+      <one-to-many class="Animal"/>
+    </bag>
+    <subclass name="PersonWithAnimals" discriminator-value="1">
+
+    </subclass>
+    <subclass name="PersonWithCats" discriminator-value="2">
+      <bag name="CatsGeneric" lazy="true" inverse="true" cascade="save-update">
+        <key column="OwnerId" />
+        <one-to-many class="Cat"/>
+      </bag>
+    </subclass>
+    <subclass name="PersonWithDogs" discriminator-value="3">
+      <bag name="DogsGeneric" lazy="true" inverse="true" cascade="save-update">
+        <key column="OwnerId" />
+        <one-to-many class="Dog"/>
+      </bag>
+    </subclass>
+    <subclass name="PersonWithSivasKangals" discriminator-value="4">
+      <bag name="SivasKangalsGeneric" lazy="true" inverse="true" cascade="save-update">
+        <key column="OwnerId" />
+        <one-to-many class="SivasKangal"/>
+      </bag>
+
+    </subclass>
+    <subclass name="PersonWithAllTypes" discriminator-value="5">
+      <bag name="DogsGeneric" lazy="true" inverse="true">
+        <key column="OwnerId" />
+        <one-to-many class="Dog"/>
+      </bag>
+      <bag name="CatsGeneric" lazy="true" inverse="true">
+        <key column="OwnerId" />
+        <one-to-many class="Cat"/>
+      </bag>
+      <bag name="SivasKangalsGeneric" lazy="true" inverse="true">
+        <key column="OwnerId" />
+        <one-to-many class="SivasKangal"/>
+      </bag>
+    </subclass>
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/Insertordering/AnimalModel/Person.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/Person.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class Person
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual IList<Animal> AnimalsGeneric { get; set; } = new List<Animal>();
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithAllTypes.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithAllTypes.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class PersonWithAllTypes : Person
+	{
+		public virtual IList<Dog> DogsGeneric { get; set; }
+		public virtual IList<SivasKangal> SivasKangalsGeneric { get; set; }
+		public virtual IList<Cat> CatsGeneric { get; set; }
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithAnimals.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithAnimals.cs
@@ -1,0 +1,6 @@
+﻿namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class PersonWithAnimals : Person
+	{
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithCats.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithCats.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class PersonWithCats : Person
+	{
+		public virtual IList<Cat> CatsGeneric { get; set; } = new List<Cat>();
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithDogs.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithDogs.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class PersonWithDogs : Person
+	{
+		public virtual IList<Dog> DogsGeneric { get; set; } = new List<Dog>();
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithSivasKangals.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/PersonWithSivasKangals.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class PersonWithSivasKangals : Person
+	{
+		public virtual IList<SivasKangal> SivasKangalsGeneric { get; set; } = new List<SivasKangal>();
+	}
+}

--- a/src/NHibernate.Test/Insertordering/AnimalModel/SivasKangal.cs
+++ b/src/NHibernate.Test/Insertordering/AnimalModel/SivasKangal.cs
@@ -1,0 +1,7 @@
+﻿namespace NHibernate.Test.Insertordering.AnimalModel
+{
+	public class SivasKangal : Dog
+	{
+		public virtual string HouseAddress { get; set; }
+	}
+}

--- a/src/NHibernate.Test/Insertordering/FamilyModel/Fixture.cs
+++ b/src/NHibernate.Test/Insertordering/FamilyModel/Fixture.cs
@@ -1,0 +1,98 @@
+using System.Collections;
+using System.Linq;
+using NHibernate.Cfg;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.Insertordering.FamilyModel
+{
+	[TestFixture]
+	public class Fixture : TestCase
+	{
+		protected override IList Mappings
+		{
+			get { return new[] { "Insertordering.FamilyModel.Mappings.hbm.xml" }; }
+		}
+
+		protected override string MappingsAssembly
+		{
+			get { return "NHibernate.Test"; }
+		}
+
+		protected override void Configure(Configuration configuration)
+		{
+			configuration.DataBaseIntegration(x =>
+			{
+				x.BatchSize = 10;
+				x.OrderInserts = true;
+				// Uncomment batcher lines here and in OnSetUp and OnTearDown for debugging purpose.
+				//x.Batcher<InsertOrderingFixture.StatsBatcherFactory>();
+			});
+		}
+
+		protected override void OnSetUp()
+		{
+			/*
+			InsertOrderingFixture.StatsBatcher.Reset();
+			InsertOrderingFixture.StatsBatcher.StatsEnabled = true;
+			*/
+		}
+
+		protected override void OnTearDown()
+		{
+			//InsertOrderingFixture.StatsBatcher.StatsEnabled = false;
+
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+				tran.Commit();
+			}
+		}
+
+		[Test]
+		public void CircularReferences()
+		{
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var jeanne = new Woman { Name = "Jeanne" };
+				var paul = new Man { Name = "Paul" };
+
+				var paulette = new Woman { Name = "Paulette", Mother = jeanne, Father = paul };
+				var monique = new Woman { Name = "Monique", Mother = jeanne, Father = paul };
+				var alice = new Woman { Name = "Alice", Mother = jeanne, Father = paul };
+				var yves = new Man { Name = "Yves", Mother = jeanne, Father = paul };
+				var denis = new Man { Name = "Denis", Mother = jeanne, Father = paul };
+
+				var laure = new Woman { Name = "Laure", Mother = paulette };
+				var valerie = new Woman { Name = "Valérie", Mother = paulette };
+				var caroline = new Woman { Name = "Caroline", Mother = monique };
+				var cathy = new Woman { Name = "Cathy", Father = yves };
+				var helene = new Woman { Name = "Hélène", Father = yves };
+				var nicolas = new Man { Name = "Nicolas", Mother = monique };
+				var frederic = new Man { Name = "Frédéric", Mother = monique };
+				var arnaud = new Man { Name = "Arnaud", Father = denis };
+
+				session.Save(alice);
+				session.Save(laure);
+				session.Save(valerie);
+				session.Save(caroline);
+				session.Save(cathy);
+				session.Save(helene);
+				session.Save(nicolas);
+				session.Save(frederic);
+				session.Save(arnaud);
+
+				Assert.DoesNotThrow(() => { tran.Commit(); });
+			}
+
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				Assert.AreEqual(9, session.Query<Woman>().Count());
+				Assert.AreEqual(6, session.Query<Man>().Count());
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/Insertordering/FamilyModel/Mappings.hbm.xml
+++ b/src/NHibernate.Test/Insertordering/FamilyModel/Mappings.hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+									 assembly="NHibernate.Test"
+									 namespace="NHibernate.Test.Insertordering.FamilyModel">
+
+  <class name="Woman">
+    <id name="Id" generator="guid.comb" />
+
+    <property name="Name"/>
+    <many-to-one name="Mother" cascade="save-update" />
+    <many-to-one name="Father" cascade="save-update" />
+  </class>
+
+  <class name="Man">
+    <id name="Id" generator="guid.comb" />
+
+    <property name="Name"/>
+    <many-to-one name="Mother" cascade="save-update" />
+    <many-to-one name="Father" cascade="save-update" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/Insertordering/FamilyModel/Person.cs
+++ b/src/NHibernate.Test/Insertordering/FamilyModel/Person.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace NHibernate.Test.Insertordering.FamilyModel
+{
+	public class Person
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual Woman Mother { get; set; }
+		public virtual Man Father { get; set; }
+	}
+
+	public class Woman : Person
+	{
+	}
+
+	public class Man : Person
+	{
+	}
+}

--- a/src/NHibernate.Test/Insertordering/InsertOrderingFixture.cs
+++ b/src/NHibernate.Test/Insertordering/InsertOrderingFixture.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NHibernate.Engine;
@@ -19,7 +20,7 @@ namespace NHibernate.Test.Insertordering
 		const int typesOfEntities = 3;
 		protected override IList Mappings
 		{
-			get { return new[] {"Insertordering.Mapping.hbm.xml"}; }
+			get { return new[] { "Insertordering.Mapping.hbm.xml" }; }
 		}
 
 		protected override string MappingsAssembly
@@ -35,11 +36,31 @@ namespace NHibernate.Test.Insertordering
 		protected override void Configure(Configuration configuration)
 		{
 			configuration.DataBaseIntegration(x =>
-											  {
-																					x.BatchSize = batchSize;
-																					x.OrderInserts = true;
-																					x.Batcher<StatsBatcherFactory>();
-											  });
+			{
+				x.BatchSize = batchSize;
+				x.OrderInserts = true;
+				x.Batcher<StatsBatcherFactory>();
+			});
+		}
+
+		protected override void OnSetUp()
+		{
+			StatsBatcher.Reset();
+			StatsBatcher.StatsEnabled = true;
+		}
+
+		protected override void OnTearDown()
+		{
+			StatsBatcher.StatsEnabled = false;
+
+			using (ISession session = OpenSession())
+			using (ITransaction transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
 		}
 
 		[Test]
@@ -50,8 +71,8 @@ namespace NHibernate.Test.Insertordering
 			{
 				for (int i = 0; i < instancesPerEach; i++)
 				{
-					var user = new User {UserName = "user-" + i};
-					var group = new Group {Name = "group-" + i};
+					var user = new User { UserName = "user-" + i };
+					var group = new Group { Name = "group-" + i };
 					s.Save(user);
 					s.Save(group);
 					user.AddMembership(group);
@@ -60,20 +81,401 @@ namespace NHibernate.Test.Insertordering
 				s.Transaction.Commit();
 			}
 
-			int expectedBatchesPerEntity = (instancesPerEach / batchSize) + ((instancesPerEach % batchSize) == 0 ?  0 : 1);
+			int expectedBatchesPerEntity = (instancesPerEach / batchSize) + ((instancesPerEach % batchSize) == 0 ? 0 : 1);
 			Assert.That(StatsBatcher.BatchSizes.Count, Is.EqualTo(expectedBatchesPerEntity * typesOfEntities));
-
-			using (ISession s = OpenSession())
-			{
-				s.BeginTransaction();
-				IList users = s.CreateQuery("from User u left join fetch u.Memberships m left join fetch m.Group").List();
-				foreach (object user in users)
-				{
-					s.Delete(user);
-				}
-				s.Transaction.Commit();
-			}
 		}
+
+		// Following tests have been added for NH-3931
+
+		#region Bidirectional many-to-many
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/0c8261b0ae499d8ecc4001892b4cb43539de195a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalManyToMany.java
+
+		// Non-reg test case.
+		[Test]
+		public void WithBidiManyToMany()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var father = new PersonM2M();
+				var mother = new PersonM2M();
+				var son = new PersonM2M();
+				var daughter = new PersonM2M();
+
+				var home = new AddressM2M();
+				var office = new AddressM2M();
+
+				home.AddPerson(father);
+				home.AddPerson(mother);
+				home.AddPerson(son);
+				home.AddPerson(daughter);
+
+				office.AddPerson(father);
+				office.AddPerson(mother);
+
+				session.Save(home);
+				session.Save(office);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 4 Person inserts, 2 Address inserts, 6 PersonAddresses inserts
+			Assert.AreEqual(3, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+		}
+
+		#endregion
+
+		#region Bidirectional many-to-one
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/0c8261b0ae499d8ecc4001892b4cb43539de195a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalOneToMany.java
+
+		// Non-reg test case.
+		[Test]
+		public void WithBidiManyToOne()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var father = new PersonM2O();
+				var mother = new PersonM2O();
+				var son = new PersonM2O();
+				var daughter = new PersonM2O();
+
+				var home = new AddressM2O();
+				var office = new AddressM2O();
+
+				home.AddPerson(father);
+				home.AddPerson(mother);
+				home.AddPerson(son);
+				home.AddPerson(daughter);
+
+				office.AddPerson(father);
+				office.AddPerson(mother);
+
+				session.Save(home);
+				session.Save(office);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 2 Address inserts, 4 Person inserts, 2 Person.Address updates
+			Assert.AreEqual(3, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(8, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Bidirectional one-to-one
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/f90845c30c2a6d5e14eeafd32a4c9d321d3a55ef/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalOneToOne.java
+
+		// Non-reg test case.
+		[Test]
+		public void WithBidiOneToOne()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var worker = new PersonO2O();
+				var homestay = new PersonO2O();
+
+				var home = new AddressO2O();
+				var office = new AddressO2O();
+
+				home.SetPerson(homestay);
+				office.SetPerson(worker);
+
+				session.Save(home);
+				session.Save(office);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 2 Person inserts, 2 Address inserts, 2 Person updates (because mapped through foreign key)
+			Assert.AreEqual(3, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(6, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Element collection
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/aa5f89326705fdb64ca8de2478c08006d11a974b/hibernate-core/src/test/java/org/hibernate/test/insertordering/ElementCollectionTest.java
+
+		// Non-reg test case.
+		[Test]
+		public void WithElementCollection()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var task = new Task();
+				task.Categories.Add(Category.A);
+				session.Save(task);
+
+				var task1 = new Task();
+				task1.Categories.Add(Category.A);
+				session.Save(task1);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 2 Task inserts, 2 Category inserts
+			Assert.AreEqual(2, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(4, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Joined table inheritance
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/0c8261b0ae499d8ecc4001892b4cb43539de195a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
+
+		// Failing test case till NH-3931 is fixed.
+		[Test]
+		public void WithJoinedTableInheritance()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var person = new PersonJI();
+				person.AddAddress(new AddressJI());
+				session.Save(person);
+
+				// Derived Object with dependent object (address)
+				var specialPerson = new SpecialPersonJI();
+				specialPerson.AddAddress(new AddressJI());
+				session.Save(specialPerson);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 2 Person inserts, 1 SpecialPerson insert (out of any batch currently), 2 Address inserts
+			Assert.AreEqual(2, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(4, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		// Failing test case till NH-3931 is fixed.
+		[Test]
+		public void WithJoinedTableInheritance_Bigger()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				for (int i = 0; i < 12; i++)
+				{
+					var person = new PersonJI();
+					person.AddAddress(new AddressJI());
+					session.Save(person);
+
+					// Derived Object with dependent object (address)
+					var specialPerson = new SpecialPersonJI();
+					specialPerson.AddAddress(new AddressJI());
+					session.Save(specialPerson);
+				}
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 24 Person inserts (2 batches + 12 due to SpecialPerson inserts which fragment batches, minus maybe 1 depending on execution order),
+			// 12 SpecialPerson inserts (out of any batch currently), 24 Address inserts (3 batches)
+			Assert.That(StatsBatcher.BatchSizes.Count, Is.InRange(16, 17), "Unexpected batches count");
+			Assert.AreEqual(48, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Joined table multi-level inheritance
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/0c8261b0ae499d8ecc4001892b4cb43539de195a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
+
+		// Failing test case till NH-3931 is fixed.
+		[Test]
+		public void WithJoinedTableInheritance_MultiLevel()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				for (int i = 0; i < 2; i++)
+				{
+					var president = new PresidentJim();
+					president.AddAddress(new AddressJim());
+					session.Save(president);
+
+					var anotherPerson = new AnotherPersonJim();
+					var office = new OfficeJim();
+					session.Save(office);
+					anotherPerson.Office = office;
+					session.Save(anotherPerson);
+
+					var person = new PersonJim();
+					session.Save(person);
+
+					var specialPerson = new SpecialPersonJim();
+					specialPerson.AddAddress(new AddressJim());
+					session.Save(specialPerson);
+				}
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 8 Person inserts (1 batch + 2 due to SpecialPerson inserts which fragment batches + 2 due to President inserts (frag too)
+			//   + 2 due to AnotherPerson inserts (frag too), minus maybe 1 depending on execution order),
+			// 4 SpecialPerson inserts (out of any batch currently), 2 President inserts (out of any batch currently),
+			// 2 AnotherPerson inserts (out of any batch currently), 2 Office inserts, 4 Address inserts
+			Assert.That(StatsBatcher.BatchSizes.Count, Is.InRange(8, 9), "Unexpected batches count");
+			Assert.AreEqual(14, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Single table inheritance
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/0c8261b0ae499d8ecc4001892b4cb43539de195a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithSingleTableInheritance.java
+
+		// Failing test case till NH-3931 is fixed.
+		[Test]
+		public void WithSingleTableInheritance()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var person = new PersonSti();
+				person.AddAddress(new AddressSti());
+				session.Save(person);
+
+				// Derived Object with dependent object (address)
+				var specialPerson = new SpecialPersonSti();
+				specialPerson.AddAddress(new AddressSti());
+				session.Save(specialPerson);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 1 Person insert, 1 SpecialPerson insert (into Person but with different columns), 2 Address inserts
+			Assert.AreEqual(3, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(4, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		// Failing test case till NH-3931 is fixed.
+		[Test]
+		public void WithSingleTableInheritance_Bigger()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				for (int i = 0; i < 12; i++)
+				{
+					var person = new PersonSti();
+					person.AddAddress(new AddressSti());
+					session.Save(person);
+
+					// Derived Object with dependent object (address)
+					var specialPerson = new SpecialPersonSti();
+					specialPerson.AddAddress(new AddressSti());
+					session.Save(specialPerson);
+				}
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 12 Person inserts (2 batches), 12 SpecialPerson inserts (into Person but with different columns, 2 batches), 24 Address inserts (3 batches)
+			Assert.AreEqual(7, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(48, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Table per concrete class inheritance
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/0c8261b0ae499d8ecc4001892b4cb43539de195a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithTablePerClassInheritance.java
+
+		// Non-reg test case
+		[Test]
+		public void WithTablePerConcreteInheritance()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var person = new PersonTpc();
+				person.AddAddress(new AddressTpc());
+				session.Save(person);
+
+				// Derived Object with dependent object (address)
+				var specialPerson = new SpecialPersonTpc();
+				specialPerson.AddAddress(new AddressTpc());
+				session.Save(specialPerson);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 1 Person insert, 1 SpecialPerson insert, 2 Address inserts
+			Assert.AreEqual(3, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(4, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		// Non-reg test case
+		[Test]
+		public void WithTablePerConcreteInheritance_Bigger()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				for (int i = 0; i < 12; i++)
+				{
+					var person = new PersonTpc();
+					person.AddAddress(new AddressTpc());
+					session.Save(person);
+
+					// Derived Object with dependent object (address)
+					var specialPerson = new SpecialPersonTpc();
+					specialPerson.AddAddress(new AddressTpc());
+					session.Save(specialPerson);
+				}
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 12 Person inserts (2 batches), 12 SpecialPerson inserts (2 batches), 24 Address inserts (3 batches)
+			Assert.AreEqual(7, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(48, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
+
+		#region Unidirectional one-to-one
+
+		// Adapted from https://github.com/hibernate/hibernate-orm/blob/f90845c30c2a6d5e14eeafd32a4c9d321d3a55ef/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithUnidirectionalOneToOne.java
+
+		// Non-reg test case.
+		[Test]
+		public void WithUnidiOneToOne()
+		{
+			using (ISession session = OpenSession())
+			using (var trx = session.BeginTransaction())
+			{
+				var worker = new PersonUO2O();
+				var homestay = new PersonUO2O();
+
+				var home = new AddressUO2O();
+				var office = new AddressUO2O();
+
+				home.SetPerson(homestay);
+				office.SetPerson(worker);
+
+				session.Save(home);
+				session.Save(office);
+
+				Assert.DoesNotThrow(() => { trx.Commit(); });
+			}
+
+			// 2 Person inserts, 2 Address inserts
+			Assert.AreEqual(2, StatsBatcher.BatchSizes.Count, "Unexpected batches count");
+			Assert.AreEqual(4, StatsBatcher.BatchSizes.Sum(), "Unexpected batched queries count");
+		}
+
+		#endregion
 
 		#region Nested type: StatsBatcher
 
@@ -83,8 +485,10 @@ namespace NHibernate.Test.Insertordering
 			private static IList<int> batchSizes = new List<int>();
 			private static int currentBatch = -1;
 
+			public static bool StatsEnabled { get; set; }
+
 			public StatsBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
-				: base(connectionManager, interceptor) {}
+				: base(connectionManager, interceptor) { }
 
 			public static IList<int> BatchSizes
 			{
@@ -101,6 +505,10 @@ namespace NHibernate.Test.Insertordering
 			public override DbCommand PrepareBatchCommand(CommandType type, SqlString sql, SqlType[] parameterTypes)
 			{
 				var result = base.PrepareBatchCommand(type, sql, parameterTypes);
+
+				if (!StatsEnabled)
+					return result;
+
 				string sqlstring = sql.ToString();
 				if (batchSQL == null || !sqlstring.Equals(batchSQL))
 				{
@@ -115,15 +523,21 @@ namespace NHibernate.Test.Insertordering
 
 			public override void AddToBatch(IExpectation expectation)
 			{
-				batchSizes[currentBatch]++;
-				Console.WriteLine("Adding to batch [" + batchSQL + "]");
+				if (StatsEnabled)
+				{
+					batchSizes[currentBatch]++;
+					Console.WriteLine("Adding to batch [" + batchSQL + "]");
+				}
 				base.AddToBatch(expectation);
 			}
 
 			protected override void DoExecuteBatch(DbCommand ps)
 			{
-				Console.WriteLine("executing batch [" + batchSQL + "]");
-				Console.WriteLine("--------------------------------------------------------");
+				if (StatsEnabled)
+				{
+					Console.WriteLine("executing batch [" + batchSQL + "]");
+					Console.WriteLine("--------------------------------------------------------");
+				}
 				batchSQL = null;
 				base.DoExecuteBatch(ps);
 			}

--- a/src/NHibernate.Test/Insertordering/Mapping.hbm.xml
+++ b/src/NHibernate.Test/Insertordering/Mapping.hbm.xml
@@ -30,4 +30,145 @@
     <many-to-one name="Group" class="Group" column="GRP_ID" cascade="all"/>
     <property name="ActivationDate" type="timestamp" column="JN_DT"/>
   </class>
+
+  <!-- NH3931 test entities -->
+  
+  <class name="AddressM2M">
+    <id name="Id" generator="guid.comb" />
+    <set name="Persons" table="PersonAddresses" cascade="save-update" inverse="true">
+      <key column="AddressId" />
+      <many-to-many class="PersonM2M" column="PersonId" />
+    </set>
+  </class>
+
+  <class name="PersonM2M">
+    <id name="Id" generator="guid.comb" />
+    <set name="Addresses" table="PersonAddresses">
+      <key column="PersonId" />
+      <many-to-many class="AddressM2M" column="AddressId" />
+    </set>
+  </class>
+
+  <class name="AddressM2O">
+    <id name="Id" generator="guid.comb" />
+    <set name="Persons" cascade="save-update" inverse="true">
+      <key column="Address" />
+      <one-to-many class="PersonM2O" />
+    </set>
+  </class>
+
+  <class name="PersonM2O">
+    <id name="Id" generator="guid.comb" />
+    <many-to-one name="Address" />
+  </class>
+
+  <class name="AddressO2O">
+    <id name="Id" generator="guid.comb" />
+    
+    <one-to-one name="Person" cascade="save-update" constrained="true" property-ref="Address" />
+  </class>
+
+  <class name="PersonO2O">
+    <id name="Id" generator="guid.comb" />
+    <many-to-one name="Address" column="AddressId" />
+  </class>
+
+  <class name="AddressJI">
+    <id name="Id" generator="guid.comb" />
+  </class>
+
+  <class name="PersonJI" discriminator-value="1">
+    <id name="Id" generator="guid.comb" />
+    <set name="Addresses" cascade="all-delete-orphan" batch-size="100">
+      <key column="PersonId" not-null="true" update="false" />
+      <one-to-many class="AddressJI" />
+    </set>
+
+    <joined-subclass name="SpecialPersonJI" table="SpecialPersonJI">
+      <key column="PersonId"/>
+      <property name="Special" length="50" />
+    </joined-subclass>
+  </class>
+
+  <class name="AddressJim">
+    <id name="Id" generator="guid.comb" />
+  </class>
+
+  <class name="OfficeJim">
+    <id name="Id" generator="guid.comb" />
+  </class>
+
+  <class name="PersonJim" discriminator-value="1">
+    <id name="Id" generator="guid.comb" />
+
+    <joined-subclass name="SpecialPersonJim" table="SpecialPersonJim">
+      <key column="PersonId"/>
+      <property name="Special" length="50" />
+      <set name="Addresses" cascade="all-delete-orphan" batch-size="100">
+        <key column="PersonId" not-null="true" update="false" />
+        <one-to-many class="AddressJim" />
+      </set>
+
+      <joined-subclass name="PresidentJim" table="PresidentJim">
+        <key column="PersonId"/>
+        <property name="Salary" />
+      </joined-subclass>
+    </joined-subclass>
+
+    <joined-subclass name="AnotherPersonJim" table="AnotherPersonJim">
+      <key column="PersonId"/>
+      <property name="Working" />
+      <many-to-one name="Office" />
+    </joined-subclass>
+  </class>
+
+  <class name="AddressSti">
+    <id name="Id" generator="guid.comb" />
+  </class>
+
+  <class name="PersonSti" discriminator-value="1">
+    <id name="Id" generator="guid.comb" />
+    <discriminator column="PersonType" type="int" />
+    <set name="Addresses" cascade="all-delete-orphan" batch-size="100">
+      <key column="PersonId" not-null="true" update="false" />
+      <one-to-many class="AddressSti" />
+    </set>
+
+    <subclass name="SpecialPersonSti" discriminator-value="2">
+      <property name="Special" length="50" />
+    </subclass>
+  </class>
+
+  <class name="AddressTpc">
+    <id name="Id" generator="guid.comb" />
+  </class>
+
+  <class name="PersonTpc" discriminator-value="1">
+    <id name="Id" generator="guid.comb" />
+    <set name="Addresses" cascade="all-delete-orphan" batch-size="100">
+      <key column="PersonId" not-null="true" update="false" />
+      <one-to-many class="AddressTpc" />
+    </set>
+
+    <union-subclass name="SpecialPersonTpc" table="SpecialPersonTpc">
+      <property name="Special" length="50" />
+    </union-subclass>
+  </class>
+
+  <class name="AddressUO2O">
+    <id name="Id" generator="guid.comb" />
+    <many-to-one name="Person" cascade="save-update" not-null="true" unique="true" />
+  </class>
+
+  <class name="PersonUO2O">
+    <id name="Id" generator="guid.comb" />
+  </class>
+
+  <class name="Task">
+    <id name="Id" generator="guid.comb" />
+    <set name="Categories" table="Categories">
+      <key column="TaskId" />
+      <element column="Category" type="NHibernate.Test.Insertordering.Category, NHibernate.Test" />
+    </set>
+  </class>
 </hibernate-mapping>

--- a/src/NHibernate.Test/Insertordering/Mapping.hbm.xml
+++ b/src/NHibernate.Test/Insertordering/Mapping.hbm.xml
@@ -73,6 +73,21 @@
     <many-to-one name="Address" column="AddressId" />
   </class>
 
+  <class name="AddressTrueO2O">
+    <id name="Id" type="guid">
+      <generator class="foreign">
+        <param name="property">Person</param>
+      </generator>
+    </id>
+
+    <one-to-one name="Person" cascade="save-update" constrained="true" />
+  </class>
+
+  <class name="PersonTrueO2O">
+    <id name="Id" generator="guid.comb" />
+    <one-to-one name="Address" />
+  </class>
+
   <class name="AddressJI">
     <id name="Id" generator="guid.comb" />
   </class>

--- a/src/NHibernate.Test/Insertordering/NH3931Entities.cs
+++ b/src/NHibernate.Test/Insertordering/NH3931Entities.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.Insertordering
+{
+	public class AddressM2M
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual ISet<PersonM2M> Persons { get; set; } = new HashSet<PersonM2M>();
+
+		public virtual void AddPerson(PersonM2M person)
+		{
+			Persons.Add(person);
+			person.Addresses.Add(this);
+		}
+	}
+
+	public class PersonM2M
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual ISet<AddressM2M> Addresses { get; set; } = new HashSet<AddressM2M>();
+	}
+
+	public class AddressM2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual ISet<PersonM2O> Persons { get; set; } = new HashSet<PersonM2O>();
+
+		public virtual void AddPerson(PersonM2O person)
+		{
+			Persons.Add(person);
+			person.Address = this;
+		}
+	}
+
+	public class PersonM2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual AddressM2O Address { get; set; }
+	}
+
+	public class AddressO2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual PersonO2O Person { get; set; }
+
+		public virtual void SetPerson(PersonO2O person)
+		{
+			Person = person;
+			person.Address = this;
+		}
+	}
+
+	public class PersonO2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual AddressO2O Address { get; set; }
+	}
+
+	public class AddressJI
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class PersonJI
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual ISet<AddressJI> Addresses { get; set; } = new HashSet<AddressJI>();
+
+		public virtual void AddAddress(AddressJI address)
+		{
+			Addresses.Add(address);
+		}
+	}
+
+	public class SpecialPersonJI : PersonJI
+	{
+		public virtual string Special { get; set; }
+	}
+
+	public class AddressJim
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class OfficeJim
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class PersonJim
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class SpecialPersonJim : PersonJim
+	{
+		public virtual string Special { get; set; }
+
+		public virtual ISet<AddressJim> Addresses { get; set; } = new HashSet<AddressJim>();
+
+		public virtual void AddAddress(AddressJim address)
+		{
+			Addresses.Add(address);
+		}
+	}
+
+	public class AnotherPersonJim : PersonJim
+	{
+		public virtual bool Working { get; set; }
+		public virtual OfficeJim Office { get; set; }
+	}
+
+	public class PresidentJim : SpecialPersonJim
+	{
+		public virtual decimal Salary { get; set; }
+	}
+
+	public class AddressSti
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class PersonSti
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual ISet<AddressSti> Addresses { get; set; } = new HashSet<AddressSti>();
+
+		public virtual void AddAddress(AddressSti address)
+		{
+			Addresses.Add(address);
+		}
+	}
+
+	public class SpecialPersonSti : PersonSti
+	{
+		public virtual string Special { get; set; }
+	}
+
+	public class AddressTpc
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class PersonTpc
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual ISet<AddressTpc> Addresses { get; set; } = new HashSet<AddressTpc>();
+
+		public virtual void AddAddress(AddressTpc address)
+		{
+			Addresses.Add(address);
+		}
+	}
+
+	public class AddressUO2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual PersonUO2O Person { get; set; }
+
+		public virtual void SetPerson(PersonUO2O person)
+		{
+			Person = person;
+		}
+	}
+
+	public class PersonUO2O
+	{
+		public virtual Guid Id { get; set; }
+	}
+
+	public class SpecialPersonTpc : PersonTpc
+	{
+		public virtual string Special { get; set; }
+	}
+
+	public class Task
+	{
+		public virtual Guid Id { get; set; }
+		public virtual ISet<Category> Categories { get; set; } = new HashSet<Category>();
+	}
+
+	public enum Category
+	{
+		A,
+		B
+	}
+}

--- a/src/NHibernate.Test/Insertordering/NH3931Entities.cs
+++ b/src/NHibernate.Test/Insertordering/NH3931Entities.cs
@@ -63,6 +63,26 @@ namespace NHibernate.Test.Insertordering
 		public virtual AddressO2O Address { get; set; }
 	}
 
+	public class AddressTrueO2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual PersonTrueO2O Person { get; set; }
+
+		public virtual void SetPerson(PersonTrueO2O person)
+		{
+			Person = person;
+			person.Address = this;
+		}
+	}
+
+	public class PersonTrueO2O
+	{
+		public virtual Guid Id { get; set; }
+
+		public virtual AddressTrueO2O Address { get; set; }
+	}
+
 	public class AddressJI
 	{
 		public virtual Guid Id { get; set; }

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -736,6 +736,7 @@
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Fixture.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\FooExample.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
+    <Compile Include="Insertordering\NH3931Entities.cs" />
     <Compile Include="NHSpecificTest\NH3247\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3247\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3386\Entity.cs" />

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -513,9 +513,22 @@
     <Compile Include="Immutable\Info.cs" />
     <Compile Include="Immutable\Party.cs" />
     <Compile Include="Immutable\Plan.cs" />
+    <Compile Include="Insertordering\FamilyModel\Fixture.cs" />
+    <Compile Include="Insertordering\FamilyModel\Person.cs" />
     <Compile Include="Insertordering\Group.cs" />
     <Compile Include="Insertordering\InsertOrderingFixture.cs" />
     <Compile Include="Insertordering\Membership.cs" />
+    <Compile Include="Insertordering\AnimalModel\Animal.cs" />
+    <Compile Include="Insertordering\AnimalModel\Cat.cs" />
+    <Compile Include="Insertordering\AnimalModel\Dog.cs" />
+    <Compile Include="Insertordering\AnimalModel\Fixture.cs" />
+    <Compile Include="Insertordering\AnimalModel\Person.cs" />
+    <Compile Include="Insertordering\AnimalModel\PersonWithAllTypes.cs" />
+    <Compile Include="Insertordering\AnimalModel\PersonWithAnimals.cs" />
+    <Compile Include="Insertordering\AnimalModel\PersonWithCats.cs" />
+    <Compile Include="Insertordering\AnimalModel\PersonWithDogs.cs" />
+    <Compile Include="Insertordering\AnimalModel\PersonWithSivasKangals.cs" />
+    <Compile Include="Insertordering\AnimalModel\SivasKangal.cs" />
     <Compile Include="Insertordering\User.cs" />
     <Compile Include="KnownBugAttribute.cs" />
     <Compile Include="Join\JoinedFilters.cs" />
@@ -3224,6 +3237,8 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Insertordering\FamilyModel\Mappings.hbm.xml" />
+    <EmbeddedResource Include="Insertordering\AnimalModel\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3247\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3386\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3961\Mappings.hbm.xml" />

--- a/src/NHibernate/Engine/ActionQueue.cs
+++ b/src/NHibernate/Engine/ActionQueue.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 using NHibernate.Action;
 using NHibernate.Cache;
+using NHibernate.Type;
 
 namespace NHibernate.Engine
 {
@@ -505,13 +506,20 @@ namespace NHibernate.Engine
 		{
 			private readonly ActionQueue _actionQueue;
 
-			// the mapping of entity names to their latest batch numbers.
+			// The map of entity names to their latest batch.
 			private readonly Dictionary<string, int> _latestBatches = new Dictionary<string, int>();
+			// The map of entities to their batch.
 			private readonly Dictionary<object, int> _entityBatchNumber;
+			// The map of entities to the latest batch (of another entities) they depend on.
+			private readonly Dictionary<object, int> _entityBatchDependency = new Dictionary<object, int>();
 
 			// the map of batch numbers to EntityInsertAction lists
 			private readonly Dictionary<int, List<EntityInsertAction>> _actionBatches = new Dictionary<int, List<EntityInsertAction>>();
 
+			/// <summary>
+			/// A sorter aiming to group inserts as much as possible for optimizing batching.
+			/// </summary>
+			/// <param name="actionQueue">The list of inserts to optimize, already sorted in order to avoid constraint violations.</param>
 			public InsertActionSorter(ActionQueue actionQueue)
 			{
 				_actionQueue = actionQueue;
@@ -520,12 +528,16 @@ namespace NHibernate.Engine
 				_entityBatchNumber = new Dictionary<object, int>(actionQueue.insertions.Count + 1);
 			}
 
+			// This sorting does not actually optimize some features like mapped inheritance or joined-table,
+			// which causes additional inserts per action, causing the batcher to flush on each. Moreover,
+			// inheritance may causes children entities batches to get split per concrete parent classes.
+			// (See InsertOrderingFixture.WithJoinedTableInheritance by example.)
+			// Trying to merge those children batches cases would probably require to much computing.
 			public void Sort()
 			{
-				// the list of entity names that indicate the batch number
+				// build the map of entity names that indicate the batch number
 				foreach (EntityInsertAction action in _actionQueue.insertions)
 				{
-					// remove the current element from insertions. It will be added back later.
 					var entityName = action.EntityName;
 
 					// the entity associated with the current action.
@@ -534,7 +546,9 @@ namespace NHibernate.Engine
 					var batchNumber = GetBatchNumber(action, entityName);
 					_entityBatchNumber[currentEntity] = batchNumber;
 					AddToBatch(batchNumber, action);
+					UpdateChildrenDependencies(batchNumber, action);
 				}
+
 				_actionQueue.insertions.Clear();
 
 				// now rebuild the insertions list. There is a batch for each entry in the name list.
@@ -555,7 +569,7 @@ namespace NHibernate.Engine
 				{
 					// There is already an existing batch for this type of entity.
 					// Check to see if the latest batch is acceptable.
-					if (IsProcessedAfterAllAssociatedEntities(action, batchNumber))
+					if (!RequireNewBatch(action, batchNumber))
 						return batchNumber;
 				}
 				
@@ -565,36 +579,47 @@ namespace NHibernate.Engine
 				// so specify that this entity is with the latest batch.
 				// doing the batch number before adding the name to the list is
 				// a faster way to get an accurate number.
-
 				batchNumber = _actionBatches.Count;
 				_latestBatches[entityName] = batchNumber;
 				return batchNumber;
 			}
 
-			private bool IsProcessedAfterAllAssociatedEntities(EntityInsertAction action, int latestBatchNumberForType)
+			private bool RequireNewBatch(EntityInsertAction action, int latestBatchNumberForType)
 			{
+				// This method assumes the original action list is already sorted in order to respect dependencies.
 				var propertyValues = action.State;
-				var propertyTypes = action.Persister.ClassMetadata.PropertyTypes;
+				var propertyTypes = action.Persister.EntityMetamodel?.PropertyTypes;
+				if (propertyTypes == null)
+				{
+					log.InfoFormat(
+						"Entity {0} persister does not provide meta-data, giving up batching grouping optimization for this entity.",
+						action.EntityName);
+					// Cancel grouping optimization for this entity.
+					return true;
+				}
+
+				int latestDependency;
+				if (_entityBatchDependency.TryGetValue(action.Instance, out latestDependency) && latestDependency > latestBatchNumberForType)
+					return true;
 
 				for (var i = 0; i < propertyValues.Length; i++)
 				{
 					var value = propertyValues[i];
 					var type = propertyTypes[i];
 
-					if (type.IsEntityType &&
-						value != null)
+					if (type.IsEntityType && value != null)
 					{
 						// find the batch number associated with the current association, if any.
 						int associationBatchNumber;
 						if (_entityBatchNumber.TryGetValue(value, out associationBatchNumber) &&
 							associationBatchNumber > latestBatchNumberForType)
 						{
-							return false;
+							return true;
 						}
 					}
 				}
 
-				return true;
+				return false;
 			}
 
 			private void AddToBatch(int batchNumber, EntityInsertAction action)
@@ -608,6 +633,50 @@ namespace NHibernate.Engine
 				}
 
 				actions.Add(action);
+			}
+
+			private void UpdateChildrenDependencies(int batchNumber, EntityInsertAction action)
+			{
+				var propertyValues = action.State;
+				var propertyTypes = action.Persister.EntityMetamodel?.PropertyTypes;
+				if (propertyTypes == null)
+				{
+					log.WarnFormat(
+						"Entity {0} persister does not provide meta-data: if there is dependent entities providing " +
+						"meta-data, they may get batched before this one and cause a failure.",
+						action.EntityName);
+					return;
+				}
+
+				var sessionFactory = action.Session.Factory;
+				for (var i = 0; i < propertyValues.Length; i++)
+				{
+					var type = propertyTypes[i];
+
+					if (!type.IsCollectionType)
+						continue;
+
+					var collectionType = (CollectionType)type;
+					var collectionPersister = sessionFactory.GetCollectionPersister(collectionType.Role);
+					if (collectionPersister.IsManyToMany || !collectionPersister.ElementType.IsEntityType)
+						continue;
+
+					var children = propertyValues[i] as IEnumerable;
+					if (children == null)
+						continue;
+					
+					foreach(var child in children)
+					{
+						if (child == null)
+							continue;
+
+						int latestDependency;
+						if (_entityBatchDependency.TryGetValue(child, out latestDependency) && latestDependency > batchNumber)
+							continue;
+
+						_entityBatchDependency[child] = batchNumber;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Test cases and fix for [NH-3931](https://nhibernate.jira.com/browse/NH-3931).

Test cases ported from HHH-9864, HHH-11216 and HHH-11585, relaxed in terms of batching expectations, and completed with some missing cases.

Fix not ported but elaborated from current NHibernate implementation.

This PR will hopefully replace the [previous one](https://github.com/nhibernate/nhibernate-core/pull/577), which was attempting a new sorting algorithm. This new algorithm was better at batching some cases, but was failing on many previously supported cases. And it was having an O(n^3) complexity over batched entities classes count, where current algorithm, even fixed, has an O(n) complexity over batched entities count.