### PR TITLE
NH-4019 - Pass assembly into log4net functions

### DIFF
--- a/src/NHibernate.Test/FilterTest/ConfigFixture.cs
+++ b/src/NHibernate.Test/FilterTest/ConfigFixture.cs
@@ -242,7 +242,7 @@ namespace NHibernate.Test.FilterTest
 			var cfg = GetConfiguration();
 			cfg.AddXmlString(filterDef);
 		    var memoryAppender = new MemoryAppender();
-		    BasicConfigurator.Configure(memoryAppender);
+		    BasicConfigurator.Configure(LogManager.GetRepository(typeof(ConfigFixture).Assembly), memoryAppender);
             try
 			{
 			    cfg.BuildSessionFactory();

--- a/src/NHibernate.Test/IdTest/AssignedFixture.cs
+++ b/src/NHibernate.Test/IdTest/AssignedFixture.cs
@@ -43,7 +43,7 @@ namespace NHibernate.Test.IdTest
 		[Test]
 		public void SaveOrUpdate_Save()
 		{
-			using (LogSpy ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (LogSpy ls = new LogSpy(LogManager.GetLogger(typeof(AssignedFixture).Assembly, "NHibernate"), Level.Warn))
 			using (ISession s = OpenSession())
 			{
 				ITransaction t = s.BeginTransaction();
@@ -70,7 +70,7 @@ namespace NHibernate.Test.IdTest
 		[Test]
 		public void SaveNoWarning()
 		{
-			using (LogSpy ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (LogSpy ls = new LogSpy(LogManager.GetLogger(typeof(AssignedFixture).Assembly, "NHibernate"), Level.Warn))
 			using (ISession s = OpenSession())
 			{
 				ITransaction t = s.BeginTransaction();
@@ -104,7 +104,7 @@ namespace NHibernate.Test.IdTest
 				t.Commit();
 			}
 
-			using (LogSpy ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (LogSpy ls = new LogSpy(LogManager.GetLogger(typeof(AssignedFixture).Assembly, "NHibernate"), Level.Warn))
 			using (ISession s = OpenSession())
 			{
 				ITransaction t = s.BeginTransaction();
@@ -142,7 +142,7 @@ namespace NHibernate.Test.IdTest
 				t.Commit();
 			}
 
-			using (LogSpy ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (LogSpy ls = new LogSpy(LogManager.GetLogger(typeof(AssignedFixture).Assembly, "NHibernate"), Level.Warn))
 			using (ISession s = OpenSession())
 			{
 				ITransaction t = s.BeginTransaction();
@@ -179,7 +179,7 @@ namespace NHibernate.Test.IdTest
 				t.Commit();
 			}
 
-			using (LogSpy ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (LogSpy ls = new LogSpy(LogManager.GetLogger(typeof(AssignedFixture).Assembly, "NHibernate"), Level.Warn))
 			using (ISession s = OpenSession())
 			{
 				ITransaction t = s.BeginTransaction();
@@ -218,7 +218,7 @@ namespace NHibernate.Test.IdTest
 				t.Commit();
 			}
 
-			using (LogSpy ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (LogSpy ls = new LogSpy(LogManager.GetLogger(typeof(AssignedFixture).Assembly, "NHibernate"), Level.Warn))
 			using (ISession s = OpenSession())
 			{
 				ITransaction t = s.BeginTransaction();

--- a/src/NHibernate.Test/LogSpy.cs
+++ b/src/NHibernate.Test/LogSpy.cs
@@ -40,8 +40,8 @@ namespace NHibernate.Test
 		public LogSpy(System.Type loggerType) : this(LogManager.GetLogger(loggerType), false) { }
 		public LogSpy(System.Type loggerType, bool disable) : this(LogManager.GetLogger(loggerType), disable) { }
 
-		public LogSpy(string loggerName) : this(LogManager.GetLogger(loggerName), false) { }
-		public LogSpy(string loggerName, bool disable) : this(LogManager.GetLogger(loggerName), disable) { }
+		public LogSpy(string loggerName) : this(LogManager.GetLogger(typeof(LogSpy).Assembly, loggerName), false) { }
+		public LogSpy(string loggerName, bool disable) : this(LogManager.GetLogger(typeof(LogSpy).Assembly, loggerName), disable) { }
 
 		public MemoryAppender Appender
 		{

--- a/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
@@ -68,7 +68,7 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 					Threshold = Level.All,
 					Writer = new StringWriter(stringBuilder)
 				};
-				loggerImpl = (Logger)LogManager.GetLogger(loggerName).Logger;
+				loggerImpl = (Logger)LogManager.GetLogger(typeof(LogsFixture).Assembly, loggerName).Logger;
 				loggerImpl.AddAppender(appender);
 				loggerImpl.Level = Level.All;
 			}

--- a/src/NHibernate.Test/NHSpecificTest/NH1093/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1093/Fixture.cs
@@ -83,7 +83,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1093
 		protected override void BuildSessionFactory()
 		{
 			// Without configured cache, should log warn.
-			using (var ls = new LogSpy(LogManager.GetLogger("NHibernate"), Level.Warn))
+			using (var ls = new LogSpy(LogManager.GetLogger(typeof(Fixture).Assembly, "NHibernate"), Level.Warn))
 			{
 				base.BuildSessionFactory();
 				Assert.That(ls.GetWholeLog(), Does.Contain("Fake cache used"));

--- a/src/NHibernate.Test/NHSpecificTest/NH1587/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1587/Fixture.cs
@@ -1,3 +1,4 @@
+using log4net;
 using log4net.Config;
 using log4net.Core;
 using NHibernate.Cfg;
@@ -11,7 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1587
 		[Test]
 		public void Bug()
 		{
-			XmlConfigurator.Configure();
+			XmlConfigurator.Configure(LogManager.GetRepository(typeof(Fixture).Assembly));
 			var cfg = new Configuration();
 			if (TestConfigurationHelper.hibernateConfigFile != null)
 				cfg.Configure(TestConfigurationHelper.hibernateConfigFile);

--- a/src/NHibernate.Test/NHSpecificTest/NH2386/Test.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2386/Test.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2386 {
 
         protected override void OnTearDown() {
             if (memoryAppender != null) {
-                var repository = (Hierarchy) LogManager.GetRepository();
+                var repository = (Hierarchy) LogManager.GetRepository(typeof(Test).Assembly);
                 repository.Root.RemoveAppender(memoryAppender);
                 memoryAppender = null;
             }

--- a/src/NHibernate.Test/NHSpecificTest/NH2779/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2779/Fixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2779
 
 			using (var session = OpenSession())
 			using (var tx = session.BeginTransaction())
-			using (new LogSpy(LogManager.GetLogger("NHibernate"), Level.All)) //  <-- Logging must be set DEBUG to reproduce bug
+			using (new LogSpy(LogManager.GetLogger(typeof(Fixture).Assembly, "NHibernate"), Level.All)) //  <-- Logging must be set DEBUG to reproduce bug
 			{
 				Order order = session.Get<Order>("Order-1");
 				Assert.IsNotNull(order);

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -13,8 +13,10 @@ using NHibernate.Type;
 using NUnit.Framework;
 using NHibernate.Hql.Ast.ANTLR;
 using System.Collections.Concurrent;
+using System.IO;
 using NUnit.Framework.Interfaces;
 using System.Text;
+using log4net.Util;
 using static NUnit.Framework.TestContext;
 
 namespace NHibernate.Test
@@ -68,7 +70,7 @@ namespace NHibernate.Test
 		static TestCase()
 		{
 			// Configure log4net here since configuration through an attribute doesn't always work.
-			XmlConfigurator.Configure();
+			XmlConfigurator.Configure(LogManager.GetRepository(typeof(TestCase).Assembly));
 		}
 
 		/// <summary>

--- a/src/NHibernate.Test/TypesTest/TypeFactoryFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TypeFactoryFixture.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.TypesTest
 	{
 		public TypeFactoryFixture()
 		{
-			log4net.Config.XmlConfigurator.Configure();
+			log4net.Config.XmlConfigurator.Configure(LogManager.GetRepository(typeof(TypeFactoryFixture).Assembly));
 		}
 
 		private static readonly ILog log = LogManager.GetLogger(typeof(TypeFactoryFixture));

--- a/src/NHibernate.Test/UtilityTest/ThreadSafeDictionaryFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/ThreadSafeDictionaryFixture.cs
@@ -12,7 +12,7 @@ namespace NHibernate.Test.UtilityTest
 	{
 		public ThreadSafeDictionaryFixture()
 		{
-			log4net.Config.XmlConfigurator.Configure();
+			log4net.Config.XmlConfigurator.Configure(LogManager.GetRepository(typeof(ThreadSafeDictionaryFixture).Assembly));
 		}
 
 		private static readonly ILog log = LogManager.GetLogger(typeof(ThreadSafeDictionaryFixture));


### PR DESCRIPTION
[NH-4019](https://nhibernate.jira.com/browse/NH-4019) - Pass assembly into log4net functions

This will be needed for the .netstandard version because `log4net` does not have access to Assembly.GetCallingAssembly() in .netstandard version.

This pull request is minimal changes and no `#if` cases.