### PR TITLE
NH-3932 - follow up for replacing an O(n²) algorithm by an O(n) one.

### DIFF
--- a/src/NHibernate/Type/GenericIdentifierBagType.cs
+++ b/src/NHibernate/Type/GenericIdentifierBagType.cs
@@ -137,10 +137,11 @@ namespace NHibernate.Type
 			}
 			else
 			{
+				var originalLookup = iterOriginal.ToLookup(e => e);
 				for (var i = 0; i < targetPc.Count; i++)
 				{
 					var currTarget = targetPc[i];
-					var orgToUse = iterOriginal.First(x => currTarget.Equals(x));
+					var orgToUse = originalLookup[currTarget].First();
 					targetPc[i] = (T)elemType.Replace(orgToUse, null, session, owner, copyCache);
 				}
 			}


### PR DESCRIPTION
[NH-3932](https://nhibernate.jira.com/browse/NH-3932) - merge firing unneeded updates, follow up for replacing an O(n²) algorithm by an O(n) one.