### PR TITLE
NH-2145 - identity: releasing of connection between insert and identity retrieval

### DIFF
--- a/src/NHibernate.Test/IdTest/IdentityClass.cs
+++ b/src/NHibernate.Test/IdTest/IdentityClass.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace NHibernate.Test.IdTest
+{
+	public class IdentityClass
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/IdTest/IdentityClass.hbm.xml
+++ b/src/NHibernate.Test/IdTest/IdentityClass.hbm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+    assembly="NHibernate.Test" namespace="NHibernate.Test.IdTest">
+  <class name="IdentityClass">
+    <id name="Id" type="int">
+      <generator class="identity" />
+    </id>
+    <property name="Name" />
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/IdTest/IdentityGeneratorFixture.cs
+++ b/src/NHibernate.Test/IdTest/IdentityGeneratorFixture.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.IdTest
+{
+	[TestFixture]
+	public class IdentityGeneratorFixture : IdFixtureBase
+	{
+		protected override string TypeName
+		{
+			get { return "Identity"; }
+		}
+
+		protected override bool AppliesTo(Dialect.Dialect dialect)
+		{
+			return dialect.SupportsIdentityColumns;
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CreateQuery("delete System.Object").ExecuteUpdate();
+				t.Commit();
+			}
+		}
+
+		[Test(Description = "NH-926")]
+		public void NonTransactedInsert()
+		{
+			using (var s = OpenSession())
+			{
+				Assert.DoesNotThrow(() => s.Save(new IdentityClass()));
+				// No need to flush with identity generator.
+				Assert.AreEqual(1, s.Query<IdentityClass>().Count());
+			}
+		}
+
+		[Test]
+		public void TransactedInsert()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				Assert.DoesNotThrow(() => s.Save(new IdentityClass()));
+				// No need to flush with identity generator.
+				Assert.AreEqual(1, s.Query<IdentityClass>().Count());
+				t.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/IdTest/IdentityGeneratorNoPoolingFixture.cs
+++ b/src/NHibernate.Test/IdTest/IdentityGeneratorNoPoolingFixture.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using NHibernate.Cfg;
+using NHibernate.Dialect;
+using NHibernate.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.IdTest
+{
+	[TestFixture]
+	public class IdentityGeneratorNoPoolingFixture : IdFixtureBase
+	{
+		protected override string TypeName
+		{
+			get { return "Identity"; }
+		}
+
+		protected override bool AppliesTo(Dialect.Dialect dialect)
+		{
+			return dialect.SupportsIdentityColumns && dialect.SupportsPoolingParameter;
+		}
+
+		protected override void Configure(Configuration configuration)
+		{
+			var connectionString = configuration.GetProperty(Cfg.Environment.ConnectionString) +
+				";Pooling=false";
+			configuration.SetProperty(Cfg.Environment.ConnectionString, connectionString);
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CreateQuery("delete System.Object").ExecuteUpdate();
+				t.Commit();
+			}
+		}
+
+		[Test(Description = "NH-3600")]
+		public void NonTransactedInsert()
+		{
+			using (var s = OpenSession())
+			{
+				Assert.DoesNotThrow(() => s.Save(new IdentityClass()));
+				// No need to flush with identity generator.
+				Assert.AreEqual(1, s.Query<IdentityClass>().Count());
+			}
+		}
+
+		[Test]
+		public void TransactedInsert()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				Assert.DoesNotThrow(() => s.Save(new IdentityClass()));
+				// No need to flush with identity generator.
+				Assert.AreEqual(1, s.Query<IdentityClass>().Count());
+				t.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -474,6 +474,9 @@
     <Compile Include="IdGen\Enhanced\Table\PooledLoTableTest.cs" />
     <Compile Include="IdTest\AssignedClass.cs" />
     <Compile Include="IdTest\AssignedFixture.cs" />
+    <Compile Include="IdTest\IdentityGeneratorNoPoolingFixture.cs" />
+    <Compile Include="IdTest\IdentityGeneratorFixture.cs" />
+    <Compile Include="IdTest\IdentityClass.cs" />
     <Compile Include="IdTest\TableGeneratorFixture.cs" />
     <Compile Include="Immutable\Contract.cs" />
     <Compile Include="Immutable\ContractVariation.cs" />
@@ -3272,6 +3275,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="SessionBuilder\Mappings.hbm.xml" />
+    <EmbeddedResource Include="IdTest\IdentityClass.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH1904\StructMappings.hbm.xml" />
     <EmbeddedResource Include="Insertordering\FamilyModel\Mappings.hbm.xml" />
     <EmbeddedResource Include="Insertordering\AnimalModel\Mappings.hbm.xml" />

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -2058,6 +2058,11 @@ namespace NHibernate.Dialect
 			get { return true; }
 		}
 
+		/// <summary>
+		/// Does this dialect support pooling parameter in connection string?
+		/// </summary>
+		public virtual bool SupportsPoolingParameter => true;
+
 		#endregion
 
 		/// <summary>

--- a/src/NHibernate/Dialect/MsSqlCeDialect.cs
+++ b/src/NHibernate/Dialect/MsSqlCeDialect.cs
@@ -207,5 +207,14 @@ namespace NHibernate.Dialect
 				return TimeSpan.TicksPerMillisecond*10L;
 			}
 		}
+
+		#region Informational metadata
+
+		/// <summary>
+		/// Does this dialect support pooling parameter in connection string?
+		/// </summary>
+		public override bool SupportsPoolingParameter => false;
+
+		#endregion
 	}
 }


### PR DESCRIPTION
[NH-2145](https://nhibernate.jira.com/browse/NH-2145) - [NH-926](https://nhibernate.jira.com/browse/NH-926) (re) - [NH-3600](https://nhibernate.jira.com/browse/NH-3600) - identity: test cases for releasing of connection between insert and identity retrieval.

Will wait the test failures for checking those new tests seems to do their job. (`NonTransacted` should failed on server supporting identity without supporting select with insert, and pooling version should failed for same servers if they allow specifying pooling. Unfortunately, it does not look like we have such servers excepted SQL Server CE (which does not support (un)setting pooling).)