### PR TITLE
NH-3964 - obsolete Linq.ReflectionHelper in favor of Util.ReflectHelper.

### DIFF
--- a/doc/reference/modules/query_linq.xml
+++ b/doc/reference/modules/query_linq.xml
@@ -590,7 +590,7 @@ IList<Cat> cats =
     {
         SupportedMethods = new[]
         {
-             ReflectionHelper.GetMethodDefinition(() => NullableExtensions.AsNullable(0))
+             ReflectHelper.GetMethodDefinition(() => NullableExtensions.AsNullable(0))
         };
     }
 

--- a/src/NHibernate.Test/Linq/BooleanMethodExtensionExample.cs
+++ b/src/NHibernate.Test/Linq/BooleanMethodExtensionExample.cs
@@ -5,13 +5,12 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Cfg;
-using NHibernate.Cfg.Loquacious;
 using NHibernate.Hql.Ast;
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Visitors;
 using NHibernate.DomainModel.Northwind.Entities;
 using NUnit.Framework;
+using NHibernate.Util;
 
 namespace NHibernate.Test.Linq
 {
@@ -27,7 +26,7 @@ namespace NHibernate.Test.Linq
 	{
 		public FreetextGenerator()
 		{
-			SupportedMethods = new[] {ReflectionHelper.GetMethodDefinition(() => BooleanLinqExtensions.FreeText(null, null))};
+			SupportedMethods = new[] {ReflectHelper.GetMethodDefinition(() => BooleanLinqExtensions.FreeText(null, null))};
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject,
@@ -48,7 +47,7 @@ namespace NHibernate.Test.Linq
 		{
 			public MyLinqToHqlGeneratorsRegistry()
 			{
-				RegisterGenerator(ReflectionHelper.GetMethodDefinition(() => BooleanLinqExtensions.FreeText(null, null)),
+				RegisterGenerator(ReflectHelper.GetMethodDefinition(() => BooleanLinqExtensions.FreeText(null, null)),
 								  new FreetextGenerator());
 			}
 		}

--- a/src/NHibernate.Test/Linq/CustomExtensionsExample.cs
+++ b/src/NHibernate.Test/Linq/CustomExtensionsExample.cs
@@ -4,12 +4,10 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using NHibernate.Cfg;
-using NHibernate.Cfg.Loquacious;
-using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Hql.Ast;
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
@@ -30,7 +28,7 @@ namespace NHibernate.Test.Linq
 	{
 		public MyLinqToHqlGeneratorsRegistry():base()
 		{
-			RegisterGenerator(ReflectionHelper.GetMethodDefinition(() => MyLinqExtensions.IsLike(null, null)),
+			RegisterGenerator(ReflectHelper.GetMethodDefinition(() => MyLinqExtensions.IsLike(null, null)),
 							  new IsLikeGenerator());
 		}
 	}
@@ -39,7 +37,7 @@ namespace NHibernate.Test.Linq
 	{
 		public IsLikeGenerator()
 		{
-			SupportedMethods = new[] {ReflectionHelper.GetMethodDefinition(() => MyLinqExtensions.IsLike(null, null))};
+			SupportedMethods = new[] {ReflectHelper.GetMethodDefinition(() => MyLinqExtensions.IsLike(null, null))};
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, 

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyGeneratorsRegistry.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyGeneratorsRegistry.cs
@@ -1,5 +1,5 @@
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
+using NHibernate.Util;
 
 namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
 {
@@ -7,7 +7,7 @@ namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
 	{
 		public EntityWithUserTypePropertyGeneratorsRegistry()
 		{
-			RegisterGenerator(ReflectionHelper.GetMethod((IExample e) => e.IsEquivalentTo(null)),
+			RegisterGenerator(ReflectHelper.GetMethod((IExample e) => e.IsEquivalentTo(null)),
 							new EntityWithUserTypePropertyIsEquivalentGenerator());
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyIsEquivalentGenerator.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EntityWithUserTypeCanHaveLinqGenerators/EntityWithUserTypePropertyIsEquivalentGenerator.cs
@@ -3,9 +3,9 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
 {
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.EntityWithUserTypeCanHaveLinqGenerators
 	{
 		public EntityWithUserTypePropertyIsEquivalentGenerator()
 		{
-			SupportedMethods = new[] {ReflectionHelper.GetMethodDefinition((IExample e) => e.IsEquivalentTo(null))};
+			SupportedMethods = new[] {ReflectHelper.GetMethodDefinition((IExample e) => e.IsEquivalentTo(null))};
 		}
 
 		public override HqlTreeNode BuildHql(

--- a/src/NHibernate.Test/NHSpecificTest/NH2318/LinqMapping.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2318/LinqMapping.cs
@@ -1,14 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
 using NHibernate.Hql.Ast;
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Test.NHSpecificTest.NH2318
 {
@@ -31,8 +28,8 @@ namespace NHibernate.Test.NHSpecificTest.NH2318
 		public TrimGenerator()
 		{
 			SupportedMethods = new[] {
-				ReflectionHelper.GetMethodDefinition(() => TrimExtensions.TrimLeading(null, null)),
-				ReflectionHelper.GetMethodDefinition(() => TrimExtensions.TrimTrailing(null, null)),
+				ReflectHelper.GetMethodDefinition(() => TrimExtensions.TrimLeading(null, null)),
+				ReflectHelper.GetMethodDefinition(() => TrimExtensions.TrimTrailing(null, null)),
 			};
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2869/IsTrueInDbFalseInLocalGenerator.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2869/IsTrueInDbFalseInLocalGenerator.cs
@@ -2,9 +2,9 @@ using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Test.NHSpecificTest.NH2869
 {
@@ -12,7 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2869
 	{
 		public IsTrueInDbFalseInLocalGenerator()
 		{
-			SupportedMethods = new[] { ReflectionHelper.GetMethodDefinition(() => MyLinqExtensions.IsOneInDbZeroInLocal(null, null)) };
+			SupportedMethods = new[] { ReflectHelper.GetMethodDefinition(() => MyLinqExtensions.IsOneInDbZeroInLocal(null, null)) };
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)

--- a/src/NHibernate.Test/NHSpecificTest/NH2869/MyLinqToHqlGeneratorsRegistry.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2869/MyLinqToHqlGeneratorsRegistry.cs
@@ -1,5 +1,5 @@
-using NHibernate.Linq;
 using NHibernate.Linq.Functions;
+using NHibernate.Util;
 
 namespace NHibernate.Test.NHSpecificTest.NH2869
 {
@@ -7,7 +7,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2869
 	{
 		public MyLinqToHqlGeneratorsRegistry()
 		{
-			RegisterGenerator(ReflectionHelper.GetMethodDefinition(() => MyLinqExtensions.IsOneInDbZeroInLocal(null, null)), new IsTrueInDbFalseInLocalGenerator());
+			RegisterGenerator(ReflectHelper.GetMethodDefinition(() => MyLinqExtensions.IsOneInDbZeroInLocal(null, null)), new IsTrueInDbFalseInLocalGenerator());
 		}
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH3604/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3604/FixtureByCode.cs
@@ -2,6 +2,7 @@
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Linq;
 using NHibernate.Mapping.ByCode;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3604
@@ -23,7 +24,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3604
 
 			mapper.Class<EntityDetail>(rc =>
 			{
-				rc.Id(x => x.Id, m => m.Generator(new ForeignGeneratorDef(ReflectionHelper.GetProperty(EntityDetail.PropertyAccessExpressions.Entity))));
+				rc.Id(x => x.Id, m => m.Generator(new ForeignGeneratorDef(ReflectHelper.GetProperty(EntityDetail.PropertyAccessExpressions.Entity))));
 				rc.OneToOne(EntityDetail.PropertyAccessExpressions.Entity, m => m.Constrained(true));
 				rc.Property(x => x.ExtraInfo);
 			});

--- a/src/NHibernate.Test/NHSpecificTest/NH3952/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3952/Fixture.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using NHibernate.Linq;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3952
@@ -83,10 +84,10 @@ namespace NHibernate.Test.NHSpecificTest.NH3952
 			}
 		}
 
-		private static readonly MethodInfo CastMethodDefinition = ReflectionHelper.GetMethodDefinition(
+		private static readonly MethodInfo CastMethodDefinition = ReflectHelper.GetMethodDefinition(
 			() => Enumerable.Cast<object>(null));
 
-		private static readonly MethodInfo CastMethod = ReflectionHelper.GetMethod(
+		private static readonly MethodInfo CastMethod = ReflectHelper.GetMethod(
 			() => Enumerable.Cast<int>(null));
 
 		[Test, Explicit("Just a blunt perf comparison among some reflection patterns used in NH")]
@@ -132,7 +133,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3952
 			swRefl.Start();
 			for (var i = 0; i < 1000; i++)
 			{
-				var cast = ReflectionHelper.GetMethod(() => Enumerable.Cast<int>(null));
+				var cast = ReflectHelper.GetMethod(() => Enumerable.Cast<int>(null));
 				Trace.TraceInformation(cast.ToString());
 			}
 			swRefl.Stop();
@@ -141,7 +142,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3952
 			swReflDef.Start();
 			for (var i = 0; i < 1000; i++)
 			{
-				var cast = ReflectionHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null))
+				var cast = ReflectHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null))
 					.MakeGenericMethod(new[] { typeof(int) });
 				Trace.TraceInformation(cast.ToString());
 			}
@@ -164,8 +165,8 @@ Cached method: {0}
 Cached method definition + make gen: {1}
 Hazzik GetMethod: {5}
 Hazzik GetMethodDefinition + make gen: {6}
-ReflectionHelper.GetMethod: {2}
-ReflectionHelper.GetMethodDefinition + make gen: {3}
+ReflectHelper.GetMethod: {2}
+ReflectHelper.GetMethodDefinition + make gen: {3}
 EnumerableHelper.GetMethod(generic overload): {4}",
 				swCached.Elapsed, swCachedDef.Elapsed, swRefl.Elapsed, swReflDef.Elapsed, swEnHlp.Elapsed,
 				swRefl2.Elapsed, swRefl2Def.Elapsed);

--- a/src/NHibernate.Test/UtilityTest/ReflectionHelperIsMethodOfTests.cs
+++ b/src/NHibernate.Test/UtilityTest/ReflectionHelperIsMethodOfTests.cs
@@ -18,14 +18,14 @@ namespace NHibernate.Test.UtilityTest
 		[Test]
 		public void WhenNullTypeThenThrows()
 		{
-			var methodInfo = ReflectionHelper.GetMethodDefinition<List<int>>(t => t.Contains(5));
+			var methodInfo = ReflectHelper.GetMethodDefinition<List<int>>(t => t.Contains(5));
 			Assert.Throws<ArgumentNullException>(() => methodInfo.IsMethodOf(null));
 		}
 
 		[Test]
 		public void WhenDeclaringTypeMatchThenTrue()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition<List<int>>(t => t.Contains(5)).IsMethodOf(typeof(List<int>)), Is.True);
+			Assert.That(ReflectHelper.GetMethodDefinition<List<int>>(t => t.Contains(5)).IsMethodOf(typeof(List<int>)), Is.True);
 		}
 
 		private class MyCollection: List<int>
@@ -36,33 +36,33 @@ namespace NHibernate.Test.UtilityTest
 		[Test]
 		public void WhenCustomTypeMatchThenTrue()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition<MyCollection>(t => t.Contains(5)).IsMethodOf(typeof(List<int>)), Is.True);
+			Assert.That(ReflectHelper.GetMethodDefinition<MyCollection>(t => t.Contains(5)).IsMethodOf(typeof(List<int>)), Is.True);
 		}
 
 		[Test]
 		public void WhenTypeIsGenericDefinitionAndMatchThenTrue()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition<List<int>>(t => t.Contains(5)).IsMethodOf(typeof(List<>)), Is.True);
+			Assert.That(ReflectHelper.GetMethodDefinition<List<int>>(t => t.Contains(5)).IsMethodOf(typeof(List<>)), Is.True);
 		}
 
 		[Test]
 		public void WhenTypeIsGenericImplementedInterfaceAndMatchThenTrue()
 		{
-			var containsMethodDefinition = ReflectionHelper.GetMethodDefinition<List<int>>(t => t.Contains(5));
+			var containsMethodDefinition = ReflectHelper.GetMethodDefinition<List<int>>(t => t.Contains(5));
 			Assert.That(containsMethodDefinition.IsMethodOf(typeof(ICollection<int>)), Is.True);
 		}
 
 		[Test]
 		public void WhenTypeIsGenericImplementedInterfaceAndMatchGenericInterfaceDefinitionThenTrue()
 		{
-			var containsMethodDefinition = ReflectionHelper.GetMethodDefinition<List<int>>(t => t.Contains(5));
+			var containsMethodDefinition = ReflectHelper.GetMethodDefinition<List<int>>(t => t.Contains(5));
 			Assert.That(containsMethodDefinition.IsMethodOf(typeof(ICollection<>)), Is.True);
 		}
 
 		[Test]
 		public void WhenNoMatchThenFalse()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition<List<int>>(t => t.Contains(5)).IsMethodOf(typeof(IEnumerable<>)), Is.False);
+			Assert.That(ReflectHelper.GetMethodDefinition<List<int>>(t => t.Contains(5)).IsMethodOf(typeof(IEnumerable<>)), Is.False);
 		}
 
 		private abstract class MyAbstractClass<T>
@@ -78,14 +78,14 @@ namespace NHibernate.Test.UtilityTest
 		[Test]
 		public void WhenTypeIsGenericImplementedAbstractAndMatchThenTrue()
 		{
-			var containsMethodDefinition = ReflectionHelper.GetMethodDefinition<MyClass>(t => t.MyMethod());
+			var containsMethodDefinition = ReflectHelper.GetMethodDefinition<MyClass>(t => t.MyMethod());
 			Assert.That(containsMethodDefinition.IsMethodOf(typeof(MyAbstractClass<int>)), Is.True);
 		}
 
 		[Test]
 		public void WhenTypeIsGenericImplementedAbstractAndMatchGenericInterfaceDefinitionThenTrue()
 		{
-			var containsMethodDefinition = ReflectionHelper.GetMethodDefinition<MyClass>(t => t.MyMethod());
+			var containsMethodDefinition = ReflectHelper.GetMethodDefinition<MyClass>(t => t.MyMethod());
 			Assert.That(containsMethodDefinition.IsMethodOf(typeof(MyAbstractClass<>)), Is.True);
 		}
 	}

--- a/src/NHibernate.Test/UtilityTest/ReflectionHelperTest.cs
+++ b/src/NHibernate.Test/UtilityTest/ReflectionHelperTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
-using NHibernate.Linq;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.UtilityTest
@@ -19,55 +19,55 @@ namespace NHibernate.Test.UtilityTest
 		[Test]
 		public void WhenGetMethodForNullThenThrows()
 		{
-			Assert.That(() => ReflectionHelper.GetMethodDefinition((Expression<System.Action>) null), Throws.TypeOf<ArgumentNullException>());
+			Assert.That(() => ReflectHelper.GetMethodDefinition((Expression<System.Action>) null), Throws.TypeOf<ArgumentNullException>());
 		}
 
 		[Test]
 		public void WhenGenericGetMethodForNullThenThrows()
 		{
-			Assert.That(() => ReflectionHelper.GetMethodDefinition<object>((Expression<System.Action<object>>)null), Throws.TypeOf<ArgumentNullException>());
+			Assert.That(() => ReflectHelper.GetMethodDefinition<object>((Expression<System.Action<object>>)null), Throws.TypeOf<ArgumentNullException>());
 		}
 
 		[Test]
 		public void WhenGetPropertyForNullThenThrows()
 		{
-			Assert.That(() => ReflectionHelper.GetProperty<object, object>(null), Throws.TypeOf<ArgumentNullException>());
+			Assert.That(() => ReflectHelper.GetProperty<object, object>(null), Throws.TypeOf<ArgumentNullException>());
 		}
 
 		[Test]
 		public void WhenGenericMethodOfClassThenReturnGenericDefinition()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition<MyClass>(mc => mc.GenericMethod<int>()), Is.EqualTo(typeof (MyClass).GetMethod("GenericMethod").GetGenericMethodDefinition()));
+			Assert.That(ReflectHelper.GetMethodDefinition<MyClass>(mc => mc.GenericMethod<int>()), Is.EqualTo(typeof (MyClass).GetMethod("GenericMethod").GetGenericMethodDefinition()));
 		}
 
 		[Test]
 		public void WhenNoGenericMethodOfClassThenReturnDefinition()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition<MyClass>(mc => mc.NoGenericMethod()), Is.EqualTo(typeof(MyClass).GetMethod("NoGenericMethod")));
+			Assert.That(ReflectHelper.GetMethodDefinition<MyClass>(mc => mc.NoGenericMethod()), Is.EqualTo(typeof(MyClass).GetMethod("NoGenericMethod")));
 		}
 
 		[Test]
 		public void WhenStaticGenericMethodThenReturnGenericDefinition()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition(() => Enumerable.All<int>(null, null)), Is.EqualTo(typeof(Enumerable).GetMethod("All").GetGenericMethodDefinition()));
+			Assert.That(ReflectHelper.GetMethodDefinition(() => Enumerable.All<int>(null, null)), Is.EqualTo(typeof(Enumerable).GetMethod("All").GetGenericMethodDefinition()));
 		}
 
 		[Test]
 		public void WhenStaticNoGenericMethodThenReturnDefinition()
 		{
-			Assert.That(ReflectionHelper.GetMethodDefinition(() => string.Join(null, null)), Is.EqualTo(typeof(string).GetMethod("Join", new []{typeof(string), typeof(string[])})));
+			Assert.That(ReflectHelper.GetMethodDefinition(() => string.Join(null, null)), Is.EqualTo(typeof(string).GetMethod("Join", new []{typeof(string), typeof(string[])})));
 		}
 
 		[Test]
 		public void WhenGetPropertyThenReturnPropertyInfo()
 		{
-			Assert.That(ReflectionHelper.GetProperty<MyClass, string>(mc => mc.BaseProperty), Is.EqualTo(typeof(MyClass).GetProperty("BaseProperty")));
+			Assert.That(ReflectHelper.GetProperty<MyClass, string>(mc => mc.BaseProperty), Is.EqualTo(typeof(MyClass).GetProperty("BaseProperty")));
 		}
 
 		[Test]
 		public void WhenGetPropertyForBoolThenReturnPropertyInfo()
 		{
-			Assert.That(ReflectionHelper.GetProperty<MyClass, bool>(mc => mc.BaseBool), Is.EqualTo(typeof(MyClass).GetProperty("BaseBool")));
+			Assert.That(ReflectHelper.GetProperty<MyClass, bool>(mc => mc.BaseBool), Is.EqualTo(typeof(MyClass).GetProperty("BaseBool")));
 		}
 	}
 }

--- a/src/NHibernate/Bytecode/EmitUtil.cs
+++ b/src/NHibernate/Bytecode/EmitUtil.cs
@@ -197,7 +197,7 @@ namespace NHibernate.Bytecode
 			il.Emit(OpCodes.Castclass, typeof(MethodInfo));
 		}
 
-		private static readonly MethodInfo CreateDelegate = ReflectionHelper.GetMethod(
+		private static readonly MethodInfo CreateDelegate = ReflectHelper.GetMethod(
 			() => Delegate.CreateDelegate(null, null));
 
 		public static void EmitCreateDelegateInstance(ILGenerator il, System.Type delegateType, MethodInfo methodInfo)

--- a/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
+++ b/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
@@ -119,7 +119,7 @@ namespace NHibernate.Bytecode.Lightweight
 			}
 		}
 
-		private static readonly MethodInfo GetterCallbackInvoke = ReflectionHelper.GetMethod<GetterCallback>(
+		private static readonly MethodInfo GetterCallbackInvoke = ReflectHelper.GetMethod<GetterCallback>(
 			g => g.Invoke(null, 0));
 
 		/// <summary>
@@ -185,7 +185,7 @@ namespace NHibernate.Bytecode.Lightweight
 			return (GetPropertyValuesInvoker) method.CreateDelegate(typeof (GetPropertyValuesInvoker));
 		}
 
-		private static readonly MethodInfo SetterCallbackInvoke = ReflectionHelper.GetMethod<SetterCallback>(
+		private static readonly MethodInfo SetterCallbackInvoke = ReflectHelper.GetMethod<SetterCallback>(
 			g => g.Invoke(null, 0, null));
 
 		/// <summary>

--- a/src/NHibernate/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Linq/DefaultQueryProvider.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using NHibernate.Engine;
 using NHibernate.Impl;
 using NHibernate.Type;
+using NHibernate.Util;
 
 namespace NHibernate.Linq
 {
@@ -18,7 +19,7 @@ namespace NHibernate.Linq
 
 	public class DefaultQueryProvider : INhQueryProvider
 	{
-		private static readonly MethodInfo CreateQueryMethodDefinition = ReflectionHelper.GetMethodDefinition((INhQueryProvider p) => p.CreateQuery<object>(null));
+		private static readonly MethodInfo CreateQueryMethodDefinition = ReflectHelper.GetMethodDefinition((INhQueryProvider p) => p.CreateQuery<object>(null));
 
 		private readonly WeakReference _session;
 
@@ -79,8 +80,8 @@ namespace NHibernate.Linq
 			return nhLinqExpression;
 		}
 
-		private static readonly MethodInfo Future = ReflectionHelper.GetMethodDefinition<IQuery>(q => q.Future<object>());
-		private static readonly MethodInfo FutureValue = ReflectionHelper.GetMethodDefinition<IQuery>(q => q.FutureValue<object>());
+		private static readonly MethodInfo Future = ReflectHelper.GetMethodDefinition<IQuery>(q => q.Future<object>());
+		private static readonly MethodInfo FutureValue = ReflectHelper.GetMethodDefinition<IQuery>(q => q.FutureValue<object>());
 
 		protected virtual object ExecuteFutureQuery(NhLinqExpression nhLinqExpression, IQuery query, NhLinqExpression nhQuery)
 		{

--- a/src/NHibernate/Linq/EnumerableHelper.cs
+++ b/src/NHibernate/Linq/EnumerableHelper.cs
@@ -2,9 +2,11 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using NHibernate.Util;
 
 namespace NHibernate.Linq
 {
+	[Obsolete("Please use NHibernate.Util.ReflectHelper instead")]
 	public static class ReflectionHelper
 	{
 		/// <summary>
@@ -16,8 +18,7 @@ namespace NHibernate.Linq
 		/// <seealso cref="MethodInfo.GetGenericMethodDefinition"/>
 		public static MethodInfo GetMethodDefinition<TSource>(Expression<Action<TSource>> method)
 		{
-			MethodInfo methodInfo = GetMethod(method);
-			return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
+			return ReflectHelper.GetMethodDefinition(method);
 		}
 
 		/// <summary>
@@ -28,10 +29,7 @@ namespace NHibernate.Linq
 		/// <returns>The <see cref="MethodInfo"/> of the method.</returns>
 		public static MethodInfo GetMethod<TSource>(Expression<Action<TSource>> method)
 		{
-			if (method == null)
-				throw new ArgumentNullException("method");
-
-			return ((MethodCallExpression)method.Body).Method;
+			return ReflectHelper.GetMethod(method);
 		}
 
 		/// <summary>
@@ -42,8 +40,7 @@ namespace NHibernate.Linq
 		/// <seealso cref="MethodInfo.GetGenericMethodDefinition"/>
 		public static MethodInfo GetMethodDefinition(Expression<System.Action> method)
 		{
-			MethodInfo methodInfo = GetMethod(method);
-			return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
+			return ReflectHelper.GetMethodDefinition(method);
 		}
 
 		/// <summary>
@@ -53,10 +50,7 @@ namespace NHibernate.Linq
 		/// <returns>The <see cref="MethodInfo"/> of the method.</returns>
 		public static MethodInfo GetMethod(Expression<System.Action> method)
 		{
-			if (method == null)
-				throw new ArgumentNullException("method");
-
-			return ((MethodCallExpression)method.Body).Method;
+			return ReflectHelper.GetMethod(method);
 		}
 
 		/// <summary>
@@ -68,32 +62,11 @@ namespace NHibernate.Linq
 		/// <returns>The <see cref="MemberInfo"/> of the property.</returns>
 		public static MemberInfo GetProperty<TSource, TResult>(Expression<Func<TSource, TResult>> property)
 		{
-			if (property == null)
-			{
-				throw new ArgumentNullException("property");
-			}
-			return ((MemberExpression)property.Body).Member;
-		}
-
-		internal static System.Type GetPropertyOrFieldType(this MemberInfo memberInfo)
-		{
-			var propertyInfo = memberInfo as PropertyInfo;
-			if (propertyInfo != null)
-			{
-				return propertyInfo.PropertyType;
-			}
-
-			var fieldInfo = memberInfo as FieldInfo;
-			if (fieldInfo != null)
-			{
-				return fieldInfo.FieldType;
-			}
-
-			return null;
+			return ReflectHelper.GetProperty(property);
 		}
 	}
 	
-	[Obsolete("Please use ReflectionHelper instead")]
+	[Obsolete("Please use NHibernate.Util.ReflectHelper instead")]
 	public static class EnumerableHelper
 	{
 		public static MethodInfo GetMethod(string name, System.Type[] parameterTypes)

--- a/src/NHibernate/Linq/ExpressionTransformers/SimplifyCompareTransformer.cs
+++ b/src/NHibernate/Linq/ExpressionTransformers/SimplifyCompareTransformer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Linq.Functions;
+using NHibernate.Util;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
 
 namespace NHibernate.Linq.ExpressionTransformers
@@ -105,13 +106,13 @@ namespace NHibernate.Linq.ExpressionTransformers
 		private static readonly IDictionary<System.Type, MethodInfo> dummies = new Dictionary<System.Type, MethodInfo>
 			{
 				// Corresponds to string.Compare(a, b).
-				{typeof (string), ReflectionHelper.GetMethod(() => DummyComparison<string>(null, null))},
+				{typeof (string), ReflectHelper.GetMethod(() => DummyComparison<string>(null, null))},
 
 				// System.Data.Services.Providers.DataServiceProviderMethods has Compare methods for these types.
-				{typeof (bool), ReflectionHelper.GetMethod(() => DummyComparison<bool>(false, false))},
-				{typeof (bool?), ReflectionHelper.GetMethod(() => DummyComparison<bool?>(null, null))},
-				{typeof (Guid), ReflectionHelper.GetMethod(() => DummyComparison<Guid>(Guid.Empty, Guid.Empty))},
-				{typeof (Guid?), ReflectionHelper.GetMethod(() => DummyComparison<Guid?>(null, null))},
+				{typeof (bool), ReflectHelper.GetMethod(() => DummyComparison<bool>(false, false))},
+				{typeof (bool?), ReflectHelper.GetMethod(() => DummyComparison<bool?>(null, null))},
+				{typeof (Guid), ReflectHelper.GetMethod(() => DummyComparison<Guid>(Guid.Empty, Guid.Empty))},
+				{typeof (Guid?), ReflectHelper.GetMethod(() => DummyComparison<Guid?>(null, null))},
 			};
 
 

--- a/src/NHibernate/Linq/Functions/CompareGenerator.cs
+++ b/src/NHibernate/Linq/Functions/CompareGenerator.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
 using System.Linq;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Functions
 {
@@ -13,28 +14,28 @@ namespace NHibernate.Linq.Functions
 	{
 		private static readonly HashSet<MethodInfo> ActingMethods = new HashSet<MethodInfo>
 			{
-				ReflectionHelper.GetMethodDefinition(() => string.Compare(null, null)),
-				ReflectionHelper.GetMethodDefinition<string>(s => s.CompareTo(s)),
-				ReflectionHelper.GetMethodDefinition<char>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition(() => string.Compare(null, null)),
+				ReflectHelper.GetMethodDefinition<string>(s => s.CompareTo(s)),
+				ReflectHelper.GetMethodDefinition<char>(x => x.CompareTo(x)),
 
-				ReflectionHelper.GetMethodDefinition<byte>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<sbyte>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<byte>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<sbyte>(x => x.CompareTo(x)),
 				
-				ReflectionHelper.GetMethodDefinition<short>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<ushort>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<short>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<ushort>(x => x.CompareTo(x)),
 
-				ReflectionHelper.GetMethodDefinition<int>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<uint>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<int>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<uint>(x => x.CompareTo(x)),
 
-				ReflectionHelper.GetMethodDefinition<long>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<ulong>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<long>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<ulong>(x => x.CompareTo(x)),
 
-				ReflectionHelper.GetMethodDefinition<float>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<double>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<decimal>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<float>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<double>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<decimal>(x => x.CompareTo(x)),
 
-				ReflectionHelper.GetMethodDefinition<DateTime>(x => x.CompareTo(x)),
-				ReflectionHelper.GetMethodDefinition<DateTimeOffset>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<DateTime>(x => x.CompareTo(x)),
+				ReflectHelper.GetMethodDefinition<DateTimeOffset>(x => x.CompareTo(x)),
 			};
 
 		internal static bool IsCompareMethod(MethodInfo methodInfo)

--- a/src/NHibernate/Linq/Functions/ConvertGenerator.cs
+++ b/src/NHibernate/Linq/Functions/ConvertGenerator.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
 using System.Collections.ObjectModel;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Functions
 {
@@ -24,10 +24,10 @@ namespace NHibernate.Linq.Functions
 		public ConvertToDateTimeGenerator()
 		{
 			SupportedMethods = new[]
-								   {
-									   ReflectionHelper.GetMethodDefinition<string>(s => DateTime.Parse(s)),
-									   ReflectionHelper.GetMethodDefinition<string>(o => Convert.ToDateTime(o))
-								   };
+			{
+				ReflectHelper.GetMethodDefinition<string>(s => DateTime.Parse(s)),
+				ReflectHelper.GetMethodDefinition<string>(o => Convert.ToDateTime(o))
+			};
 		}
 	}
 
@@ -37,10 +37,10 @@ namespace NHibernate.Linq.Functions
 		public ConvertToBooleanGenerator()
 		{
 			SupportedMethods = new[]
-								   {
-									   ReflectionHelper.GetMethodDefinition<string>(s => Boolean.Parse(s)),
-									   ReflectionHelper.GetMethodDefinition<string>(o => Convert.ToBoolean(o))
-								   };
+			{
+				ReflectHelper.GetMethodDefinition<string>(s => Boolean.Parse(s)),
+				ReflectHelper.GetMethodDefinition<string>(o => Convert.ToBoolean(o))
+			};
 		}
 	}
 
@@ -51,22 +51,22 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 								   {
-									   ReflectionHelper.GetMethodDefinition<string>(s => int.Parse(s)),
-									   ReflectionHelper.GetMethodDefinition<bool>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<byte>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<char>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<decimal>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<double>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<float>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<int>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<long>(o => Convert.ToInt32(o)), 
-									   ReflectionHelper.GetMethodDefinition<object>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<sbyte>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<short>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<string>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<uint>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<ulong>(o => Convert.ToInt32(o)),
-									   ReflectionHelper.GetMethodDefinition<ushort>(o => Convert.ToInt32(o))
+									   ReflectHelper.GetMethodDefinition<string>(s => int.Parse(s)),
+									   ReflectHelper.GetMethodDefinition<bool>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<byte>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<char>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<decimal>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<double>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<float>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<int>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<long>(o => Convert.ToInt32(o)), 
+									   ReflectHelper.GetMethodDefinition<object>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<sbyte>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<short>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<string>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<uint>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<ulong>(o => Convert.ToInt32(o)),
+									   ReflectHelper.GetMethodDefinition<ushort>(o => Convert.ToInt32(o))
 								   };
 		}
 	}
@@ -77,21 +77,21 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 								   {
-									   ReflectionHelper.GetMethodDefinition<string>(s => decimal.Parse(s)),
-									   ReflectionHelper.GetMethodDefinition<bool>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<byte>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<decimal>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<double>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<float>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<int>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<long>(o => Convert.ToDecimal(o)), 
-									   ReflectionHelper.GetMethodDefinition<object>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<sbyte>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<short>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<string>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<uint>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<ulong>(o => Convert.ToDecimal(o)),
-									   ReflectionHelper.GetMethodDefinition<ushort>(o => Convert.ToDecimal(o))
+									   ReflectHelper.GetMethodDefinition<string>(s => decimal.Parse(s)),
+									   ReflectHelper.GetMethodDefinition<bool>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<byte>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<decimal>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<double>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<float>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<int>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<long>(o => Convert.ToDecimal(o)), 
+									   ReflectHelper.GetMethodDefinition<object>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<sbyte>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<short>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<string>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<uint>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<ulong>(o => Convert.ToDecimal(o)),
+									   ReflectHelper.GetMethodDefinition<ushort>(o => Convert.ToDecimal(o))
 								   };
 		}
 	}
@@ -102,21 +102,21 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 								   {
-									   ReflectionHelper.GetMethodDefinition<string>(s => double.Parse(s)),
-									   ReflectionHelper.GetMethodDefinition<bool>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<byte>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<decimal>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<double>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<float>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<int>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<long>(o => Convert.ToDouble(o)), 
-									   ReflectionHelper.GetMethodDefinition<object>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<sbyte>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<short>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<string>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<uint>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<ulong>(o => Convert.ToDouble(o)),
-									   ReflectionHelper.GetMethodDefinition<ushort>(o => Convert.ToDouble(o))
+									   ReflectHelper.GetMethodDefinition<string>(s => double.Parse(s)),
+									   ReflectHelper.GetMethodDefinition<bool>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<byte>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<decimal>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<double>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<float>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<int>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<long>(o => Convert.ToDouble(o)), 
+									   ReflectHelper.GetMethodDefinition<object>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<sbyte>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<short>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<string>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<uint>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<ulong>(o => Convert.ToDouble(o)),
+									   ReflectHelper.GetMethodDefinition<ushort>(o => Convert.ToDouble(o))
 								   };
 		}
 	}

--- a/src/NHibernate/Linq/Functions/DateTimePropertiesHqlGenerator.cs
+++ b/src/NHibernate/Linq/Functions/DateTimePropertiesHqlGenerator.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Functions
 {
@@ -13,21 +13,21 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedProperties = new[]
 				{
-					ReflectionHelper.GetProperty((DateTime x) => x.Year),
-					ReflectionHelper.GetProperty((DateTime x) => x.Month),
-					ReflectionHelper.GetProperty((DateTime x) => x.Day),
-					ReflectionHelper.GetProperty((DateTime x) => x.Hour),
-					ReflectionHelper.GetProperty((DateTime x) => x.Minute),
-					ReflectionHelper.GetProperty((DateTime x) => x.Second),
-					ReflectionHelper.GetProperty((DateTime x) => x.Date),
+					ReflectHelper.GetProperty((DateTime x) => x.Year),
+					ReflectHelper.GetProperty((DateTime x) => x.Month),
+					ReflectHelper.GetProperty((DateTime x) => x.Day),
+					ReflectHelper.GetProperty((DateTime x) => x.Hour),
+					ReflectHelper.GetProperty((DateTime x) => x.Minute),
+					ReflectHelper.GetProperty((DateTime x) => x.Second),
+					ReflectHelper.GetProperty((DateTime x) => x.Date),
 					
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Year),
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Month),
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Day),
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Hour),
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Minute),
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Second),
-					ReflectionHelper.GetProperty((DateTimeOffset x) => x.Date),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Year),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Month),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Day),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Hour),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Minute),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Second),
+					ReflectHelper.GetProperty((DateTimeOffset x) => x.Date),
 				};
 		}
 

--- a/src/NHibernate/Linq/Functions/EqualsGenerator.cs
+++ b/src/NHibernate/Linq/Functions/EqualsGenerator.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Functions
 {
@@ -14,30 +14,30 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 				{
-					ReflectionHelper.GetMethodDefinition(() => string.Equals(default(string), default(string))),
-					ReflectionHelper.GetMethodDefinition<string>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<char>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition(() => string.Equals(default(string), default(string))),
+					ReflectHelper.GetMethodDefinition<string>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<char>(x => x.Equals(x)),
 
-					ReflectionHelper.GetMethodDefinition<sbyte>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<byte>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<sbyte>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<byte>(x => x.Equals(x)),
 
-					ReflectionHelper.GetMethodDefinition<short>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<ushort>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<short>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<ushort>(x => x.Equals(x)),
 
-					ReflectionHelper.GetMethodDefinition<int>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<uint>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<int>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<uint>(x => x.Equals(x)),
 
-					ReflectionHelper.GetMethodDefinition<long>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<ulong>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<long>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<ulong>(x => x.Equals(x)),
 
-					ReflectionHelper.GetMethodDefinition<float>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<double>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<decimal>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<float>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<double>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<decimal>(x => x.Equals(x)),
 
-					ReflectionHelper.GetMethodDefinition<Guid>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<DateTime>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<DateTimeOffset>(x => x.Equals(x)),
-					ReflectionHelper.GetMethodDefinition<bool>(x => x.Equals(default(bool)))
+					ReflectHelper.GetMethodDefinition<Guid>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<DateTime>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<DateTimeOffset>(x => x.Equals(x)),
+					ReflectHelper.GetMethodDefinition<bool>(x => x.Equals(default(bool)))
 				};
 		}
 

--- a/src/NHibernate/Linq/Functions/MathGenerator.cs
+++ b/src/NHibernate/Linq/Functions/MathGenerator.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Functions
 {
@@ -12,51 +13,51 @@ namespace NHibernate.Linq.Functions
 		public MathGenerator()
 		{
 			SupportedMethods = new[]
-								   {
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sin(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Cos(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Tan(default(double))),
-									   
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sinh(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Cosh(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Tanh(default(double))),
-									   
-									   ReflectionHelper.GetMethodDefinition(() => Math.Asin(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Acos(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Atan(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Atan2(default(double), default(double))),
+			{
+				ReflectHelper.GetMethodDefinition(() => Math.Sin(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Cos(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Tan(default(double))),
 
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sqrt(default(double))),
-									   
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(decimal))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(float))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(long))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(int))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(short))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Abs(default(sbyte))),
-									   
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(decimal))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(float))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(long))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(int))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(short))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Sign(default(sbyte))),
-									   
-									   ReflectionHelper.GetMethodDefinition(() => Math.Round(default(decimal))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Round(default(decimal), default(int))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Round(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Round(default(double), default(int))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Floor(default(decimal))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Floor(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Ceiling(default(decimal))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Ceiling(default(double))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Truncate(default(decimal))),
-									   ReflectionHelper.GetMethodDefinition(() => Math.Truncate(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sinh(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Cosh(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Tanh(default(double))),
 
-									   ReflectionHelper.GetMethodDefinition(() => Math.Pow(default(double), default(double))),
-								   };
+				ReflectHelper.GetMethodDefinition(() => Math.Asin(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Acos(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Atan(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Atan2(default(double), default(double))),
+
+				ReflectHelper.GetMethodDefinition(() => Math.Sqrt(default(double))),
+
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(decimal))),
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(float))),
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(long))),
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(int))),
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(short))),
+				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(sbyte))),
+
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(decimal))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(float))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(long))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(int))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(short))),
+				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(sbyte))),
+
+				ReflectHelper.GetMethodDefinition(() => Math.Round(default(decimal))),
+				ReflectHelper.GetMethodDefinition(() => Math.Round(default(decimal), default(int))),
+				ReflectHelper.GetMethodDefinition(() => Math.Round(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Round(default(double), default(int))),
+				ReflectHelper.GetMethodDefinition(() => Math.Floor(default(decimal))),
+				ReflectHelper.GetMethodDefinition(() => Math.Floor(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Ceiling(default(decimal))),
+				ReflectHelper.GetMethodDefinition(() => Math.Ceiling(default(double))),
+				ReflectHelper.GetMethodDefinition(() => Math.Truncate(default(decimal))),
+				ReflectHelper.GetMethodDefinition(() => Math.Truncate(default(double))),
+
+				ReflectHelper.GetMethodDefinition(() => Math.Pow(default(double), default(double))),
+			};
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression expression, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
@@ -72,7 +73,7 @@ namespace NHibernate.Linq.Functions
 			{
 				return treeBuilder.MethodCall(function, firstArgument, visitor.Visit(arguments[1]).AsExpression());
 			}
-			
+
 			return treeBuilder.MethodCall(function, firstArgument);
 		}
 	}

--- a/src/NHibernate/Linq/Functions/QueryableGenerator.cs
+++ b/src/NHibernate/Linq/Functions/QueryableGenerator.cs
@@ -15,10 +15,10 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			                   	{
-			                   		ReflectionHelper.GetMethodDefinition(() => Queryable.Any<object>(null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Queryable.Any<object>(null, null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Enumerable.Any<object>(null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Enumerable.Any<object>(null, null))
+			                   		ReflectHelper.GetMethodDefinition(() => Queryable.Any<object>(null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Queryable.Any<object>(null, null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.Any<object>(null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.Any<object>(null, null))
 			                   	};
 		}
 
@@ -54,8 +54,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			                   	{
-			                   		ReflectionHelper.GetMethodDefinition(() => Queryable.All<object>(null, null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null))
+			                   		ReflectHelper.GetMethodDefinition(() => Queryable.All<object>(null, null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null))
 			                   	};
 		}
 
@@ -89,8 +89,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			                   	{
-			                   		ReflectionHelper.GetMethodDefinition(() => Queryable.Min<object>(null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Enumerable.Min<object>(null))
+			                   		ReflectHelper.GetMethodDefinition(() => Queryable.Min<object>(null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.Min<object>(null))
 			                   	};
 		}
 
@@ -106,8 +106,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			                   	{
-			                   		ReflectionHelper.GetMethodDefinition(() => Queryable.Max<object>(null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Enumerable.Max<object>(null))
+			                   		ReflectHelper.GetMethodDefinition(() => Queryable.Max<object>(null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.Max<object>(null))
 			                   	};
 		}
 
@@ -143,8 +143,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			                   	{
-			                   		ReflectionHelper.GetMethodDefinition(() => Queryable.Contains<object>(null, null)),
-			                   		ReflectionHelper.GetMethodDefinition(() => Enumerable.Contains<object>(null, null))
+			                   		ReflectHelper.GetMethodDefinition(() => Queryable.Contains<object>(null, null)),
+			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.Contains<object>(null, null))
 			                   	};
 		}
 

--- a/src/NHibernate/Linq/Functions/StringGenerator.cs
+++ b/src/NHibernate/Linq/Functions/StringGenerator.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 
 namespace NHibernate.Linq.Functions
 {
@@ -63,7 +64,7 @@ namespace NHibernate.Linq.Functions
 	{
 		public LengthGenerator()
 		{
-			SupportedProperties = new[] { ReflectionHelper.GetProperty((string x) => x.Length) };
+			SupportedProperties = new[] { ReflectHelper.GetProperty((string x) => x.Length) };
 		}
 
 		public override HqlTreeNode BuildHql(MemberInfo member, Expression expression, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
@@ -76,7 +77,7 @@ namespace NHibernate.Linq.Functions
 	{
 		public StartsWithGenerator()
 		{
-			SupportedMethods = new[] { ReflectionHelper.GetMethodDefinition<string>(x => x.StartsWith(null)) };
+			SupportedMethods = new[] { ReflectHelper.GetMethodDefinition<string>(x => x.StartsWith(null)) };
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
@@ -93,7 +94,7 @@ namespace NHibernate.Linq.Functions
 	{
 		public EndsWithGenerator()
 		{
-			SupportedMethods = new[] { ReflectionHelper.GetMethodDefinition<string>(x => x.EndsWith(null)) };
+			SupportedMethods = new[] { ReflectHelper.GetMethodDefinition<string>(x => x.EndsWith(null)) };
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
@@ -110,7 +111,7 @@ namespace NHibernate.Linq.Functions
 	{
 		public ContainsGenerator()
 		{
-			SupportedMethods = new[] { ReflectionHelper.GetMethodDefinition<string>(x => x.Contains(null)) };
+			SupportedMethods = new[] { ReflectHelper.GetMethodDefinition<string>(x => x.Contains(null)) };
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
@@ -130,8 +131,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 									{
-										ReflectionHelper.GetMethodDefinition<string>(x => x.ToLower()),
-										ReflectionHelper.GetMethodDefinition<string>(x => x.ToLowerInvariant())
+										ReflectHelper.GetMethodDefinition<string>(x => x.ToLower()),
+										ReflectHelper.GetMethodDefinition<string>(x => x.ToLowerInvariant())
 									};
 		}
 
@@ -147,8 +148,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 									{
-										ReflectionHelper.GetMethodDefinition<string>(x => x.ToUpper()),
-										ReflectionHelper.GetMethodDefinition<string>(x => x.ToUpperInvariant()),
+										ReflectHelper.GetMethodDefinition<string>(x => x.ToUpper()),
+										ReflectHelper.GetMethodDefinition<string>(x => x.ToUpperInvariant()),
 									};
 		}
 
@@ -164,8 +165,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 									{
-										ReflectionHelper.GetMethodDefinition<string>(s => s.Substring(0)),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.Substring(0, 0))
+										ReflectHelper.GetMethodDefinition<string>(s => s.Substring(0)),
+										ReflectHelper.GetMethodDefinition<string>(s => s.Substring(0, 0))
 									};
 		}
 
@@ -188,10 +189,10 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 									{
-										ReflectionHelper.GetMethodDefinition<string>(s => s.IndexOf(' ')),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.IndexOf(" ")),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.IndexOf(' ', 0)),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.IndexOf(" ", 0))
+										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(' ')),
+										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(" ")),
+										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(' ', 0)),
+										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(" ", 0))
 									};
 		}
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
@@ -222,8 +223,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 									{
-										ReflectionHelper.GetMethodDefinition<string>(s => s.Replace(' ', ' ')),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.Replace("", ""))
+										ReflectHelper.GetMethodDefinition<string>(s => s.Replace(' ', ' ')),
+										ReflectHelper.GetMethodDefinition<string>(s => s.Replace("", ""))
 									};
 		}
 
@@ -242,10 +243,10 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 									{
-										ReflectionHelper.GetMethodDefinition<string>(s => s.Trim()),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.Trim('a')),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.TrimStart('a')),
-										ReflectionHelper.GetMethodDefinition<string>(s => s.TrimEnd('a'))
+										ReflectHelper.GetMethodDefinition<string>(s => s.Trim()),
+										ReflectHelper.GetMethodDefinition<string>(s => s.Trim('a')),
+										ReflectHelper.GetMethodDefinition<string>(s => s.TrimStart('a')),
+										ReflectHelper.GetMethodDefinition<string>(s => s.TrimEnd('a'))
 									};
 		}
 

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using NHibernate.Impl;
 using NHibernate.Type;
+using NHibernate.Util;
 using Remotion.Linq;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors;
 
@@ -31,36 +33,44 @@ namespace NHibernate.Linq
 			return new NhQueryable<T>(session.GetSessionImplementation(), entityName);
 		}
 
+		private static readonly MethodInfo CacheableDefinition = ReflectHelper.GetMethodDefinition(() => Cacheable<object>(null));
+
 		public static IQueryable<T> Cacheable<T>(this IQueryable<T> query)
 		{
-			var method = ReflectionHelper.GetMethodDefinition(() => Cacheable<object>(null)).MakeGenericMethod(typeof(T));
+			var method = CacheableDefinition.MakeGenericMethod(typeof(T));
 
 			var callExpression = Expression.Call(method, query.Expression);
 
 			return new NhQueryable<T>(query.Provider, callExpression);
 		}
 
+		private static readonly MethodInfo CacheModeDefinition = ReflectHelper.GetMethodDefinition(() => CacheMode<object>(null, NHibernate.CacheMode.Normal));
+
 		public static IQueryable<T> CacheMode<T>(this IQueryable<T> query, CacheMode cacheMode)
 		{
-			var method = ReflectionHelper.GetMethodDefinition(() => CacheMode<object>(null, NHibernate.CacheMode.Normal)).MakeGenericMethod(typeof(T));
+			var method = CacheModeDefinition.MakeGenericMethod(typeof(T));
 
 			var callExpression = Expression.Call(method, query.Expression, Expression.Constant(cacheMode));
 
 			return new NhQueryable<T>(query.Provider, callExpression);
 		}
 
+		private static readonly MethodInfo CacheRegionDefinition = ReflectHelper.GetMethodDefinition(() => CacheRegion<object>(null, null));
+
 		public static IQueryable<T> CacheRegion<T>(this IQueryable<T> query, string region)
 		{
-			var method = ReflectionHelper.GetMethodDefinition(() => CacheRegion<object>(null, null)).MakeGenericMethod(typeof(T));
+			var method = CacheRegionDefinition.MakeGenericMethod(typeof(T));
 
 			var callExpression = Expression.Call(method, query.Expression, Expression.Constant(region));
 
 			return new NhQueryable<T>(query.Provider, callExpression);
 		}
 
+		private static readonly MethodInfo TimeoutDefinition = ReflectHelper.GetMethodDefinition(() => Timeout<object>(null, 0));
+
 		public static IQueryable<T> Timeout<T>(this IQueryable<T> query, int timeout)
 		{
-			var method = ReflectionHelper.GetMethodDefinition(() => Timeout<object>(null, 0)).MakeGenericMethod(typeof(T));
+			var method = TimeoutDefinition.MakeGenericMethod(typeof(T));
 
 			var callExpression = Expression.Call(method, query.Expression, Expression.Constant(timeout));
 

--- a/src/NHibernate/Linq/NestedSelects/NestedSelectDetector.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectDetector.cs
@@ -1,8 +1,6 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
-using NHibernate.Linq.Visitors;
 using NHibernate.Util;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Parsing;
@@ -38,7 +36,7 @@ namespace NHibernate.Linq.NestedSelects
 
 		protected override Expression VisitMemberExpression(MemberExpression expression)
 		{
-			var memberType = expression.Member.GetPropertyOrFieldType();
+			var memberType = ReflectHelper.GetPropertyOrFieldType(expression.Member);
 
 			if (memberType != null && memberType.IsCollectionType()
 			    && IsChainedFromQuerySourceReference(expression)

--- a/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
@@ -16,11 +16,15 @@ namespace NHibernate.Linq.NestedSelects
 	static class NestedSelectRewriter
 	{
 		private static readonly MethodInfo CastMethod =
-			ReflectionHelper.GetMethod(() => Enumerable.Cast<object[]>(null));
-		private static readonly MethodInfo GroupByMethod = ReflectionHelper.GetMethod(
+			ReflectHelper.GetMethod(() => Enumerable.Cast<object[]>(null));
+		private static readonly MethodInfo GroupByMethod = ReflectHelper.GetMethod(
 			() => Enumerable.GroupBy<object[], Tuple, Tuple>(null, null, (Func<object[], Tuple>)null));
-		private static readonly MethodInfo WhereMethod = ReflectionHelper.GetMethod(
-			() => Enumerable.Where<Tuple>(null, (Func<Tuple, bool>)null));
+		private static readonly MethodInfo WhereMethod = ReflectHelper.GetMethod(
+			() => Enumerable.Where(null, (Func<Tuple, bool>)null));
+		private static readonly MethodInfo ObjectReferenceEquals = ReflectHelper.GetMethod(
+			() => ReferenceEquals(null, null));
+		private static readonly PropertyInfo IGroupingKeyProperty = (PropertyInfo)
+			ReflectHelper.GetProperty<IGrouping<Tuple, Tuple>, Tuple>(g => g.Key);
 
 		public static void ReWrite(QueryModel queryModel, ISessionFactory sessionFactory)
 		{
@@ -40,7 +44,7 @@ namespace NHibernate.Linq.NestedSelects
 					replacements.Add(expression, processed);
 			}
 
-			var key = Expression.Property(group, "Key");
+			var key = Expression.Property(group, IGroupingKeyProperty);
 
 			var expressions = new List<ExpressionHolder>();
 
@@ -200,9 +204,7 @@ namespace NHibernate.Linq.NestedSelects
 			var t = Expression.Parameter(typeof (Tuple), "t");
 			return Expression.Lambda(
 				Expression.Not(
-					Expression.Call(typeof (object),
-									"ReferenceEquals",
-									System.Type.EmptyTypes,
+					Expression.Call(ObjectReferenceEquals,
 									ArrayIndex(Expression.Property(t, Tuple.ItemsProperty), index),
 									Expression.Constant(null))),
 				t);

--- a/src/NHibernate/Linq/NhRelinqQueryParser.cs
+++ b/src/NHibernate/Linq/NhRelinqQueryParser.cs
@@ -4,16 +4,17 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Linq.ExpressionTransformers;
+using NHibernate.Linq.Visitors;
+using NHibernate.Util;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.StreamedData;
 using Remotion.Linq.EagerFetching.Parsing;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
 using Remotion.Linq.Parsing.Structure;
+using Remotion.Linq.Parsing.Structure.ExpressionTreeProcessors;
 using Remotion.Linq.Parsing.Structure.IntermediateModel;
 using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
-using Remotion.Linq.Parsing.Structure.ExpressionTreeProcessors;
-using NHibernate.Linq.Visitors;
 
 namespace NHibernate.Linq
 {
@@ -73,38 +74,38 @@ namespace NHibernate.Linq
 			var methodInfoRegistry = new MethodInfoBasedNodeTypeRegistry();
 
 			methodInfoRegistry.Register(
-				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.Fetch<object, object>(null, null)) },
+				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.Fetch<object, object>(null, null)) },
 				typeof(FetchOneExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.FetchMany<object, object>(null, null)) },
+				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.FetchMany<object, object>(null, null)) },
 				typeof(FetchManyExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetch<object, object, object>(null, null)) },
+				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetch<object, object, object>(null, null)) },
 				typeof(ThenFetchOneExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectionHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetchMany<object, object, object>(null, null)) },
+				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetchMany<object, object, object>(null, null)) },
 				typeof(ThenFetchManyExpressionNode));
 
 			methodInfoRegistry.Register(
 				new[]
 				{
-					ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.Cacheable<object>(null)),
-					ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.CacheMode<object>(null, CacheMode.Normal)),
-					ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.CacheRegion<object>(null, null)),
+					ReflectHelper.GetMethodDefinition(() => LinqExtensionMethods.Cacheable<object>(null)),
+					ReflectHelper.GetMethodDefinition(() => LinqExtensionMethods.CacheMode<object>(null, CacheMode.Normal)),
+					ReflectHelper.GetMethodDefinition(() => LinqExtensionMethods.CacheRegion<object>(null, null)),
 				}, typeof(CacheableExpressionNode));
 
 			methodInfoRegistry.Register(
 				new[]
 					{
-						ReflectionHelper.GetMethodDefinition(() => Queryable.AsQueryable(null)),
-						ReflectionHelper.GetMethodDefinition(() => Queryable.AsQueryable<object>(null)),
+						ReflectHelper.GetMethodDefinition(() => Queryable.AsQueryable(null)),
+						ReflectHelper.GetMethodDefinition(() => Queryable.AsQueryable<object>(null)),
 					}, typeof(AsQueryableExpressionNode)
 				);
 
 			methodInfoRegistry.Register(
 				new[]
 					{
-						ReflectionHelper.GetMethodDefinition(() => LinqExtensionMethods.Timeout<object>(null, 0)),
+						ReflectHelper.GetMethodDefinition(() => LinqExtensionMethods.Timeout<object>(null, 0)),
 					}, typeof (TimeoutExpressionNode)
 				);
 

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using NHibernate.Engine;
 using NHibernate.Param;
 using NHibernate.Type;
+using NHibernate.Util;
 using Remotion.Linq.Parsing;
 
 namespace NHibernate.Linq.Visitors
@@ -19,13 +20,13 @@ namespace NHibernate.Linq.Visitors
 		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		private static readonly MethodInfo QueryableSkipDefinition =
-			ReflectionHelper.GetMethodDefinition(() => Queryable.Skip<object>(null, 0));
+			ReflectHelper.GetMethodDefinition(() => Queryable.Skip<object>(null, 0));
 		private static readonly MethodInfo QueryableTakeDefinition =
-			ReflectionHelper.GetMethodDefinition(() => Queryable.Take<object>(null, 0));
+			ReflectHelper.GetMethodDefinition(() => Queryable.Take<object>(null, 0));
 		private static readonly MethodInfo EnumerableSkipDefinition =
-			ReflectionHelper.GetMethodDefinition(() => Enumerable.Skip<object>(null, 0));
+			ReflectHelper.GetMethodDefinition(() => Enumerable.Skip<object>(null, 0));
 		private static readonly MethodInfo EnumerableTakeDefinition =
-			ReflectionHelper.GetMethodDefinition(() => Enumerable.Take<object>(null, 0));
+			ReflectHelper.GetMethodDefinition(() => Enumerable.Take<object>(null, 0));
 
 		private readonly ICollection<MethodBase> _pagingMethods = new HashSet<MethodBase>
 			{

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFirst.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFirst.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using NHibernate.Util;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
@@ -7,9 +8,9 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 	public class ProcessFirst : ProcessFirstOrSingleBase, IResultOperatorProcessor<FirstResultOperator>
 	{
 		private static readonly MethodInfo FirstOrDefault =
-			ReflectionHelper.GetMethodDefinition(() => Queryable.FirstOrDefault<object>(null));
+			ReflectHelper.GetMethodDefinition(() => Queryable.FirstOrDefault<object>(null));
 		private static readonly MethodInfo First =
-			ReflectionHelper.GetMethodDefinition(() => Queryable.First<object>(null));
+			ReflectHelper.GetMethodDefinition(() => Queryable.First<object>(null));
 
 		public void Process(FirstResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessSingle.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessSingle.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using NHibernate.Util;
 using Remotion.Linq.Clauses.ResultOperators;
 
 namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
@@ -7,9 +8,9 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 	public class ProcessSingle : ProcessFirstOrSingleBase, IResultOperatorProcessor<SingleResultOperator>
 	{
 		private static readonly MethodInfo SingleOrDefault =
-			ReflectionHelper.GetMethodDefinition(() => Queryable.SingleOrDefault<object>(null));
+			ReflectHelper.GetMethodDefinition(() => Queryable.SingleOrDefault<object>(null));
 		private static readonly MethodInfo Single =
-			ReflectionHelper.GetMethodDefinition(() => Queryable.Single<object>(null));
+			ReflectHelper.GetMethodDefinition(() => Queryable.Single<object>(null));
 
 		public void Process(SingleResultOperator resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{

--- a/src/NHibernate/Proxy/DynamicProxy/DefaultMethodEmitter.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/DefaultMethodEmitter.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Proxy.DynamicProxy
 	{
 		private static readonly MethodInfo getInterceptor;
 
-		private static readonly MethodInfo handlerMethod = ReflectionHelper.GetMethod<IInterceptor>(
+		private static readonly MethodInfo handlerMethod = ReflectHelper.GetMethod<IInterceptor>(
 			i => i.Intercept(null));
 		private static readonly MethodInfo getArguments = typeof(InvocationInfo).GetMethod("get_Arguments");
 

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
@@ -21,11 +21,11 @@ namespace NHibernate.Proxy.DynamicProxy
 	{
 		private static readonly ConstructorInfo defaultBaseConstructor = typeof(object).GetConstructor(new System.Type[0]);
 
-		private static readonly MethodInfo getValue = ReflectionHelper.GetMethod<SerializationInfo>(
+		private static readonly MethodInfo getValue = ReflectHelper.GetMethod<SerializationInfo>(
 			si => si.GetValue(null, null));
-		private static readonly MethodInfo setType = ReflectionHelper.GetMethod<SerializationInfo>(
+		private static readonly MethodInfo setType = ReflectHelper.GetMethod<SerializationInfo>(
 			si => si.SetType(null));
-		private static readonly MethodInfo addValue = ReflectionHelper.GetMethod<SerializationInfo>(
+		private static readonly MethodInfo addValue = ReflectHelper.GetMethod<SerializationInfo>(
 			si => si.AddValue(null, null));
 
 		public ProxyFactory()

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -39,23 +39,23 @@ namespace NHibernate.Type
 		private static readonly char[] LengthSplit = new[] { '(', ')' };
 		private static readonly TypeFactory Instance;
 
-		private static readonly MethodInfo BagDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo BagDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.Bag<object>(null, null));
-		private static readonly MethodInfo IdBagDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo IdBagDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.IdBag<object>(null, null));
-		private static readonly MethodInfo ListDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo ListDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.List<object>(null, null));
-		private static readonly MethodInfo MapDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo MapDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.Map<object, object>(null, null));
-		private static readonly MethodInfo SortedListDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo SortedListDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.SortedList<object, object>(null, null, null));
-		private static readonly MethodInfo SortedDictionaryDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo SortedDictionaryDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.SortedDictionary<object, object>(null, null, null));
-		private static readonly MethodInfo SetDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo SetDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.Set<object>(null, null));
-		private static readonly MethodInfo SortedSetDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo SortedSetDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.SortedSet<object>(null, null, null));
-		private static readonly MethodInfo OrderedSetDefinition = ReflectionHelper.GetMethodDefinition<ICollectionTypeFactory>(
+		private static readonly MethodInfo OrderedSetDefinition = ReflectHelper.GetMethodDefinition<ICollectionTypeFactory>(
 			f => f.OrderedSet<object>(null, null));
 
 		/*

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 
@@ -25,6 +26,91 @@ namespace NHibernate.Util
 
 		private static readonly MethodInfo Exception_InternalPreserveStackTrace =
 			typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic);
+
+		/// <summary>
+		/// Extract the <see cref="MethodInfo"/> from a given expression.
+		/// </summary>
+		/// <typeparam name="TSource">The declaring-type of the method.</typeparam>
+		/// <param name="method">The method.</param>
+		/// <returns>The <see cref="MethodInfo"/> of the no-generic method or the generic-definition for a generic-method.</returns>
+		/// <seealso cref="MethodInfo.GetGenericMethodDefinition"/>
+		public static MethodInfo GetMethodDefinition<TSource>(Expression<Action<TSource>> method)
+		{
+			MethodInfo methodInfo = GetMethod(method);
+			return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
+		}
+
+		/// <summary>
+		/// Extract the <see cref="MethodInfo"/> from a given expression.
+		/// </summary>
+		/// <typeparam name="TSource">The declaring-type of the method.</typeparam>
+		/// <param name="method">The method.</param>
+		/// <returns>The <see cref="MethodInfo"/> of the method.</returns>
+		public static MethodInfo GetMethod<TSource>(Expression<Action<TSource>> method)
+		{
+			if (method == null)
+				throw new ArgumentNullException("method");
+
+			return ((MethodCallExpression)method.Body).Method;
+		}
+
+		/// <summary>
+		/// Extract the <see cref="MethodInfo"/> from a given expression.
+		/// </summary>
+		/// <param name="method">The method.</param>
+		/// <returns>The <see cref="MethodInfo"/> of the no-generic method or the generic-definition for a generic-method.</returns>
+		/// <seealso cref="MethodInfo.GetGenericMethodDefinition"/>
+		public static MethodInfo GetMethodDefinition(Expression<System.Action> method)
+		{
+			MethodInfo methodInfo = GetMethod(method);
+			return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
+		}
+
+		/// <summary>
+		/// Extract the <see cref="MethodInfo"/> from a given expression.
+		/// </summary>
+		/// <param name="method">The method.</param>
+		/// <returns>The <see cref="MethodInfo"/> of the method.</returns>
+		public static MethodInfo GetMethod(Expression<System.Action> method)
+		{
+			if (method == null)
+				throw new ArgumentNullException("method");
+
+			return ((MethodCallExpression)method.Body).Method;
+		}
+
+		/// <summary>
+		/// Gets the field or property to be accessed.
+		/// </summary>
+		/// <typeparam name="TSource">The declaring-type of the property.</typeparam>
+		/// <typeparam name="TResult">The type of the property.</typeparam>
+		/// <param name="property">The expression representing the property getter.</param>
+		/// <returns>The <see cref="MemberInfo"/> of the property.</returns>
+		public static MemberInfo GetProperty<TSource, TResult>(Expression<Func<TSource, TResult>> property)
+		{
+			if (property == null)
+			{
+				throw new ArgumentNullException("property");
+			}
+			return ((MemberExpression)property.Body).Member;
+		}
+
+		internal static System.Type GetPropertyOrFieldType(this MemberInfo memberInfo)
+		{
+			var propertyInfo = memberInfo as PropertyInfo;
+			if (propertyInfo != null)
+			{
+				return propertyInfo.PropertyType;
+			}
+
+			var fieldInfo = memberInfo as FieldInfo;
+			if (fieldInfo != null)
+			{
+				return fieldInfo.FieldType;
+			}
+
+			return null;
+		}
 
 		/// <summary>
 		/// Determine if the specified <see cref="System.Type"/> overrides the
@@ -565,7 +651,7 @@ namespace NHibernate.Util
 			return null;
 		}
 
-		[Obsolete("Please use Linq.ReflectionHelper instead")]
+		[Obsolete("Please use GetMethodDefinition then MethodInfo.MakeGenericMethod instead")]
 		public static MethodInfo GetGenericMethodFrom<T>(string methodName, System.Type[] genericArgs, System.Type[] signature)
 		{
 			MethodInfo result = null;

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -20,40 +20,40 @@ namespace NHibernate.Util
 		internal static class EnumerableMethods
 		{
 			internal static readonly MethodInfo AggregateDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object>(null, null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object>(null, null));
 			internal static readonly MethodInfo AggregateWithSeedDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
 			internal static readonly MethodInfo AggregateWithSeedAndResultSelectorDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
 
 			internal static readonly MethodInfo CastDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
 
-			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectionHelper.GetMethodDefinition(
-				() => Enumerable.GroupBy<object, object, object>(null, null, (Func<object, object>)null));
+			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectHelper.GetMethodDefinition(
+				() => Enumerable.GroupBy<object, object, object>(null, null, default(Func<object, object>)));
 
 			internal static readonly MethodInfo SelectDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.Select<object, object>(null, (Func<object, object>)null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.Select(null, default(Func<object, object>)));
 
 			internal static readonly MethodInfo ToArrayDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
 
 			internal static readonly MethodInfo ToListDefinition =
-				ReflectionHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
+				ReflectHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
 		}
 
 		internal static class MethodBaseMethods
 		{
 			internal static readonly MethodInfo GetMethodFromHandle =
-				ReflectionHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle()));
+				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle()));
 			internal static readonly MethodInfo GetMethodFromHandleWithDeclaringType =
-				ReflectionHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle(), new RuntimeTypeHandle()));
+				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(new RuntimeMethodHandle(), new RuntimeTypeHandle()));
 		}
 
 		internal static class TypeMethods
 		{
 			internal static readonly MethodInfo GetTypeFromHandle =
-				ReflectionHelper.GetMethod(() => System.Type.GetTypeFromHandle(new RuntimeTypeHandle()));
+				ReflectHelper.GetMethod(() => System.Type.GetTypeFromHandle(new RuntimeTypeHandle()));
 		}
 	}
 }


### PR DESCRIPTION
Follow up of [NH-3964](https://nhibernate.jira.com/browse/NH-3964) and its first PR #574 .

Methods are just moved to ReflectHelper, without changing them.

Trying to use

>    public static MethodInfo GetMethod<T, TResult>(Func<T, TResult> func, T arg1)
>    {
>        return func.Method;
>    }

is requiring as many overloads as function arguments counts

    public static MethodInfo GetMethod<T1, T2, TResult>(Func<T1, T2, TResult> func, T1 arg1, T2 arg2)
    {
        return func.Method;
    }

Then type inference is sometime inferior:

    return GetMethod(Enumerable.GroupBy, (IEnumerable<int>)null, (Func<int, decimal>)null);

Instead of 

    return GetMethod(() => Enumerable.GroupBy(null, (Func<int, decimal>)null));

And handling instance methods are requiring a `Func<Func<>>` with a non-null instance:

	public static MethodInfo GetMethod<TSource, T1, TResult>(Func<TSource, Func<T1, TResult>> func, TSource source, T1 arg1)
	{
		return func(source).Method;
	}

    GetMethod<string, int, string>(s => s.Substring, "", 10);

So well, even though some "brute force" runtime performance comparison show it is "better", I do not think it is worth all the required changes and additional code for using them.