### PR TITLE
NH-3981 - maps equality fix, collection helper cleanup.

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -1439,6 +1439,7 @@
     <Compile Include="Unionsubclass\DatabaseKeyword.cs" />
     <Compile Include="Unionsubclass\DatabaseKeywordBase.cs" />
     <Compile Include="Unionsubclass\DatabaseKeywordsFixture.cs" />
+    <Compile Include="UtilityTest\CollectionHelperFixture.cs" />
     <Compile Include="UtilityTest\ArrayHelperTests.cs" />
     <Compile Include="UnionsubclassPolymorphicFormula\Company.cs" />
     <Compile Include="UnionsubclassPolymorphicFormula\Party.cs" />

--- a/src/NHibernate.Test/UtilityTest/CollectionHelperFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/CollectionHelperFixture.cs
@@ -1,0 +1,243 @@
+﻿using System.Collections.Generic;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest
+{
+	[TestFixture]
+	public class CollectionHelperFixture
+	{
+		#region Bag
+
+		[Test]
+		public void BagComparedToSelfShouldBeEqual()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.BagEquals(c1, c1), Is.True);
+		}
+
+		[Test]
+		public void BagComparedToNullShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.BagEquals(c1, null), Is.False);
+			Assert.That(CollectionHelper.BagEquals(null, c1), Is.False);
+		}
+
+		[Test]
+		public void BagNullComparedToNullShouldBeEqual()
+		{
+			Assert.That(CollectionHelper.BagEquals<string>(null, null), Is.True);
+		}
+
+		[Test]
+		public void BagsWithSameContentShouldBeEqual()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4", "2" };
+			var c2 = new List<string> { "1", "2", "3", "4", "2" };
+			Assert.That(CollectionHelper.BagEquals(c1, c2), Is.True);
+		}
+
+		[Test]
+		public void BagsWithSameCountButDistinctValuesShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			var c2 = new List<string> { "1", "2", "3", "3" };
+			Assert.That(CollectionHelper.BagEquals(c1, c2), Is.False);
+		}
+
+		[Test]
+		public void BagsWithSameElementsButDistinctOrderShouldBeEqual()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4", "2" };
+			var c2 = new List<string> { "2", "1", "2", "4", "3" };
+			Assert.That(CollectionHelper.BagEquals(c1, c2), Is.True);
+		}
+
+		[Test]
+		public void BagsWithoutSameCountShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "2", "1" };
+			var c2 = new List<string> { "1", "2" };
+			Assert.That(CollectionHelper.BagEquals(c1, c2), Is.False);
+			Assert.That(CollectionHelper.BagEquals(c2, c1), Is.False);
+		}
+
+		#endregion
+
+		#region Dictionary/Map
+
+		[Test]
+		public void MapComparedToSelfShouldBeEqual()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d1, d1), Is.True);
+		}
+
+		[Test]
+		public void MapComparedToNullShouldBeInequal()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d1, null), Is.False);
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(null, d1), Is.False);
+		}
+
+		[Test]
+		public void MapNullComparedToNullShouldBeEqual()
+		{
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(null, null), Is.True);
+		}
+
+		[Test]
+		public void MapsWithSameContentShouldBeEqual()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d1, d2), Is.True);
+		}
+
+		// Fails till NH-3981 is fixed.
+		[Test]
+		public void MapsWithSameCountButDistinctKeysShouldBeInequal()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" }, { "4", "3" } };
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d1, d2), Is.False);
+		}
+
+		[Test]
+		public void MapsWithSameCountButDistinctValuesShouldBeInequal()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" }, { "3", "3" } };
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d1, d2), Is.False);
+		}
+
+		[Test]
+		public void MapsWithoutSameCountShouldBeInequal()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" } };
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d1, d2), Is.False);
+			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d2, d1), Is.False);
+		}
+
+		#endregion
+
+		#region Set
+
+		[Test]
+		public void SetComparedToSelfShouldBeEqual()
+		{
+			var c1 = new HashSet<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.SetEquals(c1, c1), Is.True);
+		}
+
+		[Test]
+		public void SetComparedToNullShouldBeInequal()
+		{
+			var c1 = new HashSet<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.SetEquals(c1, null), Is.False);
+			Assert.That(CollectionHelper.SetEquals(null, c1), Is.False);
+		}
+
+		[Test]
+		public void SetNullComparedToNullShouldBeEqual()
+		{
+			Assert.That(CollectionHelper.SetEquals<string>(null, null), Is.True);
+		}
+
+		[Test]
+		public void SetsWithSameContentShouldBeEqual()
+		{
+			var c1 = new HashSet<string> { "1", "2", "3", "4" };
+			var c2 = new HashSet<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.SetEquals(c1, c2), Is.True);
+		}
+
+		[Test]
+		public void SetsWithSameCountButDistinctValuesShouldBeInequal()
+		{
+			var c1 = new HashSet<string> { "1", "2", "3", "4" };
+			var c2 = new HashSet<string> { "1", "2", "3", "5" };
+			Assert.That(CollectionHelper.SetEquals(c1, c2), Is.False);
+		}
+
+		[Test]
+		public void SetsWithSameElementsButDistinctOrderShouldBeEqual()
+		{
+			var c1 = new HashSet<string> { "1", "2", "3", "4" };
+			var c2 = new HashSet<string> { "1", "2", "4", "3" };
+			Assert.That(CollectionHelper.SetEquals(c1, c2), Is.True);
+		}
+
+		[Test]
+		public void SetsWithoutSameCountShouldBeInequal()
+		{
+			var c1 = new HashSet<string> { "1", "2", "3", "4" };
+			var c2 = new HashSet<string> { "1", "2" };
+			Assert.That(CollectionHelper.SetEquals(c1, c2), Is.False);
+			Assert.That(CollectionHelper.SetEquals(c2, c1), Is.False);
+		}
+
+		#endregion
+
+		#region List/Sequence
+
+		[Test]
+		public void SequenceComparedToSelfShouldBeEqual()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.SequenceEquals(c1, c1), Is.True);
+		}
+
+		[Test]
+		public void SequenceComparedToNullShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.SequenceEquals(c1, null), Is.False);
+			Assert.That(CollectionHelper.SequenceEquals(null, c1), Is.False);
+		}
+
+		[Test]
+		public void SequenceNullComparedToNullShouldBeEqual()
+		{
+			Assert.That(CollectionHelper.SequenceEquals<string>(null, null), Is.True);
+		}
+
+		[Test]
+		public void SequencesWithSameContentShouldBeEqual()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			var c2 = new List<string> { "1", "2", "3", "4" };
+			Assert.That(CollectionHelper.SequenceEquals(c1, c2), Is.True);
+		}
+
+		[Test]
+		public void SequencesWithSameCountButDistinctValuesShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			var c2 = new List<string> { "1", "2", "3", "3" };
+			Assert.That(CollectionHelper.SequenceEquals(c1, c2), Is.False);
+		}
+
+		[Test]
+		public void SequencesWithSameElementsButDistinctOrderShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			var c2 = new List<string> { "1", "2", "4", "3" };
+			Assert.That(CollectionHelper.SequenceEquals(c1, c2), Is.False);
+		}
+
+		[Test]
+		public void SequencesWithoutSameCountShouldBeInequal()
+		{
+			var c1 = new List<string> { "1", "2", "3", "4" };
+			var c2 = new List<string> { "1", "2" };
+			Assert.That(CollectionHelper.SequenceEquals(c1, c2), Is.False);
+			Assert.That(CollectionHelper.SequenceEquals(c2, c1), Is.False);
+		}
+
+		#endregion
+	}
+}

--- a/src/NHibernate/Cache/QueryKey.cs
+++ b/src/NHibernate/Cache/QueryKey.cs
@@ -137,11 +137,11 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			if (!CollectionHelper.CollectionEquals<int>(_multiQueriesFirstRows, that._multiQueriesFirstRows))
+			if (!CollectionHelper.SequenceEquals<int>(_multiQueriesFirstRows, that._multiQueriesFirstRows))
 			{
 				return false;
 			}
-			if (!CollectionHelper.CollectionEquals<int>(_multiQueriesMaxRows, that._multiQueriesMaxRows))
+			if (!CollectionHelper.SequenceEquals<int>(_multiQueriesMaxRows, that._multiQueriesMaxRows))
 			{
 				return false;
 			}

--- a/src/NHibernate/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericList.cs
@@ -230,7 +230,7 @@ namespace NHibernate.Collection.Generic
 				return false;
 			}
 			Read();
-			return CollectionHelper.CollectionEquals(WrappedList, that);
+			return CollectionHelper.SequenceEquals(WrappedList, that);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
@@ -72,7 +72,9 @@ namespace NHibernate.Collection.Generic
 			}
 			foreach (KeyValuePair<TKey, TValue> entry in WrappedMap)
 			{
-				if (elementType.IsDirty(entry.Value, xmap[entry.Key], Session))
+				// This method is not currently called if a key has been removed/added, but better be on the safe side.
+				if (!xmap.TryGetValue(entry.Key, out var value) ||
+					elementType.IsDirty(value, entry.Value, Session))
 				{
 					return false;
 				}

--- a/src/NHibernate/Engine/Query/Sql/NativeSQLQuerySpecification.cs
+++ b/src/NHibernate/Engine/Query/Sql/NativeSQLQuerySpecification.cs
@@ -65,8 +65,8 @@ namespace NHibernate.Engine.Query.Sql
 			// Code taken back from 8e92af3f and amended according to NH-1931.
 			return hashCode == that.hashCode &&
 				queryString.Equals(that.queryString) &&
-				CollectionHelper.CollectionEquals(querySpaces, that.querySpaces) &&
-				CollectionHelper.CollectionEquals<INativeSQLQueryReturn>(sqlQueryReturns, that.sqlQueryReturns);
+				CollectionHelper.SequenceEquals(querySpaces, that.querySpaces) &&
+				CollectionHelper.SequenceEquals<INativeSQLQueryReturn>(sqlQueryReturns, that.sqlQueryReturns);
 		}
 
 		public override int GetHashCode()

--- a/src/NHibernate/Loader/Collection/OneToManyJoinWalker.cs
+++ b/src/NHibernate/Loader/Collection/OneToManyJoinWalker.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Loader.Collection
 		{
 			//disable a join back to this same association
 			bool isSameJoin = oneToManyPersister.TableName.Equals(foreignKeyTable)
-			                  && CollectionHelper.CollectionEquals<string>(foreignKeyColumns, oneToManyPersister.KeyColumnNames);
+			                  && CollectionHelper.SequenceEquals<string>(foreignKeyColumns, oneToManyPersister.KeyColumnNames);
 			return isSameJoin || base.IsDuplicateAssociation(foreignKeyTable, foreignKeyColumns);
 		}
 

--- a/src/NHibernate/Loader/JoinWalker.cs
+++ b/src/NHibernate/Loader/JoinWalker.cs
@@ -573,7 +573,7 @@ namespace NHibernate.Loader
 				if (that == null)
 					return false;
 
-				return that.table.Equals(table) && CollectionHelper.CollectionEquals<string>(columns, that.columns);
+				return that.table.Equals(table) && CollectionHelper.SequenceEquals<string>(columns, that.columns);
 			}
 
 			public override int GetHashCode()

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -1031,8 +1031,8 @@ namespace NHibernate.Mapping
 			{
 				// NH : Different implementation to prevent NH930 (look test)
 				return //y.referencedClassName.Equals(x.referencedClassName) &&
-					CollectionHelper.CollectionEquals<Column>(y.columns, x.columns)
-					&& CollectionHelper.CollectionEquals<Column>(y.referencedColumns, x.referencedColumns);
+					CollectionHelper.SequenceEquals<Column>(y.columns, x.columns)
+					&& CollectionHelper.SequenceEquals<Column>(y.referencedColumns, x.referencedColumns);
 			}
 
 			public int GetHashCode(ForeignKeyKey obj)

--- a/src/NHibernate/Type/GenericBagType.cs
+++ b/src/NHibernate/Type/GenericBagType.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using NHibernate.Collection;
 using NHibernate.Collection.Generic;
 using NHibernate.Engine;
 using NHibernate.Persister.Collection;
+using NHibernate.Util;
 
 namespace NHibernate.Type
 {
@@ -75,11 +75,7 @@ namespace NHibernate.Type
 
 		protected override bool AreCollectionElementsEqual(IEnumerable original, IEnumerable target)
 		{
-			var first = (IEnumerable<T>)original;
-			var second = (IEnumerable<T>) target;
-
-			return first.Count() == second.Count() && 
-				first.All(element => first.Count(x => x.Equals(element)) == second.Count(x => x.Equals(element)));
+			return CollectionHelper.BagEquals((IEnumerable<T>)original, (IEnumerable<T>)target);
 		}
 	}
 }

--- a/src/NHibernate/Type/GenericIdentifierBagType.cs
+++ b/src/NHibernate/Type/GenericIdentifierBagType.cs
@@ -6,6 +6,7 @@ using NHibernate.Collection;
 using NHibernate.Collection.Generic;
 using NHibernate.Engine;
 using NHibernate.Persister.Collection;
+using NHibernate.Util;
 
 namespace NHibernate.Type
 {
@@ -85,15 +86,6 @@ namespace NHibernate.Type
 			((IList<T>)collection).Add((T)element);
 		}
 
-		protected override bool AreCollectionElementsEqual(IEnumerable original, IEnumerable target)
-		{
-			var first = (IList<T>)original;
-			var second = (IList<T>)target;
-
-			return first.Count == second.Count &&
-			       first.All(element => first.Count(x => x.Equals(element)) == second.Count(x => x.Equals(element)));
-		}
-
 		public override object ReplaceElements(
 			object original,
 			object target,
@@ -151,6 +143,11 @@ namespace NHibernate.Type
 			}
 
 			return target;
+		}
+
+		protected override bool AreCollectionElementsEqual(IEnumerable original, IEnumerable target)
+		{
+			return CollectionHelper.BagEquals((IEnumerable<T>)original, (IEnumerable<T>)target);
 		}
 	}
 }

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
-using Iesi.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Util
 {
@@ -132,6 +132,7 @@ namespace NHibernate.Util
 			}
 		}
 
+		// To be removed in v6.0
 		[Serializable]
 		private class EmptyListClass : IList
 		{
@@ -214,14 +215,18 @@ namespace NHibernate.Util
 		public static readonly IEnumerable EmptyEnumerable = new EmptyEnumerableClass();
 		public static readonly IDictionary EmptyMap = new EmptyMapClass();
 		public static readonly ICollection EmptyCollection = EmptyMap;
+		// To be removed in v6.0
+		[Obsolete("It has no more usages in NHibernate and will be removed in a future version.")]
 		public static readonly IList EmptyList = new EmptyListClass();
 
+		// To be removed in v6.0
 		/// <summary>
 		/// Determines if two collections have equals elements, with the same ordering.
 		/// </summary>
 		/// <param name="c1">The first collection.</param>
 		/// <param name="c2">The second collection.</param>
 		/// <returns><c>true</c> if collection are equals, <c>false</c> otherwise.</returns>
+		[Obsolete("It has no more usages in NHibernate and will be removed in a future version.")]
 		public static bool CollectionEquals(ICollection c1, ICollection c2)
 		{
 			if (c1 == c2)
@@ -229,7 +234,7 @@ namespace NHibernate.Util
 				return true;
 			}
 
-			if(c1==null || c2==null)
+			if (c1 == null || c2 == null)
 			{
 				return false;
 			}
@@ -254,6 +259,8 @@ namespace NHibernate.Util
 			return true;
 		}
 
+		// To be removed in v6.0
+		[Obsolete("It has no more usages in NHibernate and will be removed in a future version.")]
 		public static bool DictionaryEquals(IDictionary a, IDictionary b)
 		{
 			if (Equals(a, b))
@@ -282,35 +289,7 @@ namespace NHibernate.Util
 			return true;
 		}
 
-		public static bool DictionaryEquals<K, V>(IDictionary<K, V> a, IDictionary<K, V> b)
-		{
-			if (Equals(a, b))
-			{
-				return true;
-			}
-
-			if (a == null || b == null)
-			{
-				return false;
-			}
-
-			if (a.Count != b.Count)
-			{
-				return false;
-			}
-
-			foreach (K key in a.Keys)
-			{
-				if (!Equals(a[key], b[key]))
-				{
-					return false;
-				}
-			}
-
-			return true;
-		}
-		
-
+		// To be removed in v6.0
 		/// <summary>
 		/// Computes a hash code for <paramref name="coll"/>.
 		/// </summary>
@@ -318,6 +297,7 @@ namespace NHibernate.Util
 		/// individual elements, so that the value is independent of the
 		/// collection iteration order.
 		/// </remarks>
+		[Obsolete("It has no more usages in NHibernate and will be removed in a future version.")]
 		public static int GetHashCode(IEnumerable coll)
 		{
 			unchecked
@@ -346,7 +326,7 @@ namespace NHibernate.Util
 		/// </remarks>
 		public static IDictionary<string, T> CreateCaseInsensitiveHashtable<T>()
 		{
-			return new Dictionary<string, T>(StringComparer.InvariantCultureIgnoreCase);
+			return new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
 		}
 
 		/// <summary>
@@ -359,7 +339,7 @@ namespace NHibernate.Util
 		/// </remarks>
 		public static IDictionary<string, T> CreateCaseInsensitiveHashtable<T>(IDictionary<string, T> dictionary)
 		{
-			return new Dictionary<string, T>(dictionary, StringComparer.InvariantCultureIgnoreCase);
+			return new Dictionary<string, T>(dictionary, StringComparer.OrdinalIgnoreCase);
 		}
 
 		// ~~~~~~~~~~~~~~~~~~~~~~ Generics ~~~~~~~~~~~~~~~~~~~~~~
@@ -433,7 +413,7 @@ namespace NHibernate.Util
 		}
 
 		[Serializable]
-		private class EmptyEnumerator<T> : IEnumerator<T> 
+		private class EmptyEnumerator<T> : IEnumerator<T>
 		{
 			#region IEnumerator<T> Members
 
@@ -600,40 +580,105 @@ namespace NHibernate.Util
 			}
 		}
 
-		public static bool SetEquals<T>(ISet<T> a, ISet<T> b)
-		{
-			if (Equals(a, b))
-			{
-				return true;
-			}
+		/// <summary>
+		/// Determines if two sets have equal elements. Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="T">The type of the elements.</typeparam>
+		/// <param name="s1">The first set.</param>
+		/// <param name="s2">The second set.</param>
+		/// <returns><c>true</c> if sets are equals, <c>false</c> otherwise.</returns>
+		public static bool SetEquals<T>(ISet<T> s1, ISet<T> s2)
+			=> FastCheckEquality(s1, s2) ?? s1.SetEquals(s2);
 
-			if (a == null || b == null)
-			{
-				return false;
-			}
-
-			if (a.Count != b.Count)
-			{
-				return false;
-			}
-
-			foreach (T obj in a)
-			{
-				if (!b.Contains(obj))
-					return false;
-			}
-
-			return true;
-		}
-
+		// To be removed in v6.0
 		/// <summary>
 		/// Determines if two collections have equals elements, with the same ordering.
 		/// </summary>
 		/// <typeparam name="T">The type of the elements.</typeparam>
 		/// <param name="c1">The first collection.</param>
 		/// <param name="c2">The second collection.</param>
-		/// <returns><c>true</c> if collection are equals, <c>false</c> otherwise.</returns>
+		/// <returns><c>true</c> if collections are equals, <c>false</c> otherwise.</returns>
+		[Obsolete("Please use SequenceEquals instead.")]
 		public static bool CollectionEquals<T>(ICollection<T> c1, ICollection<T> c2)
+			=> SequenceEquals(c1, c2);
+
+		/// <summary>
+		/// Determines if two collections have equals elements, with the same ordering. Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="T">The type of the elements.</typeparam>
+		/// <param name="c1">The first collection.</param>
+		/// <param name="c2">The second collection.</param>
+		/// <returns><c>true</c> if collections are equals, <c>false</c> otherwise.</returns>
+		public static bool SequenceEquals<T>(IEnumerable<T> c1, IEnumerable<T> c2)
+			=> SequenceEquals(c1, c2, null);
+
+		/// <summary>
+		/// Determines if two collections have equals elements, with the same ordering. Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="T">The type of the elements.</typeparam>
+		/// <param name="c1">The first collection.</param>
+		/// <param name="c2">The second collection.</param>
+		/// <param name="comparer">The element comparer.</param>
+		/// <returns><c>true</c> if collections are equals, <c>false</c> otherwise.</returns>
+		public static bool SequenceEquals<T>(IEnumerable<T> c1, IEnumerable<T> c2, IEqualityComparer<T> comparer)
+			=> FastCheckEquality(c1, c2) ?? c1.SequenceEqual(c2, comparer);
+
+		/// <summary>
+		/// Determines if two collections have the same elements with the same duplication count, whatever their ordering.
+		/// Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="T">The type of the elements.</typeparam>
+		/// <param name="c1">The first collection.</param>
+		/// <param name="c2">The second collection.</param>
+		/// <returns><c>true</c> if collections are equals, <c>false</c> otherwise.</returns>
+		public static bool BagEquals<T>(IEnumerable<T> c1, IEnumerable<T> c2)
+			=> BagEquals(c1, c2, null);
+
+		/// <summary>
+		/// Determines if two collections have the same elements with the same duplication count, whatever their ordering.
+		/// Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="T">The type of the elements.</typeparam>
+		/// <param name="c1">The first collection.</param>
+		/// <param name="c2">The second collection.</param>
+		/// <param name="comparer">The element comparer.</param>
+		/// <returns><c>true</c> if collections are equals, <c>false</c> otherwise.</returns>
+		public static bool BagEquals<T>(IEnumerable<T> c1, IEnumerable<T> c2, IEqualityComparer<T> comparer)
+		{
+			var result = FastCheckEquality(c1, c2);
+			if (result.HasValue)
+				return result.Value;
+			var l2 = c2.ToLookup(e => e, comparer);
+			// Lookups return an empty sequence if a key is missing, no need to test if it contains it.
+			return c1.ToLookup(e => e, comparer).All(g => g.Count() == l2[g.Key].Count());
+		}
+
+		/// <summary>
+		/// Determines if two maps have the same key-values. Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="K">The type of the keys.</typeparam>
+		/// <typeparam name="V">The type of the values.</typeparam>
+		/// <param name="m1">The first map.</param>
+		/// <param name="m2">The second map.</param>
+		/// <returns><c>true</c> if maps are equals, <c>false</c> otherwise.</returns>
+		public static bool DictionaryEquals<K, V>(IDictionary<K, V> m1, IDictionary<K, V> m2)
+			=> DictionaryEquals(m1, m2, null);
+
+		/// <summary>
+		/// Determines if two maps have the same key-values. Supports <c>null</c> arguments.
+		/// </summary>
+		/// <typeparam name="K">The type of the keys.</typeparam>
+		/// <typeparam name="V">The type of the values.</typeparam>
+		/// <param name="m1">The first map.</param>
+		/// <param name="m2">The second map.</param>
+		/// <param name="comparer">The value comparer.</param>
+		/// <returns><c>true</c> if maps are equals, <c>false</c> otherwise.</returns>
+		public static bool DictionaryEquals<K, V>(IDictionary<K, V> m1, IDictionary<K, V> m2, IEqualityComparer<V> comparer)
+			=> FastCheckEquality(m1, m2) ??
+				(comparer == null ? DictionaryEquals(m1, m2, EqualityComparer<V>.Default) :
+					m1.All(kv => m2.TryGetValue(kv.Key, out var value) && comparer.Equals(kv.Value, value)));
+
+		private static bool? FastCheckEquality<T>(IEnumerable<T> c1, IEnumerable<T> c2)
 		{
 			if (c1 == c2)
 			{
@@ -645,25 +690,13 @@ namespace NHibernate.Util
 				return false;
 			}
 
-			if (c1.Count != c2.Count)
+			if (c1.Count() != c2.Count())
 			{
 				return false;
 			}
 
-			IEnumerator e1 = c1.GetEnumerator();
-			IEnumerator e2 = c2.GetEnumerator();
-
-			while (e1.MoveNext())
-			{
-				e2.MoveNext();
-				if (!Equals(e1.Current, e2.Current))
-				{
-					return false;
-				}
-			}
-
-			return true;
+			// Requires elements comparison.
+			return null;
 		}
-
 	}
 }


### PR DESCRIPTION
[NH-3981](https://nhibernate.jira.com/browse/NH-3981) - maps equality fix, collection helper cleanup.
It is a kind of follow up to #545. For cleanup I would have ask to use the `CollectionHelper.DictionaryEquals` method, but I discovered it was flawed.

And I would have asked to put a bag equality method there for avoiding duplicating between bag and idbag. For completeness, I have already added it in this class.

As the name `CollectionEquals` was ambiguous, I have renamed it and re-added as obsolete. A bunch of dead methods are now marked obsolete too.

In this same class, a usage of `StringComparer.InvariantCultureIgnoreCase` instead of `StringComparer.OrdinalIgnoreCase` for avoiding the [Turkish i trouble](http://haacked.com/archive/2012/07/05/turkish-i-problem-and-why-you-should-care.aspx/) as stated in the xml comment has been seen and fixed by the way. (Invariant is English culture, which does not expose to the trouble, but in that case we really just want to go ordinal.)