### PR TITLE
NH-2029 - Apply `use-many-to-one=false` for property-ref one-to-one and many-to-one

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/ManyToOneFilters20Behaviour/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/ManyToOneFilters20Behaviour/Fixture.cs
@@ -7,215 +7,240 @@ namespace NHibernate.Test.NHSpecificTest.ManyToOneFilters20Behaviour
 	[TestFixture]
 	public class Fixture : BugTestCase
 	{
-		private static IList<Parent> joinGraphUsingHql(ISession s)
+		private static IList<Parent> JoinGraphUsingHql(ISession s)
 		{
 			const string hql = @"select p from Parent p
-                                    join p.Child c";
+			                     join p.Child c";
 			return s.CreateQuery(hql).List<Parent>();
 		}
 
-		private static IList<Parent> joinGraphUsingCriteria(ISession s)
+		private static IList<Parent> JoinGraphUsingCriteria(ISession s)
 		{
 			return s.CreateCriteria(typeof(Parent)).SetFetchMode("Child", FetchMode.Join).List<Parent>();
 		}
 
-		private static Parent createParent()
+		private static Parent CreateParent()
 		{
 			var ret = new Parent { Child = new Child() };
 			ret.Address = new Address { Parent = ret };
 			return ret;
 		}
 
-		private static void enableFilters(ISession s)
+		private static void EnableFilters(ISession s)
 		{
-			IFilter f = s.EnableFilter("activeChild");
+			var f = s.EnableFilter("activeChild");
 			f.SetParameter("active", true);
-			IFilter f2 = s.EnableFilter("alwaysValid");
+			var f2 = s.EnableFilter("alwaysValid");
 			f2.SetParameter("always", true);
 		}
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
-				{
-					s.Delete("from Parent");
-					tx.Commit();
-				}
+				s.Delete("from Parent");
+				tx.Commit();
 			}
 		}
 
 		[Test]
 		public void VerifyAlwaysFilter()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
-				{
-					Parent p = createParent();
-					p.Child.Always = false;
-					s.Save(p);
-					tx.Commit();
-				}
+				var p = CreateParent();
+				p.Child.Always = false;
+				s.Save(p);
+				tx.Commit();
 			}
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				enableFilters(s);
-				IList<Parent> resCriteria = joinGraphUsingCriteria(s);
-				IList<Parent> resHql = joinGraphUsingHql(s);
+				EnableFilters(s);
+				var resCriteria = JoinGraphUsingCriteria(s);
+				var resHql = JoinGraphUsingHql(s);
 
-				Assert.AreEqual(0, resCriteria.Count);
-				Assert.AreEqual(0, resHql.Count);
+				Assert.That(resCriteria.Count, Is.EqualTo(0));
+				Assert.That(resHql.Count, Is.EqualTo(0));
 			}
 		}
 
 		[Test]
 		public void VerifyFilterActiveButNotUsedInManyToOne()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
-				{
-					s.Save(createParent());
-					tx.Commit();
-				}
+				s.Save(CreateParent());
+				tx.Commit();
 			}
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				enableFilters(s);
-				IList<Parent> resCriteria = joinGraphUsingCriteria(s);
-				IList<Parent> resHql = joinGraphUsingHql(s);
+				EnableFilters(s);
+				var resCriteria = JoinGraphUsingCriteria(s);
+				var resHql = JoinGraphUsingHql(s);
 
-				Assert.AreEqual(1, resCriteria.Count);
-				Assert.IsNotNull(resCriteria[0].Child);
+				Assert.That(resCriteria.Count, Is.EqualTo(1));
+				Assert.That(resCriteria[0].Child, Is.Not.Null);
 
-				Assert.AreEqual(1, resHql.Count);
-				Assert.IsNotNull(resHql[0].Child);
+				Assert.That(resHql.Count, Is.EqualTo(1));
+				Assert.That(resHql[0].Child, Is.Not.Null);
 			}
 		}
 
 		[Test]
 		public void VerifyQueryWithWhereClause()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
-				{
-					var p = createParent();
-					p.ParentString = "a";
-					p.Child.ChildString = "b";
-					s.Save(p);
-					tx.Commit();
-				}
+				var p = CreateParent();
+				p.ParentString = "a";
+				p.Child.ChildString = "b";
+				s.Save(p);
+				tx.Commit();
 			}
 			IList<Parent> resCriteria;
 			IList<Parent> resHql;
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				enableFilters(s);
+				EnableFilters(s);
 				resCriteria = s.CreateCriteria(typeof(Parent), "p")
-												.CreateCriteria("Child", "c")
-												.SetFetchMode("Child", FetchMode.Join)
-												.Add(Restrictions.Eq("p.ParentString", "a"))
-												.Add(Restrictions.Eq("c.ChildString", "b"))
-												.List<Parent>();
-				resHql = s.CreateQuery(@"select p from Parent p
-                                                        join fetch p.Child c
-                                                    where p.ParentString='a' and c.ChildString='b'").List<Parent>();
+				               .CreateCriteria("Child", "c")
+				               .SetFetchMode("Child", FetchMode.Join)
+				               .Add(Restrictions.Eq("p.ParentString", "a"))
+				               .Add(Restrictions.Eq("c.ChildString", "b"))
+				               .List<Parent>();
+
+				resHql = s.CreateQuery(
+					          @"select p from Parent p
+				                join fetch p.Child c
+				                where p.ParentString='a' and c.ChildString='b'")
+				          .List<Parent>();
 			}
-			Assert.AreEqual(1, resCriteria.Count);
-			Assert.IsNotNull(resCriteria[0].Child);
-			Assert.AreEqual(1, resHql.Count);
-			Assert.IsNotNull(resHql[0].Child);
+			Assert.That(resCriteria.Count, Is.EqualTo(1));
+			Assert.That(resCriteria[0].Child, Is.Not.Null);
+
+			Assert.That(resHql.Count, Is.EqualTo(1));
+			Assert.That(resHql[0].Child, Is.Not.Null);
 		}
 
 		[Test]
 		public void VerifyAlwaysFiltersOnPropertyRef()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
-				{
-					Parent p = createParent();
-					s.Save(p);
-					tx.Commit();
-				}
+				var p = CreateParent();
+				s.Save(p);
+				tx.Commit();
 			}
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				enableFilters(s);
-				IList<Parent> resCriteria = joinGraphUsingCriteria(s);
-				IList<Parent> resHql = joinGraphUsingHql(s);
+				EnableFilters(s);
+				var resCriteria = JoinGraphUsingCriteria(s);
+				var resHql = JoinGraphUsingHql(s);
 
-				Assert.IsNotNull(resCriteria[0].Address);
-				Assert.IsNotNull(resHql[0].Address);
+				Assert.That(resCriteria.Count, Is.EqualTo(1));
+				Assert.That(resCriteria[0].Address, Is.Not.Null);
+				Assert.That(resHql.Count, Is.EqualTo(1));
+				Assert.That(resHql[0].Address, Is.Not.Null);
 			}
 		}
 
 		[Test]
 		public void ExplicitFiltersOnCollectionsShouldBeActive()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
+				var p = CreateParent();
+				p.Children = new List<Child>
 				{
-					Parent p = createParent();
-					p.Children = new List<Child>
-                                     {
-                                         new Child {IsActive = true},
-                                         new Child {IsActive = false},
-                                         new Child {IsActive = true}
-                                     };
-					s.Save(p);
-					tx.Commit();
-				}
+					new Child {IsActive = true},
+					new Child {IsActive = false},
+					new Child {IsActive = true}
+				};
+				s.Save(p);
+				tx.Commit();
 			}
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				IFilter f = s.EnableFilter("active");
+				var f = s.EnableFilter("active");
 				f.SetParameter("active", true);
-				IList<Parent> resCriteria = joinGraphUsingCriteria(s);
-				IList<Parent> resHql = joinGraphUsingHql(s);
+				var resCriteria = JoinGraphUsingCriteria(s);
+				var resHql = JoinGraphUsingHql(s);
 
-				Assert.AreEqual(2, resCriteria[0].Children.Count);
-				Assert.AreEqual(2, resHql[0].Children.Count);
+				Assert.That(resCriteria.Count, Is.EqualTo(1));
+				Assert.That(resCriteria[0].Children.Count, Is.EqualTo(2));
+				Assert.That(resHql.Count, Is.EqualTo(1));
+				Assert.That(resHql[0].Children.Count, Is.EqualTo(2));
 			}
 		}
 
 		[Test]
 		public void ExplicitFiltersOnCollectionsShouldBeActiveWithEagerLoad()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
 			{
-				using (ITransaction tx = s.BeginTransaction())
+				var p = CreateParent();
+				p.Children = new List<Child>
 				{
-					Parent p = createParent();
-					p.Children = new List<Child>
-                                     {
-                                         new Child {IsActive = true},
-                                         new Child {IsActive = false},
-                                         new Child {IsActive = true}
-                                     };
-					s.Save(p);
-					tx.Commit();
-				}
+					new Child {IsActive = true},
+					new Child {IsActive = false},
+					new Child {IsActive = true}
+				};
+				s.Save(p);
+				tx.Commit();
 			}
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				IFilter f = s.EnableFilter("active");
+				var f = s.EnableFilter("active");
 				f.SetParameter("active", true);
-				IList<Parent> resCriteria = s.CreateCriteria(typeof(Parent)).SetFetchMode("Children", FetchMode.Join).List<Parent>();
-				IList<Parent> resHql = s.CreateQuery("select p from Parent p join fetch p.Children").List<Parent>();
+				var resCriteria = s.CreateCriteria(typeof(Parent)).SetFetchMode("Children", FetchMode.Join).List<Parent>();
+				var resHql = s.CreateQuery("select p from Parent p join fetch p.Children").List<Parent>();
 
-				Assert.AreEqual(2, resCriteria[0].Children.Count);
-				Assert.AreEqual(2, resHql[0].Children.Count);
+				Assert.That(resCriteria[0].Children.Count, Is.EqualTo(2));
+				Assert.That(resHql[0].Children.Count, Is.EqualTo(2));
 			}
 		}
+
+		[Test]
+		public void Verify20BehaviourForPropertyRefAndFilter()
+		{
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Save(CreateParent());
+				tx.Commit();
+			}
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				s.EnableFilter("active")
+				 .SetParameter("active", true);
+
+				var resCriteria = s.CreateCriteria(typeof(Parent))
+				                   .SetFetchMode("Address", FetchMode.Join)
+				                   .List<Parent>();
+
+				var resHql = s.CreateQuery("select p from Parent p join p.Address")
+				              .List<Parent>();
+
+				Assert.That(resCriteria.Count, Is.EqualTo(1));
+				Assert.That(resCriteria[0].Address, Is.Not.Null);
+
+				Assert.That(resHql.Count, Is.EqualTo(1));
+				Assert.That(resHql[0].Address, Is.Not.Null);
+			}
+		}
+
 	}
 }

--- a/src/NHibernate/Type/EntityType.cs
+++ b/src/NHibernate/Type/EntityType.cs
@@ -484,7 +484,7 @@ namespace NHibernate.Type
 			}
 			else
 			{
-				return GetAssociatedJoinable(factory).FilterFragment(alias, enabledFilters);
+				return GetAssociatedJoinable(factory).FilterFragment(alias, FilterHelper.GetEnabledForManyToOne(enabledFilters));
 			}
 		}
 


### PR DESCRIPTION
This is just really a follow-up for NH-1998