### PR TITLE
NH-3975 - Synchronize some features dialect support properties

### DIFF
--- a/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
+++ b/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
@@ -513,9 +513,8 @@ namespace NHibernate.Test.Hql.Ast
 			ITransaction t = s.BeginTransaction();
 
 			s.CreateQuery("update Animal a set a.mother = null where a.id = 2").ExecuteUpdate();
-			if (! (Dialect is MySQLDialect))
+			if (Dialect.SupportsSubqueryOnMutatingTable)
 			{
-				// MySQL does not support (even un-correlated) subqueries against the update-mutating table
 				s.CreateQuery("update Animal a set a.mother = (from Animal where id = 1) where a.id = 2").ExecuteUpdate();
 			}
 
@@ -624,9 +623,8 @@ namespace NHibernate.Test.Hql.Ast
 				.ExecuteUpdate();
 			Assert.That(count, Is.EqualTo(6), "incorrect count on 'complex' update assignment");
 
-			if (! (Dialect is MySQLDialect))
+			if (Dialect.SupportsSubqueryOnMutatingTable)
 			{
-				// MySQL does not support (even un-correlated) subqueries against the update-mutating table
 				s.CreateQuery("update Animal set bodyWeight = ( select max(bodyWeight) from Animal )").ExecuteUpdate();
 			}
 
@@ -682,9 +680,8 @@ namespace NHibernate.Test.Hql.Ast
 			count = s.CreateQuery("update Mammal set bodyWeight = 25").ExecuteUpdate();
 			Assert.That(count, Is.EqualTo(2), "incorrect update count against 'middle' of joined-subclass hierarchy");
 
-			if (! (Dialect is MySQLDialect))
+			if (Dialect.SupportsSubqueryOnMutatingTable)
 			{
-				// MySQL does not support (even un-correlated) subqueries against the update-mutating table
 				count = s.CreateQuery("update Mammal set bodyWeight = ( select max(bodyWeight) from Animal )").ExecuteUpdate();
 				Assert.That(count, Is.EqualTo(2), "incorrect update count against 'middle' of joined-subclass hierarchy");
 			}

--- a/src/NHibernate.Test/SqlTest/Custom/MySQL/MySQLTest.cs
+++ b/src/NHibernate.Test/SqlTest/Custom/MySQL/MySQLTest.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.SqlTest.Custom.MySQL
 
 		protected override bool AppliesTo(Dialect.Dialect dialect)
 		{
-			return dialect is MySQL5Dialect || dialect is MySQLDialect;
+			return dialect is MySQLDialect;
 		}
 	}
 }

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -273,30 +273,15 @@ namespace NHibernate.Dialect
 
 		#region Overridden informational metadata
 
-		public override bool SupportsEmptyInList
-		{
-			get { return false; }
-		}
+		public override bool SupportsEmptyInList => false;
 
-		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor
-		{
-			get { return false; }
-		}
+		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor => false;
 
-		public override bool SupportsLobValueChangePropogation
-		{
-			get { return false; }
-		}
+		public override bool SupportsLobValueChangePropogation => false;
 
-		public override bool SupportsExistsInSelect
-		{
-			get { return false; }
-		}
+		public override bool SupportsExistsInSelect => false;
 
-		public override bool DoesReadCommittedCauseWritersToBlockReaders
-		{
-			get { return true; }
-		}
+		public override bool DoesReadCommittedCauseWritersToBlockReaders => true;
 
 		#endregion
 	}

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -270,5 +270,34 @@ namespace NHibernate.Dialect
 		{
 			get { return " for read only with rs"; }
 		}
+
+		#region Overridden informational metadata
+
+		public override bool SupportsEmptyInList
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsLobValueChangePropogation
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsExistsInSelect
+		{
+			get { return false; }
+		}
+
+		public override bool DoesReadCommittedCauseWritersToBlockReaders
+		{
+			get { return true; }
+		}
+
+		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -1879,7 +1879,7 @@ namespace NHibernate.Dialect
 
 		/// <summary> 
 		/// Does this dialect require that references to result variables
-		/// (i.e, select expresssion aliases) in an ORDER BY clause be
+		/// (i.e, select expression aliases) in an ORDER BY clause be
 		/// replaced by column positions (1-origin) as defined by the select clause?
 		/// </summary>
 		/// <returns> 
@@ -2050,8 +2050,6 @@ namespace NHibernate.Dialect
 			get { return true; }
 		}
 
-		#endregion
-
 		/// <summary>
 		/// Does this dialect support subselects?
 		/// </summary>
@@ -2059,6 +2057,8 @@ namespace NHibernate.Dialect
 		{
 			get { return true; }
 		}
+
+		#endregion
 
 		/// <summary>
 		/// Retrieve a set of default Hibernate properties for this database.
@@ -2136,7 +2136,7 @@ namespace NHibernate.Dialect
 		/// <summary> 
 		/// Should the value returned by <see cref="CurrentTimestampSelectString"/>
 		/// be treated as callable.  Typically this indicates that JDBC escape
-		/// sytnax is being used...
+		/// syntax is being used...
 		/// </summary>
 		public virtual bool IsCurrentTimestampSelectStringCallable
 		{

--- a/src/NHibernate/Dialect/Ingres9Dialect.cs
+++ b/src/NHibernate/Dialect/Ingres9Dialect.cs
@@ -64,5 +64,14 @@ namespace NHibernate.Dialect
 
 			return pagingBuilder.ToSqlString();
 		}
+
+		#region Overridden informational metadata
+		
+		public override bool DoesRepeatableReadCauseReadersToBlockWriters
+		{
+			get { return true; }
+		}
+
+		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/Ingres9Dialect.cs
+++ b/src/NHibernate/Dialect/Ingres9Dialect.cs
@@ -67,10 +67,7 @@ namespace NHibernate.Dialect
 
 		#region Overridden informational metadata
 		
-		public override bool DoesRepeatableReadCauseReadersToBlockWriters
-		{
-			get { return true; }
-		}
+		public override bool DoesRepeatableReadCauseReadersToBlockWriters => true;
 
 		#endregion
 	}

--- a/src/NHibernate/Dialect/IngresDialect.cs
+++ b/src/NHibernate/Dialect/IngresDialect.cs
@@ -51,5 +51,29 @@ namespace NHibernate.Dialect
 
 			DefaultProperties[Environment.ConnectionDriver] = "NHibernate.Driver.IngresDriver";
 		}
+
+		#region Overridden informational metadata
+
+		public override bool SupportsEmptyInList
+		{
+			get { return false; }
+		}
+		
+		public override bool SupportsSubselectAsInPredicateLHS
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsExpectedLobUsagePattern
+		{
+			get { return false; }
+		}
+
+		public override bool DoesReadCommittedCauseWritersToBlockReaders
+		{
+			get { return true; }
+		}
+
+		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/IngresDialect.cs
+++ b/src/NHibernate/Dialect/IngresDialect.cs
@@ -54,25 +54,13 @@ namespace NHibernate.Dialect
 
 		#region Overridden informational metadata
 
-		public override bool SupportsEmptyInList
-		{
-			get { return false; }
-		}
-		
-		public override bool SupportsSubselectAsInPredicateLHS
-		{
-			get { return false; }
-		}
+		public override bool SupportsEmptyInList => false;
 
-		public override bool SupportsExpectedLobUsagePattern
-		{
-			get { return false; }
-		}
+		public override bool SupportsSubselectAsInPredicateLHS => false;
 
-		public override bool DoesReadCommittedCauseWritersToBlockReaders
-		{
-			get { return true; }
-		}
+		public override bool SupportsExpectedLobUsagePattern => false;
+
+		public override bool DoesReadCommittedCauseWritersToBlockReaders => true;
 
 		#endregion
 	}

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -500,36 +500,18 @@ namespace NHibernate.Dialect
 
 		#region Overridden informational metadata
 
-		public override bool SupportsEmptyInList
-		{
-			get { return false; }
-		}
+		public override bool SupportsEmptyInList => false;
 
-		public override bool AreStringComparisonsCaseInsensitive
-		{
-			get { return true; }
-		}
+		public override bool AreStringComparisonsCaseInsensitive => true;
 
-		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor
-		{
-			get { return false; }
-		}
+		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor => false;
 
-		public override bool SupportsLobValueChangePropogation
-		{
-			// note: at least my local SQL Server 2005 Express shows this not working...
-			get { return false; }
-		}
+		// note: at least SQL Server 2005 Express shows this not working...
+		public override bool SupportsLobValueChangePropogation => false;
 
-		public override bool DoesReadCommittedCauseWritersToBlockReaders
-		{
-			get { return true; }
-		}
+		public override bool DoesReadCommittedCauseWritersToBlockReaders => true;
 
-		public override bool DoesRepeatableReadCauseReadersToBlockWriters
-		{
-			get { return true; }
-		}
+		public override bool DoesRepeatableReadCauseReadersToBlockWriters => true;
 
 		#endregion
 

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -498,6 +498,41 @@ namespace NHibernate.Dialect
 			get { return true; }
 		}
 
+		#region Overridden informational metadata
+
+		public override bool SupportsEmptyInList
+		{
+			get { return false; }
+		}
+
+		public override bool AreStringComparisonsCaseInsensitive
+		{
+			get { return true; }
+		}
+
+		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsLobValueChangePropogation
+		{
+			// note: at least my local SQL Server 2005 Express shows this not working...
+			get { return false; }
+		}
+
+		public override bool DoesReadCommittedCauseWritersToBlockReaders
+		{
+			get { return true; }
+		}
+
+		public override bool DoesRepeatableReadCauseReadersToBlockWriters
+		{
+			get { return true; }
+		}
+
+		#endregion
+
 		public override bool IsKnownToken(string currentToken, string nextToken)
 		{
 			return currentToken == "n" && nextToken == "'"; // unicode character

--- a/src/NHibernate/Dialect/MsSql2005Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2005Dialect.cs
@@ -109,19 +109,13 @@ namespace NHibernate.Dialect
 		/// We assume that applications using this dialect are using
 		/// SQL Server 2005 snapshot isolation modes.
 		/// </summary>
-		public override bool DoesReadCommittedCauseWritersToBlockReaders
-		{
-			get { return false; }
-		}
+		public override bool DoesReadCommittedCauseWritersToBlockReaders => false;
 
 		/// <summary>
 		/// We assume that applications using this dialect are using
 		/// SQL Server 2005 snapshot isolation modes.
 		/// </summary>
-		public override bool DoesRepeatableReadCauseReadersToBlockWriters
-		{
-			get { return false; }
-		}
+		public override bool DoesRepeatableReadCauseReadersToBlockWriters => false;
 
 		#endregion
 	}

--- a/src/NHibernate/Dialect/MsSql2005Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2005Dialect.cs
@@ -102,5 +102,27 @@ namespace NHibernate.Dialect
 
 			return tableName;
 		}
+
+		#region Overridden informational metadata
+
+		/// <summary>
+		/// We assume that applications using this dialect are using
+		/// SQL Server 2005 snapshot isolation modes.
+		/// </summary>
+		public override bool DoesReadCommittedCauseWritersToBlockReaders
+		{
+			get { return false; }
+		}
+
+		/// <summary>
+		/// We assume that applications using this dialect are using
+		/// SQL Server 2005 snapshot isolation modes.
+		/// </summary>
+		public override bool DoesRepeatableReadCauseReadersToBlockWriters
+		{
+			get { return false; }
+		}
+
+		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/MySQLDialect.cs
+++ b/src/NHibernate/Dialect/MySQLDialect.cs
@@ -389,26 +389,14 @@ namespace NHibernate.Dialect
 
 		#region Overridden informational metadata
 
-		public override bool SupportsEmptyInList
-		{
-			get { return false; }
-		}
+		public override bool SupportsEmptyInList => false;
 
-		public override bool AreStringComparisonsCaseInsensitive
-		{
-			get { return true; }
-		}
+		public override bool AreStringComparisonsCaseInsensitive => true;
 
-		public override bool SupportsLobValueChangePropogation
-		{
-			// note: at least my local MySQL 5.1 install shows this not working...
-			get { return false; }
-		}
+		// note: at least MySQL 5.1 shows this not working...
+		public override bool SupportsLobValueChangePropogation => false;
 
-		public override bool SupportsSubqueryOnMutatingTable
-		{
-			get { return false; }
-		}
+		public override bool SupportsSubqueryOnMutatingTable => false;
 
 		#endregion
 	}

--- a/src/NHibernate/Dialect/MySQLDialect.cs
+++ b/src/NHibernate/Dialect/MySQLDialect.cs
@@ -386,5 +386,30 @@ namespace NHibernate.Dialect
 				return TimeSpan.TicksPerSecond;
 			}
 		}
+
+		#region Overridden informational metadata
+
+		public override bool SupportsEmptyInList
+		{
+			get { return false; }
+		}
+
+		public override bool AreStringComparisonsCaseInsensitive
+		{
+			get { return true; }
+		}
+
+		public override bool SupportsLobValueChangePropogation
+		{
+			// note: at least my local MySQL 5.1 install shows this not working...
+			get { return false; }
+		}
+
+		public override bool SupportsSubqueryOnMutatingTable
+		{
+			get { return false; }
+		}
+
+		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -249,5 +249,34 @@ namespace NHibernate.Dialect
 		{
 			get { return "SELECT CURRENT_TIMESTAMP"; }
 		}
+
+		#region Overridden informational metadata
+
+		public override bool SupportsEmptyInList
+		{
+			get { return false; }
+		}
+
+		/// <summary> 
+		/// Should LOBs (both BLOB and CLOB) be bound using stream operations (i.e.
+		/// {@link java.sql.PreparedStatement#setBinaryStream}). 
+		/// </summary>
+		/// <returns> True if BLOBs and CLOBs should be bound using stream operations. </returns>
+		public override bool UseInputStreamToInsertBlob
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsLobValueChangePropogation
+		{
+			get { return false; }
+		}
+
+		public override bool SupportsUnboundedLobLocatorMaterialization
+		{
+			get { return false; }
+		}
+
+		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -252,30 +252,18 @@ namespace NHibernate.Dialect
 
 		#region Overridden informational metadata
 
-		public override bool SupportsEmptyInList
-		{
-			get { return false; }
-		}
+		public override bool SupportsEmptyInList => false;
 
 		/// <summary> 
 		/// Should LOBs (both BLOB and CLOB) be bound using stream operations (i.e.
 		/// {@link java.sql.PreparedStatement#setBinaryStream}). 
 		/// </summary>
 		/// <returns> True if BLOBs and CLOBs should be bound using stream operations. </returns>
-		public override bool UseInputStreamToInsertBlob
-		{
-			get { return false; }
-		}
+		public override bool UseInputStreamToInsertBlob => false;
 
-		public override bool SupportsLobValueChangePropogation
-		{
-			get { return false; }
-		}
+		public override bool SupportsLobValueChangePropogation => false;
 
-		public override bool SupportsUnboundedLobLocatorMaterialization
-		{
-			get { return false; }
-		}
+		public override bool SupportsUnboundedLobLocatorMaterialization => false;
 
 		#endregion
 	}


### PR DESCRIPTION
[NH-3975](https://nhibernate.jira.com/browse/NH-3975) - Synchronize some features dialect support properties (Informational metadata).

A bunch of "Informational metadata" properties are defined on the base dialect class, and allow tests to ignore dialects which do not support the tested feature. Unfortunately, some of them are not up-to-date and causes such tests to fail instead of ignoring the dialect.

This PR aims at updating those properties according to their current valu in Hibernate Java dialects implementation.

This has been done in a very conservative manner: each such property have been checked for not having any usage inside NHibernate (being purely informational), otherwise I have left them untouched. Some NHibernate dialect are overriding some of those properties while their Java counterpart do not, I have kept NHibernate overrides.

It would be probably nice to do a complete dialect sync, but this would have heavy transverse impacts. By example, the `SupportsTemporaryTable` seems gone in Java, while in NHibernate it enables updates and deletes on classes having joined table (subclasses notably). This is why I have limited the scope of this Jira to purely informational properties.