### PR TITLE
Fix mapping of intermediate inherited classes

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3992/Entities.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3992/Entities.cs
@@ -1,0 +1,137 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.NH3992
+{
+	public class BaseEntity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string BaseField { get; set; }
+	}
+
+	public class MappedEntity : UnmappedEntity
+	{
+		public virtual string TopLevelField { get; set; }
+	}
+
+	public class UnmappedEntity : BaseEntity
+	{
+		public virtual string ExtendedField { get; set; }
+	}
+
+	public interface IBaseInterface
+	{
+		Guid Id { get; set; }
+		string BaseField { get; set; }
+	}
+
+	public interface IUnmappedInterface : IBaseInterface
+	{
+		string ExtendedField { get; set; }
+	}
+
+	public class MappedEntityFromInterface : IUnmappedInterface
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string BaseField { get; set; }
+		public virtual string ExtendedField { get; set; }
+		public virtual string TopLevelField { get; set; }
+	}
+
+	// Animal entities copied from NH2691
+	public abstract class Animal
+	{
+		public virtual int Id { get; set; }
+		public virtual string Description { get; set; }
+		public virtual int Sequence { get; set; }
+	}
+
+	public abstract class Mammal : Animal
+	{
+		public virtual bool Pregnant { get; set; }
+		public virtual DateTime? BirthDate { get; set; }
+	}
+
+	public class Dog : Mammal { }
+
+	// Mapped -> Unmapped -> Mapped -> Root
+	namespace Longchain1
+	{
+		public class MappedRoot
+		{
+			public virtual Guid Id { get; set; }
+			public virtual string BaseField { get; set; }
+		}
+
+		public class MappedExtension : MappedRoot
+		{
+			public virtual string MappedExtensionField { get; set; }
+		}
+
+		public class UnmappedExtension : MappedExtension
+		{
+			public virtual string UnmappedExtensionField { get; set; }
+		}
+
+		public class TopLevel : UnmappedExtension
+		{
+			public virtual string TopLevelExtensionField { get; set; }
+		}
+	}
+
+	// Mapped -> Mapped -> Unmapped -> Root
+	namespace Longchain2
+	{
+		public class MappedRoot
+		{
+			public virtual Guid Id { get; set; }
+			public virtual string BaseField { get; set; }
+		}
+
+		public class UnmappedExtension : MappedRoot
+		{
+			public virtual string UnmappedExtensionField { get; set; }
+		}
+
+		public class MappedExtension : UnmappedExtension
+		{
+			public virtual string MappedExtensionField { get; set; }
+		}
+
+
+		public class TopLevel : MappedExtension
+		{
+			public virtual string TopLevelExtensionField { get; set; }
+		}
+	}
+
+	// Mapped -> Unmapped -> Mapped -> Unmapped -> Root
+	namespace Longchain3
+	{
+		public class MappedRoot
+		{
+			public virtual Guid Id { get; set; }
+			public virtual string BaseField { get; set; }
+		}
+
+		public class FirstUnmappedExtension : MappedRoot
+		{
+			public virtual string FirstUnmappedExtensionField { get; set; }
+		}
+
+		public class MappedExtension : FirstUnmappedExtension
+		{
+			public virtual string MappedExtensionField { get; set; }
+		}
+
+		public class SecondUnmappedExtension : MappedExtension
+		{
+			public virtual string SecondUnmappedExtensionField { get; set; }
+		}
+
+		public class TopLevel : SecondUnmappedExtension
+		{
+			public virtual string TopLevelExtensionField { get; set; }
+		}
+	}
+
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3992/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3992/FixtureByCode.cs
@@ -1,0 +1,413 @@
+﻿using NHibernate.Mapping.ByCode;
+using NUnit.Framework;
+using System.Linq;
+
+namespace NHibernate.Test.NHSpecificTest.NH3992
+{
+	/// <summary>
+	/// Fixture using 'by code' mappings
+	/// </summary>
+	public class ByCodeFixture
+	{
+		[Test]
+		public void Test_MappedSubclass_AllMapsAtTopLevel()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(BaseEntityMapping));
+			mapper.AddMapping(typeof(MappedEntitySubclassMapping));
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			// Check that the subclass was mapped
+			var baseMapping = mapping.RootClasses.SingleOrDefault(x => x.Name == "BaseEntity");
+			Assert.IsNotNull(baseMapping, "Mapping did not return mapping for BaseEntity");
+			var targetMapping = mapping.SubClasses.SingleOrDefault(x => x.Name == "MappedEntity");
+			Assert.IsNotNull(targetMapping, "Mapping did not return mapping for subclass MappedEntity");
+			// Check that all three fields are mapped
+			var baseProperty = baseMapping.Properties.SingleOrDefault(p => p.Name == "BaseField");
+			Assert.IsNotNull(baseProperty, "Base class mapping did not map base class property");
+			var extendedProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "ExtendedField");
+			Assert.IsNotNull(extendedProperty, "Sub class mapping did not map extended (class not mapped) class property");
+			var topLevelProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "TopLevelField");
+			Assert.IsNotNull(topLevelProperty, "Sub class mapping did not map base class property");
+
+		}
+
+		[Test]
+		public void Test_MappedJoinedSubclass_AllMapsAtTopLevel()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(BaseEntityMapping));
+			mapper.AddMapping(typeof(MappedEntityJoinedSubclassMapping));
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			// Check that the subclass was mapped
+			var baseMapping = mapping.RootClasses.SingleOrDefault(x => x.Name == "BaseEntity");
+			Assert.IsNotNull(baseMapping, "Mapping did not return mapping for BaseEntity");
+			var targetMapping = mapping.JoinedSubclasses.SingleOrDefault(x => x.Name == "MappedEntity");
+			Assert.IsNotNull(targetMapping, "Mapping did not return mapping for subclass MappedEntity");
+			// Check that all three fields are mapped
+			var baseProperty = baseMapping.Properties.SingleOrDefault(p => p.Name == "BaseField");
+			Assert.IsNotNull(baseProperty, "Base class mapping did not map base class property");
+			var extendedProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "ExtendedField");
+			Assert.IsNotNull(extendedProperty, "Sub class mapping did not map extended (class not mapped) class property");
+			var topLevelProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "TopLevelField");
+			Assert.IsNotNull(topLevelProperty, "Sub class mapping did not map base class property");
+
+		}
+
+		[Test]
+		public void Test_MappedUnionSubclass_AllMapsAtTopLevel()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(BaseEntityMapping));
+			mapper.AddMapping(typeof(MappedEntityUnionSubclassMapping));
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			// Check that the subclass was mapped
+			var baseMapping = mapping.RootClasses.SingleOrDefault(x => x.Name == "BaseEntity");
+			Assert.IsNotNull(baseMapping, "Mapping did not return mapping for BaseEntity");
+			var targetMapping = mapping.UnionSubclasses.SingleOrDefault(x => x.Name == "MappedEntity");
+			Assert.IsNotNull(targetMapping, "Mapping did not return mapping for subclass MappedEntity");
+			// Check that all three fields are mapped
+			var baseProperty = baseMapping.Properties.SingleOrDefault(p => p.Name == "BaseField");
+			Assert.IsNotNull(baseProperty, "Base class mapping did not map base class property");
+			var extendedProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "ExtendedField");
+			Assert.IsNotNull(extendedProperty, "Sub class mapping did not map extended (class not mapped) class property");
+			var topLevelProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "TopLevelField");
+			Assert.IsNotNull(topLevelProperty, "Sub class mapping did not map base class property");
+
+		}
+
+		[Test]
+		public void Test_MappedSubclassInterface_AllMapsAtTopLevel()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(BaseInterfaceMapping));
+			mapper.AddMapping(typeof(MappedEntityFromInterfaceSubclassMapping));
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			// Check that the subclass was mapped
+			var baseMapping = mapping.RootClasses.SingleOrDefault(x => x.Name == "IBaseInterface");
+			Assert.IsNotNull(baseMapping, "Mapping did not return mapping for IBaseInterface");
+			var targetMapping = mapping.SubClasses.SingleOrDefault(x => x.Name == "MappedEntityFromInterface");
+			Assert.IsNotNull(targetMapping, "Mapping did not return mapping for subclass MappedEntityFromInterface");
+			// Check that all three fields are mapped
+			var baseProperty = baseMapping.Properties.SingleOrDefault(p => p.Name == "BaseField");
+			Assert.IsNotNull(baseProperty, "Base class mapping did not map base class property");
+			var extendedProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "ExtendedField");
+			Assert.IsNotNull(extendedProperty, "Sub class mapping did not map extended (class not mapped) class property");
+			var topLevelProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "TopLevelField");
+			Assert.IsNotNull(topLevelProperty, "Sub class mapping did not map base class property");
+
+		}
+
+		[Test]
+		public void Test_MappedJoinedSubclassInterface_AllMapsAtTopLevel()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(BaseInterfaceMapping));
+			mapper.AddMapping(typeof(MappedEntityFromInterfaceJoinedSubclassMapping));
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			// Check that the subclass was mapped
+			var baseMapping = mapping.RootClasses.SingleOrDefault(x => x.Name == "IBaseInterface");
+			Assert.IsNotNull(baseMapping, "Mapping did not return mapping for IBaseInterface");
+			var targetMapping = mapping.JoinedSubclasses.SingleOrDefault(x => x.Name == "MappedEntityFromInterface");
+			Assert.IsNotNull(targetMapping, "Mapping did not return mapping for subclass MappedEntityFromInterface");
+			// Check that all three fields are mapped
+			var baseProperty = baseMapping.Properties.SingleOrDefault(p => p.Name == "BaseField");
+			Assert.IsNotNull(baseProperty, "Base class mapping did not map base class property");
+			var extendedProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "ExtendedField");
+			Assert.IsNotNull(extendedProperty, "Sub class mapping did not map extended (class not mapped) class property");
+			var topLevelProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "TopLevelField");
+			Assert.IsNotNull(topLevelProperty, "Sub class mapping did not map base class property");
+
+		}
+
+		[Test]
+		public void Test_MappedUnionSubclassInterface_AllMapsAtTopLevel()
+		{
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(BaseInterfaceMapping));
+			mapper.AddMapping(typeof(MappedEntityFromInterfaceUnionSubclassMapping));
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			// Check that the subclass was mapped
+			var baseMapping = mapping.RootClasses.SingleOrDefault(x => x.Name == "IBaseInterface");
+			Assert.IsNotNull(baseMapping, "Mapping did not return mapping for IBaseInterface");
+			var targetMapping = mapping.UnionSubclasses.SingleOrDefault(x => x.Name == "MappedEntityFromInterface");
+			Assert.IsNotNull(targetMapping, "Mapping did not return mapping for subclass MappedEntityFromInterface");
+			// Check that all three fields are mapped
+			var baseProperty = baseMapping.Properties.SingleOrDefault(p => p.Name == "BaseField");
+			Assert.IsNotNull(baseProperty, "Base class mapping did not map base class property");
+			var extendedProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "ExtendedField");
+			Assert.IsNotNull(extendedProperty, "Sub class mapping did not map extended (class not mapped) class property");
+			var topLevelProperty = targetMapping.Properties.SingleOrDefault(p => p.Name == "TopLevelField");
+			Assert.IsNotNull(topLevelProperty, "Sub class mapping did not map base class property");
+
+		}
+
+		[Test]
+		public void Test_AbstractIntermediateSubclasses()
+		{
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => false);
+			mapper.IsTablePerClassHierarchy((type, declared) => true);
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Animal), typeof(Mammal), typeof(Dog) });
+			
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have Animal as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var animalMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Animal));
+			Assert.IsNotNull(animalMapping, "Unable to find mapping for animal class");
+			Assert.AreEqual(nameof(Animal.Id), animalMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new [] { nameof(Animal.Description), nameof(Animal.Sequence) }, animalMapping.Properties.Select(p => p.Name));
+			var mammalMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Mammal));
+			Assert.IsNotNull(mammalMapping, "Unable to find mapping for Mammal class");
+			Assert.AreEqual(nameof(Animal), mammalMapping.extends, "Mammal mapping does not extend Animal as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Mammal.Pregnant), nameof(Mammal.BirthDate) }, mammalMapping.Properties.Select(p => p.Name));
+			var dogMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Dog));
+			Assert.IsNotNull(dogMapping, "Unable to find mapping for Dog class");
+			Assert.AreEqual(nameof(Mammal), dogMapping.extends, "Dog mapping does not extend Mammal as expected");
+			CollectionAssert.IsEmpty(dogMapping.Properties);
+		}
+
+		[Test]
+		public void Test_Longchain1_ExplicitMappings()
+		{
+			// Mapped -> Unmapped -> Mapped -> Root
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(Longchain1.MappedRootMapping));
+			mapper.AddMapping(typeof(Longchain1.MappedExtensionMapping));
+			mapper.AddMapping(typeof(Longchain1.TopLevelMapping));
+
+			var mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain1.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain1.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain1.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.UnmappedExtension.UnmappedExtensionField), nameof(Longchain1.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain1_ConventionMappingMappings_PerClassHierarchy()
+		{
+			// Mapped -> Unmapped -> Mapped -> Root
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => false);
+			mapper.IsTablePerClassHierarchy((type, declared) => true);
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Longchain1.MappedRoot), typeof(Longchain1.MappedExtension), typeof(Longchain1.TopLevel) });
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain1.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain1.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain1.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.UnmappedExtension.UnmappedExtensionField), nameof(Longchain1.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain1_ConventionMappingMappings_PerClass()
+		{
+			// Mapped -> Unmapped -> Mapped -> Root
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => true);
+			mapper.IsTablePerClassHierarchy((type, declared) => false);
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Longchain1.MappedRoot), typeof(Longchain1.MappedExtension), typeof(Longchain1.TopLevel) });
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.JoinedSubclasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain1.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain1.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.JoinedSubclasses.SingleOrDefault(s => s.Name == nameof(Longchain1.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain1.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.JoinedSubclasses.SingleOrDefault(s => s.Name == nameof(Longchain1.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain1.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain1.UnmappedExtension.UnmappedExtensionField), nameof(Longchain1.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain2_ExplicitMappings()
+		{
+			// Mapped -> Mapped -> Unmapped -> Root
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(Longchain2.MappedRootMapping));
+			mapper.AddMapping(typeof(Longchain2.MappedExtensionMapping));
+			mapper.AddMapping(typeof(Longchain2.TopLevelMapping));
+
+			var mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain2.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain2.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.UnmappedExtension.UnmappedExtensionField), nameof(Longchain2.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain2.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain2_ConventionMappingMappings_PerClassHierarchy()
+		{
+			// Mapped -> Mapped -> Unmapped -> Root
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => false);
+			mapper.IsTablePerClassHierarchy((type, declared) => true);
+
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Longchain2.MappedRoot), typeof(Longchain2.MappedExtension), typeof(Longchain2.TopLevel) });
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain2.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain2.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.UnmappedExtension.UnmappedExtensionField), nameof(Longchain2.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain2.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain2_ConventionMappingMappings_PerClass()
+		{
+			// Mapped -> Mapped -> Unmapped -> Root
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => true);
+			mapper.IsTablePerClassHierarchy((type, declared) => false);
+
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Longchain2.MappedRoot), typeof(Longchain2.MappedExtension), typeof(Longchain2.TopLevel) });
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.JoinedSubclasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain2.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain2.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.JoinedSubclasses.SingleOrDefault(s => s.Name == nameof(Longchain2.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain2.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.UnmappedExtension.UnmappedExtensionField), nameof(Longchain2.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.JoinedSubclasses.SingleOrDefault(s => s.Name == nameof(Longchain2.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain2.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain2.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain3_ExplicitMappings()
+		{
+			// Mapped -> Unmapped -> Mapped -> Root
+			var mapper = new ModelMapper();
+			mapper.AddMapping(typeof(Longchain3.MappedRootMapping));
+			mapper.AddMapping(typeof(Longchain3.MappedExtensionMapping));
+			mapper.AddMapping(typeof(Longchain3.TopLevelMapping));
+
+			var mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain3.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain3.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.FirstUnmappedExtension.FirstUnmappedExtensionField), nameof(Longchain3.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain3.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.SecondUnmappedExtension.SecondUnmappedExtensionField), nameof(Longchain3.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain3_ConventionMappingMappings_PerClassHierarchy()
+		{
+			// Mapped -> Unmapped -> Mapped -> Root
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => false);
+			mapper.IsTablePerClassHierarchy((type, declared) => true);
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Longchain3.MappedRoot), typeof(Longchain3.MappedExtension), typeof(Longchain3.TopLevel) });
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.SubClasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain3.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain3.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.FirstUnmappedExtension.FirstUnmappedExtensionField), nameof(Longchain3.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.SubClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain3.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.SecondUnmappedExtension.SecondUnmappedExtensionField), nameof(Longchain3.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+
+		[Test]
+		public void Test_Longchain3_ConventionMappingMappings_PerClass()
+		{
+			// Mapped -> Unmapped -> Mapped -> Root
+			var mapper = new ConventionModelMapper();
+			mapper.IsTablePerClass((type, declared) => true);
+			mapper.IsTablePerClassHierarchy((type, declared) => false);
+			var mappings = mapper.CompileMappingFor(new[] { typeof(Longchain3.MappedRoot), typeof(Longchain3.MappedExtension), typeof(Longchain3.TopLevel) });
+
+			Assert.AreEqual(1, mappings.RootClasses.Length, "Mapping should only have MappedRoot as root class");
+			Assert.AreEqual(2, mappings.JoinedSubclasses.Length, "Subclasses not mapped as expected");
+			var rootMapping = mappings.RootClasses.SingleOrDefault(s => s.Name == nameof(Longchain3.MappedRoot));
+			Assert.IsNotNull(rootMapping, "Unable to find mapping for MappedRoot class");
+			Assert.AreEqual(nameof(Longchain3.MappedRoot.Id), rootMapping.Id.name, "Identifier not mapped as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.MappedRoot.BaseField) }, rootMapping.Properties.Select(p => p.Name));
+			var mappedExtensionMapping = mappings.JoinedSubclasses.SingleOrDefault(s => s.Name == nameof(Longchain3.MappedExtension));
+			Assert.IsNotNull(mappedExtensionMapping, "Unable to find mapping for MappedExtension class");
+			Assert.AreEqual(nameof(Longchain3.MappedRoot), mappedExtensionMapping.extends, "MappedExtension extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.FirstUnmappedExtension.FirstUnmappedExtensionField), nameof(Longchain3.MappedExtension.MappedExtensionField) }, mappedExtensionMapping.Properties.Select(p => p.Name));
+			var topLevelMapping = mappings.JoinedSubclasses.SingleOrDefault(s => s.Name == nameof(Longchain3.TopLevel));
+			Assert.IsNotNull(topLevelMapping, "Unable to find mapping for TopLevel class");
+			Assert.AreEqual(nameof(Longchain3.MappedExtension), topLevelMapping.extends, "TopLevel extension not as expected");
+			CollectionAssert.AreEquivalent(new[] { nameof(Longchain3.SecondUnmappedExtension.SecondUnmappedExtensionField), nameof(Longchain3.TopLevel.TopLevelExtensionField) }, topLevelMapping.Properties.Select(p => p.Name));
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH3992/Mappings.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3992/Mappings.cs
@@ -1,0 +1,214 @@
+﻿using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+using NHibernate.Test.NHSpecificTest.NH3992.Longchain1;
+
+namespace NHibernate.Test.NHSpecificTest.NH3992
+{
+	public class BaseEntityMapping : ClassMapping<BaseEntity>
+	{
+		public BaseEntityMapping()
+		{
+			Id(i => i.Id, m => m.Generator(Generators.GuidComb));
+			Property(p => p.BaseField,
+			         map => { map.Column("BaseField"); });
+		}
+	}
+
+	public class MappedEntityJoinedSubclassMapping : JoinedSubclassMapping<MappedEntity>
+	{
+		public MappedEntityJoinedSubclassMapping()
+		{
+			Extends(typeof(BaseEntity));
+			Property(p => p.ExtendedField,
+			         map => { map.Column("ExtendedField"); });
+			Property(p => p.TopLevelField,
+			         map => { map.Column("TopLevelField"); });
+		}
+	}
+
+	public class MappedEntityUnionSubclassMapping : UnionSubclassMapping<MappedEntity>
+	{
+		public MappedEntityUnionSubclassMapping()
+		{
+			Extends(typeof(BaseEntity));
+			Property(p => p.ExtendedField,
+			         map => { map.Column("ExtendedField"); });
+			Property(p => p.TopLevelField,
+			         map => { map.Column("TopLevelField"); });
+		}
+	}
+
+	public class MappedEntitySubclassMapping : SubclassMapping<MappedEntity>
+	{
+		public MappedEntitySubclassMapping()
+		{
+			Extends(typeof(BaseEntity));
+			Property(p => p.ExtendedField,
+			         map => { map.Column("ExtendedField"); });
+			Property(p => p.TopLevelField,
+			         map => { map.Column("TopLevelField"); });
+		}
+	}
+
+	public class BaseInterfaceMapping : ClassMapping<IBaseInterface>
+	{
+		public BaseInterfaceMapping()
+		{
+			Id(i => i.Id, m => m.Generator(Generators.GuidComb));
+			Property(p => p.BaseField,
+			         map => { map.Column("BaseField"); });
+		}
+	}
+
+	public class MappedEntityFromInterfaceJoinedSubclassMapping : JoinedSubclassMapping<MappedEntityFromInterface>
+	{
+		public MappedEntityFromInterfaceJoinedSubclassMapping()
+		{
+			Extends(typeof(IBaseInterface));
+			Property(p => p.ExtendedField,
+			         map => { map.Column("ExtendedField"); });
+			Property(p => p.TopLevelField,
+			         map => { map.Column("TopLevelField"); });
+		}
+	}
+
+	public class MappedEntityFromInterfaceUnionSubclassMapping : UnionSubclassMapping<MappedEntityFromInterface>
+	{
+		public MappedEntityFromInterfaceUnionSubclassMapping()
+		{
+			Extends(typeof(IBaseInterface));
+			Property(p => p.ExtendedField,
+			         map => { map.Column("ExtendedField"); });
+			Property(p => p.TopLevelField,
+			         map => { map.Column("TopLevelField"); });
+		}
+	}
+
+	public class MappedEntityFromInterfaceSubclassMapping : SubclassMapping<MappedEntityFromInterface>
+	{
+		public MappedEntityFromInterfaceSubclassMapping()
+		{
+			Extends(typeof(IBaseInterface));
+			Property(p => p.ExtendedField,
+			         map => { map.Column("ExtendedField"); });
+			Property(p => p.TopLevelField,
+			         map => { map.Column("TopLevelField"); });
+		}
+	}
+
+	// Mapped -> Unmapped -> Mapped -> TopLevel
+	namespace Longchain1
+	{
+		public class MappedRootMapping : ClassMapping<MappedRoot>
+		{
+			public MappedRootMapping()
+			{
+				Id(i => i.Id, m => m.Generator(Generators.Identity));
+				Property(p => p.BaseField,
+				         map => { map.Column("BaseField"); });
+			}
+		}
+
+		public class MappedExtensionMapping : SubclassMapping<MappedExtension>
+		{
+			public MappedExtensionMapping()
+			{
+				Extends(typeof(MappedRoot));
+				
+				Property(p => p.MappedExtensionField,
+				         map => { map.Column("MappedExtensionField"); });
+			}
+		}
+
+		public class TopLevelMapping : SubclassMapping<TopLevel>
+		{
+			public TopLevelMapping()
+			{
+				Extends(typeof(MappedExtension));
+				Property(p => p.UnmappedExtensionField,
+						 map => { map.Column("UnmappedExtensionField"); });
+				Property(p => p.TopLevelExtensionField,
+				         map => { map.Column("TopLevelExtensionField"); });
+			}
+		}
+	}
+
+	// Mapped -> Mapped -> Unmapped -> TopLevel
+	namespace Longchain2
+	{
+		public class MappedRootMapping : ClassMapping<MappedRoot>
+		{
+			public MappedRootMapping()
+			{
+				Id(i => i.Id, m => m.Generator(Generators.Identity));
+				Property(p => p.BaseField,
+				         map => { map.Column("BaseField"); });
+			}
+		}
+
+		public class MappedExtensionMapping : SubclassMapping<MappedExtension>
+		{
+			public MappedExtensionMapping()
+			{
+				Extends(typeof(MappedRoot));
+				Property(p => p.UnmappedExtensionField,
+				         map => { map.Column("UnmappedExtensionField"); });
+				Property(p => p.MappedExtensionField,
+				         map => { map.Column("MappedExtensionField"); });
+			}
+		}
+
+		public class TopLevelMapping : SubclassMapping<TopLevel>
+		{
+			public TopLevelMapping()
+			{
+				Extends(typeof(MappedExtension));
+				Property(p => p.TopLevelExtensionField,
+				         map => { map.Column("TopLevelExtensionField"); });
+			}
+		}
+	}
+
+	// Mapped -> Unmapped -> Mapped -> Unmapped -> TopLevel
+	namespace Longchain3
+	{
+		public class MappedRootMapping : ClassMapping<MappedRoot>
+		{
+			public MappedRootMapping()
+			{
+				Id(i => i.Id, m => m.Generator(Generators.Identity));
+				Property(
+					p => p.BaseField,
+					map => { map.Column("BaseField"); });
+			}
+		}
+
+		public class MappedExtensionMapping : SubclassMapping<MappedExtension>
+		{
+			public MappedExtensionMapping()
+			{
+				Extends(typeof(MappedRoot));
+				Property(
+					p => p.FirstUnmappedExtensionField,
+					map => { map.Column("FirstUnmappedExtensionField"); });
+				Property(
+					p => p.MappedExtensionField,
+					map => { map.Column("MappedExtensionField"); });
+			}
+		}
+
+		public class TopLevelMapping : SubclassMapping<TopLevel>
+		{
+			public TopLevelMapping()
+			{
+				Extends(typeof(MappedExtension));
+				Property(
+					p => p.SecondUnmappedExtensionField,
+					map => { map.Column("SecondUnmappedExtensionField"); });
+				Property(
+					p => p.TopLevelExtensionField,
+					map => { map.Column("TopLevelExtensionField"); });
+			}
+		}
+	}
+}

--- a/src/NHibernate/Mapping/ByCode/ModelMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/ModelMapper.cs
@@ -549,29 +549,32 @@ namespace NHibernate.Mapping.ByCode
 				throw new ArgumentNullException("types");
 			}
 
-			var typeToMap = OrderTypesByHierarchy(types);
+			var entitiesToMap = GetEntitiesToMapOrderedByHierarchy(types);
 
 			string defaultAssemblyName = null;
 			string defaultNamespace = null;
-			System.Type firstType = typeToMap.FirstOrDefault();
-			if (firstType != null && typeToMap.All(t => t.Assembly.Equals(firstType.Assembly)))
+			System.Type firstType = entitiesToMap.FirstOrDefault();
+			if (firstType != null && entitiesToMap.All(t => t.Assembly.Equals(firstType.Assembly)))
 			{
 				//NH-2831: always use the full name of the assembly because it may come from GAC
 				defaultAssemblyName = firstType.Assembly.GetName().FullName;
 			}
-			if (firstType != null && typeToMap.All(t => t.Namespace == firstType.Namespace))
+			if (firstType != null && entitiesToMap.All(t => t.Namespace == firstType.Namespace))
 			{
 				defaultNamespace = firstType.Namespace;
 			}
 			var mapping = NewHbmMapping(defaultAssemblyName, defaultNamespace);
-			foreach (var type in RootClasses(typeToMap))
+			foreach (var type in RootClasses(entitiesToMap))
 			{
 				MapRootClass(type, mapping);
 			}
-			foreach (var type in Subclasses(typeToMap))
+
+			var entitiesSet = new HashSet<System.Type>(entitiesToMap);
+			foreach (var type in Subclasses(entitiesToMap))
 			{
-				AddSubclassMapping(mapping, type);
+				AddSubclassMapping(mapping, type, entitiesSet);
 			}
+
 			return mapping;
 		}
 
@@ -581,21 +584,27 @@ namespace NHibernate.Mapping.ByCode
 			{
 				throw new ArgumentNullException("types");
 			}
-			var typeToMap = OrderTypesByHierarchy(types);
+
+			var entitiesToMap = GetEntitiesToMapOrderedByHierarchy(types);
 
 			//NH-2831: always use the full name of the assembly because it may come from GAC
-			foreach (var type in RootClasses(typeToMap))
+			var mappings = new List<HbmMapping>();
+			foreach (var type in RootClasses(entitiesToMap))
 			{
 				var mapping = NewHbmMapping(type.Assembly.GetName().FullName, type.Namespace);
 				MapRootClass(type, mapping);
-				yield return mapping;
+				mappings.Add(mapping);
 			}
-			foreach (var type in Subclasses(typeToMap))
+
+			var entitiesSet = new HashSet<System.Type>(entitiesToMap);
+			foreach (var type in Subclasses(entitiesToMap))
 			{
 				var mapping = NewHbmMapping(type.Assembly.GetName().FullName, type.Namespace);
-				AddSubclassMapping(mapping, type);
-				yield return mapping;
+				AddSubclassMapping(mapping, type, entitiesSet);
+				mappings.Add(mapping);
 			}
+
+			return mappings;
 		}
 
 		private HbmMapping NewHbmMapping(string defaultAssemblyName, string defaultNamespace)
@@ -608,40 +617,40 @@ namespace NHibernate.Mapping.ByCode
 			return hbmMapping;
 		}
 
-		private IEnumerable<System.Type> Subclasses(IEnumerable<System.Type> types)
+		private IEnumerable<System.Type> Subclasses(IEnumerable<System.Type> entities)
 		{
-			return types.Where(type => modelInspector.IsEntity(type) && !modelInspector.IsRootEntity(type));
+			return entities.Where(type => !modelInspector.IsRootEntity(type));
 		}
 
-		private IEnumerable<System.Type> RootClasses(IEnumerable<System.Type> types)
+		private IEnumerable<System.Type> RootClasses(IEnumerable<System.Type> entities)
 		{
-			return types.Where(type => modelInspector.IsEntity(type) && modelInspector.IsRootEntity(type));
+			return entities.Where(type => modelInspector.IsRootEntity(type));
 		}
 
-		private void AddSubclassMapping(HbmMapping mapping, System.Type type)
+		private void AddSubclassMapping(HbmMapping mapping, System.Type type, ICollection<System.Type> mappedEntities)
 		{
 			if (modelInspector.IsTablePerClassHierarchy(type))
 			{
-				MapSubclass(type, mapping);
+				MapSubclass(type, mapping, mappedEntities);
 			}
 			else if (modelInspector.IsTablePerClass(type))
 			{
-				MapJoinedSubclass(type, mapping);
+				MapJoinedSubclass(type, mapping, mappedEntities);
 			}
 			else if (modelInspector.IsTablePerConcreteClass(type))
 			{
-				MapUnionSubclass(type, mapping);
+				MapUnionSubclass(type, mapping, mappedEntities);
 			}
 		}
 
-		private void MapUnionSubclass(System.Type type, HbmMapping mapping)
+		private void MapUnionSubclass(System.Type type, HbmMapping mapping, ICollection<System.Type> mappedEntities)
 		{
 			var classMapper = new UnionSubclassMapper(type, mapping);
 
 			IEnumerable<MemberInfo> candidateProperties = null;
-			if (!modelInspector.IsEntity(type.BaseType))
+			if (!mappedEntities.Contains(type.BaseType))
 			{
-				System.Type baseType = GetEntityBaseType(type);
+				var baseType = GetEntityBaseType(type, mappedEntities);
 				if (baseType != null)
 				{
 					classMapper.Extends(baseType);
@@ -659,13 +668,13 @@ namespace NHibernate.Mapping.ByCode
 			MapProperties(type, propertiesToMap, classMapper);
 		}
 
-		private void MapSubclass(System.Type type, HbmMapping mapping)
+		private void MapSubclass(System.Type type, HbmMapping mapping, ICollection<System.Type> mappedEntities)
 		{
 			var classMapper = new SubclassMapper(type, mapping);
 			IEnumerable<MemberInfo> candidateProperties = null;
-			if (!modelInspector.IsEntity(type.BaseType))
+			if (!mappedEntities.Contains(type.BaseType))
 			{
-				System.Type baseType = GetEntityBaseType(type);
+				var baseType = GetEntityBaseType(type, mappedEntities);
 				if (baseType != null)
 				{
 					classMapper.Extends(baseType);
@@ -701,13 +710,13 @@ namespace NHibernate.Mapping.ByCode
 			InvokeAfterMapSubclass(type, classMapper);
 		}
 
-		private void MapJoinedSubclass(System.Type type, HbmMapping mapping)
+		private void MapJoinedSubclass(System.Type type, HbmMapping mapping, ICollection<System.Type> mappedEntities)
 		{
 			var classMapper = new JoinedSubclassMapper(type, mapping);
 			IEnumerable<MemberInfo> candidateProperties = null;
-			if (!modelInspector.IsEntity(type.BaseType))
+			if (!mappedEntities.Contains(type.BaseType))
 			{
-				System.Type baseType = GetEntityBaseType(type);
+				var baseType = GetEntityBaseType(type, mappedEntities);
 				if (baseType != null)
 				{
 					classMapper.Extends(baseType);
@@ -715,6 +724,7 @@ namespace NHibernate.Mapping.ByCode
 					candidateProperties = membersProvider.GetSubEntityMembers(type, baseType);
 				}
 			}
+
 			candidateProperties = candidateProperties ?? membersProvider.GetSubEntityMembers(type, type.BaseType);
 			IEnumerable<MemberInfo> propertiesToMap =
 				candidateProperties.Where(p => modelInspector.IsPersistentProperty(p) && !modelInspector.IsPersistentId(p));
@@ -726,18 +736,19 @@ namespace NHibernate.Mapping.ByCode
 			MapProperties(type, propertiesToMap, classMapper);
 		}
 
-		private System.Type GetEntityBaseType(System.Type type)
+		private static System.Type GetEntityBaseType(System.Type type, ICollection<System.Type> mappedEntities)
 		{
 			System.Type analyzingType = type;
 			while (analyzingType != null && analyzingType != typeof (object))
 			{
 				analyzingType = analyzingType.BaseType;
-				if (modelInspector.IsEntity(analyzingType))
+				if (mappedEntities.Contains(analyzingType))
 				{
 					return analyzingType;
 				}
 			}
-			return type.GetInterfaces().FirstOrDefault(i => modelInspector.IsEntity(i));
+
+			return type.GetInterfaces().FirstOrDefault(i => mappedEntities.Contains(i));
 		}
 
 		private void MapRootClass(System.Type type, HbmMapping mapping)
@@ -1805,7 +1816,7 @@ namespace NHibernate.Mapping.ByCode
 			return CompileMappingForEach(customizerHolder.GetAllCustomizedEntities());
 		}
 
-		private static List<System.Type> OrderTypesByHierarchy(IEnumerable<System.Type> types)
+		private List<System.Type> GetEntitiesToMapOrderedByHierarchy(IEnumerable<System.Type> types)
 		{
 			var typesCache = new HashSet<System.Type>(types);
 
@@ -1815,6 +1826,9 @@ namespace NHibernate.Mapping.ByCode
 				var type = typesCache.First();
 				result.AddRange(type.GetHierarchyFromBase().Where(baseType => typesCache.Remove(baseType)));
 			}
+
+			result.RemoveAll(type => !modelInspector.IsEntity(type));
+
 			return result;
 		}
 	}


### PR DESCRIPTION
If two mapped classes A and B are in a class hierarchy where B indirectly inherits from A and mappings are declared for A and B, but not for the classes between A and B, NHibernate doesn't find any members declared in the classes between A and B that are mapped in B.

Fixes #1358