### PR TITLE
NH-4003 - porting ISessionCreationOptions

### DIFF
--- a/src/NHibernate.Test/Legacy/FumTest.cs
+++ b/src/NHibernate.Test/Legacy/FumTest.cs
@@ -617,7 +617,7 @@ namespace NHibernate.Test.Legacy
 			// instead of just the usual openSession()
 			using (ISession s = sessions.OpenSession())
 			{
-				s.FlushMode = FlushMode.Never;
+				s.FlushMode = FlushMode.Manual;
 
 				Simple simple = new Simple();
 				simple.Address = "123 Main St. Anytown USA";
@@ -656,7 +656,7 @@ namespace NHibernate.Test.Legacy
 
 			using (ISession s = sessions.OpenSession())
 			{
-				s.FlushMode = FlushMode.Never;
+				s.FlushMode = FlushMode.Manual;
 				Simple simple = (Simple) s.Get(typeof(Simple), 10L);
 				Assert.AreEqual(check.Name, simple.Name, "Not same parent instances");
 				Assert.AreEqual(check.Other.Name, other.Name, "Not same child instances");
@@ -679,7 +679,7 @@ namespace NHibernate.Test.Legacy
 			// Test deletions across serializations
 			using (ISession s = sessions.OpenSession())
 			{
-				s.FlushMode = FlushMode.Never;
+				s.FlushMode = FlushMode.Manual;
 				Simple simple = (Simple) s.Get(typeof(Simple), 10L);
 				Assert.AreEqual(check.Name, simple.Name, "Not same parent instances");
 				Assert.AreEqual(check.Other.Name, other.Name, "Not same child instances");

--- a/src/NHibernate.Test/NHSpecificTest/EmptyMappingsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EmptyMappingsFixture.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Test.NHSpecificTest
 		public void NullInterceptor()
 		{
 			IInterceptor nullInterceptor = null;
-			Assert.Throws<ArgumentNullException>(() => sessions.OpenSession(nullInterceptor).Close());
+			Assert.Throws<ArgumentNullException>(() => sessions.WithOptions().Interceptor(nullInterceptor).OpenSession().Close());
 		}
 
 		[Test]

--- a/src/NHibernate.Test/NHSpecificTest/NH1082/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1082/Fixture.cs
@@ -16,15 +16,11 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 		[Test]
 		public void ExceptionsInBeforeTransactionCompletionAbortTransaction()
 		{
-#pragma warning disable 618
-			Assert.IsFalse(sessions.Settings.IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled);
-#pragma warning restore 618
-
 			var c = new C {ID = 1, Value = "value"};
 
 			var sessionInterceptor = new SessionInterceptorThatThrowsExceptionAtBeforeTransactionCompletion();
-			using (ISession s = sessions.OpenSession(sessionInterceptor))
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = sessions.WithOptions().Interceptor(sessionInterceptor).OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(c);
 
@@ -42,10 +38,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 		[Test]
 		public void ExceptionsInSynchronizationBeforeTransactionCompletionAbortTransaction()
 		{
-#pragma warning disable 618
-			Assert.IsFalse(sessions.Settings.IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled);
-#pragma warning restore 618
-
 			var c = new C { ID = 1, Value = "value" };
 
 			var synchronization = new SynchronizationThatThrowsExceptionAtBeforeTransactionCompletion();
@@ -63,80 +55,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 			{
 				var objectInDb = s.Get<C>(1);
 				Assert.IsNull(objectInDb);
-			}
-		}
-	}
-
-
-	[TestFixture]
-	[Obsolete("Can be removed when Environment.InterceptorsBeforeTransactionCompletionIgnoreExceptions is removed.")]
-	public class OldBehaviorEnabledFixture : BugTestCase
-	{
-		public override string BugNumber
-		{
-			get { return "NH1082"; }
-		}
-
-		protected override void Configure(Configuration configuration)
-		{
-			configuration.SetProperty(Environment.InterceptorsBeforeTransactionCompletionIgnoreExceptions, "true");
-			base.Configure(configuration);
-		}
-
-		[Test]
-		public void ExceptionsInBeforeTransactionCompletionAreIgnored()
-		{
-			Assert.IsTrue(sessions.Settings.IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled);
-
-			var c = new C {ID = 1, Value = "value"};
-
-			var sessionInterceptor = new SessionInterceptorThatThrowsExceptionAtBeforeTransactionCompletion();
-			using (ISession s = sessions.OpenSession(sessionInterceptor))
-			using (ITransaction t = s.BeginTransaction())
-			{
-				s.Save(c);
-
-				Assert.DoesNotThrow(t.Commit);
-			}
-
-			using (ISession s = sessions.OpenSession())
-			{
-				var objectInDb = s.Get<C>(1);
-
-				Assert.IsNotNull(objectInDb);
-
-				s.Delete(objectInDb);
-				s.Flush();
-			}
-		}
-
-
-		[Test]
-		public void ExceptionsInSynchronizationBeforeTransactionCompletionAreIgnored()
-		{
-			Assert.IsTrue(sessions.Settings.IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled);
-
-			var c = new C { ID = 1, Value = "value" };
-
-			var synchronization = new SynchronizationThatThrowsExceptionAtBeforeTransactionCompletion();
-			using (ISession s = sessions.OpenSession())
-			using (ITransaction t = s.BeginTransaction())
-			{
-				t.RegisterSynchronization(synchronization);
-
-				s.Save(c);
-
-				Assert.DoesNotThrow(t.Commit);
-			}
-
-			using (ISession s = sessions.OpenSession())
-			{
-				var objectInDb = s.Get<C>(1);
-
-				Assert.IsNotNull(objectInDb);
-
-				s.Delete(objectInDb);
-				s.Flush();
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1159/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1159/Fixture.cs
@@ -69,7 +69,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1159
 			using (ISession session = OpenSession(new HibernateInterceptor()))
 			using (ITransaction tran = session.BeginTransaction())
 			{
-				session.FlushMode = FlushMode.Never;
+				session.FlushMode = FlushMode.Manual;
 				Assert.That(HibernateInterceptor.CallCount, Is.EqualTo(0));
 				Contact contact = session.Get<Contact>((Int64)1);
 				contact.PreferredName = "Updated preferred name";

--- a/src/NHibernate.Test/NHSpecificTest/NH1632/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1632/Fixture.cs
@@ -106,7 +106,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 
 			using (var tx = new TransactionScope())
 			{
-				using (var s = sessions.OpenSession(connection))
+				using (var s = sessions.WithOptions().Connection(connection).OpenSession())
 				{
 					var nums = s.Load<Nums>(29);
 					Assert.AreEqual(1, nums.NumA);
@@ -156,7 +156,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 			{
 				using (ISession s = sessions.OpenSession())
 				{
-					s.FlushMode = FlushMode.Never;
+					s.FlushMode = FlushMode.Manual;
 					id = s.Save(new Nums { NumA = 1, NumB = 2, ID = 5 });
 				}
 				tx.Complete();

--- a/src/NHibernate.Test/NHSpecificTest/NH1714/SimpleReproductionFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1714/SimpleReproductionFixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1714
                     var entity = new DomainClass();
                     session.Save(entity);
 
-                    using (var otherSession = session.GetChildSession())
+                    using (var otherSession = session.SessionWithOptions().Connection().OpenSession())
                     {
                         otherSession.Save(new DomainClass());
                         otherSession.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH1714/UseCaseDemonstrationFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1714/UseCaseDemonstrationFixture.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1714
 				return false;
 
 			// this will join into the parent's transaction
-			using (var session = e.Session.GetChildSession())
+			using (var session = e.Session.SessionWithOptions().Connection().OpenSession())
 			{
 				//should insert log record here
 				session.Save(new LogClass());

--- a/src/NHibernate.Test/NHSpecificTest/NH2374/NH2374Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2374/NH2374Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2374
 
 			using (ISession sroot = OpenSession())
 			{
-				using (ISession s = sroot.GetChildSession())
+				using (ISession s = sroot.SessionWithOptions().Connection().OpenSession())
 				{
 					using (ITransaction t = s.BeginTransaction())
 					{

--- a/src/NHibernate.Test/NHSpecificTest/NH2420/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2420/Fixture.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2420
 				using (connection)
 				{
 					connection.Open();
-					using (s = Sfi.OpenSession(connection))
+					using (s = Sfi.WithOptions().Connection(connection).OpenSession())
 					{
 						s.Save(new MyTable { String = "hello!" });
 					}

--- a/src/NHibernate.Test/NHSpecificTest/NH3985/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3985/Fixture.cs
@@ -14,11 +14,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3985
 		{
 			using (var rootSession = OpenSession())
 			{
-				using (var childSession1 = rootSession.GetChildSession())
+				using (var childSession1 = rootSession.SessionWithOptions().Connection().OpenSession())
 				{
 				}
 
-				using (var childSession2 = rootSession.GetChildSession())
+				using (var childSession2 = rootSession.SessionWithOptions().Connection().OpenSession())
 				{
 					Assert.DoesNotThrow(() => { childSession2.Get<Process>(Guid.NewGuid()); });
 				}
@@ -30,10 +30,10 @@ namespace NHibernate.Test.NHSpecificTest.NH3985
 		{
 			using (var rootSession = OpenSession())
 			{
-				var childSession1 = rootSession.GetChildSession();
+				var childSession1 = rootSession.SessionWithOptions().Connection().OpenSession();
 				childSession1.Close();
 
-				using (var childSession2 = rootSession.GetChildSession())
+				using (var childSession2 = rootSession.SessionWithOptions().Connection().OpenSession())
 				{
 					Assert.DoesNotThrow(() => { childSession2.Get<Process>(Guid.NewGuid()); });
 				}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -1420,6 +1420,8 @@
     <Compile Include="ReadOnly\StudentDto.cs" />
     <Compile Include="ReadOnly\TextHolder.cs" />
     <Compile Include="ReadOnly\VersionedNode.cs" />
+    <Compile Include="SessionBuilder\Entity.cs" />
+    <Compile Include="SessionBuilder\Fixture.cs" />
     <Compile Include="SqlCommandTest\SqlTokenizerFixture.cs" />
     <Compile Include="RecordingInterceptor.cs" />
     <Compile Include="Stateless\Contact.cs" />
@@ -3269,6 +3271,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="SessionBuilder\Mappings.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH1904\StructMappings.hbm.xml" />
     <EmbeddedResource Include="Insertordering\FamilyModel\Mappings.hbm.xml" />
     <EmbeddedResource Include="Insertordering\AnimalModel\Mappings.hbm.xml" />

--- a/src/NHibernate.Test/SessionBuilder/Entity.cs
+++ b/src/NHibernate.Test/SessionBuilder/Entity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NHibernate.Test.SessionBuilder
+{
+	class Entity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/SessionBuilder/Fixture.cs
+++ b/src/NHibernate.Test/SessionBuilder/Fixture.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using NHibernate.Cfg;
+using NHibernate.Impl;
+using NUnit.Framework;
+
+namespace NHibernate.Test.SessionBuilder
+{
+	public class Fixture : TestCase
+	{
+		protected override string MappingsAssembly => "NHibernate.Test";
+
+		protected override IList Mappings =>
+			new string[]
+			{
+				"SessionBuilder.Mappings.hbm.xml"
+			};
+
+		protected override void Configure(Configuration configuration)
+		{
+			// Do not use .Instance here, we want another instance.
+			configuration.Interceptor = new EmptyInterceptor();
+		}
+
+		[Test]
+		public void CanSetAutoClose()
+		{
+			var sb = sessions.WithOptions();
+			CanSetAutoClose(sb);
+			using (var s = sb.OpenSession())
+			{
+				CanSetAutoClose(s.SessionWithOptions());
+			}
+		}
+
+		private void CanSetAutoClose<T>(T sb) where T : ISessionBuilder<T>
+		{
+			var options = (ISessionCreationOptions)sb;
+			CanSet(sb, sb.AutoClose, options.ShouldAutoClose,
+				sb is ISharedSessionBuilder ssb ? ssb.AutoClose : default(Func<ISharedSessionBuilder>),
+				// initial values
+				false,
+				// values
+				true, false);
+		}
+
+		[Test]
+		public void CanSetConnection()
+		{
+			var sb = sessions.WithOptions();
+			CanSetConnection(sb);
+			using (var s = sb.OpenSession())
+			{
+				CanSetConnection(s.SessionWithOptions());
+			}
+		}
+
+		private void CanSetConnection<T>(T sb) where T : ISessionBuilder<T>
+		{
+			var sbType = sb.GetType().Name;
+			var conn = sessions.ConnectionProvider.GetConnection();
+			try
+			{
+				var options = (ISessionCreationOptions)sb;
+				Assert.IsNull(options.GetConnection(), $"{sbType}: Initial value");
+				var fsb = sb.Connection(conn);
+				Assert.AreEqual(conn, options.GetConnection(), $"{sbType}: After call with a connection");
+				Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with a connection");
+
+				if (sb is ISharedSessionBuilder ssb)
+				{
+					var sharedOptions = (ISharedSessionCreationOptions)options;
+					Assert.IsFalse(sharedOptions.IsTransactionCoordinatorShared(), $"{sbType}: Transaction coordinator shared before sharing");
+					Assert.IsNull(sharedOptions.GetConnectionManager(), $"{sbType}: Connection manager shared before sharing");
+
+					var fssb = ssb.Connection();
+					// Sharing connection shares the connection manager, not the connection.
+					Assert.IsNull(options.GetConnection(), $"{sbType}: After call with previous session connection");
+					Assert.IsTrue(sharedOptions.IsTransactionCoordinatorShared(), $"{sbType}: Transaction coordinator not shared after sharing");
+					Assert.IsNotNull(sharedOptions.GetConnectionManager(), $"{sbType}: Connection manager not shared after sharing");
+					Assert.AreEqual(sb, fssb, $"{sbType}: Unexpected fluent return on shared");
+
+					fsb = sb.Connection(null);
+					Assert.IsNull(options.GetConnection(), $"{sbType}: After call with null");
+					Assert.IsFalse(sharedOptions.IsTransactionCoordinatorShared(), $"{sbType}: Transaction coordinator shared after un-sharing");
+					Assert.IsNull(sharedOptions.GetConnectionManager(), $"{sbType}: Connection manager shared after un-sharing");
+					Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after un-sharing");
+				}
+				else
+				{
+					fsb = sb.Connection(null);
+					Assert.IsNull(options.GetConnection(), $"{sbType}: After call with null");
+					Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with null");
+				}
+			}
+			finally
+			{
+				sessions.ConnectionProvider.CloseConnection(conn);
+			}
+		}
+
+		[Test]
+		public void CanSetConnectionOnStateless()
+		{
+			var sb = sessions.WithStatelessOptions();
+			var sbType = sb.GetType().Name;
+			var conn = sessions.ConnectionProvider.GetConnection();
+			try
+			{
+				var options = (ISessionCreationOptions)sb;
+				Assert.IsNull(options.GetConnection(), $"{sbType}: Initial value");
+				var fsb = sb.Connection(conn);
+				Assert.AreEqual(conn, options.GetConnection(), $"{sbType}: After call with a connection");
+				Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with a connection");
+
+				fsb = sb.Connection(null);
+				Assert.IsNull(options.GetConnection(), $"{sbType}: After call with null");
+				Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with null");
+			}
+			finally
+			{
+				sessions.ConnectionProvider.CloseConnection(conn);
+			}
+		}
+
+		[Test]
+		public void CanSetConnectionReleaseMode()
+		{
+			var sb = sessions.WithOptions();
+			CanSetConnectionReleaseMode(sb);
+			using (var s = sb.OpenSession())
+			{
+				CanSetConnectionReleaseMode(s.SessionWithOptions());
+			}
+		}
+
+		private void CanSetConnectionReleaseMode<T>(T sb) where T : ISessionBuilder<T>
+		{
+			var options = (ISessionCreationOptions)sb;
+			CanSet(sb, sb.ConnectionReleaseMode, options.GetConnectionReleaseMode,
+				sb is ISharedSessionBuilder ssb ? ssb.ConnectionReleaseMode : default(Func<ISharedSessionBuilder>),
+				// initial values
+				sessions.Settings.ConnectionReleaseMode,
+				// values
+				ConnectionReleaseMode.OnClose, ConnectionReleaseMode.AfterStatement, ConnectionReleaseMode.AfterTransaction);
+		}
+
+		[Test]
+		public void CanSetFlushMode()
+		{
+			var sb = sessions.WithOptions();
+			CanSetFlushMode(sb);
+			using (var s = sb.OpenSession())
+			{
+				CanSetFlushMode(s.SessionWithOptions());
+			}
+		}
+
+		private void CanSetFlushMode<T>(T sb) where T : ISessionBuilder<T>
+		{
+			var options = (ISessionCreationOptions)sb;
+			CanSet(sb, sb.FlushMode, options.GetInitialSessionFlushMode,
+				sb is ISharedSessionBuilder ssb ? ssb.FlushMode : default(Func<ISharedSessionBuilder>),
+				// initial values
+				sessions.Settings.DefaultFlushMode,
+				// values
+				FlushMode.Always, FlushMode.Auto, FlushMode.Commit, FlushMode.Manual);
+		}
+
+		[Test]
+		public void CanSetInterceptor()
+		{
+			var sb = sessions.WithOptions();
+			CanSetInterceptor(sb);
+			using (var s = sb.OpenSession())
+			{
+				CanSetInterceptor(s.SessionWithOptions());
+			}
+		}
+
+		private void CanSetInterceptor<T>(T sb) where T : ISessionBuilder<T>
+		{
+			var sbType = sb.GetType().Name;
+			// Do not use .Instance here, we want another instance.
+			var interceptor = new EmptyInterceptor();
+			var options = (ISessionCreationOptions)sb;
+
+			Assert.AreEqual(sessions.Interceptor, options.GetInterceptor(), $"{sbType}: Initial value");
+			var fsb = sb.Interceptor(interceptor);
+			Assert.AreEqual(interceptor, options.GetInterceptor(), $"{sbType}: After call with an interceptor");
+			Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with an interceptor");
+
+			if (sb is ISharedSessionBuilder ssb)
+			{
+				var fssb = ssb.Interceptor();
+				Assert.AreEqual(EmptyInterceptor.Instance, options.GetInterceptor(), $"{sbType}: After call with shared interceptor");
+				Assert.AreEqual(sb, fssb, $"{sbType}: Unexpected fluent return on shared");
+			}
+
+			Assert.Throws<ArgumentNullException>(() => sb.Interceptor(null), $"{sbType}: After call with null");
+
+			fsb = sb.NoInterceptor();
+			Assert.AreEqual(EmptyInterceptor.Instance, options.GetInterceptor(), $"{sbType}: After no call");
+			Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after no call");
+		}
+
+		private void CanSet<T, V>(T sb, Func<V, T> setter, Func<V> getter, Func<ISharedSessionBuilder> shared, V initialValue,
+			params V[] values) where T : ISessionBuilder<T>
+		{
+			var sbType = sb.GetType().Name;
+			Assert.AreEqual(initialValue, getter(), $"{sbType}: Initial value");
+			if (shared != null)
+			{
+				var fssb = shared();
+				Assert.AreEqual(values.Last(), getter(), $"{sbType}: After call with shared setting");
+				Assert.AreEqual(sb, fssb, $"{sbType}: Unexpected fluent return on shared");
+			}
+			foreach (var value in values)
+			{
+				var fsb = setter(value);
+				Assert.AreEqual(value, getter(), $"{sbType}: After call with {value}");
+				Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with {value}");
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/SessionBuilder/Mappings.hbm.xml
+++ b/src/NHibernate.Test/SessionBuilder/Mappings.hbm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test" namespace="NHibernate.Test.SessionBuilder">
+
+	<class name="Entity">
+		<id name="Id" generator="guid.comb" />
+		<property name="Name" />
+	</class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/SystemTransactions/TransactionNotificationFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/TransactionNotificationFixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void NoTransaction()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (sessions.OpenSession(interceptor))
+			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				Assert.AreEqual(0, interceptor.afterTransactionBeginCalled);
 				Assert.AreEqual(0, interceptor.beforeTransactionCompletionCalled);
@@ -33,7 +33,7 @@ namespace NHibernate.Test.SystemTransactions
 		{
 			var interceptor = new RecordingInterceptor();
 			using (new TransactionScope()) 
-			using (sessions.OpenSession(interceptor))
+			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				Assert.AreEqual(1, interceptor.afterTransactionBeginCalled);
 				Assert.AreEqual(0, interceptor.beforeTransactionCompletionCalled);
@@ -48,7 +48,7 @@ namespace NHibernate.Test.SystemTransactions
 			ISession session;
 			using(var scope = new TransactionScope())
 			{
-				session = sessions.OpenSession(interceptor);
+				session = sessions.WithOptions().Interceptor(interceptor).OpenSession();
 				scope.Complete();
 			}
 			session.Dispose();
@@ -62,7 +62,7 @@ namespace NHibernate.Test.SystemTransactions
 		{
 			var interceptor = new RecordingInterceptor();
 			using (new TransactionScope())
-			using (sessions.OpenSession(interceptor))
+			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 			}
 			Assert.AreEqual(0, interceptor.beforeTransactionCompletionCalled);
@@ -73,7 +73,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void TwoTransactionScopesInsideOneSession()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.OpenSession(interceptor))
+			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				using (var scope = new TransactionScope())
 				{
@@ -96,7 +96,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void OneTransactionScopesInsideOneSession()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.OpenSession(interceptor))
+			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				using (var scope = new TransactionScope())
 				{
@@ -165,16 +165,9 @@ namespace NHibernate.Test.SystemTransactions
 
 				try
 				{
-					try
+					using (s1 = sessions.WithOptions().Connection(ownConnection1).Interceptor(interceptor).OpenSession())
 					{
-						s1 = sessions.OpenSession(ownConnection1, interceptor);
-
 						s1.CreateCriteria<object>().List();
-					}
-					finally
-					{
-						if (s1 != null)
-							s1.Dispose();
 					}
 
 					if (doCommit)

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -376,7 +376,7 @@ namespace NHibernate.Test
 
 		protected virtual ISession OpenSession(IInterceptor sessionLocalInterceptor)
 		{
-			_lastOpenedSession = sessions.OpenSession(sessionLocalInterceptor);
+			_lastOpenedSession = sessions.WithOptions().Interceptor(sessionLocalInterceptor).OpenSession();
 			_openedSessions.Add(_lastOpenedSession);
 			return _lastOpenedSession;
 		}

--- a/src/NHibernate.Test/TransactionTest/TransactionNotificationFixture.cs
+++ b/src/NHibernate.Test/TransactionTest/TransactionNotificationFixture.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Test.TransactionTest
 		public void NoTransaction()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (sessions.OpenSession(interceptor))
+			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				Assert.That(interceptor.afterTransactionBeginCalled, Is.EqualTo(0));
 				Assert.That(interceptor.beforeTransactionCompletionCalled, Is.EqualTo(0));
@@ -29,7 +29,7 @@ namespace NHibernate.Test.TransactionTest
 		public void AfterBegin()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (ISession session = sessions.OpenSession(interceptor))
+			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			using (session.BeginTransaction())
 			{
 				Assert.That(interceptor.afterTransactionBeginCalled, Is.EqualTo(1));
@@ -42,7 +42,7 @@ namespace NHibernate.Test.TransactionTest
 		public void Commit()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (ISession session = sessions.OpenSession(interceptor))
+			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				ITransaction tx = session.BeginTransaction();
 				tx.Commit();
@@ -56,7 +56,7 @@ namespace NHibernate.Test.TransactionTest
 		public void Rollback()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (ISession session = sessions.OpenSession(interceptor))
+			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				ITransaction tx = session.BeginTransaction();
 				tx.Rollback();
@@ -98,7 +98,7 @@ namespace NHibernate.Test.TransactionTest
 
 			using (var ownConnection = sessions.ConnectionProvider.GetConnection())
 			{
-				using (s = sessions.OpenSession(ownConnection, interceptor))
+				using (s = sessions.WithOptions().Connection(ownConnection).Interceptor(interceptor).OpenSession())
 				using (s.BeginTransaction())
 				{
 					s.CreateCriteria<object>().List();

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -172,7 +172,7 @@ namespace NHibernate.Cfg
 			secondPasses = new List<SecondPassCommand>();
 			propertyReferences = new List<Mappings.PropertyReference>();
 			FilterDefinitions = new Dictionary<string, FilterDefinition>();
-			interceptor = emptyInterceptor;
+			interceptor = EmptyInterceptor.Instance;
 			properties = Environment.Properties;
 			auxiliaryDatabaseObjects = new List<IAuxiliaryDatabaseObject>();
 			SqlFunctions = new Dictionary<string, ISQLFunction>();
@@ -184,6 +184,7 @@ namespace NHibernate.Cfg
 			columnNameBindingPerTable = new Dictionary<Table, Mappings.ColumnNames>();
 			filtersSecondPasses = new Queue<FilterSecondPassArgs>();
 		}
+
 		[Serializable]
 		private class Mapping : IMapping
 		{
@@ -1216,8 +1217,7 @@ namespace NHibernate.Cfg
 		{
 			get { return eventListeners; }
 		}
-
-		private static readonly IInterceptor emptyInterceptor = new EmptyInterceptor();
+		
 		private string defaultAssembly;
 		private string defaultNamespace;
 

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -185,14 +185,6 @@ namespace NHibernate.Cfg
 		/// This may need to be set to 3 if you are using the OdbcDriver with MS SQL Server 2008+.
 		/// </summary>
 		public const string OdbcDateTimeScale = "odbc.explicit_datetime_scale";
-		
-		/// <summary>
-		/// If this setting is set to false, exceptions in IInterceptor.BeforeTransactionCompletion bubble to the caller of ITransaction.Commit and abort the commit.
-		/// If this setting is set to true, exceptions in IInterceptor.BeforeTransactionCompletion are ignored and the commit is performed.
-		/// The default setting is false.
-		/// </summary>
-		[Obsolete("This setting is likely to be removed in a future version of NHibernate. The workaround is to catch all exceptions in the IInterceptor implementation.")]
-		public const string InterceptorsBeforeTransactionCompletionIgnoreExceptions = "interceptors.beforetransactioncompletion_ignore_exceptions";
 
 		private static readonly Dictionary<string, string> GlobalProperties;
 

--- a/src/NHibernate/Cfg/MappingSchema/Hbm.generated.cs
+++ b/src/NHibernate/Cfg/MappingSchema/Hbm.generated.cs
@@ -4294,14 +4294,18 @@ namespace NHibernate.Cfg.MappingSchema {
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("auto")]
         Auto,
-        
+
         /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("never")]
-        Never,
-        
+        [System.Xml.Serialization.XmlEnumAttribute("manual")]
+        Manual,
+
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("always")]
         Always,
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlEnumAttribute("never")]
+        Never,
     }
     
     /// <remarks/>

--- a/src/NHibernate/Cfg/Settings.cs
+++ b/src/NHibernate/Cfg/Settings.cs
@@ -81,6 +81,8 @@ namespace NHibernate.Cfg
 
 		public bool IsIdentifierRollbackEnabled { get; internal set; }
 
+		// Since v5
+		[Obsolete("Please use DefaultFlushMode instead.")]
 		public bool IsFlushBeforeCompletionEnabled { get; internal set; }
 
 		public bool IsAutoCloseSessionEnabled { get; internal set; }
@@ -129,9 +131,6 @@ namespace NHibernate.Cfg
 		/// Get the registry to provide Hql-Generators for known properties/methods.
 		/// </summary>
 		public ILinqToHqlGeneratorsRegistry LinqToHqlGeneratorsRegistry { get; internal set; }
-
-		[Obsolete("This setting is likely to be removed in a future version of NHibernate. The workaround is to catch all exceptions in the IInterceptor implementation.")]
-		public bool IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled { get; internal set; }
 
 		public IQueryModelRewriterFactory QueryModelRewriterFactory { get; internal set; }
 		

--- a/src/NHibernate/Cfg/SettingsFactory.cs
+++ b/src/NHibernate/Cfg/SettingsFactory.cs
@@ -281,12 +281,6 @@ namespace NHibernate.Cfg
 			bool namedQueryChecking = PropertiesHelper.GetBoolean(Environment.QueryStartupChecking, properties, true);
 			log.Info("Named query checking : " + EnabledDisabled(namedQueryChecking));
 			settings.IsNamedQueryStartupCheckingEnabled = namedQueryChecking;
-
-#pragma warning disable 618 // Disable warning for use of obsolete symbols.
-			var interceptorsBeforeTransactionCompletionIgnoreExceptions = PropertiesHelper.GetBoolean(Environment.InterceptorsBeforeTransactionCompletionIgnoreExceptions, properties, false);
-			log.Info("Ignoring exceptions in BeforeTransactionCompletion : " + EnabledDisabled(interceptorsBeforeTransactionCompletionIgnoreExceptions));
-			settings.IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled = interceptorsBeforeTransactionCompletionIgnoreExceptions;
-#pragma warning restore 618
 			
 			// Not ported - settings.StatementFetchSize = statementFetchSize;
 			// Not ported - ScrollableResultSetsEnabled

--- a/src/NHibernate/Cfg/XmlHbmBinding/FlushModeConverter.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/FlushModeConverter.cs
@@ -26,8 +26,9 @@ namespace NHibernate.Cfg.XmlHbmBinding
 				case HbmFlushMode.Auto:
 					return FlushMode.Auto;
 
+				case HbmFlushMode.Manual:
 				case HbmFlushMode.Never:
-					return FlushMode.Never;
+					return FlushMode.Manual;
 
 				case HbmFlushMode.Always:
 					return FlushMode.Always;

--- a/src/NHibernate/EmptyInterceptor.cs
+++ b/src/NHibernate/EmptyInterceptor.cs
@@ -5,9 +5,17 @@ using NHibernate.Type;
 
 namespace NHibernate
 {
+	/// <summary>
+	/// An interceptor that does nothing.  May be used as a base class for application-defined custom interceptors.
+	/// </summary>
 	[Serializable]
 	public class EmptyInterceptor : IInterceptor
 	{
+		/// <summary>
+		/// The singleton reference.
+		/// </summary>
+		public static readonly EmptyInterceptor Instance = new EmptyInterceptor();
+
 		public virtual void OnDelete(object entity, object id, object[] state, string[] propertyNames, IType[] types)
 		{
 		}
@@ -25,7 +33,7 @@ namespace NHibernate
 		}
 
 		public virtual bool OnFlushDirty(object entity, object id, object[] currentState, object[] previousState,
-		                                 string[] propertyNames, IType[] types)
+			string[] propertyNames, IType[] types)
 		{
 			return false;
 		}
@@ -69,7 +77,7 @@ namespace NHibernate
 		}
 
 		public virtual int[] FindDirty(object entity, object id, object[] currentState, object[] previousState,
-		                               string[] propertyNames, IType[] types)
+			 string[] propertyNames, IType[] types)
 		{
 			return null;
 		}

--- a/src/NHibernate/FlushMode.cs
+++ b/src/NHibernate/FlushMode.cs
@@ -22,7 +22,15 @@ namespace NHibernate
 		/// called by the application. This mode is very efficient for read only
 		/// transactions
 		/// </summary>
-		Never = 0,
+		Manual = 0,
+		// Obsolete in v5.
+		/// <summary>
+		/// The <c>ISession</c> is never flushed unless <c>Flush()</c> is explicitly
+		/// called by the application. This mode is very efficient for read only
+		/// transactions
+		/// </summary>
+		[Obsolete("Please use Manual instead.")]
+		Never = Manual,
 		/// <summary>
 		/// The <c>ISession</c> is flushed when <c>Transaction.Commit()</c> is called
 		/// </summary>
@@ -32,7 +40,7 @@ namespace NHibernate
 		/// ensure that queries never return stale state. This is the default flush mode.
 		/// </summary>
 		Auto = 10,
-		/// <summary> 
+		/// <summary>
 		/// The <see cref="ISession"/> is flushed before every query. This is
 		/// almost always unnecessary and inefficient.
 		/// </summary>

--- a/src/NHibernate/ISession.cs
+++ b/src/NHibernate/ISession.cs
@@ -74,6 +74,13 @@ namespace NHibernate
 	public interface ISession : IDisposable
 	{
 		/// <summary>
+		/// Obtain a <see cref="ISession"/> builder with the ability to grab certain information from
+		/// this session. The built <c>ISession</c> will require its own flushes and disposal.
+		/// </summary>
+		/// <returns>The session builder.</returns>
+		ISharedSessionBuilder SessionWithOptions();
+
+		/// <summary>
 		/// Force the <c>ISession</c> to flush.
 		/// </summary>
 		/// <remarks>
@@ -929,12 +936,16 @@ namespace NHibernate
 		/// <summary> Get the statistics for this session.</summary>
 		ISessionStatistics Statistics { get; }
 
-		///  <summary>
-		///  Starts a new Session. This secondary Session inherits the connection, transaction,
-		///  and other context information from the primary Session. It doesn't need to be flushed
-		///  or closed by the developer.
-		///  </summary>
-		/// <returns>The new session</returns>
-		ISession GetChildSession();
+		// Obsolete since v5.
+		/// <summary>
+		/// Starts a new Session with the given entity mode in effect. This secondary
+		/// Session inherits the connection, transaction, and other context
+		///	information from the primary Session. It has to be flushed
+		/// or disposed by the developer since v5.
+		/// </summary>
+		/// <param name="entityMode">Ignored.</param>
+		/// <returns>The new session.</returns>
+		[Obsolete("Please use SessionWithOptions instead. Now requires to be flushed and disposed of.")]
+		ISession GetSession(EntityMode entityMode);
 	}
 }

--- a/src/NHibernate/ISessionBuilder.cs
+++ b/src/NHibernate/ISessionBuilder.cs
@@ -1,0 +1,75 @@
+using System.Data.Common;
+using NHibernate.Connection;
+
+namespace NHibernate
+{
+	// NH specific: Java does not require this, it looks as still having a better covariance support.
+	/// <summary>
+	/// Represents a consolidation of all session creation options into a builder style delegate.
+	/// </summary>
+	public interface ISessionBuilder : ISessionBuilder<ISessionBuilder> { }
+
+	/// <summary>
+	/// Represents a consolidation of all session creation options into a builder style delegate.
+	/// </summary>
+	public interface ISessionBuilder<T> where T : ISessionBuilder<T>
+	{
+		/// <summary>
+		/// Opens a session with the specified options.
+		/// </summary>
+		/// <returns>The session.</returns>
+		ISession OpenSession();
+
+		/// <summary>
+		/// Adds a specific interceptor to the session options.
+		/// </summary>
+		/// <param name="interceptor">The interceptor to use.</param>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		T Interceptor(IInterceptor interceptor);
+
+		/// <summary>
+		/// Signifies that no <see cref="IInterceptor"/> should be used.
+		/// </summary>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		/// <remarks>
+		/// By default the <see cref="IInterceptor"/> associated with the <see cref="ISessionFactory"/> is
+		/// passed to the <see cref="ISession"/> whenever we open one without the user having specified a
+		/// specific interceptor to use.
+		/// </remarks>
+		T NoInterceptor();
+
+		/// <summary>
+		/// Adds a specific connection to the session options.
+		/// </summary>
+		/// <param name="connection">The connection to use.</param>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		/// <remarks>
+		/// Note that the second-level cache will be disabled if you
+		/// supply a ADO.NET connection. NHibernate will not be able to track
+		/// any statements you might have executed in the same transaction.
+		/// Consider implementing your own <see cref="IConnectionProvider" />.
+		/// </remarks>
+		T Connection(DbConnection connection);
+
+		/// <summary>
+		/// Use a specific connection release mode for these session options.
+		/// </summary>
+		/// <param name="connectionReleaseMode">The connection release mode to use.</param>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		T ConnectionReleaseMode(ConnectionReleaseMode connectionReleaseMode);
+
+		/// <summary>
+		/// Should the session be automatically closed after transaction completion?
+		/// </summary>
+		/// <param name="autoClose">Should the session be automatically closed.</param>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		T AutoClose(bool autoClose);
+
+		/// <summary>
+		/// Specify the initial FlushMode to use for the opened Session.
+		/// </summary>
+		/// <param name="flushMode">The initial FlushMode to use for the opened Session.</param>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		T FlushMode(FlushMode flushMode);
+	}
+}

--- a/src/NHibernate/ISessionFactory.cs
+++ b/src/NHibernate/ISessionFactory.cs
@@ -26,9 +26,16 @@ namespace NHibernate
 	public interface ISessionFactory : IDisposable
 	{
 		/// <summary>
-		/// Open a <c>ISession</c> on the given connection
+		/// Obtain a <see cref="ISession"/> builder.
 		/// </summary>
-		/// <param name="conn">A connection provided by the application</param>
+		/// <returns>The session builder.</returns>
+		ISessionBuilder WithOptions();
+
+		// Obsolete in v5.
+		/// <summary>
+		/// Open a <see cref="ISession"/> on the given connection
+		/// </summary>
+		/// <param name="connection">A connection provided by the application</param>
 		/// <returns>A session</returns>
 		/// <remarks>
 		/// Note that the second-level cache will be disabled if you
@@ -36,34 +43,58 @@ namespace NHibernate
 		/// any statements you might have executed in the same transaction.
 		/// Consider implementing your own <see cref="IConnectionProvider" />.
 		/// </remarks>
-		ISession OpenSession(DbConnection conn);
+		[Obsolete("Please use WithOptions instead.")]
+		ISession OpenSession(DbConnection connection);
 
+		// Obsolete in v5.
 		/// <summary>
-		/// Create database connection and open a <c>ISession</c> on it, specifying an interceptor
+		/// Create database connection and open a <see cref="ISession"/> on it, specifying an interceptor
 		/// </summary>
 		/// <param name="sessionLocalInterceptor">A session-scoped interceptor</param>
-		/// <returns>A session</returns>
+		/// <returns>A session.</returns>
+		[Obsolete("Please use WithOptions instead.")]
 		ISession OpenSession(IInterceptor sessionLocalInterceptor);
 
+		// Obsolete in v5.
 		/// <summary>
-		/// Open a <c>ISession</c> on the given connection, specifying an interceptor
+		/// Open a <see cref="ISession"/> on the given connection, specifying an interceptor
 		/// </summary>
 		/// <param name="conn">A connection provided by the application</param>
 		/// <param name="sessionLocalInterceptor">A session-scoped interceptor</param>
-		/// <returns>A session</returns>
+		/// <returns>A session.</returns>
 		/// <remarks>
 		/// Note that the second-level cache will be disabled if you
 		/// supply a ADO.NET connection. NHibernate will not be able to track
 		/// any statements you might have executed in the same transaction.
 		/// Consider implementing your own <see cref="IConnectionProvider" />.
 		/// </remarks>
+		[Obsolete("Please use WithOptions instead.")]
 		ISession OpenSession(DbConnection conn, IInterceptor sessionLocalInterceptor);
 
 		/// <summary>
-		/// Create a database connection and open a <c>ISession</c> on it
+		/// Create a database connection and open a <see cref="ISession"/> on it
 		/// </summary>
-		/// <returns></returns>
+		/// <returns>A session.</returns>
 		ISession OpenSession();
+
+		/// <summary>
+		/// Obtain a <see cref="IStatelessSession"/> builder.
+		/// </summary>
+		/// <returns>The session builder.</returns>
+		IStatelessSessionBuilder WithStatelessOptions();
+
+		/// <summary>
+		/// Get a new <see cref="IStatelessSession"/>.
+		/// </summary>
+		/// <returns>A stateless session</returns>
+		IStatelessSession OpenStatelessSession();
+
+		/// <summary>
+		/// Get a new <see cref="IStatelessSession"/> for the given ADO.NET connection.
+		/// </summary>
+		/// <param name="connection">A connection provided by the application</param>
+		/// <returns>A stateless session</returns>
+		IStatelessSession OpenStatelessSession(DbConnection connection);
 
 		/// <summary>
 		/// Get the <see cref="IClassMetadata"/> associated with the given entity class
@@ -166,12 +197,6 @@ namespace NHibernate
 		/// </summary>
 		/// <param name="cacheRegion"></param>
 		void EvictQueries(string cacheRegion);
-
-		/// <summary> Get a new stateless session.</summary>
-		IStatelessSession OpenStatelessSession();
-
-		/// <summary> Get a new stateless session for the given ADO.NET connection.</summary>
-		IStatelessSession OpenStatelessSession(DbConnection connection);
 
 		/// <summary>
 		/// Obtain the definition of a filter by name.

--- a/src/NHibernate/ISharedSessionBuilder.cs
+++ b/src/NHibernate/ISharedSessionBuilder.cs
@@ -1,0 +1,40 @@
+namespace NHibernate
+{
+	// NH different implementation: will not try to support covariant return type for specializations
+	// until it is needed.
+	/// <summary>
+	/// Specialized <see cref="ISessionBuilder"/> with access to stuff from another session.
+	/// </summary>
+	public interface ISharedSessionBuilder : ISessionBuilder<ISharedSessionBuilder>
+	{
+		/// <summary>
+		/// Signifies that the connection from the original session should be used to create the new session.
+		/// </summary>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		ISharedSessionBuilder Connection();
+
+		/// <summary>
+		/// Signifies the interceptor from the original session should be used to create the new session.
+		/// </summary>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		ISharedSessionBuilder Interceptor();
+
+		/// <summary>
+		/// Signifies that the connection release mode from the original session should be used to create the new session.
+		/// </summary>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		ISharedSessionBuilder ConnectionReleaseMode();
+
+		/// <summary>
+		/// Signifies that the FlushMode from the original session should be used to create the new session.
+		/// </summary>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		ISharedSessionBuilder FlushMode();
+
+		/// <summary>
+		/// Signifies that the autoClose flag from the original session should be used to create the new session.
+		/// </summary>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		ISharedSessionBuilder AutoClose();
+	}
+}

--- a/src/NHibernate/IStatelessSessionBuilder.cs
+++ b/src/NHibernate/IStatelessSessionBuilder.cs
@@ -1,0 +1,34 @@
+using System.Data.Common;
+using NHibernate.Connection;
+
+namespace NHibernate
+{
+	// NH different implementation: will not try to support covariant return type for specializations
+	// until it is needed.
+	/// <summary>
+	/// Represents a consolidation of all stateless session creation options into a builder style delegate.
+	/// </summary>
+	public interface IStatelessSessionBuilder
+	{
+		/// <summary>
+		/// Opens a session with the specified options.
+		/// </summary>
+		/// <returns>The session.</returns>
+		IStatelessSession OpenStatelessSession();
+
+		/// <summary>
+		/// Adds a specific connection to the session options.
+		/// </summary>
+		/// <param name="connection">The connection to use.</param>
+		/// <returns><see langword="this" />, for method chaining.</returns>
+		/// <remarks>
+		/// Note that the second-level cache will be disabled if you
+		/// supply a ADO.NET connection. NHibernate will not be able to track
+		/// any statements you might have executed in the same transaction.
+		/// Consider implementing your own <see cref="IConnectionProvider" />.
+		/// </remarks>
+		IStatelessSessionBuilder Connection(DbConnection connection);
+
+		// NH remark: seems a bit overkill for now. On Hibernate side, they have at least another option: the tenant.
+	}
+}

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -19,16 +19,14 @@ using NHibernate.Type;
 
 namespace NHibernate.Impl
 {
-	
-
 	/// <summary> Functionality common to stateless and stateful sessions </summary>
 	[Serializable]
 	public abstract class AbstractSessionImpl : ISessionImplementor
 	{
 		[NonSerialized]
-		private ISessionFactoryImplementor factory;
+		private ISessionFactoryImplementor _factory;
+		private FlushMode _flushMode;
 
-		private readonly Guid sessionId = Guid.NewGuid();
 		private bool closed;
 
 		public ITransactionContext TransactionContext
@@ -40,22 +38,16 @@ namespace NHibernate.Impl
 
 		private static readonly IInternalLogger logger = LoggerProvider.LoggerFor(typeof(AbstractSessionImpl));
 
-		public Guid SessionId
-		{
-			get { return sessionId; }
-		}
+		public Guid SessionId { get; } = Guid.NewGuid();
 
 		internal AbstractSessionImpl() { }
 
-		protected internal AbstractSessionImpl(ISessionFactoryImplementor factory)
+		protected internal AbstractSessionImpl(ISessionFactoryImplementor factory, ISessionCreationOptions options)
 		{
-			this.factory = factory;
-		}
-
-		protected internal AbstractSessionImpl(ISessionFactoryImplementor factory, Guid sessionId)
-			: this(factory)
-		{
-			this.sessionId = sessionId;
+			_factory = factory;
+			Timestamp = factory.Settings.CacheProvider.NextTimestamp();
+			_flushMode = options.GetInitialSessionFlushMode();
+			Interceptor = options.GetInterceptor() ?? EmptyInterceptor.Instance;
 		}
 
 		#region ISessionImplementor Members
@@ -71,7 +63,6 @@ namespace NHibernate.Impl
 		public abstract void InitializeCollection(IPersistentCollection collection, bool writing);
 		public abstract object InternalLoad(string entityName, object id, bool eager, bool isNullable);
 		public abstract object ImmediateLoad(string entityName, object id);
-		public abstract long Timestamp { get; }
 
 		public EntityKey GenerateEntityKey(object id, IEntityPersister persister)
 		{
@@ -85,8 +76,8 @@ namespace NHibernate.Impl
 
 		public ISessionFactoryImplementor Factory
 		{
-			get { return factory; }
-			protected set { factory = value; }
+			get => _factory;
+			protected set => _factory = value;
 		}
 
 		public abstract IBatcher Batcher { get; }
@@ -112,9 +103,10 @@ namespace NHibernate.Impl
 
 		public virtual IList List(IQueryExpression queryExpression, QueryParameters parameters)
 		{
-			var results = (IList) typeof (List<>).MakeGenericType(queryExpression.Type)
-												 .GetConstructor(System.Type.EmptyTypes)
-												 .Invoke(null);
+			var results = (IList)typeof(List<>)
+				.MakeGenericType(queryExpression.Type)
+				.GetConstructor(System.Type.EmptyTypes)
+				.Invoke(null);
 			List(queryExpression, parameters, results);
 			return results;
 		}
@@ -142,7 +134,7 @@ namespace NHibernate.Impl
 		}
 
 		public abstract void List(CriteriaImpl criteria, IList results);
-		
+
 		public virtual IList List(CriteriaImpl criteria)
 		{
 			using (new SessionIdLoggingContext(SessionId))
@@ -218,13 +210,13 @@ namespace NHibernate.Impl
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				CheckAndUpdateSessionStatus();
-				NamedSQLQueryDefinition nsqlqd = factory.GetNamedSQLQuery(name);
+				var nsqlqd = _factory.GetNamedSQLQuery(name);
 				if (nsqlqd == null)
 				{
 					throw new MappingException("Named SQL query not known: " + name);
 				}
-				IQuery query = new SqlQueryImpl(nsqlqd, this,
-												factory.QueryPlanCache.GetSQLParameterMetadata(nsqlqd.QueryString));
+				var query = new SqlQueryImpl(nsqlqd, this,
+					_factory.QueryPlanCache.GetSQLParameterMetadata(nsqlqd.QueryString));
 				query.SetComment("named native SQL query " + name);
 				InitQuery(query, nsqlqd);
 				return query;
@@ -236,9 +228,8 @@ namespace NHibernate.Impl
 		{
 			return GetQueries(query.ToQueryExpression(), scalar);
 		}
-		
+
 		public abstract IQueryTranslator[] GetQueries(IQueryExpression query, bool scalar);
-		public abstract IInterceptor Interceptor { get; }
 		public abstract EventListeners Listeners { get; }
 		public abstract int DontFlushFromFind { get; }
 		public abstract ConnectionManager ConnectionManager { get; }
@@ -248,7 +239,6 @@ namespace NHibernate.Impl
 		public abstract CacheMode CacheMode { get; set; }
 		public abstract bool IsOpen { get; }
 		public abstract bool IsConnected { get; }
-		public abstract FlushMode FlushMode { get; set; }
 		public abstract string FetchProfile { get; set; }
 		public abstract string BestGuessEntityName(object entity);
 		public abstract string GuessEntityName(object entity);
@@ -257,28 +247,36 @@ namespace NHibernate.Impl
 		public abstract FutureCriteriaBatch FutureCriteriaBatch { get; protected internal set; }
 		public abstract FutureQueryBatch FutureQueryBatch { get; protected internal set; }
 
+		public virtual IInterceptor Interceptor { get; protected set; }
+
+		public virtual FlushMode FlushMode
+		{
+			get => _flushMode;
+			set => _flushMode = value;
+		}
+
 		public virtual IQuery GetNamedQuery(string queryName)
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				CheckAndUpdateSessionStatus();
-				NamedQueryDefinition nqd = factory.GetNamedQuery(queryName);
+				var nqd = _factory.GetNamedQuery(queryName);
 				IQuery query;
 				if (nqd != null)
 				{
-					string queryString = nqd.QueryString;
+					var queryString = nqd.QueryString;
 					query = new QueryImpl(queryString, nqd.FlushMode, this, GetHQLQueryPlan(queryString.ToQueryExpression(), false).ParameterMetadata);
 					query.SetComment("named HQL query " + queryName);
 				}
 				else
 				{
-					NamedSQLQueryDefinition nsqlqd = factory.GetNamedSQLQuery(queryName);
+					var nsqlqd = _factory.GetNamedSQLQuery(queryName);
 					if (nsqlqd == null)
 					{
 						throw new MappingException("Named query not known: " + queryName);
 					}
 					query = new SqlQueryImpl(nsqlqd, this,
-											 factory.QueryPlanCache.GetSQLParameterMetadata(nsqlqd.QueryString));
+						_factory.QueryPlanCache.GetSQLParameterMetadata(nsqlqd.QueryString));
 					query.SetComment("named native SQL query " + queryName);
 					nqd = nsqlqd;
 				}
@@ -286,6 +284,8 @@ namespace NHibernate.Impl
 				return query;
 			}
 		}
+
+		public virtual long Timestamp { get; protected set; }
 
 		public bool IsClosed
 		{
@@ -302,7 +302,7 @@ namespace NHibernate.Impl
 		{
 			if (IsClosed || IsAlreadyDisposed)
 			{
-				throw new ObjectDisposedException("ISession", "Session is closed!");
+				throw new ObjectDisposedException(nameof(ISession), "Session is closed!");
 			}
 		}
 
@@ -387,7 +387,7 @@ namespace NHibernate.Impl
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				CheckAndUpdateSessionStatus();
-				SqlQueryImpl query = new SqlQueryImpl(sql, this, factory.QueryPlanCache.GetSQLParameterMetadata(sql));
+				var query = new SqlQueryImpl(sql, this, _factory.QueryPlanCache.GetSQLParameterMetadata(sql));
 				query.SetComment("dynamic native SQL query");
 				return query;
 			}
@@ -403,7 +403,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				return factory.QueryPlanCache.GetHQLQueryPlan(queryExpression, shallow, EnabledFilters);
+				return _factory.QueryPlanCache.GetHQLQueryPlan(queryExpression, shallow, EnabledFilters);
 			}
 		}
 
@@ -411,7 +411,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				return factory.QueryPlanCache.GetNativeSQLQueryPlan(spec);
+				return _factory.QueryPlanCache.GetNativeSQLQueryPlan(spec);
 			}
 		}
 
@@ -419,7 +419,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				return ADOExceptionHelper.Convert(factory.SQLExceptionConverter, sqlException, message);
+				return ADOExceptionHelper.Convert(_factory.SQLExceptionConverter, sqlException, message);
 			}
 		}
 
@@ -437,7 +437,7 @@ namespace NHibernate.Impl
 
 		protected void EnlistInAmbientTransactionIfNeeded()
 		{
-			factory.TransactionFactory.EnlistInDistributedTransactionIfNeeded(this);
+			_factory.TransactionFactory.EnlistInDistributedTransactionIfNeeded(this);
 		}
 
 		internal IOuterJoinLoadable GetOuterJoinLoadable(string entityName)

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -46,8 +46,8 @@ namespace NHibernate.Impl
 		{
 			_factory = factory;
 			Timestamp = factory.Settings.CacheProvider.NextTimestamp();
-			_flushMode = options.GetInitialSessionFlushMode();
-			Interceptor = options.GetInterceptor() ?? EmptyInterceptor.Instance;
+			_flushMode = options.InitialSessionFlushMode;
+			Interceptor = options.SessionInterceptor ?? EmptyInterceptor.Instance;
 		}
 
 		#region ISessionImplementor Members

--- a/src/NHibernate/Impl/ISessionCreationOptions.cs
+++ b/src/NHibernate/Impl/ISessionCreationOptions.cs
@@ -1,0 +1,24 @@
+using System.Data.Common;
+
+namespace NHibernate.Impl
+{
+	/// <summary>
+	/// Options for session creation.
+	/// </summary>
+	/// <seealso cref="ISessionBuilder"/>
+	public interface ISessionCreationOptions
+	{
+		// NH note: it is tempting to convert them to properties, but then their names conflict
+		// with ISessionBuilder, which is implemented along this interface.
+		FlushMode GetInitialSessionFlushMode();
+
+		bool ShouldAutoClose();
+
+		DbConnection GetConnection();
+
+		IInterceptor GetInterceptor();
+
+		// Todo: port PhysicalConnectionHandlingMode
+		ConnectionReleaseMode GetConnectionReleaseMode();
+	}
+}

--- a/src/NHibernate/Impl/ISessionCreationOptions.cs
+++ b/src/NHibernate/Impl/ISessionCreationOptions.cs
@@ -8,17 +8,17 @@ namespace NHibernate.Impl
 	/// <seealso cref="ISessionBuilder"/>
 	public interface ISessionCreationOptions
 	{
-		// NH note: it is tempting to convert them to properties, but then their names conflict
-		// with ISessionBuilder, which is implemented along this interface.
-		FlushMode GetInitialSessionFlushMode();
+		// NH note: naming "adjusted" for converting Java methods to properties while avoiding conflicts with
+		// ISessionBuilder.
+		FlushMode InitialSessionFlushMode { get; }
 
-		bool ShouldAutoClose();
+		bool ShouldAutoClose { get; }
 
-		DbConnection GetConnection();
+		DbConnection UserSuppliedConnection { get; }
 
-		IInterceptor GetInterceptor();
+		IInterceptor SessionInterceptor { get; }
 
 		// Todo: port PhysicalConnectionHandlingMode
-		ConnectionReleaseMode GetConnectionReleaseMode();
+		ConnectionReleaseMode SessionConnectionReleaseMode { get; }
 	}
 }

--- a/src/NHibernate/Impl/ISharedSessionCreationOptions.cs
+++ b/src/NHibernate/Impl/ISharedSessionCreationOptions.cs
@@ -1,0 +1,17 @@
+using NHibernate.AdoNet;
+
+namespace NHibernate.Impl
+{
+	/// <summary>
+	/// An extension of SessionCreationOptions for cases where the Session to be created shares
+	/// some part of the "transaction context" of another Session.
+	/// </summary>
+	/// <seealso cref="ISharedSessionBuilder"/>
+	public interface ISharedSessionCreationOptions : ISessionCreationOptions
+	{
+		// NH note: not converting them to properties for staying in sync with ISessionCreationOptions.
+		bool IsTransactionCoordinatorShared();
+		// NH different implementation: need to port Hibernate transaction management.
+		ConnectionManager GetConnectionManager();
+	}
+}

--- a/src/NHibernate/Impl/ISharedSessionCreationOptions.cs
+++ b/src/NHibernate/Impl/ISharedSessionCreationOptions.cs
@@ -9,9 +9,10 @@ namespace NHibernate.Impl
 	/// <seealso cref="ISharedSessionBuilder"/>
 	public interface ISharedSessionCreationOptions : ISessionCreationOptions
 	{
-		// NH note: not converting them to properties for staying in sync with ISessionCreationOptions.
-		bool IsTransactionCoordinatorShared();
+		// NH note: naming "adjusted" for converting Java methods to properties while avoiding conflicts with
+		// ISessionBuilder.
+		bool IsTransactionCoordinatorShared { get; }
 		// NH different implementation: need to port Hibernate transaction management.
-		ConnectionManager GetConnectionManager();
+		ConnectionManager ConnectionManager { get; }
 	}
 }

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1309,20 +1309,18 @@ namespace NHibernate.Impl
 
 			// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 			// SessionCreationOptions
-			// NH note: it is tempting to convert them to properties, but then their names conflict
-			// with SessionBuilder interface.
 
-			public virtual FlushMode GetInitialSessionFlushMode() => _flushMode;
+			public virtual FlushMode InitialSessionFlushMode => _flushMode;
 
-			public virtual bool ShouldAutoClose() => _autoClose;
+			public virtual bool ShouldAutoClose => _autoClose;
 
-			public DbConnection GetConnection() => _connection;
+			public DbConnection UserSuppliedConnection => _connection;
 
 			// NH different implementation: Hibernate here ignore EmptyInterceptor.Instance too, resulting
 			// in the "NoInterceptor" being unable to override a session factory interceptor.
-			public virtual IInterceptor GetInterceptor() => _interceptor ?? _sessionFactory.Interceptor;
+			public virtual IInterceptor SessionInterceptor => _interceptor ?? _sessionFactory.Interceptor;
 
-			public virtual ConnectionReleaseMode GetConnectionReleaseMode() => _connectionReleaseMode;
+			public virtual ConnectionReleaseMode SessionConnectionReleaseMode => _connectionReleaseMode;
 
 			// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 			// SessionBuilder
@@ -1400,15 +1398,15 @@ namespace NHibernate.Impl
 				return this;
 			}
 
-			public FlushMode GetInitialSessionFlushMode() => FlushMode.Always;
+			public FlushMode InitialSessionFlushMode => FlushMode.Always;
 
-			public bool ShouldAutoClose() => false;
+			public bool ShouldAutoClose => false;
 
-			public DbConnection GetConnection() => _connection;
+			public DbConnection UserSuppliedConnection => _connection;
 
-			public IInterceptor GetInterceptor() => EmptyInterceptor.Instance;
+			public IInterceptor SessionInterceptor => EmptyInterceptor.Instance;
 
-			public ConnectionReleaseMode GetConnectionReleaseMode() => ConnectionReleaseMode.AfterTransaction;
+			public ConnectionReleaseMode SessionConnectionReleaseMode => ConnectionReleaseMode.AfterTransaction;
 		}
 	}
 }

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -189,22 +189,22 @@ namespace NHibernate.Impl
 				actionQueue = new ActionQueue(this);
 				persistenceContext = new StatefulPersistenceContext(this);
 
-				autoCloseSessionEnabled = options.ShouldAutoClose();
+				autoCloseSessionEnabled = options.ShouldAutoClose;
 
 				listeners = factory.EventListeners;
-				connectionReleaseMode = options.GetConnectionReleaseMode();
+				connectionReleaseMode = options.SessionConnectionReleaseMode;
 
-				if (options is ISharedSessionCreationOptions sharedOptions && sharedOptions.IsTransactionCoordinatorShared())
+				if (options is ISharedSessionCreationOptions sharedOptions && sharedOptions.IsTransactionCoordinatorShared)
 				{
 					// NH specific implementation: need to port Hibernate transaction management.
 					_transactionCoordinatorShared = true;
-					if (options.GetConnection() != null)
+					if (options.UserSuppliedConnection != null)
 						throw new SessionException("Cannot simultaneously share transaction context and specify connection");
-					connectionManager = sharedOptions.GetConnectionManager();
+					connectionManager = sharedOptions.ConnectionManager;
 				}
 				else
 				{
-					connectionManager = new ConnectionManager(this, options.GetConnection(), connectionReleaseMode, Interceptor);
+					connectionManager = new ConnectionManager(this, options.UserSuppliedConnection, connectionReleaseMode, Interceptor);
 				}
 
 				if (factory.Statistics.IsStatisticsEnabled)
@@ -2555,11 +2555,10 @@ namespace NHibernate.Impl
 			// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 			// SharedSessionCreationOptions
 
-			// NH note: not converting them to properties for staying in sync with ISessionCreationOptions.
-			public virtual bool IsTransactionCoordinatorShared() => _shareTransactionContext;
+			public virtual bool IsTransactionCoordinatorShared => _shareTransactionContext;
 
 			// NH different implementation: need to port Hibernate transaction management.
-			public ConnectionManager GetConnectionManager() => _shareTransactionContext ? _session.ConnectionManager : null;
+			public ConnectionManager ConnectionManager => _shareTransactionContext ? _session.ConnectionManager : null;
 		}
 	}
 }

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -27,11 +27,11 @@ using NHibernate.Util;
 namespace NHibernate.Impl
 {
 	/// <summary>
-	/// Concrete implementation of an <see cref="NHibernate.ISession" />, also the central, organizing component
+	/// Concrete implementation of an <see cref="ISession" />, also the central, organizing component
 	/// of NHibernate's internal implementation.
 	/// </summary>
 	/// <remarks>
-	/// Exposes two interfaces: <see cref="NHibernate.ISession" /> itself, to the application and 
+	/// Exposes two interfaces: <see cref="ISession" /> itself, to the application and 
 	/// <see cref="ISessionImplementor" /> to other components of NHibernate. This is where the 
 	/// hard stuff is... This class is NOT THREADSAFE.
 	/// </remarks>
@@ -40,12 +40,7 @@ namespace NHibernate.Impl
 	{
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof(SessionImpl));
 
-		private readonly long timestamp;
-
 		private CacheMode cacheMode = CacheMode.Normal;
-		private FlushMode flushMode = FlushMode.Auto;
-
-		private readonly IInterceptor interceptor;
 
 		[NonSerialized]
 		private FutureCriteriaBatch futureCriteriaBatch;
@@ -73,19 +68,11 @@ namespace NHibernate.Impl
 		private readonly StatefulPersistenceContext persistenceContext;
 
 		[NonSerialized]
-		private readonly SessionImpl rootSession;
-
-		[NonSerialized]
-		ISession _childSession;
-
-		[NonSerialized]
-		private readonly bool flushBeforeCompletionEnabled;
-		[NonSerialized]
 		private readonly bool autoCloseSessionEnabled;
 		[NonSerialized]
-		private readonly bool ignoreExceptionBeforeTransactionCompletion;
-		[NonSerialized]
 		private readonly ConnectionReleaseMode connectionReleaseMode;
+		[NonSerialized]
+		private readonly bool _transactionCoordinatorShared;
 
 		#region System.Runtime.Serialization.ISerializable Members
 
@@ -101,8 +88,7 @@ namespace NHibernate.Impl
 		/// </remarks>
 		private SessionImpl(SerializationInfo info, StreamingContext context)
 		{
-			timestamp = info.GetInt64("timestamp");
-
+			Timestamp = info.GetInt64("timestamp");
 			SessionFactoryImpl fact = (SessionFactoryImpl)info.GetValue("factory", typeof(SessionFactoryImpl));
 			Factory = fact;
 			listeners = fact.EventListeners;
@@ -110,10 +96,10 @@ namespace NHibernate.Impl
 
 			actionQueue = (ActionQueue)info.GetValue("actionQueue", typeof(ActionQueue));
 
-			flushMode = (FlushMode)info.GetValue("flushMode", typeof(FlushMode));
+			FlushMode = (FlushMode)info.GetValue("flushMode", typeof(FlushMode));
 			cacheMode = (CacheMode)info.GetValue("cacheMode", typeof(CacheMode));
 
-			interceptor = (IInterceptor)info.GetValue("interceptor", typeof(IInterceptor));
+			Interceptor = (IInterceptor)info.GetValue("interceptor", typeof(IInterceptor));
 
 			enabledFilters = (IDictionary<string, IFilter>)info.GetValue("enabledFilters", typeof(Dictionary<string, IFilter>));
 			enabledFilterNames = (List<string>)info.GetValue("enabledFilterNames", typeof(List<string>));
@@ -140,15 +126,19 @@ namespace NHibernate.Impl
 			{
 				throw new InvalidOperationException("Cannot serialize a Session while connected");
 			}
+			if (_transactionCoordinatorShared)
+			{
+				throw new InvalidOperationException("Cannot serialize a Session sharing its transaction coordinator");
+			}
 
 			info.AddValue("factory", Factory, typeof(SessionFactoryImpl));
 			info.AddValue("persistenceContext", persistenceContext, typeof(StatefulPersistenceContext));
 			info.AddValue("actionQueue", actionQueue, typeof(ActionQueue));
-			info.AddValue("timestamp", timestamp);
-			info.AddValue("flushMode", flushMode);
+			info.AddValue("timestamp", Timestamp);
+			info.AddValue("flushMode", FlushMode);
 			info.AddValue("cacheMode", cacheMode);
 
-			info.AddValue("interceptor", interceptor, typeof(IInterceptor));
+			info.AddValue("interceptor", Interceptor, typeof(IInterceptor));
 
 			info.AddValue("enabledFilters", enabledFilters, typeof(IDictionary<string, IFilter>));
 			info.AddValue("enabledFilterNames", enabledFilterNames, typeof(List<string>));
@@ -189,86 +179,41 @@ namespace NHibernate.Impl
 		/// Constructor used for OpenSession(...) processing, as well as construction
 		/// of sessions for GetCurrentSession().
 		/// </summary>
-		/// <param name="connection">The user-supplied connection to use for this session.</param>
-		/// <param name="factory">The factory from which this session was obtained</param>
-		/// <param name="autoclose">NOT USED</param>
-		/// <param name="timestamp">The timestamp for this session</param>
-		/// <param name="interceptor">The interceptor to be applied to this session</param>
-		/// <param name="flushBeforeCompletionEnabled">Should we auto flush before completion of transaction</param>
-		/// <param name="autoCloseSessionEnabled">Should we auto close after completion of transaction</param>
-		/// <param name="ignoreExceptionBeforeTransactionCompletion">Should we ignore exceptions in IInterceptor.BeforeTransactionCompletion</param>
-		/// <param name="connectionReleaseMode">The mode by which we should release JDBC connections.</param>
-		/// <param name="defaultFlushMode">The default flush mode for this session</param>
-		internal SessionImpl(
-			DbConnection connection,
-			SessionFactoryImpl factory,
-			bool autoclose,
-			long timestamp,
-			IInterceptor interceptor,
-			bool flushBeforeCompletionEnabled,
-			bool autoCloseSessionEnabled,
-			bool ignoreExceptionBeforeTransactionCompletion,
-			ConnectionReleaseMode connectionReleaseMode,
-			FlushMode defaultFlushMode)
-			: base(factory)
+		/// <param name="factory">The factory from which this session was obtained.</param>
+		/// <param name="options">The options of the session.</param>
+		internal SessionImpl(SessionFactoryImpl factory, ISessionCreationOptions options)
+			: base(factory, options)
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				if (interceptor == null)
-					throw new AssertionFailure("The interceptor can not be null.");
-
-				rootSession = null;
-				this.timestamp = timestamp;
-				this.interceptor = interceptor;
-				listeners = factory.EventListeners;
 				actionQueue = new ActionQueue(this);
 				persistenceContext = new StatefulPersistenceContext(this);
-				this.flushBeforeCompletionEnabled = flushBeforeCompletionEnabled;
-				this.autoCloseSessionEnabled = autoCloseSessionEnabled;
-				this.connectionReleaseMode = connectionReleaseMode;
-				this.ignoreExceptionBeforeTransactionCompletion = ignoreExceptionBeforeTransactionCompletion;
-				connectionManager = new ConnectionManager(this, connection, connectionReleaseMode, interceptor);
-				this.flushMode = defaultFlushMode;
+
+				autoCloseSessionEnabled = options.ShouldAutoClose();
+
+				listeners = factory.EventListeners;
+				connectionReleaseMode = options.GetConnectionReleaseMode();
+
+				if (options is ISharedSessionCreationOptions sharedOptions && sharedOptions.IsTransactionCoordinatorShared())
+				{
+					// NH specific implementation: need to port Hibernate transaction management.
+					_transactionCoordinatorShared = true;
+					if (options.GetConnection() != null)
+						throw new SessionException("Cannot simultaneously share transaction context and specify connection");
+					connectionManager = sharedOptions.GetConnectionManager();
+				}
+				else
+				{
+					connectionManager = new ConnectionManager(this, options.GetConnection(), connectionReleaseMode, Interceptor);
+				}
 
 				if (factory.Statistics.IsStatisticsEnabled)
 				{
 					factory.StatisticsImplementor.OpenSession();
 				}
 
-				if (log.IsDebugEnabled)
-				{
-					log.DebugFormat("[session-id={0}] opened session at timestamp: {1}, for session factory: [{2}/{3}]",
-						SessionId, timestamp, factory.Name, factory.Uuid);
-				}
-
-				CheckAndUpdateSessionStatus();
-			}
-		}
-
-		/// <summary>
-		/// Constructor used in building "child sessions".
-		/// </summary>
-		/// <param name="parent">The parent Session</param>
-		private SessionImpl(SessionImpl parent)
-			: base(parent.Factory, parent.SessionId)
-		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				rootSession = parent;
-				timestamp = parent.timestamp;
-				connectionManager = parent.connectionManager;
-				interceptor = parent.interceptor;
-				listeners = parent.listeners;
-				actionQueue = new ActionQueue(this);
-				persistenceContext = new StatefulPersistenceContext(this);
-				flushBeforeCompletionEnabled = false;
-				autoCloseSessionEnabled = false;
-				connectionReleaseMode = parent.ConnectionReleaseMode; // NH different
-
-				if (Factory.Statistics.IsStatisticsEnabled)
-					Factory.StatisticsImplementor.OpenSession();
-
-				log.Debug("Opened session");
+				log.DebugFormat("[session-id={0}] opened session at timestamp: {1}, for session factory: [{2}/{3}]",
+					SessionId, Timestamp, factory.Name, factory.Uuid);
 
 				CheckAndUpdateSessionStatus();
 			}
@@ -312,12 +257,6 @@ namespace NHibernate.Impl
 			}
 		}
 
-		/// <summary></summary>
-		public override long Timestamp
-		{
-			get { return timestamp; }
-		}
-
 		public ConnectionReleaseMode ConnectionReleaseMode
 		{
 			get { return connectionReleaseMode; }
@@ -357,22 +296,7 @@ namespace NHibernate.Impl
 
 				try
 				{
-					try
-					{
-						if (_childSession != null)
-						{
-							if (_childSession.IsOpen)
-							{
-								_childSession.Close();
-							}
-						}
-					}
-					catch
-					{
-						// just ignore
-					}
-
-					if (rootSession == null)
+					if (!_transactionCoordinatorShared)
 						return connectionManager.Close();
 					else
 						return null;
@@ -381,7 +305,6 @@ namespace NHibernate.Impl
 				{
 					SetClosed();
 					Cleanup();
-					if (rootSession != null) rootSession._childSession = null;
 				}
 			}
 		}
@@ -404,11 +327,11 @@ namespace NHibernate.Impl
 				connectionManager.AfterTransaction();
 				persistenceContext.AfterTransactionCompletion();
 				actionQueue.AfterTransactionCompletion(success);
-				if (rootSession == null)
+				if (!_transactionCoordinatorShared)
 				{
 					try
 					{
-						interceptor.AfterTransactionCompletion(tx);
+						Interceptor.AfterTransactionCompletion(tx);
 					}
 					catch (Exception t)
 					{
@@ -861,7 +784,7 @@ namespace NHibernate.Impl
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				ErrorIfClosed();
-				object result = interceptor.Instantiate(persister.EntityName, id);
+				object result = Interceptor.Instantiate(persister.EntityName, id);
 				if (result == null)
 				{
 					result = persister.Instantiate(id);
@@ -1000,17 +923,9 @@ namespace NHibernate.Impl
 			}
 		}
 
-		/// <summary></summary>
-		public override FlushMode FlushMode
-		{
-			get { return flushMode; }
-			set { flushMode = value; }
-		}
-
-		public bool FlushBeforeCompletionEnabled
-		{
-			get { return flushBeforeCompletionEnabled; }
-		}
+		// Obsolete in v5, and was already having no usages previously.
+		[Obsolete("Please use FlushMode instead.")]
+		public bool FlushBeforeCompletionEnabled => FlushMode >= FlushMode.Commit;
 
 		public override string BestGuessEntityName(object entity)
 		{
@@ -1022,7 +937,7 @@ namespace NHibernate.Impl
 					ILazyInitializer initializer = proxy.HibernateLazyInitializer;
 
 					// it is possible for this method to be called during flush processing,
-					// so make certain that we do not accidently initialize an uninitialized proxy
+					// so make certain that we do not accidentally initialize an uninitialized proxy
 					if (initializer.IsUninitialized)
 					{
 						return initializer.PersistentClass.FullName;
@@ -1051,7 +966,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				string entityName = interceptor.GetEntityName(entity);
+				string entityName = Interceptor.GetEntityName(entity);
 				if (entityName == null)
 				{
 					System.Type t = entity.GetType();
@@ -1080,7 +995,7 @@ namespace NHibernate.Impl
 
 				if (result == null)
 				{
-					object newObject = interceptor.GetEntity(key.EntityName, key.Identifier);
+					object newObject = Interceptor.GetEntity(key.EntityName, key.Identifier);
 					if (newObject != null)
 					{
 						Lock(newObject, LockMode.None);
@@ -1384,7 +1299,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				if (rootSession != null)
+				if (_transactionCoordinatorShared)
 				{
 					// Todo : should seriously consider not allowing a txn to begin from a child session
 					//      can always route the request to the root session...
@@ -1400,7 +1315,7 @@ namespace NHibernate.Impl
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
-				if (rootSession != null)
+				if (_transactionCoordinatorShared)
 				{
 					// Todo : should seriously consider not allowing a txn to begin from a child session
 					//      can always route the request to the root session...
@@ -1992,7 +1907,11 @@ namespace NHibernate.Impl
 			}
 		}
 
-		/// <summary></summary>
+		public ISharedSessionBuilder SessionWithOptions()
+		{
+			return new SharedSessionBuilderImpl(this);
+		}
+
 		public void Clear()
 		{
 			using (new SessionIdLoggingContext(SessionId))
@@ -2173,7 +2092,7 @@ namespace NHibernate.Impl
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				CheckAndUpdateSessionStatus();
-				interceptor.AfterTransactionBegin(tx);
+				Interceptor.AfterTransactionBegin(tx);
 			}
 		}
 
@@ -2183,18 +2102,17 @@ namespace NHibernate.Impl
 			{
 				log.Debug("before transaction completion");
 				actionQueue.BeforeTransactionCompletion();
-				if (rootSession == null)
+				if (!_transactionCoordinatorShared)
 				{
 					try
 					{
-						interceptor.BeforeTransactionCompletion(tx);
+						Interceptor.BeforeTransactionCompletion(tx);
 					}
 					catch (Exception e)
 					{
 						log.Error("exception in interceptor BeforeTransactionCompletion()", e);
 
-						if (ignoreExceptionBeforeTransactionCompletion == false)
-							throw;
+						throw;
 					}
 				}
 			}
@@ -2206,36 +2124,21 @@ namespace NHibernate.Impl
 			return this;
 		}
 
-
 		public ISessionImplementor GetSessionImplementation()
 		{
 			return this;
 		}
 
-		public ISession GetChildSession()
+		// Obsolete since v5
+		[Obsolete("Please use SessionWithOptions instead.")]
+		public ISession GetSession(EntityMode entityMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				if (rootSession != null)
-				{
-					return rootSession.GetChildSession();
-				}
-
-				CheckAndUpdateSessionStatus();
-
-				if (_childSession == null)
-				{
-					log.Debug("Creating child session.");
-					_childSession = new SessionImpl(this);
-				}
-
-				return _childSession;
-			}
-		}
-
-		public override IInterceptor Interceptor
-		{
-			get { return interceptor; }
+			return SessionWithOptions()
+				.Connection()
+				.ConnectionReleaseMode()
+				.FlushMode()
+				.Interceptor()
+				.OpenSession();
 		}
 
 		/// <summary> Retrieves the configured event listeners from this event source. </summary>
@@ -2605,6 +2508,58 @@ namespace NHibernate.Impl
 					}
 				}
 			}
+		}
+
+		// NH different implementation: will not try to support covariant return type for specializations
+		// of SharedSessionBuilderImpl until they need to exist.
+		private class SharedSessionBuilderImpl : SessionFactoryImpl.SessionBuilderImpl<ISharedSessionBuilder>,
+			ISharedSessionBuilder, ISharedSessionCreationOptions
+		{
+			private readonly SessionImpl _session;
+			private bool _shareTransactionContext;
+
+			public SharedSessionBuilderImpl(SessionImpl session)
+				: base((SessionFactoryImpl)session.Factory)
+			{
+				_session = session;
+				SetSelf(this);
+			}
+
+			// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			// SharedSessionBuilder
+
+			public virtual ISharedSessionBuilder Interceptor() => Interceptor(_session.Interceptor);
+
+			public virtual ISharedSessionBuilder Connection()
+			{
+				// Ensure any previously user supplied connection is removed.
+				base.Connection(null);
+				// We share the connection manager
+				_shareTransactionContext = true; 
+				return this;
+			}
+
+			public virtual ISharedSessionBuilder ConnectionReleaseMode() => ConnectionReleaseMode(_session.ConnectionReleaseMode);
+
+			public virtual ISharedSessionBuilder FlushMode() => FlushMode(_session.FlushMode);
+
+			public virtual ISharedSessionBuilder AutoClose() => AutoClose(_session.autoCloseSessionEnabled);
+
+			// NH different implementation, avoid an error case.
+			public override ISharedSessionBuilder Connection(DbConnection connection)
+			{
+				_shareTransactionContext = false;
+				return base.Connection(connection);
+			}
+
+			// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			// SharedSessionCreationOptions
+
+			// NH note: not converting them to properties for staying in sync with ISessionCreationOptions.
+			public virtual bool IsTransactionCoordinatorShared() => _shareTransactionContext;
+
+			// NH different implementation: need to port Hibernate transaction management.
+			public ConnectionManager GetConnectionManager() => _shareTransactionContext ? _session.ConnectionManager : null;
 		}
 	}
 }

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -16,7 +16,6 @@ using NHibernate.Hql;
 using NHibernate.Id;
 using NHibernate.Loader.Criteria;
 using NHibernate.Loader.Custom;
-using NHibernate.Loader.Custom.Sql;
 using NHibernate.Persister.Entity;
 using NHibernate.Proxy;
 using NHibernate.Type;
@@ -33,14 +32,14 @@ namespace NHibernate.Impl
 		[NonSerialized]
 		private readonly StatefulPersistenceContext temporaryPersistenceContext;
 
-		internal StatelessSessionImpl(DbConnection connection, SessionFactoryImpl factory)
-			: base(factory)
+		internal StatelessSessionImpl(SessionFactoryImpl factory, ISessionCreationOptions options)
+			: base(factory, options)
 		{
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				temporaryPersistenceContext = new StatefulPersistenceContext(this);
-				connectionManager = new ConnectionManager(this, connection, ConnectionReleaseMode.AfterTransaction,
-														  new EmptyInterceptor());
+				connectionManager = new ConnectionManager(this, options.GetConnection(), ConnectionReleaseMode.AfterTransaction,
+					EmptyInterceptor.Instance);
 
 				if (log.IsDebugEnabled)
 				{
@@ -291,7 +290,7 @@ namespace NHibernate.Impl
 
 		public override IInterceptor Interceptor
 		{
-			get { return new EmptyInterceptor(); }
+			get { return EmptyInterceptor.Instance; }
 		}
 
 		public override EventListeners Listeners

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Impl
 			using (new SessionIdLoggingContext(SessionId))
 			{
 				temporaryPersistenceContext = new StatefulPersistenceContext(this);
-				connectionManager = new ConnectionManager(this, options.GetConnection(), ConnectionReleaseMode.AfterTransaction,
+				connectionManager = new ConnectionManager(this, options.UserSuppliedConnection, ConnectionReleaseMode.AfterTransaction,
 					EmptyInterceptor.Instance);
 
 				if (log.IsDebugEnabled)

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -145,6 +145,11 @@
     <Compile Include="Connection\IConnectionProvider.cs" />
     <Compile Include="Connection\UserSuppliedConnectionProvider.cs" />
     <Compile Include="Dialect\PostgreSQL83Dialect.cs" />
+    <Compile Include="Impl\ISharedSessionCreationOptions.cs" />
+    <Compile Include="ISharedSessionBuilder.cs" />
+    <Compile Include="IStatelessSessionBuilder.cs" />
+    <Compile Include="ISessionBuilder.cs" />
+    <Compile Include="Impl\ISessionCreationOptions.cs" />
     <Compile Include="Tool\hbm2ddl\IDatabaseMetadata.cs" />
     <Compile Include="Util\DelegateHelper.cs" />
     <Compile Include="Dialect\BitwiseFunctionOperation.cs" />

--- a/src/NHibernate/Persister/Collection/NamedQueryCollectionInitializer.cs
+++ b/src/NHibernate/Persister/Collection/NamedQueryCollectionInitializer.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Persister.Collection
 			{
 				query.SetParameter(0, key, persister.KeyType);
 			}
-			query.SetCollectionKey(key).SetFlushMode(FlushMode.Never).List();
+			query.SetCollectionKey(key).SetFlushMode(FlushMode.Manual).List();
 		}
 	}
 }

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -4160,7 +4160,7 @@ namespace NHibernate.Persister.Entity
 			query.SetOptionalId(id);
 			query.SetOptionalEntityName(this.EntityName);
 			query.SetOptionalObject(entity);
-			query.SetFlushMode(FlushMode.Never);
+			query.SetFlushMode(FlushMode.Manual);
 			query.List();
 		}
 

--- a/src/NHibernate/Persister/Entity/NamedQueryLoader.cs
+++ b/src/NHibernate/Persister/Entity/NamedQueryLoader.cs
@@ -40,7 +40,7 @@ namespace NHibernate.Persister.Entity
 			query.SetOptionalId(id);
 			query.SetOptionalEntityName(persister.EntityName);
 			query.SetOptionalObject(optionalObject);
-			query.SetFlushMode(FlushMode.Never);
+			query.SetFlushMode(FlushMode.Manual);
 			query.List();
 
 			// now look up the object we are really interested in!

--- a/src/NHibernate/Transaction/AdoNetWithDistributedTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetWithDistributedTransactionFactory.cs
@@ -115,7 +115,7 @@ namespace NHibernate.Transaction
 						using (var tx = new TransactionScope(AmbientTransation))
 						{
 							sessionImplementor.BeforeTransactionCompletion(null);
-							if (sessionImplementor.FlushMode != FlushMode.Never && sessionImplementor.ConnectionManager.IsConnected)
+							if (sessionImplementor.FlushMode != FlushMode.Manual && sessionImplementor.ConnectionManager.IsConnected)
 							{
 								using (sessionImplementor.ConnectionManager.FlushingFromDtcTransaction)
 								{

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -119,7 +119,7 @@ namespace NHibernate.Transaction
 				{
 					throw new TransactionException("Cannot restart transaction after failed commit");
 				}
-				
+
 				if (isolationLevel == IsolationLevel.Unspecified)
 				{
 					isolationLevel = session.Factory.Settings.IsolationLevel;
@@ -186,7 +186,7 @@ namespace NHibernate.Transaction
 
 				log.Debug("Start Commit");
 
-				if (session.FlushMode != FlushMode.Never)
+				if (session.FlushMode != FlushMode.Manual)
 				{
 					session.Flush();
 				}
@@ -426,10 +426,7 @@ namespace NHibernate.Transaction
 					catch (Exception e)
 					{
 						log.Error("exception calling user Synchronization", e);
-#pragma warning disable 618
-						if (!session.Factory.Settings.IsInterceptorsBeforeTransactionCompletionIgnoreExceptionsEnabled)
-							throw;
-#pragma warning restore 618
+						throw;
 					}
 				}
 			}

--- a/src/NHibernate/nhibernate-mapping.xsd
+++ b/src/NHibernate/nhibernate-mapping.xsd
@@ -1682,8 +1682,13 @@
 	<xs:simpleType name="flushMode">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="auto" />
-			<xs:enumeration value="never" />
+			<xs:enumeration value="manual" />
 			<xs:enumeration value="always" />
+			<xs:enumeration value="never">
+				<xs:annotation>
+					<xs:documentation>Obsolete, please use manual instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="cacheMode">


### PR DESCRIPTION
[NH-4003](https://nhibernate.jira.com/browse/NH-4003) - Refactor session constructor

I consider this as a prerequisite for porting the current transaction handling from Hibernate. This handling especially relies on the `ISharedSessionBuilder`, introduced by this PR.

I have dropped the obsolete parameter `InterceptorsBeforeTransactionCompletionIgnoreExceptions` in the process.

The `GetChildSession` introduced in 5.0 by the removal of entity mode switching is removed in favor of Hibernate `ISession.WithSessionOptions()` which yield a builder of session, allowing to build new sessions taking a part of their stuff (like the connection manager currently) from the original session. These new sessions are not closed or flushed from the original session.

I have reintroduced as obsolete the old `ISession.GetSession()`, for hinting at using `ISession.WithSessionOptions()`.

All that by the way obsoletes [NH-3985](https://nhibernate.jira.com/browse/NH-3985) (already resolved, #600, about disposed child session being returned) and [NH-3986](https://nhibernate.jira.com/browse/NH-3986) (Enable multiple child sessions per root session: the new semantic allows this, though there are no more actually children, the "parent" has no knowledge of them currently).

Some stuff has moved around, Hibernate having put many more things in the AbstractSessionImpl.