### PR TITLE
NH-4013 - SQL-Server batcher failure after CloseCommands.

### DIFF
--- a/src/NHibernate.Test/ConnectionTest/BatcherFixture.cs
+++ b/src/NHibernate.Test/ConnectionTest/BatcherFixture.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NHibernate.Cfg;
+using NHibernate.Util;
+using NUnit.Framework;
+using Environment = NHibernate.Cfg.Environment;
+
+namespace NHibernate.Test.ConnectionTest
+{
+	[TestFixture]
+	public class BatcherFixture : ConnectionManagementTestCase
+	{
+		protected override void Configure(Configuration config)
+		{
+			base.Configure(config);
+			config.SetProperty(Environment.BatchSize, "10");
+		}
+
+		protected override ISession GetSessionUnderTest()
+			=> OpenSession();
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			{
+				s.CreateQuery("delete from System.Object").ExecuteUpdate();
+			}
+		}
+
+		[Test]
+		public void CanCloseCommandsAndUseBatcher()
+		{
+			using (var s = OpenSession())
+			{
+				// Need a generator strategy not causing insert at save.
+				var silly = new YetAnother { Name = "Silly" };
+				s.Save(silly);
+				s.GetSessionImplementation().ConnectionManager.Batcher.CloseCommands();
+				
+				Assert.DoesNotThrow(s.Flush, "Flush failure after closing commands.");
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/ConnectionTest/Silly.hbm.xml
+++ b/src/NHibernate.Test/ConnectionTest/Silly.hbm.xml
@@ -16,4 +16,11 @@
 		</id>
 		<property name="Name"/>
 	</class>
+
+  <class name="YetAnother">
+    <id name="Id" type="long">
+      <generator class="hilo"/>
+    </id>
+    <property name="Name"/>
+  </class>
 </hibernate-mapping>

--- a/src/NHibernate.Test/ConnectionTest/YetAnother.cs
+++ b/src/NHibernate.Test/ConnectionTest/YetAnother.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NHibernate.Test.ConnectionTest
+{
+	[Serializable]
+	public class YetAnother
+	{
+		public virtual long Id { get; set; }
+
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -202,8 +202,10 @@
     <Compile Include="CompositeId\Order.cs" />
     <Compile Include="CompositeId\Product.cs" />
     <Compile Include="ConnectionStringTest\NamedConnectionStringFixture.cs" />
+    <Compile Include="ConnectionTest\BatcherFixture.cs" />
     <Compile Include="ConnectionTest\AggressiveReleaseTest.cs" />
     <Compile Include="ConnectionTest\ConnectionManagementTestCase.cs" />
+    <Compile Include="ConnectionTest\YetAnother.cs" />
     <Compile Include="ConnectionTest\Other.cs" />
     <Compile Include="ConnectionTest\Silly.cs" />
     <Compile Include="ConnectionTest\MapBasedSessionContextFixture.cs" />

--- a/src/NHibernate/AdoNet/SqlClientBatchingBatcher.cs
+++ b/src/NHibernate/AdoNet/SqlClientBatchingBatcher.cs
@@ -61,7 +61,7 @@ namespace NHibernate.AdoNet
 			{
 				Log.Debug("Adding to batch:" + lineWithParameters);
 			}
-			_currentBatch.Append((System.Data.SqlClient.SqlCommand) batchUpdate);
+			_currentBatch.Append((System.Data.SqlClient.SqlCommand)batchUpdate);
 
 			if (_currentBatch.CountOfCommands >= _batchSize)
 			{
@@ -71,27 +71,31 @@ namespace NHibernate.AdoNet
 
 		protected override void DoExecuteBatch(DbCommand ps)
 		{
-			Log.DebugFormat("Executing batch");
-			CheckReaders();
-			Prepare(_currentBatch.BatchCommand);
-			if (Factory.Settings.SqlStatementLogger.IsDebugEnabled)
-			{
-				Factory.Settings.SqlStatementLogger.LogBatchCommand(_currentBatchCommandsLog.ToString());
-			}
-
-			int rowsAffected;
 			try
 			{
-				rowsAffected = _currentBatch.ExecuteNonQuery();
+				Log.DebugFormat("Executing batch");
+				CheckReaders();
+				Prepare(_currentBatch.BatchCommand);
+				if (Factory.Settings.SqlStatementLogger.IsDebugEnabled)
+				{
+					Factory.Settings.SqlStatementLogger.LogBatchCommand(_currentBatchCommandsLog.ToString());
+				}
+				int rowsAffected;
+				try
+				{
+					rowsAffected = _currentBatch.ExecuteNonQuery();
+				}
+				catch (DbException e)
+				{
+					throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "could not execute batch command.");
+				}
+
+				Expectations.VerifyOutcomeBatched(_totalExpectedRowsAffected, rowsAffected);
 			}
-			catch (DbException e)
+			finally
 			{
-				throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "could not execute batch command.");
+				ClearCurrentBatch();
 			}
-
-			Expectations.VerifyOutcomeBatched(_totalExpectedRowsAffected, rowsAffected);
-
-			ClearCurrentBatch();
 		}
 
 		private SqlClientSqlCommandSet CreateConfiguredBatch()


### PR DESCRIPTION
[NH-4013](https://nhibernate.jira.com/browse/NH-4013) - `SqlClientBatchingBatcher` CloseCommands contract violated

`CloseCommands` causes `SqlClientBatchingBatcher` and `MySqlClientBatchingBatcher` to be unusable although its xml comment states:

> ```C#
> /// Use this method instead of <c>Dispose</c> if the <see cref="IBatcher"/>
> /// can be used again.
> ```

Test case and fix.