### PR TITLE
NH-2520 - fix flaky timestamp utc test.

### DIFF
--- a/src/NHibernate.Test/TypesTest/TimestampUtcTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TimestampUtcTypeFixture.cs
@@ -114,8 +114,9 @@ namespace NHibernate.Test.TypesTest
 				var revision = result.Revision;
 				Assert.AreEqual(DateTimeKind.Utc, revision.Kind, "Kind is NOT Utc");
 
-				var differenceInSeconds = Math.Abs((revision - DateTime.UtcNow).TotalSeconds);
-				Assert.IsTrue(differenceInSeconds < 1d, "Difference should be less then 1 second.");
+				var differenceInMinutes = Math.Abs((revision - DateTime.UtcNow).TotalMinutes);
+				// Take a wide margin for accounting for sometimes bad build servers performances.
+				Assert.Less(differenceInMinutes, 2, "Difference should be less than 2 minutes.");
 
 				tx.Commit();
 				session.Close();


### PR DESCRIPTION
As of #580 comment, one test looks flaky to me. It creates a timestamp versioned entity and re-read it from db, then test its version is less than one second off current utc time.

But sometimes it appears TeamCity build servers performances are quite sluggish, so one second is a bit too short. Bumped to two minutes.

(Since the aim was very likely to detect a local time timestamp instead of an utc one, it could be anything up to a couple of minutes. Currently, it could even be near but less than one hour : there are zones off by a quarter or a half hour, but not around +0.)