### PR TITLE
NH-4020 - Use .netstandard compatible CreateTypeInfo()

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3954/ProxyCacheFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3954/ProxyCacheFixture.cs
@@ -24,11 +24,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3954
 
 			_internalCache = (ConcurrentDictionary<ProxyCacheEntry, System.Type>)InternalCacheField.GetValue(null);
 
-			_cache.StoreProxyType(typeof(Entity1FakeProxy), typeof(Entity1));
-			_cache.StoreProxyType(typeof(Entity2FakeProxy), typeof(Entity2), typeof(INHibernateProxy));
-			_cache.StoreProxyType(typeof(Entity3FakeProxy), typeof(Entity3));
-			_cache.StoreProxyType(typeof(Entity4FakeProxy), typeof(Entity4), typeof(IProxy));
-			_cache.StoreProxyType(typeof(Entity5FakeProxy), typeof(Entity5), typeof(INHibernateProxy), typeof(IProxy));
+			_cache.StoreProxyType(typeof(Entity1FakeProxy).GetTypeInfo(), typeof(Entity1));
+			_cache.StoreProxyType(typeof(Entity2FakeProxy).GetTypeInfo(), typeof(Entity2), typeof(INHibernateProxy));
+			_cache.StoreProxyType(typeof(Entity3FakeProxy).GetTypeInfo(), typeof(Entity3));
+			_cache.StoreProxyType(typeof(Entity4FakeProxy).GetTypeInfo(), typeof(Entity4), typeof(IProxy));
+			_cache.StoreProxyType(typeof(Entity5FakeProxy).GetTypeInfo(), typeof(Entity5), typeof(INHibernateProxy), typeof(IProxy));
 
 			// Artificially inject other entries with same hashcodes
 			_hashCode1 = new ProxyCacheEntry(typeof(Entity1), null).GetHashCode();
@@ -148,7 +148,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3954
 			// Beware not testing the lookup failure of any combination, even tweaked, actually added in cache.
 			// (Otherwise the test may starts failing unexpectedly sometimes, as the original bug ...)
 			// This one was not added in anyway.
-			System.Type result;
+			TypeInfo result;
 			Assert.IsFalse(_cache.TryGetProxyType(typeof(Entity2), new[] { typeof(IProxy) }, out result));
 		}
 	}

--- a/src/NHibernate/Proxy/DynamicProxy/IProxyCache.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/IProxyCache.cs
@@ -7,16 +7,17 @@
 #endregion
 
 using System;
+using System.Reflection;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	public interface IProxyCache
 	{
 		bool Contains(System.Type baseType, params System.Type[] baseInterfaces);
-		System.Type GetProxyType(System.Type baseType, params System.Type[] baseInterfaces);
+		TypeInfo GetProxyType(System.Type baseType, params System.Type[] baseInterfaces);
 
-		bool TryGetProxyType(System.Type baseType, System.Type[] baseInterfaces, out System.Type proxyType);
+		bool TryGetProxyType(System.Type baseType, System.Type[] baseInterfaces, out TypeInfo proxyType);
 
-		void StoreProxyType(System.Type result, System.Type baseType, params System.Type[] baseInterfaces);
+		void StoreProxyType(TypeInfo result, System.Type baseType, params System.Type[] baseInterfaces);
 	}
 }

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyCache.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyCache.cs
@@ -7,12 +7,13 @@
 #endregion
 
 using System.Collections.Concurrent;
+using System.Reflection;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	public class ProxyCache : IProxyCache
 	{
-		private static readonly ConcurrentDictionary<ProxyCacheEntry, System.Type> cache = new ConcurrentDictionary<ProxyCacheEntry, System.Type>();
+		private static readonly ConcurrentDictionary<ProxyCacheEntry, TypeInfo> cache = new ConcurrentDictionary<ProxyCacheEntry, TypeInfo>();
 
 		#region IProxyCache Members
 
@@ -27,13 +28,13 @@ namespace NHibernate.Proxy.DynamicProxy
 			return cache.ContainsKey(entry);
 		}
 
-		public System.Type GetProxyType(System.Type baseType, params System.Type[] baseInterfaces)
+		public TypeInfo GetProxyType(System.Type baseType, params System.Type[] baseInterfaces)
 		{
 			var entry = new ProxyCacheEntry(baseType, baseInterfaces);
 			return cache[entry];
 		}
 
-		public bool TryGetProxyType(System.Type baseType, System.Type[] baseInterfaces, out System.Type proxyType)
+		public bool TryGetProxyType(System.Type baseType, System.Type[] baseInterfaces, out TypeInfo proxyType)
 		{
 			proxyType = null;
 
@@ -44,7 +45,7 @@ namespace NHibernate.Proxy.DynamicProxy
 			return cache.TryGetValue(entry, out proxyType);
 		}
 
-		public void StoreProxyType(System.Type result, System.Type baseType, params System.Type[] baseInterfaces)
+		public void StoreProxyType(TypeInfo result, System.Type baseType, params System.Type[] baseInterfaces)
 		{
 			var entry = new ProxyCacheEntry(baseType, baseInterfaces);
 			cache[entry] = result;

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
@@ -68,29 +68,29 @@ namespace NHibernate.Proxy.DynamicProxy
 		{
 			System.Type[] baseInterfaces = ReferenceEquals(null, interfaces) ? new System.Type[0] : interfaces.Where(t => t != null).ToArray();
 			
-			System.Type proxyType;
+			TypeInfo proxyTypeInfo;
 
 			// Reuse the previous results, if possible, Fast path without locking.
-			if (Cache.TryGetProxyType(baseType, baseInterfaces, out proxyType))
-				return proxyType;
+			if (Cache.TryGetProxyType(baseType, baseInterfaces, out proxyTypeInfo))
+				return proxyTypeInfo;
 
 			lock (Cache)
 			{
 				// Recheck in case we got interrupted.
-				if (!Cache.TryGetProxyType(baseType, baseInterfaces, out proxyType))
+				if (!Cache.TryGetProxyType(baseType, baseInterfaces, out proxyTypeInfo))
 				{
-					proxyType = CreateUncachedProxyType(baseType, baseInterfaces);
+					proxyTypeInfo = CreateUncachedProxyType(baseType, baseInterfaces);
 
 					// Cache the proxy type
-					if (proxyType != null && Cache != null)
-						Cache.StoreProxyType(proxyType, baseType, baseInterfaces);
+					if (proxyTypeInfo != null && Cache != null)
+						Cache.StoreProxyType(proxyTypeInfo, baseType, baseInterfaces);
 				}
 
-				return proxyType;
+				return proxyTypeInfo;
 			}
 		}
 
-		private System.Type CreateUncachedProxyType(System.Type baseType, System.Type[] baseInterfaces)
+		private TypeInfo CreateUncachedProxyType(System.Type baseType, System.Type[] baseInterfaces)
 		{
 			AppDomain currentDomain = AppDomain.CurrentDomain;
 			string typeName = string.Format("{0}Proxy", baseType.Name);
@@ -145,7 +145,7 @@ namespace NHibernate.Proxy.DynamicProxy
 
 			// Make the proxy serializable
 			AddSerializationSupport(baseType, baseInterfaces, typeBuilder, interceptorField, defaultConstructor);
-			System.Type proxyType = typeBuilder.CreateType();
+			TypeInfo proxyType = typeBuilder.CreateTypeInfo();
 
 			ProxyAssemblyBuilder.Save(assemblyBuilder);
 			return proxyType;


### PR DESCRIPTION
[NH-4020](https://nhibernate.jira.com/browse/NH-4020)

TypeBuilder.CreateType() is now TypeBuilder.CreateTypeInfo(). Switched cached System.Type to System.Reflection.TypeInfo

This will be needed for the .netstandard version and is compatible with .NET 4.61.