### PR TITLE
NH-3985 - Bugfix for subsequent child sessions being returned in disposed state

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3985/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3985/Entity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3985
+{
+	public partial class Process
+	{
+		public virtual Guid ProcessID { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3985/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3985/Fixture.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3985
+{
+	/// <summary>
+	/// The test verifies that subsequent child sessions are not issued in already-disposed state.
+	/// </summary>
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		[Test]
+		public void GetChildSession_ShouldReturnNonDisposedInstance()
+		{
+			using (var rootSession = OpenSession())
+			{
+				using (var childSession1 = rootSession.GetChildSession())
+				{
+				}
+
+				using (var childSession2 = rootSession.GetChildSession())
+				{
+					Assert.DoesNotThrow(() => { childSession2.Get<Process>(Guid.NewGuid()); });
+				}
+			}
+		}
+
+		[Test]
+		public void GetChildSession_ShouldReturnNonClosedInstance()
+		{
+			using (var rootSession = OpenSession())
+			{
+				var childSession1 = rootSession.GetChildSession();
+				childSession1.Close();
+
+				using (var childSession2 = rootSession.GetChildSession())
+				{
+					Assert.DoesNotThrow(() => { childSession2.Get<Process>(Guid.NewGuid()); });
+				}
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3985/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH3985/Mappings.hbm.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.NHSpecificTest.NH3985">
+	<class name="Process">
+		<id name="ProcessID" generator="guid.comb" />
+		<property name="Name" />
+	</class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -743,6 +743,8 @@
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
     <Compile Include="Insertordering\NH3931Entities.cs" />
     <Compile Include="NHSpecificTest\NH1904\StructFixture.cs" />
+    <Compile Include="NHSpecificTest\NH3985\Entity.cs" />
+    <Compile Include="NHSpecificTest\NH3985\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3247\Entity.cs" />
     <Compile Include="NHSpecificTest\NH3247\Fixture.cs" />
     <Compile Include="NHSpecificTest\NH3386\Entity.cs" />
@@ -2668,6 +2670,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH2195\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3187\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH3932\Model\Mappings.hbm.xml" />
+    <EmbeddedResource Include="NHSpecificTest\NH3985\Mappings.hbm.xml" />
     <EmbeddedResource Include="TypedManyToOne\Customer.hbm.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Impl
 		private readonly StatefulPersistenceContext persistenceContext;
 
 		[NonSerialized]
-		private readonly ISession rootSession;
+		private readonly SessionImpl rootSession;
 
 		[NonSerialized]
 		ISession _childSession;
@@ -381,6 +381,7 @@ namespace NHibernate.Impl
 				{
 					SetClosed();
 					Cleanup();
+					if (rootSession != null) rootSession._childSession = null;
 				}
 			}
 		}
@@ -1681,6 +1682,7 @@ namespace NHibernate.Impl
 				// free unmanaged resources here
 
 				IsAlreadyDisposed = true;
+
 				// nothing for Finalizer to do - so tell the GC to ignore it
 				GC.SuppressFinalize(this);
 			}


### PR DESCRIPTION
[NH-3985](https://nhibernate.jira.com/browse/NH-3985) - Test case and fix for subsequent child sessions being returned in disposed state