### PR TITLE
NH-3850 - Polymorphic Linq query results aggregators failures

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/SumTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/SumTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq.ByMethod
@@ -14,7 +15,10 @@ namespace NHibernate.Test.Linq.ByMethod
 				{
 					db.OrderLines.Where(ol => false).Sum(ol => ol.Discount);
 				},
-				Throws.InstanceOf<HibernateException>());
+				// Before NH-3850
+				Throws.InstanceOf<HibernateException>()
+				// After NH-3850
+				.Or.InstanceOf<InvalidOperationException>());
 		}
 
 		[Test]

--- a/src/NHibernate.Test/NHSpecificTest/Dates/FixtureBase.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Dates/FixtureBase.cs
@@ -32,10 +32,6 @@ namespace NHibernate.Test.NHSpecificTest.Dates
 			{
 				return false;
 			}
-			catch (Exception)
-			{
-				Assert.Fail("Probably a bug in the test case.");
-			}
 
 			return true;
 		}

--- a/src/NHibernate.Test/NHSpecificTest/NH3850/Domain.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3850/Domain.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3850
+{
+	public abstract class DomainClassBase
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual int? Integer { get; set; }
+		public virtual long? Long { get; set; }
+		public virtual decimal? Decimal { get; set; }
+		public virtual double? Double { get; set; }
+		public virtual DateTime? DateTime { get; set; }
+		public virtual DateTimeOffset? DateTimeOffset { get; set; }
+		public virtual decimal NonNullableDecimal { get; set; }
+	}
+
+	public class DomainClassAExtendingB : DomainClassBExtendedByA
+	{
+	}
+
+	public class DomainClassBExtendedByA : DomainClassBase
+	{
+	}
+
+	public class DomainClassCExtendedByD : DomainClassBase
+	{
+	}
+
+	public class DomainClassDExtendingC : DomainClassCExtendedByD
+	{
+	}
+
+	public class DomainClassE : DomainClassBase
+	{
+	}
+
+	public class DomainClassF : DomainClassBase
+	{
+	}
+
+	public class DomainClassGExtendedByH : DomainClassBase
+	{
+	}
+
+	public class DomainClassHExtendingG : DomainClassGExtendedByH
+	{
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3850/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3850/Fixture.cs
@@ -1,0 +1,1255 @@
+﻿using System;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using NHibernate.Dialect;
+using NHibernate.Driver;
+using NHibernate.Linq;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH3850
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		private const string _searchName1 = "name";
+		private const string _searchName2 = "name2";
+		private const int _totalEntityCount = 10;
+		private readonly DateTime _testDate = DateTime.Now;
+		private readonly DateTimeOffset _testDateWithOffset = DateTimeOffset.Now;
+		
+		protected override bool AppliesTo(Dialect.Dialect dialect)
+		{
+			var typeNames = (TypeNames)typeof(Dialect.Dialect).GetField("_typeNames", ReflectHelper.AnyVisibilityInstance).GetValue(Dialect);
+			try
+			{
+				typeNames.Get(DbType.DateTimeOffset);
+			}
+			catch (ArgumentException)
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		protected override bool AppliesTo(Engine.ISessionFactoryImplementor factory)
+		{
+			// Cannot handle DbType.DateTimeOffset via ODBC.
+			return !(factory.ConnectionProvider.Driver is OdbcDriver);
+		}
+
+		protected override void OnSetUp()
+		{
+			base.OnSetUp();
+			using (var session = OpenSession())
+			{
+				var dateTime1 = _testDate.AddDays(-1);
+				var dateTime2 = _testDate.AddDays(1);
+				var dateTimeOffset1 = _testDateWithOffset.AddDays(-1);
+				var dateTimeOffset2 = _testDateWithOffset.AddDays(1);
+				Action<DomainClassBase> init1 = dc =>
+				{
+					dc.Id = 1;
+					dc.Name = _searchName1;
+					dc.Integer = 1;
+					dc.Long = 1;
+					dc.Decimal = 1;
+					dc.Double = 1;
+					dc.DateTime = dateTime1;
+					dc.DateTimeOffset = dateTimeOffset1;
+					dc.NonNullableDecimal = 1;
+				};
+				Action<DomainClassBase> init2 = dc =>
+				{
+					dc.Id = 2;
+					dc.Name = _searchName2;
+					dc.Integer = 2;
+					dc.Long = 2;
+					dc.Decimal = 2;
+					dc.Double = 2;
+					dc.DateTime = dateTime2;
+					dc.DateTimeOffset = dateTimeOffset2;
+					dc.NonNullableDecimal = 2;
+				};
+
+				DomainClassBase entity = new DomainClassBExtendedByA();
+				init1(entity);
+				session.Save(entity);
+				entity = new DomainClassBExtendedByA();
+				init2(entity);
+				session.Save(entity);
+
+				entity = new DomainClassCExtendedByD();
+				init1(entity);
+				session.Save(entity);
+				entity = new DomainClassCExtendedByD();
+				init2(entity);
+				session.Save(entity);
+
+				entity = new DomainClassE();
+				init1(entity);
+				session.Save(entity);
+				entity = new DomainClassE();
+				init2(entity);
+				session.Save(entity);
+
+				entity = new DomainClassGExtendedByH();
+				init1(entity);
+				session.Save(entity);
+				entity = new DomainClassGExtendedByH();
+				init2(entity);
+				session.Save(entity);
+				entity = new DomainClassHExtendingG
+				{
+					Id = 3,
+					Name = _searchName1,
+					Integer = 3,
+					Long = 3,
+					Decimal = 3,
+					Double = 3,
+					DateTime = dateTime1,
+					DateTimeOffset = dateTimeOffset1,
+					NonNullableDecimal = 3
+				};
+				session.Save(entity);
+				entity = new DomainClassHExtendingG
+				{
+					Id = 4,
+					Name = _searchName2,
+					Integer = 4,
+					Long = 4,
+					Decimal = 4,
+					Double = 4,
+					DateTime = dateTime2,
+					DateTimeOffset = dateTimeOffset2,
+					NonNullableDecimal = 4
+				};
+				session.Save(entity);
+
+				session.Flush();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			base.OnTearDown();
+			using (var session = OpenSession())
+			{
+				var hql = "from System.Object";
+				session.Delete(hql);
+				session.Flush();
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AggregateGBase()
+		{
+			using (var session = OpenSession())
+			{
+				// This case should work because the aggregate is insensitive to ordering.
+				var result = session.Query<DomainClassGExtendedByH>()
+					.OrderBy(dc => dc.Id)
+					.Select(dc => dc.Id)
+					.Aggregate((p, n) => p + n);
+				Assert.AreEqual(10, result);
+			}
+		}
+
+		// Failing case due to lack of polymorphic results ordering.
+		[Test, Ignore("Polymorphic results sets are unioned without reordering, whatever the API")]
+		public void AggregateGBaseOrderingMismatch()
+		{
+			using (var session = OpenSession())
+			{
+				// This case cannot work because the aggregate is sensitive to ordering, and NHibernate currently always order polymorphic queries by class names,
+				// then only honors query ordering as secondary order criteria.
+				var result = session.Query<DomainClassGExtendedByH>()
+					.OrderByDescending(dc => dc.Id)
+					.Select(dc => dc.Id.ToString())
+					.Aggregate((p, n) => p + "," + n);
+				// Currently yields "2,1,4,3" instead.
+				Assert.AreEqual("4,3,2,1", result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AggregateMutableSeedGBase()
+		{
+			using (var session = OpenSession())
+			{
+				// This case works because the ordering accidentally matches with classes ordering.
+				// (And moreover, with current dataset, selected values are same whatever the classes.)
+				var result = session.Query<DomainClassGExtendedByH>()
+					.OrderBy(dc => dc.Id)
+					.Aggregate(new StringBuilder(), (s, dc) => s.Append(dc.Name).Append(","));
+				Assert.AreEqual(_searchName1 + "," + _searchName2 + "," + _searchName1 + "," + _searchName2 + ",", result.ToString());
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AggregateSeedGBase()
+		{
+			using (var session = OpenSession())
+			{
+				// This case should work because the aggregate is insensitive to ordering.
+				var result = session.Query<DomainClassGExtendedByH>()
+					.OrderBy(dc => dc.Id)
+					.Aggregate(5, (s, dc) => s + dc.Id);
+				Assert.AreEqual(15, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AllBBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().All(dc => dc.Name == _searchName1);
+				Assert.IsFalse(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AllCBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().All(dc => dc.Name == _searchName1);
+				Assert.IsFalse(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AllEWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().All(dc => dc.Name == _searchName1);
+				Assert.IsFalse(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AllFWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().All(dc => dc.Name == _searchName1);
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AllGBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().All(dc => dc.Name == _searchName1);
+				Assert.IsFalse(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AllGBaseWithNameFilteredByName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>()
+					.Where(dc => dc.Name == _searchName1)
+					.All(dc => dc.Name == _searchName1);
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AnyBBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().Any();
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AnyBBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().Any(dc => dc.Name == _searchName1);
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyCBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().Any();
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyCBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().Any(dc => dc.Name == _searchName1);
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyE()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().Any();
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyEWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().Any(dc => dc.Name == _searchName1);
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyF()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().Any();
+				Assert.IsFalse(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyFWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().Any(dc => dc.Name == _searchName1);
+				Assert.IsFalse(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyGBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().Any();
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void AnyGBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().Any(dc => dc.Name == _searchName1);
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AnyObject()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<object>().Any();
+				Assert.IsTrue(result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AverageBBase()
+		{
+			Average<DomainClassBExtendedByA>(1.5m);
+		}
+
+		// Non-reg case
+		[Test]
+		public void AverageCBase()
+		{
+			Average<DomainClassCExtendedByD>(1.5m);
+		}
+
+		// Non-reg case
+		[Test]
+		public void AverageE()
+		{
+			Average<DomainClassE>(1.5m);
+		}
+
+		// Non-reg case
+		[Test]
+		public void AverageF()
+		{
+			Average<DomainClassF>(null);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AverageGBase()
+		{
+			Average<DomainClassGExtendedByH>(2.5m);
+		}
+
+		private void Average<DC>(decimal? expectedResult) where DC : DomainClassBase
+		{
+			using (var session = OpenSession())
+			{
+				var dcQuery = session.Query<DC>();
+				var integ = dcQuery.Average(dc => dc.Integer);
+				Assert.AreEqual(expectedResult, integ, "Integer average has failed");
+				var longInt = dcQuery.Average(dc => dc.Long);
+				Assert.AreEqual(expectedResult, longInt, "Long integer average has failed");
+				var dec = dcQuery.Average(dc => dc.Decimal);
+				Assert.AreEqual(expectedResult, dec, "Decimal average has failed");
+				var dbl = dcQuery.Average(dc => dc.Double);
+				Assert.AreEqual(expectedResult, dbl, "Double average has failed");
+
+				if (expectedResult.HasValue)
+				{
+					var nonNullableDecimal = -1m;
+					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Average(dc => dc.NonNullableDecimal); }, "Non nullable decimal average has failed");
+					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal average has failed");
+				}
+				else
+				{
+					Assert.That(() => { dcQuery.Average(dc => dc.NonNullableDecimal); },
+						Throws.InnerException.InstanceOf<ArgumentNullException>(),
+						"Non nullable decimal average has failed");
+				}
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void AverageObject()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<object>().Average(o => (int?)2);
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void CountBBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().Count();
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void CountBBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().Count(dc => dc.Name == _searchName1);
+				Assert.AreEqual(1, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void CountCBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().Count();
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void CountCBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().Count(dc => dc.Name == _searchName1);
+				Assert.AreEqual(1, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void CountE()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().Count();
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void CountEWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().Count(dc => dc.Name == _searchName1);
+				Assert.AreEqual(1, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void CountF()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().Count();
+				Assert.AreEqual(0, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void CountFWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().Count(dc => dc.Name == _searchName1);
+				Assert.AreEqual(0, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void CountGBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().Count();
+				Assert.AreEqual(4, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void CountGBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().Count(dc => dc.Name == _searchName1);
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void CountObject()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<object>().Count();
+				Assert.AreEqual(_totalEntityCount, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultBBase()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassBExtendedByA>();
+				DomainClassBExtendedByA result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
+				Assert.IsNotNull(result);
+				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultBBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassBExtendedByA>();
+				DomainClassBExtendedByA result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultCBase()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassCExtendedByD>();
+				DomainClassCExtendedByD result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
+				Assert.IsNotNull(result);
+				Assert.IsInstanceOf<DomainClassCExtendedByD>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultCBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassCExtendedByD>();
+				DomainClassCExtendedByD result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				Assert.IsInstanceOf<DomainClassCExtendedByD>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultE()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassE>();
+				DomainClassE result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
+				Assert.IsNotNull(result);
+				Assert.IsInstanceOf<DomainClassE>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultEWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassE>();
+				DomainClassE result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				Assert.IsInstanceOf<DomainClassE>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultF()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassF>();
+				DomainClassF result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
+				Assert.IsNull(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultFWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassF>();
+				DomainClassF result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNull(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultGBase()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassGExtendedByH>();
+				DomainClassGExtendedByH result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
+				Assert.IsNotNull(result);
+				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
+				Assert.IsInstanceOf<DomainClassGExtendedByH>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultGBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassGExtendedByH>();
+				DomainClassGExtendedByH result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
+				Assert.IsInstanceOf<DomainClassGExtendedByH>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void FirstOrDefaultObject()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<object>();
+				object result = null;
+				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
+				Assert.IsNotNull(result);
+				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
+				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void LongCountBBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().LongCount();
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void LongCountBBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassBExtendedByA>().LongCount(dc => dc.Name == _searchName1);
+				Assert.AreEqual(1, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void LongCountCBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().LongCount();
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void LongCountCBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassCExtendedByD>().LongCount(dc => dc.Name == _searchName1);
+				Assert.AreEqual(1, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void LongCountE()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().LongCount();
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void LongCountEWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassE>().LongCount(dc => dc.Name == _searchName1);
+				Assert.AreEqual(1, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void LongCountF()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().LongCount();
+				Assert.AreEqual(0, result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void LongCountFWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassF>().LongCount(dc => dc.Name == _searchName1);
+				Assert.AreEqual(0, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void LongCountGBase()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().LongCount();
+				Assert.AreEqual(4, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void LongCountGBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<DomainClassGExtendedByH>().LongCount(dc => dc.Name == _searchName1);
+				Assert.AreEqual(2, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void LongCountObject()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<object>().LongCount();
+				Assert.AreEqual(_totalEntityCount, result);
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void MaxBBase()
+		{
+			Max<DomainClassBExtendedByA>(2);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void MaxCBase()
+		{
+			Max<DomainClassCExtendedByD>(2);
+		}
+
+		// Non-reg case
+		[Test]
+		public void MaxE()
+		{
+			Max<DomainClassE>(2);
+		}
+
+		// Non-reg case
+		[Test]
+		public void MaxF()
+		{
+			Max<DomainClassF>(null);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void MaxGBase()
+		{
+			Max<DomainClassGExtendedByH>(4);
+		}
+
+		private void Max<DC>(int? expectedResult) where DC : DomainClassBase
+		{
+			using (var session = OpenSession())
+			{
+				var dcQuery = session.Query<DC>();
+				var name = dcQuery.Max(dc => dc.Name);
+				Assert.AreEqual(expectedResult.HasValue ? _searchName2 : null, name, "String max has failed");
+				var integ = dcQuery.Max(dc => dc.Integer);
+				Assert.AreEqual(expectedResult, integ, "Integer max has failed");
+				var longInt = dcQuery.Max(dc => dc.Long);
+				Assert.AreEqual(expectedResult, longInt, "Long integer max has failed");
+				var dec = dcQuery.Max(dc => dc.Decimal);
+				Assert.AreEqual(expectedResult, dec, "Decimal max has failed");
+				var dbl = dcQuery.Max(dc => dc.Double);
+				Assert.AreEqual(expectedResult.HasValue, dbl.HasValue, "Double max has failed");
+				if (expectedResult.HasValue)
+					Assert.AreEqual(expectedResult.Value, dbl.Value, 0.001d, "Double max has failed");
+
+				var date = dcQuery.Max(dc => dc.DateTime);
+				var dateWithOffset = dcQuery.Max(dc => dc.DateTimeOffset);
+				if (expectedResult.HasValue)
+				{
+					Assert.Greater(date, _testDate, "DateTime max has failed");
+					Assert.Greater(dateWithOffset, _testDateWithOffset, "DateTimeOffset max has failed");
+				}
+				else
+				{
+					Assert.Null(date, "DateTime max has failed");
+					Assert.Null(dateWithOffset, "DateTimeOffset max has failed");
+				}
+
+				if (expectedResult.HasValue)
+				{
+					var nonNullableDecimal = -1m;
+					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Max(dc => dc.NonNullableDecimal); }, "Non nullable decimal max has failed");
+					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal max has failed");
+				}
+				else
+				{
+					Assert.That(() => { dcQuery.Max(dc => dc.NonNullableDecimal); },
+						Throws.InnerException.InstanceOf<ArgumentNullException>(),
+						"Non nullable decimal max has failed");
+				}
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void MinBBase()
+		{
+			Min<DomainClassBExtendedByA>(1);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void MinCBase()
+		{
+			Min<DomainClassCExtendedByD>(1);
+		}
+
+		// Non-reg case
+		[Test]
+		public void MinE()
+		{
+			Min<DomainClassE>(1);
+		}
+
+		// Non-reg case
+		[Test]
+		public void MinF()
+		{
+			Min<DomainClassF>(null);
+		}
+
+		// Non-reg case
+		[Test]
+		public void MinGBase()
+		{
+			Min<DomainClassGExtendedByH>(1);
+		}
+
+		private void Min<DC>(int? expectedResult) where DC : DomainClassBase
+		{
+			using (var session = OpenSession())
+			{
+				var dcQuery = session.Query<DC>();
+				var name = dcQuery.Min(dc => dc.Name);
+				Assert.AreEqual(expectedResult.HasValue ? _searchName1 : null, name, "String min has failed");
+				var integ = dcQuery.Min(dc => dc.Integer);
+				Assert.AreEqual(expectedResult, integ, "Integer min has failed");
+				var longInt = dcQuery.Min(dc => dc.Long);
+				Assert.AreEqual(expectedResult, longInt, "Long integer min has failed");
+				var dec = dcQuery.Min(dc => dc.Decimal);
+				Assert.AreEqual(expectedResult, dec, "Decimal min has failed");
+				var dbl = dcQuery.Min(dc => dc.Double);
+				Assert.AreEqual(expectedResult.HasValue, dbl.HasValue, "Double min has failed");
+				if (expectedResult.HasValue)
+					Assert.AreEqual(expectedResult.Value, dbl.Value, 0.001d, "Double min has failed");
+
+				var date = dcQuery.Min(dc => dc.DateTime);
+				var dateWithOffset = dcQuery.Min(dc => dc.DateTimeOffset);
+				if (expectedResult.HasValue)
+				{
+					Assert.Less(date, _testDate, "DateTime min has failed");
+					Assert.Less(dateWithOffset, _testDateWithOffset, "DateTimeOffset min has failed");
+				}
+				else
+				{
+					Assert.Null(date, "DateTime min has failed");
+					Assert.Null(dateWithOffset, "DateTimeOffset min has failed");
+				}
+
+				if (expectedResult.HasValue)
+				{
+					var nonNullableDecimal = -1m;
+					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Min(dc => dc.NonNullableDecimal); }, "Non nullable decimal min has failed");
+					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal min has failed");
+				}
+				else
+				{
+					Assert.That(() => { dcQuery.Min(dc => dc.NonNullableDecimal); },
+						Throws.InnerException.InstanceOf<ArgumentNullException>(),
+						"Non nullable decimal min has failed");
+				}
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultBBase()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassBExtendedByA>();
+				DomainClassBExtendedByA result = null;
+				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultBBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassBExtendedByA>();
+				DomainClassBExtendedByA result = null;
+				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultCBase()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassCExtendedByD>();
+				DomainClassCExtendedByD result = null;
+				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultCBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassCExtendedByD>();
+				DomainClassCExtendedByD result = null;
+				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				Assert.IsInstanceOf<DomainClassCExtendedByD>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultE()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassE>();
+				DomainClassE result = null;
+				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultEWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassE>();
+				DomainClassE result = null;
+				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNotNull(result);
+				Assert.AreEqual(_searchName1, result.Name);
+				Assert.IsInstanceOf<DomainClassE>(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultF()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassF>();
+				DomainClassF result = null;
+				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(); });
+				Assert.IsNull(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultFWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassF>();
+				DomainClassF result = null;
+				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
+				Assert.IsNull(result);
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultGBase()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassGExtendedByH>();
+				DomainClassGExtendedByH result = null;
+				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultGBaseWithName()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<DomainClassGExtendedByH>();
+				DomainClassGExtendedByH result = null;
+				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
+			}
+		}
+
+		// Non-reg case
+		[Test]
+		public void SingleOrDefaultObject()
+		{
+			using (var session = OpenSession())
+			{
+				var query = session.Query<object>();
+				object result = null;
+				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+			}
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void SumBBase()
+		{
+			Sum<DomainClassBExtendedByA>(3);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void SumCBase()
+		{
+			Sum<DomainClassCExtendedByD>(3);
+		}
+
+		// Non-reg case
+		[Test]
+		public void SumE()
+		{
+			Sum<DomainClassE>(3);
+		}
+
+		// Non-reg case
+		[Test]
+		public void SumF()
+		{
+			Sum<DomainClassF>(null);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void SumGBase()
+		{
+			Sum<DomainClassGExtendedByH>(10);
+		}
+
+		// Failing case till NH-3850 is fixed
+		[Test]
+		public void SumObject()
+		{
+			using (var session = OpenSession())
+			{
+				var result = session.Query<object>().Sum(o => (int?)2);
+				Assert.AreEqual(_totalEntityCount * 2, result);
+			}
+		}
+
+		private void Sum<DC>(int? expectedResult) where DC : DomainClassBase
+		{
+			using (var session = OpenSession())
+			{
+				var dcQuery = session.Query<DC>();
+				var integ = dcQuery.Sum(dc => dc.Integer);
+				Assert.AreEqual(expectedResult, integ, "Integer sum has failed");
+				var longInt = dcQuery.Sum(dc => dc.Long);
+				Assert.AreEqual(expectedResult, longInt, "Long integer sum has failed");
+				var dec = dcQuery.Sum(dc => dc.Decimal);
+				Assert.AreEqual(expectedResult, dec, "Decimal sum has failed");
+				var dbl = dcQuery.Sum(dc => dc.Double);
+				Assert.AreEqual(expectedResult.HasValue, dbl.HasValue, "Double sum has failed");
+				if (expectedResult.HasValue)
+					Assert.AreEqual(expectedResult.Value, dbl.Value, 0.001d, "Double sum has failed");
+
+				if (expectedResult.HasValue)
+				{
+					var nonNullableDecimal = -1m;
+					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Sum(dc => dc.NonNullableDecimal); }, "Non nullable decimal sum has failed");
+					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal sum has failed");
+				}
+				else
+				{
+					Assert.That(() => { dcQuery.Sum(dc => dc.NonNullableDecimal); },
+						Throws.InnerException.InstanceOf<ArgumentNullException>(),
+						"Non nullable decimal sum has failed");
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3850/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3850/Mappings.hbm.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.NH3850" default-access="property"
+                   default-lazy="true">
+	<class name="DomainClassAExtendingB">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+	</class>
+	<class name="DomainClassBExtendedByA">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+	</class>
+	<class name="DomainClassCExtendedByD">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+	</class>
+	<class name="DomainClassDExtendingC">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+	</class>
+	<class name="DomainClassE">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+  </class>
+	<class name="DomainClassF">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+  </class>
+	<class name="DomainClassGExtendedByH">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+	</class>
+	<class name="DomainClassHExtendingG">
+		<id name="Id">
+			<generator class="assigned" />
+		</id>
+		<property name="Name" />
+		<property name="Integer" column="`Integer`" />
+		<property name="Long" column="`Long`" />
+		<property name="Decimal" column="`Decimal`" length="19" precision="4" />
+		<property name="Double" column="`Double`" />
+		<property name="DateTime" column="`DateTime`" type="timestamp" />
+		<property name="DateTimeOffset" column="`DateTimeOffset`" />
+    <property name="NonNullableDecimal" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -759,6 +759,8 @@
     <Compile Include="NHSpecificTest\NH3952\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3951\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3951\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH3850\Domain.cs" />
+    <Compile Include="NHSpecificTest\NH3850\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH2204\Model.cs" />
     <Compile Include="NHSpecificTest\NH2204\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3912\BatcherLovingEntity.cs" />
@@ -3242,6 +3244,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH3950\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3952\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3951\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\NH3850\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2204\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3874\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Mappings.hbm.xml" />

--- a/src/NHibernate/Linq/EnumerableHelper.cs
+++ b/src/NHibernate/Linq/EnumerableHelper.cs
@@ -65,7 +65,7 @@ namespace NHibernate.Linq
 			return ReflectHelper.GetProperty(property);
 		}
 	}
-	
+
 	[Obsolete("Please use NHibernate.Util.ReflectHelper instead")]
 	public static class EnumerableHelper
 	{
@@ -73,7 +73,7 @@ namespace NHibernate.Linq
 		{
 			return typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
 				.Where(m => m.Name == name &&
-							ParameterTypesMatch(m.GetParameters(), parameterTypes))
+					ReflectHelper.ParameterTypesMatch(m.GetParameters(), parameterTypes))
 				.Single();
 		}
 
@@ -83,35 +83,9 @@ namespace NHibernate.Linq
 				.Where(m => m.Name == name &&
 							m.ContainsGenericParameters &&
 							m.GetGenericArguments().Count() == genericTypeParameters.Length &&
-							ParameterTypesMatch(m.GetParameters(), parameterTypes))
+							ReflectHelper.ParameterTypesMatch(m.GetParameters(), parameterTypes))
 				.Single()
 				.MakeGenericMethod(genericTypeParameters);
-		}
-
-		private static bool ParameterTypesMatch(ParameterInfo[] parameters, System.Type[] types)
-		{
-			if (parameters.Length != types.Length)
-			{
-				return false;
-			}
-
-			for (int i = 0; i < parameters.Length; i++)
-			{
-				if (parameters[i].ParameterType == types[i])
-				{
-					continue;
-				}
-
-				if (parameters[i].ParameterType.ContainsGenericParameters && types[i].ContainsGenericParameters &&
-					parameters[i].ParameterType.GetGenericArguments().Length == types[i].GetGenericArguments().Length)
-				{
-					continue;
-				}
-
-				return false;
-			}
-
-			return true;
 		}
 	}
 }

--- a/src/NHibernate/Linq/ExpressionToHqlTranslationResults.cs
+++ b/src/NHibernate/Linq/ExpressionToHqlTranslationResults.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Type;
 
@@ -11,16 +8,23 @@ namespace NHibernate.Linq
 {
 	public class ExpressionToHqlTranslationResults
 	{
-		public HqlTreeNode Statement { get; private set; }
-		public ResultTransformer ResultTransformer { get; private set; }
-		public Delegate PostExecuteTransformer { get; private set; }
-		public List<Action<IQuery, IDictionary<string, Tuple<object, IType>>>> AdditionalCriteria { get; private set; }
+		public HqlTreeNode Statement { get;  }
+		public ResultTransformer ResultTransformer { get; }
+		public Delegate PostExecuteTransformer { get; }
+		public List<Action<IQuery, IDictionary<string, Tuple<object, IType>>>> AdditionalCriteria { get; }
+
+		/// <summary>
+		/// If execute result type does not match expected final result type (implying a post execute transformer
+		/// will yield expected result type), the intermediate execute type.
+		/// </summary>
+		public System.Type ExecuteResultTypeOverride { get; }
 
 		public ExpressionToHqlTranslationResults(HqlTreeNode statement, 
 			IList<LambdaExpression> itemTransformers, 
 			IList<LambdaExpression> listTransformers,
 			IList<LambdaExpression> postExecuteTransformers,
-			List<Action<IQuery, IDictionary<string, Tuple<object, IType>>>> additionalCriteria)
+			List<Action<IQuery, IDictionary<string, Tuple<object, IType>>>> additionalCriteria,
+			System.Type executeResultTypeOverride)
 		{
 			Statement = statement;
 
@@ -35,6 +39,7 @@ namespace NHibernate.Linq
 			}
 
 			AdditionalCriteria = additionalCriteria;
+			ExecuteResultTypeOverride = executeResultTypeOverride;
 		}
 
 		private static TDelegate MergeLambdasAndCompile<TDelegate>(IList<LambdaExpression> itemTransformers) 

--- a/src/NHibernate/Linq/Functions/QueryableGenerator.cs
+++ b/src/NHibernate/Linq/Functions/QueryableGenerator.cs
@@ -53,10 +53,10 @@ namespace NHibernate.Linq.Functions
 		public AllHqlGenerator()
 		{
 			SupportedMethods = new[]
-			                   	{
-			                   		ReflectHelper.GetMethodDefinition(() => Queryable.All<object>(null, null)),
-			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null))
-			                   	};
+			{
+				ReflectHelper.GetMethodDefinition(() => Queryable.All<object>(null, null)),
+				ReflectHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null))
+			};
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)

--- a/src/NHibernate/Linq/IntermediateHqlTree.cs
+++ b/src/NHibernate/Linq/IntermediateHqlTree.cs
@@ -50,7 +50,13 @@ namespace NHibernate.Linq
 			}
 		}
 
-		public HqlTreeBuilder TreeBuilder { get; private set; }
+		/// <summary>
+		/// If execute result type does not match expected final result type (implying a post execute transformer
+		/// will yield expected result type), the intermediate execute type.
+		/// </summary>
+		public System.Type ExecuteResultTypeOverride { get; set; }
+
+		public HqlTreeBuilder TreeBuilder { get; }
 
 		public IntermediateHqlTree(bool root)
 		{
@@ -62,10 +68,11 @@ namespace NHibernate.Linq
 		public ExpressionToHqlTranslationResults GetTranslation()
 		{
 			return new ExpressionToHqlTranslationResults(Root,
-														 _itemTransformers,
-														 _listTransformers,
-														 _postExecuteTransformers,
-														 _additionalCriteria);
+				_itemTransformers,
+				_listTransformers,
+				_postExecuteTransformers,
+				_additionalCriteria,
+				ExecuteResultTypeOverride);
 		}
 
 		public void AddDistinctRootOperator()

--- a/src/NHibernate/Linq/Visitors/HqlGeneratorExpressionTreeVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/HqlGeneratorExpressionTreeVisitor.cs
@@ -542,7 +542,7 @@ possible solutions:
 
 		protected HqlTreeNode VisitSubQueryExpression(SubQueryExpression expression)
 		{
-			ExpressionToHqlTranslationResults query = QueryModelVisitor.GenerateHqlQuery(expression.QueryModel, _parameters, false);
+			ExpressionToHqlTranslationResults query = QueryModelVisitor.GenerateHqlQuery(expression.QueryModel, _parameters, false, null);
 			return query.Statement;
 		}
 

--- a/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
@@ -1,15 +1,17 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Clauses;
+using NHibernate.Linq.Expressions;
 using NHibernate.Linq.GroupBy;
 using NHibernate.Linq.GroupJoin;
 using NHibernate.Linq.NestedSelects;
 using NHibernate.Linq.ResultOperators;
 using NHibernate.Linq.ReWriters;
 using NHibernate.Linq.Visitors.ResultOperatorProcessors;
+using NHibernate.Util;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.ResultOperators;
@@ -20,7 +22,8 @@ namespace NHibernate.Linq.Visitors
 {
 	public class QueryModelVisitor : QueryModelVisitorBase
 	{
-		public static ExpressionToHqlTranslationResults GenerateHqlQuery(QueryModel queryModel, VisitorParameters parameters, bool root)
+		public static ExpressionToHqlTranslationResults GenerateHqlQuery(QueryModel queryModel, VisitorParameters parameters, bool root,
+			NhLinqExpressionReturnType? rootReturnType)
 		{
 			NestedSelectRewriter.ReWrite(queryModel, parameters.SessionFactory);
 
@@ -29,7 +32,7 @@ namespace NHibernate.Linq.Visitors
 
 			// Merge aggregating result operators (distinct, count, sum etc) into the select clause
 			MergeAggregatingResultsRewriter.ReWrite(queryModel);
-			
+
 			// Swap out non-aggregating group-bys
 			NonAggregatingGroupByRewriter.ReWrite(queryModel);
 
@@ -79,7 +82,7 @@ namespace NHibernate.Linq.Visitors
 			// Identify and name query sources
 			QuerySourceIdentifier.Visit(parameters.QuerySourceNamer, queryModel);
 
-			var visitor = new QueryModelVisitor(parameters, root, queryModel)
+			var visitor = new QueryModelVisitor(parameters, root, queryModel, rootReturnType)
 			{
 				RewrittenOperatorResult = result,
 			};
@@ -89,16 +92,17 @@ namespace NHibernate.Linq.Visitors
 		}
 
 		private readonly IntermediateHqlTree _hqlTree;
+		private readonly NhLinqExpressionReturnType? _rootReturnType;
 		private static readonly ResultOperatorMap ResultOperatorMap;
 		private bool _serverSide = true;
 
-		public VisitorParameters VisitorParameters { get; private set; }
+		public VisitorParameters VisitorParameters { get; }
 
 		public IStreamedDataInfo CurrentEvaluationType { get; private set; }
 
 		public IStreamedDataInfo PreviousEvaluationType { get; private set; }
 
-		public QueryModel Model { get; private set; }
+		public QueryModel Model { get; }
 
 		public ResultOperatorRewriterResult RewrittenOperatorResult { get; private set; }
 
@@ -128,16 +132,150 @@ namespace NHibernate.Linq.Visitors
 			ResultOperatorMap.Add<CastResultOperator, ProcessCast>();
 		}
 
-		private QueryModelVisitor(VisitorParameters visitorParameters, bool root, QueryModel queryModel)
+		private QueryModelVisitor(VisitorParameters visitorParameters, bool root, QueryModel queryModel,
+			NhLinqExpressionReturnType? rootReturnType)
 		{
 			VisitorParameters = visitorParameters;
 			Model = queryModel;
+			_rootReturnType = root ? rootReturnType : null;
 			_hqlTree = new IntermediateHqlTree(root);
 		}
 
 		private void Visit()
 		{
 			VisitQueryModel(Model);
+			AddAdditionalPostExecuteTransformer();
+		}
+
+		private void AddAdditionalPostExecuteTransformer()
+		{
+			if (_rootReturnType == NhLinqExpressionReturnType.Scalar && Model.ResultTypeOverride != null)
+			{
+				// NH-3850: handle polymorphic scalar results aggregation
+				switch ((NhExpressionType)Model.SelectClause.Selector.NodeType)
+				{
+					case NhExpressionType.Average:
+						// Polymorphic case complex to handle and not implemented. (HQL query must be reshaped for adding
+						// additional data to allow a meaningful overall average computation.)
+						// Leaving it untouched for allowing non polymorphic cases to work.
+						break;
+					case NhExpressionType.Count:
+						AddPostExecuteTransformerForCount();
+						break;
+					case NhExpressionType.Max:
+						AddPostExecuteTransformerForResultAggregate(ReflectionCache.EnumerableMethods.MaxDefinition);
+						break;
+					case NhExpressionType.Min:
+						AddPostExecuteTransformerForResultAggregate(ReflectionCache.EnumerableMethods.MinDefinition);
+						break;
+					case NhExpressionType.Sum:
+						AddPostExecuteTransformerForSum();
+						break;
+				}
+			}
+		}
+
+		private void AddPostExecuteTransformerForCount()
+		{
+			// Count results have to be summed. No null case to take into account.
+			var elementType = Model.ResultTypeOverride;
+			var inputListType = typeof(IEnumerable<>).MakeGenericType(elementType);
+			var inputList = Expression.Parameter(inputListType, "inputList");
+			// Sum has no suitable generic overload, throw in Sum on int, then the code using it
+			// will check and adjust it if it is long instead of int (GetAggregateMethodCall does that).
+			var aggregateCall = GetAggregateMethodCall(ReflectionCache.EnumerableMethods.SumOnInt, inputListType, elementType, inputList);
+			_hqlTree.AddPostExecuteTransformer(Expression.Lambda(aggregateCall, inputList));
+		}
+
+		private void AddPostExecuteTransformerForResultAggregate(MethodInfo aggregateMethodTemplate)
+		{
+			var elementType = Model.ResultTypeOverride;
+
+			LambdaExpression aggregateLambda;
+
+			// string may be aggregated and are not Nullable<> but can be null, and qualifies as reference
+			if (elementType.IsNullableOrReference())
+			{
+				var inputListType = typeof(IEnumerable<>).MakeGenericType(elementType);
+				var inputList = Expression.Parameter(inputListType, "inputList");
+				var aggregateCall = GetAggregateMethodCall(aggregateMethodTemplate, inputListType, elementType, inputList);
+				aggregateLambda = Expression.Lambda(aggregateCall, inputList);
+			}
+			else
+			{
+				// On non nullable, we have to preserve the behavior "nothing to aggregate => exception",
+				// while supporting the polymorphic case "nothing to aggregate for some classes but something to aggregate
+				// for others" => aggregate of others.
+				// For this, overriding result type of concrete queries as nullable, aggregating concrete results,
+				// casting back to non nullable (and failing if null).
+				// This still causes a change: the expected failure case will yield an InvalidOperationException instead of
+				// a GenericADOException with an ArgumentNullException inner exception.
+
+				var nullableElementType = typeof(Nullable<>).MakeGenericType(elementType);
+				var nullableInputListType = typeof(IEnumerable<>).MakeGenericType(nullableElementType);
+				var nullableInputList = Expression.Parameter(nullableInputListType, "nullableInputList");
+				_hqlTree.ExecuteResultTypeOverride = nullableElementType;
+
+				var aggregateCall = GetAggregateMethodCall(aggregateMethodTemplate, nullableInputListType, nullableElementType, nullableInputList);
+
+				var convert = Expression.Convert(aggregateCall, elementType);
+				aggregateLambda = Expression.Lambda(convert, nullableInputList);
+			}
+
+			_hqlTree.AddPostExecuteTransformer(aggregateLambda);
+		}
+
+		private void AddPostExecuteTransformerForSum()
+		{
+			// Sum is a bit hard, due to an additional mismatch between linq-to-objects and sql semantics on sum, when there are nothing to sum.
+			// linq-to-objets => 0, sql => null
+			// We have to emulate the sql behavior when aggregating polymorphic results.
+			var elementType = Model.ResultTypeOverride;
+			var concreteQueryElementType = elementType;
+			var elementTypeIsNullable = elementType.IsNullable();
+			if (!elementTypeIsNullable)
+			{
+				// Same as in AddPostExecuteTransformerForResultAggregate, override the result type of concrete queries to nullable.
+				// But then, let the nullable sql emulation yield null if there is nothing to sum, and finally try casting the result
+				// to non nullable.
+				concreteQueryElementType = typeof(Nullable<>).MakeGenericType(elementType);
+				_hqlTree.ExecuteResultTypeOverride = concreteQueryElementType;
+			}
+
+			var inputListType = typeof(IEnumerable<>).MakeGenericType(concreteQueryElementType);
+			var inputList = Expression.Parameter(inputListType, "inputList");
+			// Sum has no suitable generic overload, throw in Sum on int, then the code using it
+			// will check and adjust it if it is long instead of int (GetAggregateMethodCall does that).
+			var aggregateCall = GetAggregateMethodCall(ReflectionCache.EnumerableMethods.SumOnInt, inputListType, concreteQueryElementType, inputList);
+
+			var allMethod = ReflectionCache.EnumerableMethods.AllDefinition.MakeGenericMethod(concreteQueryElementType);
+			var element = Expression.Parameter(concreteQueryElementType, "element");
+			// The concreteQueryElementType is always nullable, see above if block.
+			var noSumCondition = Expression.Equal(element, Expression.Constant(null, concreteQueryElementType));
+			var allCall = Expression.Call(allMethod, inputList, Expression.Lambda(noSumCondition, element));
+
+			Expression conditionalAggregateCall = Expression.Condition(allCall,
+				Expression.Constant(null, concreteQueryElementType),
+				aggregateCall);
+			if (!elementTypeIsNullable)
+				conditionalAggregateCall = Expression.Convert(conditionalAggregateCall, elementType);
+			_hqlTree.AddPostExecuteTransformer(Expression.Lambda(conditionalAggregateCall, inputList));
+		}
+
+		private MethodCallExpression GetAggregateMethodCall(MethodInfo aggregateMethodTemplate, System.Type inputListType,
+			System.Type elementType, Expression inputList)
+		{
+			MethodInfo aggregateMethod;
+			if (aggregateMethodTemplate.IsGenericMethodDefinition)
+			{
+				aggregateMethod = aggregateMethodTemplate.MakeGenericMethod(elementType);
+			}
+			else
+			{
+				// Ensure we use the right overload.
+				aggregateMethod = ReflectHelper.GetMethodOverload(aggregateMethodTemplate, inputListType);
+			}
+			return Expression.Call(aggregateMethod, inputList);
 		}
 
 		public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregate.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregate.cs
@@ -19,20 +19,22 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 				resultOperator.Func.Parameters[0],
 				paramExpr);
 
-			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(typeof(object)), "inputList");
-
-			var castToItem = ReflectionCache.EnumerableMethods.CastDefinition.MakeGenericMethod(new[] { inputType });
-			var castToItemExpr = Expression.Call(castToItem, inputList);
-
+			// NH-3850: changed from list transformer (working on IEnumerable<object>) to post execute
+			// transformer (working on IEnumerable<inputType>) for globally aggregating polymorphic results
+			// instead of aggregating results for each class separately and yielding only the first.
+			// If the aggregation relies on ordering, final result will still be wrong due to
+			// polymorphic results being union-ed without re-ordering. (This is a limitation of all polymorphic
+			// queries, this is not specific to LINQ provider.)
+			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(inputType), "inputList");
 			var aggregate = ReflectionCache.EnumerableMethods.AggregateDefinition.MakeGenericMethod(inputType);
-
 			MethodCallExpression call = Expression.Call(
 				aggregate,
-				castToItemExpr,
+				inputList,
 				accumulatorFunc
 				);
-
-			tree.AddListTransformer(Expression.Lambda(call, inputList));
+			tree.AddPostExecuteTransformer(Expression.Lambda(call, inputList));
+			// There is no more a list transformer yielding an IList<resultType>, but this aggregate case
+			// have inputType = resultType, so no further action is required.
 		}
 	}
 }

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregateFromSeed.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAggregateFromSeed.cs
@@ -20,10 +20,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 				paramExpr);
 
 			var accumulatorType = resultOperator.Func.Parameters[0].Type;
-			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(typeof(object)), "inputList");
-
-			var castToItem = ReflectionCache.EnumerableMethods.CastDefinition.MakeGenericMethod(new[] { inputType });
-			var castToItemExpr = Expression.Call(castToItem, inputList);
+			var inputList = Expression.Parameter(typeof(IEnumerable<>).MakeGenericType(inputType), "inputList");
 
 			MethodCallExpression call;
 
@@ -34,7 +31,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 				call = Expression.Call(
 					aggregate,
-					castToItemExpr,
+					inputList,
 					resultOperator.Seed,
 					accumulatorFunc
 					);
@@ -47,14 +44,23 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 				call = Expression.Call(
 					aggregate,
-					castToItemExpr,
+					inputList,
 					resultOperator.Seed,
 					accumulatorFunc,
 					resultOperator.OptionalResultSelector
 					);
 			}
 
-			tree.AddListTransformer(Expression.Lambda(call, inputList));
+			// NH-3850: changed from list transformer (working on IEnumerable<object>) to post execute
+			// transformer (working on IEnumerable<inputType>) for globally aggregating polymorphic results
+			// instead of aggregating results for each class separately and yielding only the first.
+			// If the aggregation relies on ordering, final result will still be wrong due to
+			// polymorphic results being union-ed without re-ordering. (This is a limitation of all polymorphic
+			// queries, this is not specific to LINQ provider.)
+			tree.AddPostExecuteTransformer(Expression.Lambda(call, inputList));
+			// There is no more a list transformer yielding an IList<resultType>, have to override the execute
+			// result type.
+			tree.ExecuteResultTypeOverride = inputType;
 		}
 	}
 }

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAll.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAll.cs
@@ -21,6 +21,10 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 				Expression<Func<IEnumerable<object>, bool>> x = l => !l.Any();
 				tree.AddListTransformer(x);
+
+				// NH-3850: Queries with polymorphism yields many results which must be combined.
+				Expression<Func<IEnumerable<bool>, bool>> px = l => l.All(r => r);
+				tree.AddPostExecuteTransformer(px);
 			}
 			else
 			{

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAny.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAny.cs
@@ -17,6 +17,10 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 				Expression<Func<IEnumerable<object>, bool>> x = l => l.Any();
 				tree.AddListTransformer(x);
+
+				// NH-3850: Queries with polymorphism yields many results which must be combined.
+				Expression<Func<IEnumerable<bool>, bool>> px = l => l.Any(r => r);
+				tree.AddPostExecuteTransformer(px);
 			}
 			else
 			{

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using NHibernate.Linq;
 
 namespace NHibernate.Util
 {
@@ -26,14 +26,26 @@ namespace NHibernate.Util
 			internal static readonly MethodInfo AggregateWithSeedAndResultSelectorDefinition =
 				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
 
+			internal static readonly MethodInfo AllDefinition =
+				ReflectHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null));
+
 			internal static readonly MethodInfo CastDefinition =
 				ReflectHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
 
 			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectHelper.GetMethodDefinition(
 				() => Enumerable.GroupBy<object, object, object>(null, null, default(Func<object, object>)));
 
+			internal static readonly MethodInfo MaxDefinition =
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Max<object>(null));
+
+			internal static readonly MethodInfo MinDefinition =
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Min<object>(null));
+
 			internal static readonly MethodInfo SelectDefinition =
 				ReflectHelper.GetMethodDefinition(() => Enumerable.Select(null, default(Func<object, object>)));
+
+			internal static readonly MethodInfo SumOnInt =
+				ReflectHelper.GetMethod(() => Enumerable.Sum(default(IEnumerable<int>)));
 
 			internal static readonly MethodInfo ToArrayDefinition =
 				ReflectHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
@@ -45,15 +57,15 @@ namespace NHibernate.Util
 		internal static class MethodBaseMethods
 		{
 			internal static readonly MethodInfo GetMethodFromHandle =
-				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle()));
+				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(default(RuntimeMethodHandle)));
 			internal static readonly MethodInfo GetMethodFromHandleWithDeclaringType =
-				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle(), new RuntimeTypeHandle()));
+				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(default(RuntimeMethodHandle), default(RuntimeTypeHandle)));
 		}
 
 		internal static class TypeMethods
 		{
 			internal static readonly MethodInfo GetTypeFromHandle =
-				ReflectHelper.GetMethod(() => System.Type.GetTypeFromHandle(new RuntimeTypeHandle()));
+				ReflectHelper.GetMethod(() => System.Type.GetTypeFromHandle(default(RuntimeTypeHandle)));
 		}
 	}
 }


### PR DESCRIPTION
Fix and test cases for [NH-3850](https://nhibernate.jira.com/browse/NH-3850).

Currently, LINQ queries such as `query.Count()`, `query.Any()` do not support polymorphic queries: they take into account only the results of the first entity class matching the query and ignores the other classes results.

This fix implements polymorphic support for `Aggregate`, `Any`, `Count`, `LongCount`, `Max`, `Min` and `Sum`.  
`Average` is not fixed: supporting it requires to select additional columns in the query (`Sum` and `Count`) and compute the average on client side. I do not think it is worth the hassle.

This fix introduces a possible breaking change: `Sum` on nullables will no more yield `null` when there is no rows to compute from, but will yield `0`. This change is due to usage of `Enumerable.Sum` for aggregating polymorphic results, and this is its documented behavior. This happens even on non polymorphic queries: when adding the `Enumerable.Sum` post result transformer, we do not already knows if the query will be polymorphic, so we add it to non polymorphic queries too. (Determining if the query is polymorphic would require some computation currently done in query plan computation.)  
Avoiding this change should be doable by building a more elaborated expression as post result transformer. But this changes looks to me very minor and not contradictory with Linq contracts. It causes the loss of the ability to tell from the result there was nothing to `Sum`, but that does not look to me as being part of `Sum` contract. So I have not implemented a workaround for avoiding this change.