### PR TITLE
NH-3997 - identity and Sql Server Ce: fix

### DIFF
--- a/src/NHibernate/Dialect/MsSqlCeDialect.cs
+++ b/src/NHibernate/Dialect/MsSqlCeDialect.cs
@@ -125,8 +125,6 @@ namespace NHibernate.Dialect
 			get { return false; }
 		}
 
-		public override System.Type NativeIdentifierGeneratorClass => typeof(TableHiLoGenerator);
-
 		public override bool SupportsCircularCascadeDeleteConstraints => false;
 
 		public override IDataBaseSchema GetDataBaseSchema(DbConnection connection)


### PR DESCRIPTION
[NH-3997](https://nhibernate.jira.com/browse/NH-3997) - identity and Sql Server Ce: fix releasing of connection between insert and select of identity.

This is a proposition of another fix to the Sql Server Ce trouble with identity.

Sql Server Ce supports identity, replacing it with HiLo because it was failing when used without a transaction is a breaking change forcing those using it (with transaction) to change their schema, which could be a serious hassle.

Studying what causes the failure without transaction, I think NHibernate has a more general bug concerning most db but probably mitigated by connection pooling: when the connection release mode is `AfterTransaction` and there is no transaction, the connection is released between the actual insert and the identity select. This causes the identity select command to potentially run with another connection. In such case, it cannot retrieve inserted identity.

The release of connection between actual insert and retrieval of identity is triggered by the closing of insert command. So as a "quick" workaround, I have delayed this closure to after identity retrieval.

I know Java Hibernate has made heavy changes on its identity handling and on its connection releasing, and they very likely handle that more "gracefully". A better fix would probably to sync with Hibernate, but it looks heavy.

If agreeing on this fix, I will reword NH-3997 in Jira.