### PR TITLE
NH-4010 - Update .SLN to VS 2017

### DIFF
--- a/src/NHibernate.Everything.sln
+++ b/src/NHibernate.Everything.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support", "Support", "{9BDB5C84-14EC-4384-B423-9E319675B3CA}"
 	ProjectSection(FolderStartupServices) = postProject

--- a/src/NHibernate.sln
+++ b/src/NHibernate.sln
@@ -1,7 +1,7 @@
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{593DCEA7-C933-46F3-939F-D8172399AB05}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Since C# 7 is being used, the Visual Studio Version Selector needs to
launch Visual Studio 2017 if it's available on the system.  It uses the
VisualStudioVersion value in the .SLN file.