### PR TITLE
NH-3970 - avoid losing original failure in case of additional failure

### DIFF
--- a/src/NHibernate.Test/Legacy/MasterDetailTest.cs
+++ b/src/NHibernate.Test/Legacy/MasterDetailTest.cs
@@ -661,6 +661,7 @@ namespace NHibernate.Test.Legacy
 			MemoryStream stream = new MemoryStream();
 			BinaryFormatter f = new BinaryFormatter();
 			f.Serialize(stream, s);
+			s.Close();
 			stream.Position = 0;
 			Console.WriteLine(stream.Length);
 
@@ -694,6 +695,7 @@ namespace NHibernate.Test.Legacy
 			s.Disconnect();
 			stream = new MemoryStream();
 			f.Serialize(stream, s);
+			s.Close();
 			stream.Position = 0;
 
 			s = (ISession) f.Deserialize(stream);

--- a/src/NHibernate.Test/NHSpecificTest/NH1098/FilterParameterOrderFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1098/FilterParameterOrderFixture.cs
@@ -11,209 +11,224 @@ namespace NHibernate.Test.NHSpecificTest.NH1098
 	{
 		protected override void OnSetUp()
 		{
-			ISession session = OpenSession();
+			using (ISession session = OpenSession())
+			{
 
-			var a1 = new A {Id = 1, ValueA = 5, Enabled = false};
-			session.Save(a1);
+				var a1 = new A { Id = 1, ValueA = 5, Enabled = false };
+				session.Save(a1);
 
-			var a2 = new A {Id = 2, ValueA = 6, Enabled = true};
-			session.Save(a2);
+				var a2 = new A { Id = 2, ValueA = 6, Enabled = true };
+				session.Save(a2);
 
-			var a3 = new A {Id = 3, ValueA = 4, Enabled = true};
-			session.Save(a3);
+				var a3 = new A { Id = 3, ValueA = 4, Enabled = true };
+				session.Save(a3);
 
-			var a4 = new A {Id = 4, ValueA = 6, Enabled = true};
-			session.Save(a4);
+				var a4 = new A { Id = 4, ValueA = 6, Enabled = true };
+				session.Save(a4);
 
-			var b1 = new B {Id = 1, ValueB = 5, Enabled = false};
-			session.Save(b1);
+				var b1 = new B { Id = 1, ValueB = 5, Enabled = false };
+				session.Save(b1);
 
-			var b2 = new B {Id = 2, ValueB = 6, Enabled = true};
-			session.Save(b2);
+				var b2 = new B { Id = 2, ValueB = 6, Enabled = true };
+				session.Save(b2);
 
-			var b3 = new B {Id = 3, ValueB = 2, Enabled = false};
-			session.Save(b3);
+				var b3 = new B { Id = 3, ValueB = 2, Enabled = false };
+				session.Save(b3);
 
-			var b4 = new B {Id = 4, ValueB = 6, Enabled = true};
-			session.Save(b4);
+				var b4 = new B { Id = 4, ValueB = 6, Enabled = true };
+				session.Save(b4);
 
-			a1.C.Add(a1.Id, "Text1");
-			a1.C.Add(a2.Id, "Text2");
+				a1.C.Add(a1.Id, "Text1");
+				a1.C.Add(a2.Id, "Text2");
 
-			session.Flush();
-			session.Close();
+				session.Flush();
+				session.Close();
+			}
 		}
 
 		protected override void OnTearDown()
 		{
-			ISession session = OpenSession();
-			session.Delete("from A");
-			session.Delete("from B");
-			session.Flush();
-			session.Close();
+			using (ISession session = OpenSession())
+			{
+				session.Delete("from A");
+				session.Delete("from B");
+				session.Flush();
+				session.Close();
+			}
 		}
 
 		[Test]
 		public void CriteriaParameterOrder()
 		{
-			ISession session = OpenSession();
-			session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
+			using (ISession session = OpenSession())
+			{
+				session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
 
-			DetachedCriteria detached = DetachedCriteria.For(typeof (B), "b");
-			detached.Add(Restrictions.LtProperty("a.ValueA", "b.ValueB")).Add(Restrictions.Gt("ValueB", 5)).SetProjection(
-				Projections.Property("ValueB"));
+				DetachedCriteria detached = DetachedCriteria.For(typeof(B), "b");
+				detached.Add(Restrictions.LtProperty("a.ValueA", "b.ValueB")).Add(Restrictions.Gt("ValueB", 5)).SetProjection(
+					Projections.Property("ValueB"));
 
-			ICriteria crit = session.CreateCriteria(typeof (A), "a");
-			crit.Add(Restrictions.Lt("ValueA", 6)).Add(Subqueries.Exists(detached));
+				ICriteria crit = session.CreateCriteria(typeof(A), "a");
+				crit.Add(Restrictions.Lt("ValueA", 6)).Add(Subqueries.Exists(detached));
 
-			//
-			// Query:
-			// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
-			//       from table_a a0_ 
-			//       where a0_.enabled = ? and ((a0_.val_a<? )and
-			//          (exists(select b1_.val_b 
-			//                   from table_b b1_ 
-			//                   where b1_.enabled = ? and 
-			//                       ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
-			// 
-			// Parameter:
-			// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
-			// 2) "this_.val_a < (?)" [positional #1]
-			// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
-			// 4) "this_0_.val_b > (?)" [positional #2]
-			// 
-			// => OK, parameter are in correct order: filter #1, pos #1, filter #2, pos #2
-			//
+				//
+				// Query:
+				// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
+				//       from table_a a0_ 
+				//       where a0_.enabled = ? and ((a0_.val_a<? )and
+				//          (exists(select b1_.val_b 
+				//                   from table_b b1_ 
+				//                   where b1_.enabled = ? and 
+				//                       ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
+				// 
+				// Parameter:
+				// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
+				// 2) "this_.val_a < (?)" [positional #1]
+				// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
+				// 4) "this_0_.val_b > (?)" [positional #2]
+				// 
+				// => OK, parameter are in correct order: filter #1, pos #1, filter #2, pos #2
+				//
 
-			IList<A> result = crit.List<A>();
-			Assert.AreEqual(1, result.Count);
+				IList<A> result = crit.List<A>();
+				Assert.AreEqual(1, result.Count);
+			}
 		}
 
 		[Test]
 		public void QueryWithNamedParameters()
 		{
-			ISession session = OpenSession();
-			session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
+			using (ISession session = OpenSession())
+			{
+				session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
 
-			var sql = new StringBuilder();
-			sql.Append("from A as a where a.ValueA < :ValA");
-			sql.Append(" and exists (select b.ValueB from B as b where ");
-			sql.Append(" a.ValueA < b.ValueB and b.ValueB > :ValB)");
+				var sql = new StringBuilder();
+				sql.Append("from A as a where a.ValueA < :ValA");
+				sql.Append(" and exists (select b.ValueB from B as b where ");
+				sql.Append(" a.ValueA < b.ValueB and b.ValueB > :ValB)");
 
-			IQuery query = session.CreateQuery(sql.ToString());
-			query.SetParameter("ValA", 6);
-			query.SetParameter("ValB", 5);
+				IQuery query = session.CreateQuery(sql.ToString());
+				query.SetParameter("ValA", 6);
+				query.SetParameter("ValB", 5);
 
-			//
-			// Query:
-			// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
-			//     from table_a a0_ 
-			//     where a0_.enabled = ? and ((a0_.val_a<? )and
-			//        (exists(select b1_.val_b 
-			//            from table_b b1_ 
-			//            where b1_.enabled = ? and ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
-			// 
-			// Parameter:
-			// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
-			// 2) "this_.val_a < (?)" [named parameter #1]
-			// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
-			// 4) "this_0_.val_b > (?)" [named parameter #2]
-			// 
-			// => ERROR, parameters are in wrong order: filter #1, filter #2, named #1, named #2
-			//
+				//
+				// Query:
+				// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
+				//     from table_a a0_ 
+				//     where a0_.enabled = ? and ((a0_.val_a<? )and
+				//        (exists(select b1_.val_b 
+				//            from table_b b1_ 
+				//            where b1_.enabled = ? and ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
+				// 
+				// Parameter:
+				// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
+				// 2) "this_.val_a < (?)" [named parameter #1]
+				// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
+				// 4) "this_0_.val_b > (?)" [named parameter #2]
+				// 
+				// => ERROR, parameters are in wrong order: filter #1, filter #2, named #1, named #2
+				//
 
-			IList<A> result = query.List<A>();
-			Assert.AreEqual(1, result.Count);
+				IList<A> result = query.List<A>();
+				Assert.AreEqual(1, result.Count);
+			}
 		}
 
 		[Test]
 		public void QueryWithPositionalParameter()
 		{
-			ISession session = OpenSession();
-			session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
+			using (ISession session = OpenSession())
+			{
+				session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
 
-			var sql = new StringBuilder();
-			sql.Append("from A as a where a.ValueA < ?");
-			sql.Append(" and exists (select b.ValueB from B as b where ");
-			sql.Append(" a.ValueA < b.ValueB and b.ValueB > ?)");
+				var sql = new StringBuilder();
+				sql.Append("from A as a where a.ValueA < ?");
+				sql.Append(" and exists (select b.ValueB from B as b where ");
+				sql.Append(" a.ValueA < b.ValueB and b.ValueB > ?)");
 
-			IQuery query = session.CreateQuery(sql.ToString());
-			query.SetInt32(0, 6);
-			query.SetInt32(1, 5);
+				IQuery query = session.CreateQuery(sql.ToString());
+				query.SetInt32(0, 6);
+				query.SetInt32(1, 5);
 
-			//
-			// Query:
-			// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
-			//     from table_a a0_ 
-			//     where a0_.enabled = ? and ((a0_.val_a<? )and
-			//        (exists(select b1_.val_b 
-			//                  from table_b b1_ 
-			//                  where b1_.enabled = ? and ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
-			// 
-			// Parameter:
-			// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
-			// 2) "this_.val_a < (?)" [positional parameter #1]
-			// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
-			// 4) "this_0_.val_b > (?)" [positional parameter #2]
-			// 
-			// => OK, parameters are in correct order: filter #1, pos 12, filter #2, pos #2
-			//
+				//
+				// Query:
+				// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
+				//     from table_a a0_ 
+				//     where a0_.enabled = ? and ((a0_.val_a<? )and
+				//        (exists(select b1_.val_b 
+				//                  from table_b b1_ 
+				//                  where b1_.enabled = ? and ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
+				// 
+				// Parameter:
+				// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
+				// 2) "this_.val_a < (?)" [positional parameter #1]
+				// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
+				// 4) "this_0_.val_b > (?)" [positional parameter #2]
+				// 
+				// => OK, parameters are in correct order: filter #1, pos 12, filter #2, pos #2
+				//
 
-			IList<A> result = query.List<A>();
-			Assert.AreEqual(1, result.Count);
+				IList<A> result = query.List<A>();
+				Assert.AreEqual(1, result.Count);
+			}
 		}
 
 		[Test]
 		public void QueryWithMixedParameters()
 		{
-			ISession session = OpenSession();
-			session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
+			using (ISession session = OpenSession())
+			{
+				session.EnableFilter("EnabledObjects").SetParameter("Enabled", true);
 
-			var sql = new StringBuilder();
-			sql.Append("from A as a where a.ValueA < :ValA");
-			sql.Append(" and exists (select b.ValueB from B as b where ");
-			sql.Append(" a.ValueA < b.ValueB and b.ValueB > ?)");
+				var sql = new StringBuilder();
+				sql.Append("from A as a where a.ValueA < :ValA");
+				sql.Append(" and exists (select b.ValueB from B as b where ");
+				sql.Append(" a.ValueA < b.ValueB and b.ValueB > ?)");
 
-			Assert.Throws<SemanticException>(() => session.CreateQuery(sql.ToString()));
-			//
-			// Query:
-			// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
-			//     from table_a a0_ 
-			//     where a0_.enabled = ? and ((a0_.val_a<? )and
-			//        (exists(select b1_.val_b 
-			//                  from table_b b1_ 
-			//                  where b1_.enabled = ? and ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
-			// 
-			// Parameter:
-			// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
-			// 2) "this_.val_a < (?)" [named parameter #1]
-			// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
-			// 4) "this_0_.val_b > (?)" [positional parameter #1]
-			// 
-			// => ERROR, parameters are in wrong order: filter #1, pos #1, filter #2, named #1
-			//
+				Assert.Throws<SemanticException>(() => session.CreateQuery(sql.ToString()));
+				//
+				// Query:
+				// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
+				//     from table_a a0_ 
+				//     where a0_.enabled = ? and ((a0_.val_a<? )and
+				//        (exists(select b1_.val_b 
+				//                  from table_b b1_ 
+				//                  where b1_.enabled = ? and ((a0_.val_a<b1_.val_b )and(b1_.val_b>? )))))}
+				// 
+				// Parameter:
+				// 1) "this_.enabled = :EnabledObjects.Enabled" [filter #1]
+				// 2) "this_.val_a < (?)" [named parameter #1]
+				// 3) "this_0_.enabled = :EnabledObjects.Enabled" [filter #2]
+				// 4) "this_0_.val_b > (?)" [positional parameter #1]
+				// 
+				// => ERROR, parameters are in wrong order: filter #1, pos #1, filter #2, named #1
+				//
+			}
 		}
 
 		[Test]
 		public void QueryMapElements()
 		{
-			IQuery query = OpenSession().CreateQuery("from A a where a.C[:ValC] = :Text");
-			query.SetInt32("ValC", 1);
-			query.SetString("Text", "Text1");
+			using (var session = OpenSession())
+			{
+				IQuery query = session.CreateQuery("from A a where a.C[:ValC] = :Text");
+				query.SetInt32("ValC", 1);
+				query.SetString("Text", "Text1");
 
-			// Query:
-			// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
-			//         from table_a a0_, table_c c1_ 
-			//         where (c1_.text = (?) and a0_.id=c1_.val_a and c1_.val_c = (?) ); }
-			// Parameter:
-			// 1) "c1_.text = (?)" [named parameter #2 Text]
-			// 2) "c1_.val_c = (?)" [named parameter #1 ValC]
-			//
-			// => ERROR, parameters are in wrong order: named ValC, named Text
+				// Query:
+				// {select a0_.id as id0_, a0_.val_a as val2_0_, a0_.enabled as enabled0_ 
+				//         from table_a a0_, table_c c1_ 
+				//         where (c1_.text = (?) and a0_.id=c1_.val_a and c1_.val_c = (?) ); }
+				// Parameter:
+				// 1) "c1_.text = (?)" [named parameter #2 Text]
+				// 2) "c1_.val_c = (?)" [named parameter #1 ValC]
+				//
+				// => ERROR, parameters are in wrong order: named ValC, named Text
 
-			var a = query.UniqueResult<A>();
+				var a = query.UniqueResult<A>();
 
-			Assert.AreEqual(a.C[1], "Text1");
+				Assert.AreEqual(a.C[1], "Text1");
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1882
 				{
 					if (oldValues != null && oldValues[i] != null)
 					{
-						if (! NHibernateUtil.IsInitialized(oldValues[i]))
+						if (!NHibernateUtil.IsInitialized(oldValues[i]))
 						{
 							// force any proxies and/or collections to initialize to illustrate HHH-2763
 							FoundAny = true;
@@ -87,31 +87,36 @@ namespace NHibernate.Test.NHSpecificTest.NH1882
 		{
 			Assert.False(listener.Executed);
 			Assert.False(listener.FoundAny);
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			var publisher = new Publisher("acme");
-			var author = new Author("john");
-			author.Publisher = publisher;
-			publisher.Authors.Add(author);
-			author.Books.Add(new Book("Reflections on a Wimpy Kid", author));
-			s.Save(author);
-			s.Transaction.Commit();
-			s.Clear();
 
-			s = OpenSession();
-			s.BeginTransaction();
-			publisher = s.Get<Publisher>(publisher.Id);
-			publisher.Name = "random nally";
-			s.Flush();
-			s.Transaction.Commit();
-			s.Clear();
-
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete(author);
-			s.Transaction.Commit();
-			s.Clear();
-			s.Close();
+			using (var s1 = OpenSession())
+			{
+				s1.BeginTransaction();
+				var publisher = new Publisher("acme");
+				var author = new Author("john");
+				author.Publisher = publisher;
+				publisher.Authors.Add(author);
+				author.Books.Add(new Book("Reflections on a Wimpy Kid", author));
+				s1.Save(author);
+				s1.Transaction.Commit();
+				s1.Clear();
+				using (var s2 = OpenSession())
+				{
+					s2.BeginTransaction();
+					publisher = s2.Get<Publisher>(publisher.Id);
+					publisher.Name = "random nally";
+					s2.Flush();
+					s2.Transaction.Commit();
+					s2.Clear();
+					using (var s3 = OpenSession())
+					{
+						s3.BeginTransaction();
+						s3.Delete(author);
+						s3.Transaction.Commit();
+						s3.Clear();
+						s3.Close();
+					}
+				}
+			}
 			Assert.That(listener.Executed, Is.True);
 			Assert.That(listener.FoundAny, Is.True);
 		}

--- a/src/NHibernate.Test/NHSpecificTest/NH317/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH317/Fixture.cs
@@ -31,7 +31,7 @@ namespace NHibernate.Test.NHSpecificTest.NH317
 			node.Id = 1;
 			node.Name = "Node 1";
 
-			ISession s = sessions.OpenSession();
+			ISession s = OpenSession();
 			s.Save(node);
 			s.Flush();
 			s.Close();

--- a/src/NHibernate.Test/NHSpecificTest/NH901/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH901/Fixture.cs
@@ -8,12 +8,6 @@ namespace NHibernate.Test.NHSpecificTest.NH901
 {
 	public abstract class FixtureBase : TestCase
 	{
-		private new ISession OpenSession(IInterceptor interceptor)
-		{
-			lastOpenedSession = sessions.OpenSession(interceptor);
-			return lastOpenedSession;
-		}
-
 		protected override void OnTearDown()
 		{
 			base.OnTearDown();

--- a/src/NHibernate.Test/NHSpecificTest/NH940/NH940Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH940/NH940Fixture.cs
@@ -15,33 +15,39 @@ namespace NHibernate.Test.NHSpecificTest.NH940
 			B b = new B();
 			a.B = b;
 
-			ISession s = OpenSession();
-			ITransaction t = s.BeginTransaction();
-			s.Save(a);
-			t.Commit();
-			s.Close();
-
-			s = OpenSession();
-			IList l = s.CreateCriteria(typeof(A)).List();
-			try
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
 			{
-				((A) l[0]).Execute();
-				Assert.Fail("Should have thrown MyException");
-			}
-			catch (MyException)
-			{
-				// OK
-			}
-			catch (Exception e)
-			{
-				Assert.Fail("Should have thrown MyException, thrown {0} instead", e);
+				s.Save(a);
+				t.Commit();
+				s.Close();
 			}
 
-			s = OpenSession();
-			t = s.BeginTransaction();
-			s.Delete(a);
-			t.Commit();
-			s.Close();
+			using (ISession s = OpenSession())
+			{
+				IList l = s.CreateCriteria(typeof(A)).List();
+				try
+				{
+					((A)l[0]).Execute();
+					Assert.Fail("Should have thrown MyException");
+				}
+				catch (MyException)
+				{
+					// OK
+				}
+				catch (Exception e)
+				{
+					Assert.Fail("Should have thrown MyException, thrown {0} instead", e);
+				}
+			}
+
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				s.Delete(a);
+				t.Commit();
+				s.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/TestTestCase.cs
+++ b/src/NHibernate.Test/TestTestCase.cs
@@ -15,12 +15,61 @@ namespace NHibernate.Test
 			get { return new string[0]; }
 		}
 
+		private bool _failOnTearDown;
+
+		protected override void OnTearDown()
+		{
+			if (!_failOnTearDown)
+				return;
+
+			_failOnTearDown = false;
+			throw new InvalidOperationException("Tear-down failure");
+		}
+
+		[Test(Description = "This test will fail with a \"Hard coded test failure.\" exception message.")]
+		[Explicit("Testing test failure")]
+		public void TearDownFailure()
+		{
+			throw new InvalidOperationException("Hard coded test failure.");
+		}
+
+		[Test(Description = "This test will fail with a \"Hard coded test failure.\" exception message, and additionally will cause a tear-down failure. The tear-down failure should not hide original failure.")]
+		[Explicit("Testing test failure")]
+		public void TearDownFailureShouldNotHideTestFailure()
+		{
+			_failOnTearDown = true;
+
+			throw new InvalidOperationException("Hard coded test failure.");
+		}
+
+		private ISession _nonClosedSession;
+
+		[Test(Description = "This test will fail with a \"Hard coded test failure.\" exception message, and additionally will cause a tear-down not clean failure. The tear-down failure should not hide original failure.")]
+		[Explicit("Testing test failure")]
+		public void TearDownNotCleanFailureShouldNotHideTestFailure()
+		{
+			_nonClosedSession = OpenSession();
+
+			throw new InvalidOperationException("Hard coded test failure.");
+		}
+
+		[Test(Description = "This test tear-down should fail due to unclosed session. If test is successful, it has indeed failed.")]
+		[Explicit("Testing test failure")]
+		public void TearDownShouldFailDueToUncloseSession()
+		{
+			_nonClosedSession = OpenSession();
+			using (var otherSession = OpenSession())
+			{
+				// Dummy code.
+				otherSession.BeginTransaction().Rollback();
+			}
+		}
 
 		[Test]
 		public void TestExecuteStatement()
 		{
-			base.ExecuteStatement("create table yyyy (x int)");
-			base.ExecuteStatement("drop table yyyy");
+			ExecuteStatement("create table yyyy (x int)");
+			ExecuteStatement("drop table yyyy");
 		}
 	}
 }


### PR DESCRIPTION
Test cases (explicit execution), and fix for [NH-3970](https://nhibernate.jira.com/browse/NH-3970) - TestCase base class: avoid hiding test failure on tear-down.

There is many things I would like to fix in the tests, but this one is really annoying. When a test fails but we cannot have its root cause (at least in NUnit gui), it is quite impractical.