### PR TITLE
NH-4021 - enforce session tracking in tests

### DIFF
--- a/src/NHibernate.Test/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/BatcherFixture.cs
@@ -34,16 +34,16 @@ namespace NHibernate.Test.Ado
 		[Description("The batcher should run all INSERT queries in only one roundtrip.")]
 		public void OneRoundTripInserts()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			FillDb();
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 
 		private void Cleanup()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (s.BeginTransaction())
 			{
 				s.CreateQuery("delete from VerySimple").ExecuteUpdate();
@@ -54,7 +54,7 @@ namespace NHibernate.Test.Ado
 
 		private void FillDb()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				s.Save(new VerySimple {Id = 1, Name = "Fabio", Weight = 119.5});
@@ -69,20 +69,20 @@ namespace NHibernate.Test.Ado
 		{
 			FillDb();
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var vs1 = s.Get<VerySimple>(1);
 				var vs2 = s.Get<VerySimple>(2);
 				vs1.Weight -= 10;
 				vs2.Weight -= 1;
-				sessions.Statistics.Clear();
+				Sfi.Statistics.Clear();
 				s.Update(vs1);
 				s.Update(vs2);
 				tx.Commit();
 			}
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 
@@ -90,13 +90,13 @@ namespace NHibernate.Test.Ado
 		[Description("SqlClient: The batcher should run all different INSERT queries in only one roundtrip.")]
 		public void SqlClientOneRoundTripForUpdateAndInsert()
 		{
-			if (sessions.Settings.BatcherFactory is SqlClientBatchingBatcherFactory == false)
+			if (Sfi.Settings.BatcherFactory is SqlClientBatchingBatcherFactory == false)
 				Assert.Ignore("This test is for SqlClientBatchingBatcher only");
 
 			FillDb();
 
 			using(var sqlLog = new SqlLogSpy())
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				s.Save(new VerySimple
@@ -128,7 +128,7 @@ namespace NHibernate.Test.Ado
 		[Description("SqlClient: The batcher log output should be formatted")]
 		public void BatchedoutputShouldBeFormatted()
 		{
-			if (sessions.Settings.BatcherFactory is SqlClientBatchingBatcherFactory == false)
+			if (Sfi.Settings.BatcherFactory is SqlClientBatchingBatcherFactory == false)
 				Assert.Ignore("This test is for SqlClientBatchingBatcher only");
 
 			using (var sqlLog = new SqlLogSpy())
@@ -148,18 +148,18 @@ namespace NHibernate.Test.Ado
 		{
 			FillDb();
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var vs1 = s.Get<VerySimple>(1);
 				var vs2 = s.Get<VerySimple>(2);
-				sessions.Statistics.Clear();
+				Sfi.Statistics.Clear();
 				s.Delete(vs1);
 				s.Delete(vs2);
 				tx.Commit();
 			}
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 
@@ -174,7 +174,7 @@ namespace NHibernate.Test.Ado
 			{
 				using (var sl = new SqlLogSpy())
 				{
-					sessions.Statistics.Clear();
+					Sfi.Statistics.Clear();
 					FillDb();
 					string logs = sl.GetWholeLog();
 					Assert.That(logs, Does.Not.Contain("Adding to batch").IgnoreCase);
@@ -183,7 +183,7 @@ namespace NHibernate.Test.Ado
 				}
 			}
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 
@@ -198,7 +198,7 @@ namespace NHibernate.Test.Ado
 			{
 				using (var sl = new SqlLogSpy())
 				{
-					sessions.Statistics.Clear();
+					Sfi.Statistics.Clear();
 					FillDb();
 					string logs = sl.GetWholeLog();
 					Assert.That(logs, Does.Contain("batch").IgnoreCase);
@@ -213,7 +213,7 @@ namespace NHibernate.Test.Ado
 				}
 			}
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 
@@ -224,14 +224,14 @@ namespace NHibernate.Test.Ado
 			{
 				using (var sl = new SqlLogSpy())
 				{
-					sessions.Statistics.Clear();
+					Sfi.Statistics.Clear();
 					FillDb();
 					string logs = sl.GetWholeLog();
 					Assert.That(logs, Does.Contain("Batch commands:").IgnoreCase);
 				}
 			}
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 
@@ -244,7 +244,7 @@ namespace NHibernate.Test.Ado
 			{
 				using (var sl = new SqlLogSpy())
 				{
-					sessions.Statistics.Clear();
+					Sfi.Statistics.Clear();
 					FillDb();
 					foreach (var loggingEvent in sl.Appender.GetEvents())
 					{
@@ -266,7 +266,7 @@ namespace NHibernate.Test.Ado
 				}
 			}
 
-			Assert.That(sessions.Statistics.PrepareStatementCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
 		}
 	}

--- a/src/NHibernate.Test/BulkManipulation/BaseFixture.cs
+++ b/src/NHibernate.Test/BulkManipulation/BaseFixture.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Test.BulkManipulation
 
 		public string GetSql(string query)
 		{
-			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, sessions).Parse(), emptyfilters, sessions);
+			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, Sfi).Parse(), emptyfilters, Sfi);
 			qt.Compile(null, false);
 			return qt.SQLString;
 		}

--- a/src/NHibernate.Test/CacheTest/FilterKeyFixture.cs
+++ b/src/NHibernate.Test/CacheTest/FilterKeyFixture.cs
@@ -22,13 +22,13 @@ namespace NHibernate.Test.CacheTest
 		public void ToStringIncludeAll()
 		{
 			string filterName = "DescriptionLike";
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pLike", "so%");
 			var fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			Assert.That(fk.ToString(), Is.EqualTo("FilterKey[DescriptionLike{'pLike'='so%'}]"));
 
 			filterName = "DescriptionEqualAndValueGT";
-			f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pDesc", "something").SetParameter("pValue", 10);
 			fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			Assert.That(fk.ToString(), Is.EqualTo("FilterKey[DescriptionEqualAndValueGT{'pDesc'='something', 'pValue'='10'}]"));
@@ -49,11 +49,11 @@ namespace NHibernate.Test.CacheTest
 		private void FilterDescLikeToCompare(out FilterKey fk, out FilterKey fk1)
 		{
 			const string filterName = "DescriptionLike";
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pLike", "so%");
 			fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 
-			var f1 = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f1 = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f1.SetParameter("pLike", "%ing");
 			fk1 = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 		}
@@ -61,11 +61,11 @@ namespace NHibernate.Test.CacheTest
 		private void FilterDescValueToCompare(out FilterKey fk, out FilterKey fk1)
 		{
 			const string filterName = "DescriptionEqualAndValueGT";
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pDesc", "something").SetParameter("pValue", 10);
 			fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 
-			var f1 = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f1 = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f1.SetParameter("pDesc", "something").SetParameter("pValue", 11);
 			fk1 = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 		}

--- a/src/NHibernate.Test/CacheTest/QueryKeyFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryKeyFixture.cs
@@ -38,34 +38,34 @@ namespace NHibernate.Test.CacheTest
 		private void QueryKeyFilterDescLikeToCompare(out QueryKey qk, out QueryKey qk1)
 		{
 			const string filterName = "DescriptionLike";
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pLike", "so%");
 			var fk =  new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			ISet<FilterKey> fks = new HashSet<FilterKey> { fk };
-			qk = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			qk = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 
-			var f1 = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f1 = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f1.SetParameter("pLike", "%ing");
 			var fk1 = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			fks = new HashSet<FilterKey> { fk1 };
-			qk1 = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			qk1 = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 		}
 
 		private void QueryKeyFilterDescValueToCompare(out QueryKey qk, out QueryKey qk1)
 		{
 			const string filterName = "DescriptionEqualAndValueGT";
 
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pDesc", "something").SetParameter("pValue", 10);
 			var fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			ISet<FilterKey> fks = new HashSet<FilterKey> { fk };
-			qk = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			qk = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 
-			var f1 = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f1 = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f1.SetParameter("pDesc", "something").SetParameter("pValue", 11);
 			var fk1 = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			fks = new HashSet<FilterKey> { fk1 };
-			qk1 = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			qk1 = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 		}
 
 		[Test]
@@ -109,19 +109,19 @@ namespace NHibernate.Test.CacheTest
 		public void ToStringWithFilters()
 		{
 			string filterName = "DescriptionLike";
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pLike", "so%");
 			var fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			ISet<FilterKey> fks = new HashSet<FilterKey> { fk };
-			var qk = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			var qk = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 			Assert.That(qk.ToString(), Does.Contain(string.Format("filters: ['{0}']",fk)));
 
 			filterName = "DescriptionEqualAndValueGT";
-			f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pDesc", "something").SetParameter("pValue", 10);
 			fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 			fks = new HashSet<FilterKey> { fk };
-			qk = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			qk = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 			Assert.That(qk.ToString(), Does.Contain(string.Format("filters: ['{0}']", fk)));
 		}
 
@@ -129,17 +129,17 @@ namespace NHibernate.Test.CacheTest
 		public void ToStringWithMoreFilters()
 		{
 			string filterName = "DescriptionLike";
-			var f = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var f = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			f.SetParameter("pLike", "so%");
 			var fk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 
 			filterName = "DescriptionEqualAndValueGT";
-			var fv = new FilterImpl(sessions.GetFilterDefinition(filterName));
+			var fv = new FilterImpl(Sfi.GetFilterDefinition(filterName));
 			fv.SetParameter("pDesc", "something").SetParameter("pValue", 10);
 			var fvk = new FilterKey(filterName, f.Parameters, f.FilterDefinition.ParameterTypes);
 
 			ISet<FilterKey> fks = new HashSet<FilterKey> { fk, fvk };
-			var qk = new QueryKey(sessions, SqlAll, new QueryParameters(), fks, null);
+			var qk = new QueryKey(Sfi, SqlAll, new QueryParameters(), fks, null);
 			Assert.That(qk.ToString(), Does.Contain(string.Format("filters: ['{0}', '{1}']", fk, fvk)));
 		}
 	}

--- a/src/NHibernate.Test/Cascade/Circle/MultiPathCircleCascadeTest.cs
+++ b/src/NHibernate.Test/Cascade/Circle/MultiPathCircleCascadeTest.cs
@@ -424,22 +424,22 @@ namespace NHibernate.Test.Cascade.Circle
 		
 		protected void ClearCounts()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 		}
 		
 		protected void AssertInsertCount(long expected)
 		{
-			Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(expected), "unexpected insert count");
+			Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(expected), "unexpected insert count");
 		}
 		
 		protected void AssertUpdateCount(long expected)
 		{
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(expected), "unexpected update count");
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(expected), "unexpected update count");
 		}
 		
 		protected void AssertDeleteCount(long expected)
 		{
-			Assert.That(sessions.Statistics.EntityDeleteCount, Is.EqualTo(expected), "unexpected delete count");
+			Assert.That(Sfi.Statistics.EntityDeleteCount, Is.EqualTo(expected), "unexpected delete count");
 		}
 	}
 }

--- a/src/NHibernate.Test/Classic/LifecycleFixture.cs
+++ b/src/NHibernate.Test/Classic/LifecycleFixture.cs
@@ -25,13 +25,13 @@ namespace NHibernate.Test.Classic
 		[Test]
 		public void Save()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			using (ISession s = OpenSession())
 			{
 				s.Save(new EntityWithLifecycle());
 				s.Flush();
 			}
-			Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(0));
 
 			var v = new EntityWithLifecycle("Shinobi", 10, 10);
 			using (ISession s = OpenSession())
@@ -53,14 +53,14 @@ namespace NHibernate.Test.Classic
 			}
 
 			// update detached
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			v.Heigth = 0;
 			using (ISession s = OpenSession())
 			{
 				s.Update(v);
 				s.Flush();
 			}
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(0));
 
 			// cleanup
 			using (ISession s = OpenSession())
@@ -81,13 +81,13 @@ namespace NHibernate.Test.Classic
 				s.Flush();
 			}
 			v.Heigth = 0;
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			using (ISession s = OpenSession())
 			{
 				s.Merge(v);
 				s.Flush();
 			}
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(0));
 
 			var v1 = new EntityWithLifecycle("Shinobi", 0, 10);
 			using (ISession s = OpenSession())
@@ -95,8 +95,8 @@ namespace NHibernate.Test.Classic
 				s.Merge(v1);
 				s.Flush();
 			}
-			Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(0));
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(0));
 
 
 			// cleanup
@@ -116,11 +116,11 @@ namespace NHibernate.Test.Classic
 			{
 				s.Save(v);
 				s.Flush();
-				sessions.Statistics.Clear();
+				Sfi.Statistics.Clear();
 				v.Heigth = 0;
 				s.Delete(v);
 				s.Flush();
-				Assert.That(sessions.Statistics.EntityDeleteCount, Is.EqualTo(0));
+				Assert.That(Sfi.Statistics.EntityDeleteCount, Is.EqualTo(0));
 			}
 
 			using (ISession s = OpenSession())

--- a/src/NHibernate.Test/CollectionTest/IdBagFixture.cs
+++ b/src/NHibernate.Test/CollectionTest/IdBagFixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.CollectionTest
 
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from A" );
 				s.Flush();

--- a/src/NHibernate.Test/CollectionTest/NullableValueTypeElementMapFixture.cs
+++ b/src/NHibernate.Test/CollectionTest/NullableValueTypeElementMapFixture.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Test.CollectionTest
 
 		protected override void OnTearDown()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				s.Delete("from Parent");
 				s.Flush();

--- a/src/NHibernate.Test/Component/Basic/ComponentTest.cs
+++ b/src/NHibernate.Test/Component/Basic/ComponentTest.cs
@@ -49,7 +49,7 @@ namespace NHibernate.Test.Component.Basic
 	
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.Delete("from User");
@@ -65,9 +65,9 @@ namespace NHibernate.Test.Component.Basic
 		{
 			User u;
 			
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 				
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				u = new User("gavin", "secret", new Person("Gavin King", new DateTime(1999, 12, 31), "Karbarook Ave"));
@@ -78,10 +78,10 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(1));
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(0));
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				u = (User)s.Get(typeof(User), "gavin");
@@ -91,7 +91,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			Assert.That(sessions.Statistics.EntityDeleteCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.EntityDeleteCount, Is.EqualTo(1));
 		}
 		
 		[Test]
@@ -99,7 +99,7 @@ namespace NHibernate.Test.Component.Basic
 		{
 			User u;
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				u = new User("gavin", "secret", new Person("Gavin King", new DateTime(1999, 12, 31), "Karbarook Ave"));
@@ -109,7 +109,7 @@ namespace NHibernate.Test.Component.Basic
 				t.Commit();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{			
 				u = (User)s.Get(typeof(User), "gavin");
@@ -120,7 +120,7 @@ namespace NHibernate.Test.Component.Basic
 				t.Commit();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				u = (User)s.Get(typeof(User), "gavin");
@@ -136,20 +136,20 @@ namespace NHibernate.Test.Component.Basic
 		public void TestComponentStateChangeAndDirtiness() 
 		{
 			// test for HHH-2366
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				User u = new User("steve", "hibernater", new Person( "Steve Ebersole", new DateTime(1999, 12, 31), "Main St"));
 				s.Persist(u);
 				s.Flush();
-				long intialUpdateCount = sessions.Statistics.EntityUpdateCount;
+				long intialUpdateCount = Sfi.Statistics.EntityUpdateCount;
 				u.Person.Address = "Austin";
 				s.Flush();
-				Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(intialUpdateCount + 1));
-				intialUpdateCount = sessions.Statistics.EntityUpdateCount;
+				Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(intialUpdateCount + 1));
+				intialUpdateCount = Sfi.Statistics.EntityUpdateCount;
 				u.Person.Address = "Cedar Park";
 				s.Flush();
-				Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(intialUpdateCount + 1));
+				Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(intialUpdateCount + 1));
 				s.Delete(u);
 				t.Commit();
 				s.Close();
@@ -163,7 +163,7 @@ namespace NHibernate.Test.Component.Basic
 			const double HEIGHT_INCHES = 73;
 			const double HEIGHT_CENTIMETERS = HEIGHT_INCHES * 2.54d;
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				User u = new User("steve", "hibernater", new Person( "Steve Ebersole", new DateTime(1999, 12, 31), "Main St"));
@@ -208,7 +208,7 @@ namespace NHibernate.Test.Component.Basic
 		[Ignore("Ported from Hibernate - failing in NH")]
 		public void TestComponentQueries() 
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				Employee emp = new Employee();
@@ -231,7 +231,7 @@ namespace NHibernate.Test.Component.Basic
 		[Test]
 		public void TestComponentFormulaQuery() 
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{			
 				s.CreateQuery("from User u where u.Person.Yob = 1999").List();
@@ -254,7 +254,7 @@ namespace NHibernate.Test.Component.Basic
 		[Test]
 		public void TestNamedQuery() 
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.GetNamedQuery("userNameIn")
@@ -271,7 +271,7 @@ namespace NHibernate.Test.Component.Basic
 			Employee emp = null;
 			IEnumerator<Employee> enumerator = null;
 				
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = new Employee();
@@ -284,7 +284,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Get(typeof(Employee), emp.Id);
@@ -298,7 +298,7 @@ namespace NHibernate.Test.Component.Basic
 			emp.OptionalComponent.Value1 = "emp-value1";
 			emp.OptionalComponent.Value2 = "emp-value2";
 	
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Merge(emp);
@@ -306,7 +306,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Get(typeof(Employee), emp.Id);
@@ -320,7 +320,7 @@ namespace NHibernate.Test.Component.Basic
 			emp.OptionalComponent.Value1 = null;
 			emp.OptionalComponent.Value2 = null;
 	
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Merge(emp);
@@ -328,7 +328,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Get(typeof(Employee), emp.Id);
@@ -346,7 +346,7 @@ namespace NHibernate.Test.Component.Basic
 			emp1.Person.Dob = new DateTime(1999, 12, 31);
 			emp.DirectReports.Add(emp1);
 	
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Merge(emp);
@@ -354,7 +354,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Get(typeof(Employee), emp.Id);
@@ -374,7 +374,7 @@ namespace NHibernate.Test.Component.Basic
 			emp1.OptionalComponent.Value1 = "emp1-value1";
 			emp1.OptionalComponent.Value2 = "emp1-value2";
 	
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Merge(emp);
@@ -382,7 +382,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Get(typeof(Employee), emp.Id);
@@ -402,7 +402,7 @@ namespace NHibernate.Test.Component.Basic
 			emp1.OptionalComponent.Value1 = null;
 			emp1.OptionalComponent.Value2 = null;
 	
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Merge(emp);
@@ -410,7 +410,7 @@ namespace NHibernate.Test.Component.Basic
 				s.Close();
 			}
 			
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				emp = (Employee)s.Get(typeof(Employee), emp.Id);
@@ -426,7 +426,7 @@ namespace NHibernate.Test.Component.Basic
 			emp1 = (Employee)enumerator.Current;
 			Assert.That(emp1.OptionalComponent, Is.Null);
 	
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.Delete( emp );

--- a/src/NHibernate.Test/Component/Basic/ComponentWithUniqueConstraintTests.cs
+++ b/src/NHibernate.Test/Component/Basic/ComponentWithUniqueConstraintTests.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Test.Component.Basic
 
 		protected override void OnTearDown()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
 				session.Delete("from Employee");

--- a/src/NHibernate.Test/CompositeId/ClassWithCompositeIdFixture.cs
+++ b/src/NHibernate.Test/CompositeId/ClassWithCompositeIdFixture.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Test.CompositeId
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from ClassWithCompositeId");
 				s.Flush();

--- a/src/NHibernate.Test/ConnectionTest/AggressiveReleaseTest.cs
+++ b/src/NHibernate.Test/ConnectionTest/AggressiveReleaseTest.cs
@@ -176,8 +176,8 @@ namespace NHibernate.Test.ConnectionTest
 		{
 			Prepare();
 
-			using (var originalConnection = sessions.ConnectionProvider.GetConnection())
-			using (var session = sessions.WithOptions().Connection(originalConnection).OpenSession())
+			using (var originalConnection = Sfi.ConnectionProvider.GetConnection())
+			using (var session = Sfi.WithOptions().Connection(originalConnection).OpenSession())
 			{
 				var silly = new Silly("silly");
 				session.Save(silly);

--- a/src/NHibernate.Test/ConnectionTest/ThreadLocalCurrentSessionTest.cs
+++ b/src/NHibernate.Test/ConnectionTest/ThreadLocalCurrentSessionTest.cs
@@ -24,9 +24,9 @@ namespace NHibernate.Test.ConnectionTest
 
 		protected override void Release(ISession session)
 		{
-			long initialCount = sessions.Statistics.SessionCloseCount;
+			long initialCount = Sfi.Statistics.SessionCloseCount;
 			session.Transaction.Commit();
-			long subsequentCount = sessions.Statistics.SessionCloseCount;
+			long subsequentCount = Sfi.Statistics.SessionCloseCount;
 			Assert.AreEqual(initialCount + 1, subsequentCount, "Session still open after commit");
 			// also make sure it was cleaned up from the internal ThreadLocal...
 			Assert.IsFalse(TestableThreadLocalContext.HasBind(), "session still bound to internal ThreadLocal");
@@ -36,7 +36,7 @@ namespace NHibernate.Test.ConnectionTest
 		[Test]
 		public void ContextCleanup()
 		{
-			ISession session = sessions.OpenSession();
+			ISession session = Sfi.OpenSession();
 			session.BeginTransaction();
 			session.Transaction.Commit();
 			Assert.IsFalse(session.IsOpen, "session open after txn completion");

--- a/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
+++ b/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
@@ -2559,17 +2559,17 @@ namespace NHibernate.Test.Criteria
 		{
 			using (ISession session = OpenSession())
 			{
-				bool current = sessions.Statistics.IsStatisticsEnabled;
-				sessions.Statistics.IsStatisticsEnabled = true;
-				sessions.Statistics.Clear();
+				bool current = Sfi.Statistics.IsStatisticsEnabled;
+				Sfi.Statistics.IsStatisticsEnabled = true;
+				Sfi.Statistics.Clear();
 				DetachedCriteria dc = DetachedCriteria.For(typeof (Student))
 				.Add(Property.ForName("Name").Eq("Gavin King"))
 				.SetProjection(Property.ForName("StudentNumber"))
 				.SetCacheable(true);
-				Assert.That(sessions.Statistics.QueryCacheMissCount,Is.EqualTo(0));
-				Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(0));
+				Assert.That(Sfi.Statistics.QueryCacheMissCount,Is.EqualTo(0));
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
 				dc.GetExecutableCriteria(session).List();
-				Assert.That(sessions.Statistics.QueryCacheMissCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(1));
 
 				dc = DetachedCriteria.For(typeof(Student))
 				.Add(Property.ForName("Name").Eq("Gavin King"))
@@ -2577,9 +2577,9 @@ namespace NHibernate.Test.Criteria
 				.SetCacheable(true);
 				dc.GetExecutableCriteria(session).List();
 
-				Assert.That(sessions.Statistics.QueryCacheMissCount, Is.EqualTo(1));
-				Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(1));
-				sessions.Statistics.IsStatisticsEnabled = false;
+				Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+				Sfi.Statistics.IsStatisticsEnabled = false;
 			}
 		}
 		

--- a/src/NHibernate.Test/Criteria/Lambda/IntegrationFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/IntegrationFixture.cs
@@ -340,7 +340,7 @@ namespace NHibernate.Test.Criteria.Lambda
 		[Test]
 		public void MultiCriteria()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (!driver.SupportsMultipleQueries)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 
@@ -418,7 +418,7 @@ namespace NHibernate.Test.Criteria.Lambda
 		public void StatelessSession()
 		{
 			int personId;
-			using (var ss = sessions.OpenStatelessSession())
+			using (var ss = Sfi.OpenStatelessSession())
 			using (var t = ss.BeginTransaction())
 			{
 				var person = new Person { Name = "test1" };
@@ -427,7 +427,7 @@ namespace NHibernate.Test.Criteria.Lambda
 				t.Commit();
 			}
 
-			using (var ss = sessions.OpenStatelessSession())
+			using (var ss = Sfi.OpenStatelessSession())
 			using (ss.BeginTransaction())
 			{
 				var statelessPerson1 = ss.QueryOver<Person>()

--- a/src/NHibernate.Test/Criteria/ProjectionsTest.cs
+++ b/src/NHibernate.Test/Criteria/ProjectionsTest.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Test.Criteria
 
 		protected override void OnTearDown()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				session.Delete("from System.Object");
 				session.Flush();
@@ -54,7 +54,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UsingSqlFunctions_Concat()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				string result = session.CreateCriteria(typeof(Student))
 					.SetProjection(new SqlFunctionProjection("concat",
@@ -75,7 +75,7 @@ namespace NHibernate.Test.Criteria
 			{
 				Assert.Ignore("Not supported by the active dialect:{0}.", Dialect);
 			}
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				string result = session.CreateCriteria(typeof(Student))
 					.SetProjection(Projections.SqlFunction("concat",
@@ -92,7 +92,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void CanUseParametersWithProjections()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				long result = session.CreateCriteria(typeof(Student))
 					.SetProjection(new AddNumberProjection("id", 15))
@@ -104,7 +104,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UsingConditionals()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				string result = session.CreateCriteria(typeof(Student))
 					.SetProjection(
@@ -132,7 +132,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseInWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.In(Projections.Id(), new object[] { 27 }))
@@ -145,7 +145,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseLikeWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Like(Projections.Property("Name"), "aye", MatchMode.Start))
@@ -157,7 +157,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseInsensitiveLikeWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.InsensitiveLike(Projections.Property("Name"), "AYE", MatchMode.Start))
@@ -169,7 +169,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseIdEqWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.IdEq(Projections.Id()))
@@ -181,7 +181,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseEqWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Eq(Projections.Id(), 27L))
@@ -194,7 +194,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseGtWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Gt(Projections.Id(), 2L))
@@ -206,7 +206,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseLtWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Lt(Projections.Id(), 200L))
@@ -218,7 +218,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseLeWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Le(Projections.Id(), 27L))
@@ -230,7 +230,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseGeWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Ge(Projections.Id(), 27L))
@@ -242,7 +242,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseBetweenWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.Between(Projections.Id(), 10L, 28L))
@@ -254,7 +254,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseIsNullWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.IsNull(Projections.Id()))
@@ -266,7 +266,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseIsNotNullWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.IsNotNull(Projections.Id()))
@@ -278,7 +278,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseEqPropertyWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.EqProperty(Projections.Id(), Projections.Id()))
@@ -290,7 +290,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseGePropertyWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.GeProperty(Projections.Id(), Projections.Id()))
@@ -302,7 +302,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseGtPropertyWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.GtProperty(Projections.Id(), Projections.Id()))
@@ -314,7 +314,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseLtPropertyWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.LtProperty(Projections.Id(), Projections.Id()))
@@ -326,7 +326,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseLePropertyWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.LeProperty(Projections.Id(), Projections.Id()))
@@ -338,7 +338,7 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void UseNotEqPropertyWithProjection()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				IList<Student> list = session.CreateCriteria(typeof(Student))
 					.Add(Expression.NotEqProperty("id", Projections.Id()))

--- a/src/NHibernate.Test/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/DebugSessionFactory.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using log4net;
+using NHibernate.Cache;
+using NHibernate.Cfg;
+using NHibernate.Connection;
+using NHibernate.Context;
+using NHibernate.Dialect.Function;
+using NHibernate.Engine;
+using NHibernate.Engine.Query;
+using NHibernate.Event;
+using NHibernate.Exceptions;
+using NHibernate.Id;
+using NHibernate.Impl;
+using NHibernate.Metadata;
+using NHibernate.Persister.Collection;
+using NHibernate.Persister.Entity;
+using NHibernate.Proxy;
+using NHibernate.Stat;
+using NHibernate.Transaction;
+using NHibernate.Type;
+
+namespace NHibernate.Test
+{
+	/// <summary>
+	/// This session factory keeps a list of all opened sessions,
+	/// it is used when testing to check that tests clean up after themselves.
+	/// </summary>
+	/// <remarks>Sessions opened from other sessions are not tracked.</remarks>
+	public class DebugSessionFactory : ISessionFactoryImplementor
+	{
+		public DebugConnectionProvider ConnectionProvider { get; }
+		public ISessionFactoryImplementor ActualFactory { get; }
+
+		public EventListeners EventListeners => ((SessionFactoryImpl)ActualFactory).EventListeners;
+
+		private readonly ConcurrentBag<ISessionImplementor> _openedSessions = new ConcurrentBag<ISessionImplementor>();
+		private static readonly ILog _log = LogManager.GetLogger(typeof(DebugSessionFactory).Assembly, typeof(TestCase));
+
+		public DebugSessionFactory(ISessionFactory actualFactory)
+		{
+			ActualFactory = (ISessionFactoryImplementor)actualFactory;
+			ConnectionProvider = (DebugConnectionProvider)ActualFactory.ConnectionProvider;
+		}
+
+		#region Session tracking
+
+		public bool CheckSessionsWereClosed()
+		{
+			var allClosed = true;
+			foreach (var session in _openedSessions)
+			{
+				if (session.IsOpen)
+				{
+					if (session.TransactionContext?.ShouldCloseSessionOnDistributedTransactionCompleted ?? false)
+					{
+						// Delayed transactions not having completed and closed their sessions? Give them a chance to complete.
+						Thread.Sleep(100);
+						if (!session.IsOpen)
+						{
+							_log.Warn($"Test case had a delayed close of session {session.SessionId}.");
+							continue;
+						}
+					}
+
+					_log.Error($"Test case didn't close session {session.SessionId}, closing");
+					allClosed = false;
+					(session as ISession)?.Close();
+					(session as IStatelessSession)?.Close();
+				}
+			}
+
+			return allClosed;
+		}
+
+		ISessionBuilder ISessionFactory.WithOptions()
+		{
+			return new SessionBuilder(ActualFactory.WithOptions(), this);
+		}
+
+		ISession ISessionFactory.OpenSession(DbConnection connection)
+		{
+#pragma warning disable CS0618 // Type or member is obsolete
+			var s = ActualFactory.OpenSession(connection);
+#pragma warning restore CS0618 // Type or member is obsolete
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		ISession ISessionFactory.OpenSession(IInterceptor sessionLocalInterceptor)
+		{
+#pragma warning disable CS0618 // Type or member is obsolete
+			var s = ActualFactory.OpenSession(sessionLocalInterceptor);
+#pragma warning restore CS0618 // Type or member is obsolete
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		ISession ISessionFactory.OpenSession(DbConnection conn, IInterceptor sessionLocalInterceptor)
+		{
+#pragma warning disable CS0618 // Type or member is obsolete
+			var s = ActualFactory.OpenSession(conn, sessionLocalInterceptor);
+#pragma warning restore CS0618 // Type or member is obsolete
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		ISession ISessionFactory.OpenSession()
+		{
+			var s = ActualFactory.OpenSession();
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		IStatelessSessionBuilder ISessionFactory.WithStatelessOptions()
+		{
+			return new StatelessSessionBuilder(ActualFactory.WithStatelessOptions(), this);
+		}
+
+		IStatelessSession ISessionFactory.OpenStatelessSession()
+		{
+			var s = ActualFactory.OpenStatelessSession();
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		IStatelessSession ISessionFactory.OpenStatelessSession(DbConnection connection)
+		{
+			var s = ActualFactory.OpenStatelessSession(connection);
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		ISession ISessionFactoryImplementor.OpenSession(
+			DbConnection connection,
+			bool flushBeforeCompletionEnabled,
+			bool autoCloseSessionEnabled,
+			ConnectionReleaseMode connectionReleaseMode)
+		{
+			var s = ActualFactory.OpenSession(connection, flushBeforeCompletionEnabled, autoCloseSessionEnabled, connectionReleaseMode);
+			_openedSessions.Add(s.GetSessionImplementation());
+			return s;
+		}
+
+		#endregion
+
+		#region Delegated calls without any changes
+
+		IType IMapping.GetIdentifierType(string className)
+		{
+			return ActualFactory.GetIdentifierType(className);
+		}
+
+		string IMapping.GetIdentifierPropertyName(string className)
+		{
+			return ActualFactory.GetIdentifierPropertyName(className);
+		}
+
+		IType IMapping.GetReferencedPropertyType(string className, string propertyName)
+		{
+			return ActualFactory.GetReferencedPropertyType(className, propertyName);
+		}
+
+		bool IMapping.HasNonIdentifierPropertyNamedId(string className)
+		{
+			return ActualFactory.HasNonIdentifierPropertyNamedId(className);
+		}
+
+		void IDisposable.Dispose()
+		{
+			ActualFactory.Dispose();
+		}
+
+		IClassMetadata ISessionFactory.GetClassMetadata(System.Type persistentClass)
+		{
+			return ActualFactory.GetClassMetadata(persistentClass);
+		}
+
+		IClassMetadata ISessionFactory.GetClassMetadata(string entityName)
+		{
+			return ActualFactory.GetClassMetadata(entityName);
+		}
+
+		ICollectionMetadata ISessionFactory.GetCollectionMetadata(string roleName)
+		{
+			return ActualFactory.GetCollectionMetadata(roleName);
+		}
+
+		IDictionary<string, IClassMetadata> ISessionFactory.GetAllClassMetadata()
+		{
+			return ActualFactory.GetAllClassMetadata();
+		}
+
+		IDictionary<string, ICollectionMetadata> ISessionFactory.GetAllCollectionMetadata()
+		{
+			return ActualFactory.GetAllCollectionMetadata();
+		}
+
+		void ISessionFactory.Close()
+		{
+			ActualFactory.Close();
+		}
+
+		void ISessionFactory.Evict(System.Type persistentClass)
+		{
+			ActualFactory.Evict(persistentClass);
+		}
+
+		void ISessionFactory.Evict(System.Type persistentClass, object id)
+		{
+			ActualFactory.Evict(persistentClass, id);
+		}
+
+		void ISessionFactory.EvictEntity(string entityName)
+		{
+			ActualFactory.EvictEntity(entityName);
+		}
+
+		void ISessionFactory.EvictEntity(string entityName, object id)
+		{
+			ActualFactory.EvictEntity(entityName, id);
+		}
+
+		void ISessionFactory.EvictCollection(string roleName)
+		{
+			ActualFactory.EvictCollection(roleName);
+		}
+
+		void ISessionFactory.EvictCollection(string roleName, object id)
+		{
+			ActualFactory.EvictCollection(roleName, id);
+		}
+
+		void ISessionFactory.EvictQueries()
+		{
+			ActualFactory.EvictQueries();
+		}
+
+		void ISessionFactory.EvictQueries(string cacheRegion)
+		{
+			ActualFactory.EvictQueries(cacheRegion);
+		}
+
+		FilterDefinition ISessionFactory.GetFilterDefinition(string filterName)
+		{
+			return ActualFactory.GetFilterDefinition(filterName);
+		}
+
+		ISession ISessionFactory.GetCurrentSession()
+		{
+			return ActualFactory.GetCurrentSession();
+		}
+
+		IStatistics ISessionFactory.Statistics => ActualFactory.Statistics;
+
+		bool ISessionFactory.IsClosed => ActualFactory.IsClosed;
+
+		ICollection<string> ISessionFactory.DefinedFilterNames => ActualFactory.DefinedFilterNames;
+
+		Dialect.Dialect ISessionFactoryImplementor.Dialect => ActualFactory.Dialect;
+
+		IInterceptor ISessionFactoryImplementor.Interceptor => ActualFactory.Interceptor;
+
+		QueryPlanCache ISessionFactoryImplementor.QueryPlanCache => ActualFactory.QueryPlanCache;
+
+		IConnectionProvider ISessionFactoryImplementor.ConnectionProvider => ActualFactory.ConnectionProvider;
+
+		ITransactionFactory ISessionFactoryImplementor.TransactionFactory => ActualFactory.TransactionFactory;
+
+		UpdateTimestampsCache ISessionFactoryImplementor.UpdateTimestampsCache => ActualFactory.UpdateTimestampsCache;
+
+		IStatisticsImplementor ISessionFactoryImplementor.StatisticsImplementor => ActualFactory.StatisticsImplementor;
+
+		ISQLExceptionConverter ISessionFactoryImplementor.SQLExceptionConverter => ActualFactory.SQLExceptionConverter;
+
+		Settings ISessionFactoryImplementor.Settings => ActualFactory.Settings;
+
+		IEntityNotFoundDelegate ISessionFactoryImplementor.EntityNotFoundDelegate => ActualFactory.EntityNotFoundDelegate;
+
+		SQLFunctionRegistry ISessionFactoryImplementor.SQLFunctionRegistry => ActualFactory.SQLFunctionRegistry;
+
+		IDictionary<string, ICache> ISessionFactoryImplementor.GetAllSecondLevelCacheRegions()
+		{
+			return ActualFactory.GetAllSecondLevelCacheRegions();
+		}
+
+		IEntityPersister ISessionFactoryImplementor.GetEntityPersister(string entityName)
+		{
+			return ActualFactory.GetEntityPersister(entityName);
+		}
+
+		ICollectionPersister ISessionFactoryImplementor.GetCollectionPersister(string role)
+		{
+			return ActualFactory.GetCollectionPersister(role);
+		}
+
+		IType[] ISessionFactoryImplementor.GetReturnTypes(string queryString)
+		{
+			return ActualFactory.GetReturnTypes(queryString);
+		}
+
+		string[] ISessionFactoryImplementor.GetReturnAliases(string queryString)
+		{
+			return ActualFactory.GetReturnAliases(queryString);
+		}
+
+		string[] ISessionFactoryImplementor.GetImplementors(string entityOrClassName)
+		{
+			return ActualFactory.GetImplementors(entityOrClassName);
+		}
+
+		string ISessionFactoryImplementor.GetImportedClassName(string name)
+		{
+			return ActualFactory.GetImportedClassName(name);
+		}
+
+		IQueryCache ISessionFactoryImplementor.QueryCache => ActualFactory.QueryCache;
+
+		IQueryCache ISessionFactoryImplementor.GetQueryCache(string regionName)
+		{
+			return ActualFactory.GetQueryCache(regionName);
+		}
+
+		NamedQueryDefinition ISessionFactoryImplementor.GetNamedQuery(string queryName)
+		{
+			return ActualFactory.GetNamedQuery(queryName);
+		}
+
+		NamedSQLQueryDefinition ISessionFactoryImplementor.GetNamedSQLQuery(string queryName)
+		{
+			return ActualFactory.GetNamedSQLQuery(queryName);
+		}
+
+		ResultSetMappingDefinition ISessionFactoryImplementor.GetResultSetMapping(string resultSetRef)
+		{
+			return ActualFactory.GetResultSetMapping(resultSetRef);
+		}
+
+		IIdentifierGenerator ISessionFactoryImplementor.GetIdentifierGenerator(string rootEntityName)
+		{
+			return ActualFactory.GetIdentifierGenerator(rootEntityName);
+		}
+
+		ICache ISessionFactoryImplementor.GetSecondLevelCacheRegion(string regionName)
+		{
+			return ActualFactory.GetSecondLevelCacheRegion(regionName);
+		}
+
+		ISet<string> ISessionFactoryImplementor.GetCollectionRolesByEntityParticipant(string entityName)
+		{
+			return ActualFactory.GetCollectionRolesByEntityParticipant(entityName);
+		}
+
+		ICurrentSessionContext ISessionFactoryImplementor.CurrentSessionContext => ActualFactory.CurrentSessionContext;
+
+		IEntityPersister ISessionFactoryImplementor.TryGetEntityPersister(string entityName)
+		{
+			return ActualFactory.TryGetEntityPersister(entityName);
+		}
+
+		string ISessionFactoryImplementor.TryGetGuessEntityName(System.Type implementor)
+		{
+			return ActualFactory.TryGetGuessEntityName(implementor);
+		}
+
+		#endregion
+
+		public static ISessionCreationOptions GetCreationOptions<T>(ISessionBuilder<T> sessionBuilder) where T : ISessionBuilder<T>
+		{
+			return (sessionBuilder as SessionBuilder)?.CreationOptions ??
+				(ISessionCreationOptions)sessionBuilder;
+		}
+
+		public static ISessionCreationOptions GetCreationOptions(IStatelessSessionBuilder sessionBuilder)
+		{
+			return ((StatelessSessionBuilder)sessionBuilder).CreationOptions;
+		}
+
+		internal class SessionBuilder : ISessionBuilder
+		{
+			private readonly ISessionBuilder _actualBuilder;
+			private readonly DebugSessionFactory _debugFactory;
+
+			internal ISessionCreationOptions CreationOptions => (ISessionCreationOptions)_actualBuilder;
+
+			public SessionBuilder(ISessionBuilder actualBuilder, DebugSessionFactory debugFactory)
+			{
+				_actualBuilder = actualBuilder;
+				_debugFactory = debugFactory;
+			}
+
+			ISession ISessionBuilder<ISessionBuilder>.OpenSession()
+			{
+				var s = _actualBuilder.OpenSession();
+				_debugFactory._openedSessions.Add(s.GetSessionImplementation());
+				return s;
+			}
+
+			#region Delegated calls without any changes
+
+			ISessionBuilder ISessionBuilder<ISessionBuilder>.Interceptor(IInterceptor interceptor)
+			{
+				_actualBuilder.Interceptor(interceptor);
+				return this;
+			}
+
+			ISessionBuilder ISessionBuilder<ISessionBuilder>.NoInterceptor()
+			{
+				_actualBuilder.NoInterceptor();
+				return this;
+			}
+
+			ISessionBuilder ISessionBuilder<ISessionBuilder>.Connection(DbConnection connection)
+			{
+				_actualBuilder.Connection(connection);
+				return this;
+			}
+
+			ISessionBuilder ISessionBuilder<ISessionBuilder>.ConnectionReleaseMode(ConnectionReleaseMode connectionReleaseMode)
+			{
+				_actualBuilder.ConnectionReleaseMode(connectionReleaseMode);
+				return this;
+			}
+
+			ISessionBuilder ISessionBuilder<ISessionBuilder>.AutoClose(bool autoClose)
+			{
+				_actualBuilder.AutoClose(autoClose);
+				return this;
+			}
+
+			ISessionBuilder ISessionBuilder<ISessionBuilder>.FlushMode(FlushMode flushMode)
+			{
+				_actualBuilder.FlushMode(flushMode);
+				return this;
+			}
+
+			#endregion
+		}
+
+		internal class StatelessSessionBuilder : IStatelessSessionBuilder
+		{
+			private readonly IStatelessSessionBuilder _actualBuilder;
+			private readonly DebugSessionFactory _debugFactory;
+
+			internal ISessionCreationOptions CreationOptions => (ISessionCreationOptions)_actualBuilder;
+
+			public StatelessSessionBuilder(IStatelessSessionBuilder actualBuilder, DebugSessionFactory debugFactory)
+			{
+				_actualBuilder = actualBuilder;
+				_debugFactory = debugFactory;
+			}
+
+			IStatelessSession IStatelessSessionBuilder.OpenStatelessSession()
+			{
+				var s = _actualBuilder.OpenStatelessSession();
+				_debugFactory._openedSessions.Add(s.GetSessionImplementation());
+				return s;
+			}
+
+			#region Delegated calls without any changes
+
+			IStatelessSessionBuilder IStatelessSessionBuilder.Connection(DbConnection connection)
+			{
+				_actualBuilder.Connection(connection);
+				return this;
+			}
+
+			#endregion
+		}
+	}
+}

--- a/src/NHibernate.Test/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/DebugSessionFactory.cs
@@ -43,7 +43,7 @@ namespace NHibernate.Test
 		public DebugSessionFactory(ISessionFactory actualFactory)
 		{
 			ActualFactory = (ISessionFactoryImplementor)actualFactory;
-			ConnectionProvider = (DebugConnectionProvider)ActualFactory.ConnectionProvider;
+			ConnectionProvider = ActualFactory.ConnectionProvider as DebugConnectionProvider;
 		}
 
 		#region Session tracking

--- a/src/NHibernate.Test/DriverTest/SqlClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/SqlClientDriverFixture.cs
@@ -90,7 +90,7 @@ namespace NHibernate.Test.DriverTest
 		[Test]
 		public void QueryPlansAreReused()
 		{
-			if (!(sessions.ConnectionProvider.Driver is SqlClientDriver))
+			if (!(Sfi.ConnectionProvider.Driver is SqlClientDriver))
 				Assert.Ignore("Test designed for SqlClientDriver only");
 
 			using (ISession s = OpenSession())

--- a/src/NHibernate.Test/Events/Collections/AbstractCollectionEventFixture.cs
+++ b/src/NHibernate.Test/Events/Collections/AbstractCollectionEventFixture.cs
@@ -50,7 +50,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void SaveParentEmptyChildren()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNoChildren("parent");
 			Assert.That(parent.Children.Count, Is.EqualTo(0));
 			int index = 0;
@@ -73,7 +73,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public virtual void SaveParentOneChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			int index = 0;
 			CheckResult(listeners, listeners.PreCollectionRecreate, parent, index++);
@@ -91,7 +91,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentNullToOneChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNullChildren("parent");
 			listeners.Clear();
 			Assert.That(parent.Children, Is.Null);
@@ -121,7 +121,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentNoneToOneChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNoChildren("parent");
 			listeners.Clear();
 			Assert.That(parent.Children.Count, Is.EqualTo(0));
@@ -150,7 +150,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentOneToTwoChildren()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			Assert.That(parent.Children.Count, Is.EqualTo(1));
 			listeners.Clear();
@@ -179,7 +179,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public virtual void UpdateParentOneToTwoSameChildren()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IChild child = GetFirstChild(parent.Children);
 			Assert.That(parent.Children.Count, Is.EqualTo(1));
@@ -227,7 +227,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentNullToOneChildDiffCollection()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNullChildren("parent");
 			listeners.Clear();
 			Assert.That(parent.Children, Is.Null);
@@ -259,7 +259,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentNoneToOneChildDiffCollection()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNoChildren("parent");
 			listeners.Clear();
 			Assert.That(parent.Children.Count, Is.EqualTo(0));
@@ -292,7 +292,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentOneChildDiffCollectionSameChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IChild child = GetFirstChild(parent.Children);
 			listeners.Clear();
@@ -341,7 +341,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentOneChildDiffCollectionDiffChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IChild oldChild = GetFirstChild(parent.Children);
 			listeners.Clear();
@@ -389,7 +389,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentOneChildToNoneByRemove()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			Assert.That(parent.Children.Count, Is.EqualTo(1));
 			IChild child = GetFirstChild(parent.Children);
@@ -432,7 +432,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentOneChildToNoneByClear()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			Assert.That(parent.Children.Count, Is.EqualTo(1));
 			IChild child = GetFirstChild(parent.Children);
@@ -474,7 +474,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void UpdateParentTwoChildrenToOne()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			Assert.That(parent.Children.Count, Is.EqualTo(1));
 			IChild oldChild = GetFirstChild(parent.Children);
@@ -525,7 +525,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void DeleteParentWithNullChildren()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNullChildren("parent");
 			listeners.Clear();
 			ISession s = OpenSession();
@@ -544,7 +544,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void DeleteParentWithNoChildren()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithNoChildren("parent");
 			listeners.Clear();
 			ISession s = OpenSession();
@@ -564,7 +564,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void DeleteParentAndChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IChild child = GetFirstChild(parent.Children);
 			listeners.Clear();
@@ -604,7 +604,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void MoveChildToDifferentParent()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IParentWithCollection otherParent = CreateParentWithOneChild("otherParent", "otherChild");
 			IChild child = GetFirstChild(parent.Children);
@@ -651,7 +651,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void MoveAllChildrenToDifferentParent()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IParentWithCollection otherParent = CreateParentWithOneChild("otherParent", "otherChild");
 			IChild child = GetFirstChild(parent.Children);
@@ -698,7 +698,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void MoveCollectionToDifferentParent()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IParentWithCollection otherParent = CreateParentWithOneChild("otherParent", "otherChild");
 			listeners.Clear();
@@ -749,7 +749,7 @@ namespace NHibernate.Test.Events.Collections
 		[Test]
 		public void MoveCollectionToDifferentParentFlushMoveToDifferentParent()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			IParentWithCollection otherParent = CreateParentWithOneChild("otherParent", "otherChild");
 			IParentWithCollection otherOtherParent = CreateParentWithNoChildren("otherParent");

--- a/src/NHibernate.Test/Events/Collections/Association/AbstractAssociationCollectionEventFixture.cs
+++ b/src/NHibernate.Test/Events/Collections/Association/AbstractAssociationCollectionEventFixture.cs
@@ -8,7 +8,7 @@ namespace NHibernate.Test.Events.Collections.Association
 		[Test]
 		public void DeleteParentButNotChild()
 		{
-			CollectionListeners listeners = new CollectionListeners(sessions);
+			CollectionListeners listeners = new CollectionListeners(Sfi);
 			IParentWithCollection parent = CreateParentWithOneChild("parent", "child");
 			ChildEntity child = (ChildEntity) GetFirstChild(parent.Children);
 			listeners.Clear();

--- a/src/NHibernate.Test/Events/Collections/CollectionListeners.cs
+++ b/src/NHibernate.Test/Events/Collections/CollectionListeners.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Event;
 using NHibernate.Event.Default;
-using NHibernate.Impl;
 
 namespace NHibernate.Test.Events.Collections
 {
@@ -28,22 +27,21 @@ namespace NHibernate.Test.Events.Collections
 			postCollectionRecreateListener = new PostCollectionRecreateListener(this);
 			postCollectionRemoveListener = new PostCollectionRemoveListener(this);
 			postCollectionUpdateListener = new PostCollectionUpdateListener(this);
-			SessionFactoryImpl impl = (SessionFactoryImpl) sf;
-			impl.EventListeners.InitializeCollectionEventListeners = new IInitializeCollectionEventListener[]
-			                                                         	{initializeCollectionListener};
-
-			impl.EventListeners.PreCollectionRecreateEventListeners = new IPreCollectionRecreateEventListener[]
-			                                                          	{preCollectionRecreateListener};
-			impl.EventListeners.PostCollectionRecreateEventListeners = new IPostCollectionRecreateEventListener[]
-			                                                           	{postCollectionRecreateListener};
-			impl.EventListeners.PreCollectionRemoveEventListeners = new IPreCollectionRemoveEventListener[]
-			                                                        	{preCollectionRemoveListener};
-			impl.EventListeners.PostCollectionRemoveEventListeners = new IPostCollectionRemoveEventListener[]
-			                                                         	{postCollectionRemoveListener};
-			impl.EventListeners.PreCollectionUpdateEventListeners = new IPreCollectionUpdateEventListener[]
-			                                                        	{preCollectionUpdateListener};
-			impl.EventListeners.PostCollectionUpdateEventListeners = new IPostCollectionUpdateEventListener[]
-			                                                         	{postCollectionUpdateListener};
+			var listeners = ((DebugSessionFactory)sf).EventListeners;
+			listeners.InitializeCollectionEventListeners =
+				new IInitializeCollectionEventListener[] { initializeCollectionListener };
+			listeners.PreCollectionRecreateEventListeners =
+				new IPreCollectionRecreateEventListener[] { preCollectionRecreateListener };
+			listeners.PostCollectionRecreateEventListeners =
+				new IPostCollectionRecreateEventListener[] { postCollectionRecreateListener };
+			listeners.PreCollectionRemoveEventListeners =
+				new IPreCollectionRemoveEventListener[] { preCollectionRemoveListener };
+			listeners.PostCollectionRemoveEventListeners =
+				new IPostCollectionRemoveEventListener[] { postCollectionRemoveListener };
+			listeners.PreCollectionUpdateEventListeners =
+				new IPreCollectionUpdateEventListener[] { preCollectionUpdateListener };
+			listeners.PostCollectionUpdateEventListeners =
+				new IPostCollectionUpdateEventListener[] { postCollectionUpdateListener };
 		}
 
 		public IList ListenersCalled
@@ -168,7 +166,7 @@ namespace NHibernate.Test.Events.Collections
 
 		public class PostCollectionRecreateListener : AbstractListener, IPostCollectionRecreateEventListener
 		{
-			public PostCollectionRecreateListener(CollectionListeners listeners) : base(listeners) {}
+			public PostCollectionRecreateListener(CollectionListeners listeners) : base(listeners) { }
 
 			#region IPostCollectionRecreateEventListener Members
 
@@ -186,7 +184,7 @@ namespace NHibernate.Test.Events.Collections
 
 		public class PostCollectionRemoveListener : AbstractListener, IPostCollectionRemoveEventListener
 		{
-			public PostCollectionRemoveListener(CollectionListeners listeners) : base(listeners) {}
+			public PostCollectionRemoveListener(CollectionListeners listeners) : base(listeners) { }
 
 			#region IPostCollectionRemoveEventListener Members
 
@@ -204,7 +202,7 @@ namespace NHibernate.Test.Events.Collections
 
 		public class PostCollectionUpdateListener : AbstractListener, IPostCollectionUpdateEventListener
 		{
-			public PostCollectionUpdateListener(CollectionListeners listeners) : base(listeners) {}
+			public PostCollectionUpdateListener(CollectionListeners listeners) : base(listeners) { }
 
 			#region IPostCollectionUpdateEventListener Members
 
@@ -222,7 +220,7 @@ namespace NHibernate.Test.Events.Collections
 
 		public class PreCollectionRecreateListener : AbstractListener, IPreCollectionRecreateEventListener
 		{
-			public PreCollectionRecreateListener(CollectionListeners listeners) : base(listeners) {}
+			public PreCollectionRecreateListener(CollectionListeners listeners) : base(listeners) { }
 
 			#region IPreCollectionRecreateEventListener Members
 
@@ -240,7 +238,7 @@ namespace NHibernate.Test.Events.Collections
 
 		public class PreCollectionRemoveListener : AbstractListener, IPreCollectionRemoveEventListener
 		{
-			public PreCollectionRemoveListener(CollectionListeners listeners) : base(listeners) {}
+			public PreCollectionRemoveListener(CollectionListeners listeners) : base(listeners) { }
 
 			#region IPreCollectionRemoveEventListener Members
 
@@ -258,7 +256,7 @@ namespace NHibernate.Test.Events.Collections
 
 		public class PreCollectionUpdateListener : AbstractListener, IPreCollectionUpdateEventListener
 		{
-			public PreCollectionUpdateListener(CollectionListeners listeners) : base(listeners) {}
+			public PreCollectionUpdateListener(CollectionListeners listeners) : base(listeners) { }
 
 			#region IPreCollectionUpdateEventListener Members
 

--- a/src/NHibernate.Test/Events/PostEvents/PostUpdateFixture.cs
+++ b/src/NHibernate.Test/Events/PostEvents/PostUpdateFixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.Events.PostEvents
 		[Test]
 		public void ImplicitFlush()
 		{
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
 			                                                                          	{
 			                                                                          		new AssertOldStatePostListener(
 			                                                                          			eArgs =>
@@ -44,13 +44,13 @@ namespace NHibernate.Test.Events.PostEvents
 			}
 
 			DbCleanup();
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
 		}
 
 		[Test]
 		public void ExplicitUpdate()
 		{
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
 			                                                                          	{
 			                                                                          		new AssertOldStatePostListener(
 			                                                                          			eArgs =>
@@ -73,13 +73,13 @@ namespace NHibernate.Test.Events.PostEvents
 			}
 
 			DbCleanup();
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
 		}
 
 		[Test]
 		public void WithDetachedObject()
 		{
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
 			                                                                          	{
 			                                                                          		new AssertOldStatePostListener(
 			                                                                          			eArgs =>
@@ -111,7 +111,7 @@ namespace NHibernate.Test.Events.PostEvents
 			}
 
 			DbCleanup();
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
 		}
 
 		[Test]
@@ -119,7 +119,7 @@ namespace NHibernate.Test.Events.PostEvents
 		{
 			// When the update is used directly as method to reattach a entity the OldState is null
 			// that mean that NH should not retrieve info from DB
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
 			                                                                          	{
 			                                                                          		new AssertOldStatePostListener(
 			                                                                          			eArgs =>
@@ -151,13 +151,13 @@ namespace NHibernate.Test.Events.PostEvents
 			}
 
 			DbCleanup();
-			((SessionFactoryImpl) sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
+			((DebugSessionFactory) Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
 		}
 
 		[Test]
 		public void UpdateDetachedObjectWithLock()
 		{
-			((SessionFactoryImpl)sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
+			((DebugSessionFactory)Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[]
 			                                                                          	{
 			                                                                          		new AssertOldStatePostListener(
 			                                                                          			eArgs =>
@@ -190,7 +190,7 @@ namespace NHibernate.Test.Events.PostEvents
 			}
 
 			DbCleanup();
-			((SessionFactoryImpl)sessions).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
+			((DebugSessionFactory)Sfi).EventListeners.PostUpdateEventListeners = new IPostUpdateEventListener[0];
 		}
 		private void DbCleanup()
 		{

--- a/src/NHibernate.Test/ExceptionsTest/NullQueryTest.cs
+++ b/src/NHibernate.Test/ExceptionsTest/NullQueryTest.cs
@@ -36,7 +36,7 @@ namespace NHibernate.Test.ExceptionsTest
 			catch (Exception sqle)
 			{
 				Assert.DoesNotThrow(
-					() => ADOExceptionHelper.Convert(sessions.SQLExceptionConverter, sqle, "could not get or update next value", null));
+					() => ADOExceptionHelper.Convert(Sfi.SQLExceptionConverter, sqle, "could not get or update next value", null));
 			}
 			finally
 			{

--- a/src/NHibernate.Test/ExceptionsTest/SQLExceptionConversionTest.cs
+++ b/src/NHibernate.Test/ExceptionsTest/SQLExceptionConversionTest.cs
@@ -71,7 +71,7 @@ namespace NHibernate.Test.ExceptionsTest
 		{
 
 			//ISQLExceptionConverter converter = Dialect.BuildSQLExceptionConverter();
-			ISQLExceptionConverter converter = sessions.Settings.SqlExceptionConverter;
+			ISQLExceptionConverter converter = Sfi.Settings.SqlExceptionConverter;
 
 			ISession session = OpenSession();
 			session.BeginTransaction();
@@ -134,7 +134,7 @@ namespace NHibernate.Test.ExceptionsTest
 		public void BadGrammar()
 		{
 			//ISQLExceptionConverter converter = Dialect.BuildSQLExceptionConverter();
-			ISQLExceptionConverter converter = sessions.Settings.SqlExceptionConverter;
+			ISQLExceptionConverter converter = Sfi.Settings.SqlExceptionConverter;
 
 			ISession session = OpenSession();
 			var connection = session.Connection;

--- a/src/NHibernate.Test/ExpressionTest/Projection/ProjectionSqlFixture.cs
+++ b/src/NHibernate.Test/ExpressionTest/Projection/ProjectionSqlFixture.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Test.ExpressionTest.Projection
 
         protected override void OnTearDown()
         {
-            using (ISession s = sessions.OpenSession())
+            using (ISession s = Sfi.OpenSession())
             {
                 s.Delete("from ProjectionTestClass");
                 s.Flush();

--- a/src/NHibernate.Test/ExpressionTest/SubQueries/SubQueriesSqlFixture.cs
+++ b/src/NHibernate.Test/ExpressionTest/SubQueries/SubQueriesSqlFixture.cs
@@ -59,7 +59,7 @@ namespace NHibernate.Test.ExpressionTest.SubQueries
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from Comment");
 				s.Delete("from Post");
@@ -78,7 +78,7 @@ namespace NHibernate.Test.ExpressionTest.SubQueries
 				.Add(Expression.Eq("id", post1.PostId))
 				.Add(Property.ForName("posts.Blog.id").EqProperty("blog.id"));
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				IList list = s.CreateCriteria(typeof(Blog), "blog")
 					.Add(Subqueries.Exists(dc))

--- a/src/NHibernate.Test/Extralazy/ExtraLazyFixture.cs
+++ b/src/NHibernate.Test/Extralazy/ExtraLazyFixture.cs
@@ -54,8 +54,8 @@ namespace NHibernate.Test.Extralazy
 
 				t.Commit();
 			}
-			sessions.Evict(typeof (User));
-			sessions.Evict(typeof (Photo));
+			Sfi.Evict(typeof (User));
+			Sfi.Evict(typeof (Photo));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
+++ b/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
@@ -29,11 +29,11 @@ namespace NHibernate.Test.FilterTest
 			// Force a collection into the second level cache, with its non-filtered elements
 			Salesperson sp = (Salesperson) session.Load(typeof(Salesperson), testData.steveId);
 			NHibernateUtil.Initialize(sp.Orders);
-			ICollectionPersister persister = ((ISessionFactoryImplementor) sessions)
+			ICollectionPersister persister = ((ISessionFactoryImplementor) Sfi)
 				.GetCollectionPersister(typeof(Salesperson).FullName + ".Orders");
 			Assert.IsTrue(persister.HasCache, "No cache for collection");
 			CacheKey cacheKey =
-				new CacheKey(testData.steveId, persister.KeyType, persister.Role, (ISessionFactoryImplementor) sessions);
+				new CacheKey(testData.steveId, persister.KeyType, persister.Role, (ISessionFactoryImplementor) Sfi);
 			CollectionCacheEntry cachedData = (CollectionCacheEntry)persister.Cache.Cache.Get(cacheKey);
 			Assert.IsNotNull(cachedData, "collection was not in cache");
 

--- a/src/NHibernate.Test/GenericTest/BagGeneric/BagGenericFixture.cs
+++ b/src/NHibernate.Test/GenericTest/BagGeneric/BagGenericFixture.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.GenericTest.BagGeneric
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/GenericTest/IdBagGeneric/IdBagGenericFixture.cs
+++ b/src/NHibernate.Test/GenericTest/IdBagGeneric/IdBagGenericFixture.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.GenericTest.IdBagGeneric
 
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from A" );
 				s.Flush();

--- a/src/NHibernate.Test/GenericTest/ListGeneric/ListGenericFixture.cs
+++ b/src/NHibernate.Test/GenericTest/ListGeneric/ListGenericFixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.GenericTest.ListGeneric
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/GenericTest/MapGeneric/MapGenericFixture.cs
+++ b/src/NHibernate.Test/GenericTest/MapGeneric/MapGenericFixture.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Test.GenericTest.MapGeneric
 
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from A" );
 				s.Flush();
@@ -206,7 +206,7 @@ namespace NHibernate.Test.GenericTest.MapGeneric
 			{
 				a = s.Load<A>( a.Id );
 
-				ISessionFactoryImplementor si = (ISessionFactoryImplementor)sessions;
+				ISessionFactoryImplementor si = (ISessionFactoryImplementor)Sfi;
 				ICollectionPersister cpSortedList = si.GetCollectionPersister(typeof(A).FullName + ".SortedList");
 				ICollectionPersister cpSortedDictionary = si.GetCollectionPersister(typeof(A).FullName + ".SortedDictionary");
 

--- a/src/NHibernate.Test/GenericTest/SetGeneric/SetGenericFixture.cs
+++ b/src/NHibernate.Test/GenericTest/SetGeneric/SetGenericFixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.GenericTest.SetGeneric
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/GhostProperty/GhostPropertyFixture.cs
+++ b/src/NHibernate.Test/GhostProperty/GhostPropertyFixture.cs
@@ -57,12 +57,13 @@ namespace NHibernate.Test.GhostProperty
 			}
 		}
 
-		protected override void BuildSessionFactory()
+		protected override DebugSessionFactory BuildSessionFactory()
 		{
 			using (var logSpy = new LogSpy(typeof(EntityMetamodel)))
 			{
-				base.BuildSessionFactory();
+				var factory = base.BuildSessionFactory();
 				log = logSpy.GetWholeLog();
+				return factory;
 			}
 		}
 

--- a/src/NHibernate.Test/Hql/Ast/BaseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/BaseFixture.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Test.Hql.Ast
 
 		public string GetSql(string query, IDictionary<string, string> replacements)
 		{
-			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, sessions).Parse(), emptyfilters, sessions);
+			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, Sfi).Parse(), emptyfilters, Sfi);
 			qt.Compile(replacements, false);
 			return qt.SQLString;
 		}

--- a/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
+++ b/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
@@ -163,7 +163,7 @@ namespace NHibernate.Test.Hql.Ast
 		public void InsertWithGeneratedId()
 		{
 			// Make sure the env supports bulk inserts with generated ids...
-			IEntityPersister persister = sessions.GetEntityPersister(typeof (PettingZoo).FullName);
+			IEntityPersister persister = Sfi.GetEntityPersister(typeof (PettingZoo).FullName);
 			IIdentifierGenerator generator = persister.IdentifierGenerator;
 			if (!HqlSqlWalker.SupportsIdGenWithBulkInsertion(generator))
 			{
@@ -206,7 +206,7 @@ namespace NHibernate.Test.Hql.Ast
 		public void InsertWithGeneratedVersionAndId()
 		{
 			// Make sure the env supports bulk inserts with generated ids...
-			IEntityPersister persister = sessions.GetEntityPersister(typeof (IntegerVersioned).FullName);
+			IEntityPersister persister = Sfi.GetEntityPersister(typeof (IntegerVersioned).FullName);
 			IIdentifierGenerator generator = persister.IdentifierGenerator;
 			if (!HqlSqlWalker.SupportsIdGenWithBulkInsertion(generator))
 			{
@@ -257,7 +257,7 @@ namespace NHibernate.Test.Hql.Ast
 		public void InsertWithGeneratedTimestampVersion()
 		{
 			// Make sure the env supports bulk inserts with generated ids...
-			IEntityPersister persister = sessions.GetEntityPersister(typeof (TimestampVersioned).FullName);
+			IEntityPersister persister = Sfi.GetEntityPersister(typeof (TimestampVersioned).FullName);
 			IIdentifierGenerator generator = persister.IdentifierGenerator;
 			if (!HqlSqlWalker.SupportsIdGenWithBulkInsertion(generator))
 			{

--- a/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
@@ -15,7 +15,7 @@ namespace NHibernate.Test.Hql.Ast
 	{
 		protected HQLQueryPlan CreateQueryPlan(string hql, bool scalar)
 		{
-			return new QueryExpressionPlan(new StringQueryExpression(hql), scalar, new CollectionHelper.EmptyMapClass<string, IFilter>(), sessions);
+			return new QueryExpressionPlan(new StringQueryExpression(hql), scalar, new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
 		}
 
 		protected HQLQueryPlan CreateQueryPlan(string hql)

--- a/src/NHibernate.Test/IdGen/Enhanced/Forcedtable/BasicForcedTableSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Forcedtable/BasicForcedTableSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Forcedtable
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Forcedtable/HiLoForcedTableSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Forcedtable/HiLoForcedTableSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Forcedtable
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Forcedtable/PooledForcedTableSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Forcedtable/PooledForcedTableSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Forcedtable
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Sequence/BasicSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Sequence/BasicSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Sequence
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Sequence/DefaultOptimizedSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Sequence/DefaultOptimizedSequenceTest.cs
@@ -43,7 +43,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Sequence
 			// if an increment size greater than 1 is specified, and that the global
 			// property Cfg.Environment.PreferPooledValuesLo takes effect.
 
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Sequence/HiLoSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Sequence/HiLoSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Sequence
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Sequence/PooledSequenceTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Sequence/PooledSequenceTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Sequence
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<SequenceStyleGenerator>());
 
 			var generator = (SequenceStyleGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Table/BasicTableTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Table/BasicTableTest.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Table
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<TableGenerator>());
 
 			var generator = (TableGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Table/HiLoTableTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Table/HiLoTableTest.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Table
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<TableGenerator>());
 
 			var generator = (TableGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Table/PooledLoTableTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Table/PooledLoTableTest.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Table
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<TableGenerator>());
 
 			var generator = (TableGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/IdGen/Enhanced/Table/PooledTableTest.cs
+++ b/src/NHibernate.Test/IdGen/Enhanced/Table/PooledTableTest.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.IdGen.Enhanced.Table
 		[Test]
 		public void TestNormalBoundary()
 		{
-			var persister = sessions.GetEntityPersister(typeof(Entity).FullName);
+			var persister = Sfi.GetEntityPersister(typeof(Entity).FullName);
 			Assert.That(persister.IdentifierGenerator, Is.TypeOf<TableGenerator>());
 
 			var generator = (TableGenerator)persister.IdentifierGenerator;

--- a/src/NHibernate.Test/Immutable/EntityWithMutableCollection/AbstractEntityWithManyToManyTest.cs
+++ b/src/NHibernate.Test/Immutable/EntityWithMutableCollection/AbstractEntityWithManyToManyTest.cs
@@ -33,11 +33,11 @@ namespace NHibernate.Test.Immutable.EntityWithMutableCollection
 		{
 			base.OnSetUp();
 			
-			isPlanContractsInverse = sessions.GetCollectionPersister(typeof(Plan).FullName + ".Contracts").IsInverse;
+			isPlanContractsInverse = Sfi.GetCollectionPersister(typeof(Plan).FullName + ".Contracts").IsInverse;
 
 			try
 			{
-				sessions.GetCollectionPersister(typeof(Contract).FullName + ".Plans");
+				Sfi.GetCollectionPersister(typeof(Contract).FullName + ".Plans");
 				isPlanContractsBidirectional = true;
 			}
 			catch (MappingException)
@@ -45,8 +45,8 @@ namespace NHibernate.Test.Immutable.EntityWithMutableCollection
 				isPlanContractsBidirectional = false;
 			}
 
-			isPlanVersioned = sessions.GetEntityPersister(typeof(Plan).FullName).IsVersioned;
-			isContractVersioned = sessions.GetEntityPersister(typeof(Contract).FullName).IsVersioned;
+			isPlanVersioned = Sfi.GetEntityPersister(typeof(Plan).FullName).IsVersioned;
+			isContractVersioned = Sfi.GetEntityPersister(typeof(Contract).FullName).IsVersioned;
 		}
 		
 		[Test]

--- a/src/NHibernate.Test/Immutable/EntityWithMutableCollection/AbstractEntityWithOneToManyTest.cs
+++ b/src/NHibernate.Test/Immutable/EntityWithMutableCollection/AbstractEntityWithOneToManyTest.cs
@@ -41,10 +41,10 @@ namespace NHibernate.Test.Immutable.EntityWithMutableCollection
 	
 		protected override void OnSetUp()
 		{
-			isContractPartiesInverse = sessions.GetCollectionPersister(typeof(Contract).FullName + ".Parties").IsInverse;
+			isContractPartiesInverse = Sfi.GetCollectionPersister(typeof(Contract).FullName + ".Parties").IsInverse;
 			try
 			{
-				sessions.GetEntityPersister(typeof(Party).FullName).GetPropertyType("Contract");
+				Sfi.GetEntityPersister(typeof(Party).FullName).GetPropertyType("Contract");
 				isContractPartiesBidirectional = true;
 			}
 			catch (QueryException)
@@ -53,7 +53,7 @@ namespace NHibernate.Test.Immutable.EntityWithMutableCollection
 			}
 			try
 			{
-				sessions.GetEntityPersister(typeof(ContractVariation).FullName).GetPropertyType("Contract");
+				Sfi.GetEntityPersister(typeof(ContractVariation).FullName).GetPropertyType("Contract");
 				isContractVariationsBidirectional = true;
 			}
 			catch (QueryException)
@@ -61,7 +61,7 @@ namespace NHibernate.Test.Immutable.EntityWithMutableCollection
 				isContractVariationsBidirectional = false;
 			}
 	
-			isContractVersioned = sessions.GetEntityPersister(typeof(Contract).FullName).IsVersioned;
+			isContractVersioned = Sfi.GetEntityPersister(typeof(Contract).FullName).IsVersioned;
 		}
 		
 		[Test]

--- a/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
@@ -19,12 +19,13 @@ namespace NHibernate.Test.LazyProperty
 			get { return new[] { "LazyProperty.Mappings.hbm.xml" }; }
 		}
 
-		protected override void BuildSessionFactory()
+		protected override DebugSessionFactory BuildSessionFactory()
 		{
 			using (var logSpy = new LogSpy(typeof(EntityMetamodel)))
 			{
-				base.BuildSessionFactory();
+				var factory = base.BuildSessionFactory();
 				log = logSpy.GetWholeLog();
+				return factory;
 			}
 		}
 

--- a/src/NHibernate.Test/Legacy/ABCProxyTest.cs
+++ b/src/NHibernate.Test/Legacy/ABCProxyTest.cs
@@ -264,13 +264,9 @@ namespace NHibernate.Test.Legacy
 			s.Close();
 		}
 
-		[Test]
+		[Test, Ignore("ANTLR parser : Not supported ")]
 		public void OnoToOneComparing()
 		{
-			if (IsAntlrParser)
-			{
-				Assert.Ignore("ANTLR parser : Not supported ");
-			}
 			A a = new A();
 			E d1 = new E();
 			C1 c = new C1();

--- a/src/NHibernate.Test/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Legacy/FooBarTest.cs
@@ -266,7 +266,7 @@ namespace NHibernate.Test.Legacy
 				s.Flush();
 			}
 
-			sessions.EvictCollection("NHibernate.DomainModel.Baz.FooSet");
+			Sfi.EvictCollection("NHibernate.DomainModel.Baz.FooSet");
 
 			using (ISession s = OpenSession())
 			{
@@ -323,7 +323,7 @@ namespace NHibernate.Test.Legacy
 				s.Flush();
 			}
 
-			sessions.EvictCollection("NHibernate.DomainModel.Baz.FooSet");
+			Sfi.EvictCollection("NHibernate.DomainModel.Baz.FooSet");
 
 			using (ISession s = OpenSession())
 			{
@@ -1677,7 +1677,7 @@ namespace NHibernate.Test.Legacy
 		[Test]
 		public void ForceOuterJoin()
 		{
-			if (sessions.Settings.IsOuterJoinFetchEnabled == false)
+			if (Sfi.Settings.IsOuterJoinFetchEnabled == false)
 			{
 				// don't bother to run the test if we can't test it
 				return;
@@ -3554,7 +3554,7 @@ namespace NHibernate.Test.Legacy
 				txn.Commit();
 			}
 
-			sessions.Evict(typeof(Glarch));
+			Sfi.Evict(typeof(Glarch));
 
 			using (ISession s = OpenSession())
 			using (ITransaction txn = s.BeginTransaction())
@@ -3576,7 +3576,7 @@ namespace NHibernate.Test.Legacy
 				txn.Commit();
 			}
 
-			sessions.Evict(typeof(Glarch));
+			Sfi.Evict(typeof(Glarch));
 
 			using (ISession s = OpenSession())
 			using (ITransaction txn = s.BeginTransaction())
@@ -4979,7 +4979,7 @@ namespace NHibernate.Test.Legacy
 		{
 			using (var prov = ConnectionProviderFactory.NewConnectionProvider(cfg.Properties))
 			using (var connection = prov.GetConnection())
-			using (var s = sessions.WithOptions().Connection(connection).OpenSession())
+			using (var s = Sfi.WithOptions().Connection(connection).OpenSession())
 			{
 				using (var tx = s.BeginTransaction())
 				{
@@ -5374,7 +5374,7 @@ namespace NHibernate.Test.Legacy
 				|| (b2 == barprox && !(b1 is INHibernateProxy))); //one-to-many
 			Assert.IsTrue(baz.FooArray[0] is INHibernateProxy); //many-to-many
 			Assert.AreEqual(bar2prox, baz.FooArray[1]);
-			if (sessions.Settings.IsOuterJoinFetchEnabled)
+			if (Sfi.Settings.IsOuterJoinFetchEnabled)
 			{
 				enumer = baz.FooBag.GetEnumerator();
 				enumer.MoveNext();

--- a/src/NHibernate.Test/Legacy/FumTest.cs
+++ b/src/NHibernate.Test/Legacy/FumTest.cs
@@ -615,7 +615,7 @@ namespace NHibernate.Test.Legacy
 
 			// NOTE: H2.1 has getSessions().openSession() here (and below),
 			// instead of just the usual openSession()
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.FlushMode = FlushMode.Manual;
 
@@ -654,7 +654,7 @@ namespace NHibernate.Test.Legacy
 			///////////////////////////////////////////////////////////////////////////
 			// Test updates across serializations
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.FlushMode = FlushMode.Manual;
 				Simple simple = (Simple) s.Get(typeof(Simple), 10L);
@@ -677,7 +677,7 @@ namespace NHibernate.Test.Legacy
 
 			///////////////////////////////////////////////////////////////////////////
 			// Test deletions across serializations
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.FlushMode = FlushMode.Manual;
 				Simple simple = (Simple) s.Get(typeof(Simple), 10L);

--- a/src/NHibernate.Test/Legacy/MasterDetailTest.cs
+++ b/src/NHibernate.Test/Legacy/MasterDetailTest.cs
@@ -1199,7 +1199,7 @@ namespace NHibernate.Test.Legacy
 			s.Flush();
 			s.Close();
 
-			sessions.EvictCollection("NHibernate.DomainModel.Assignable.Categories");
+			Sfi.EvictCollection("NHibernate.DomainModel.Assignable.Categories");
 
 			s = OpenSession();
 			a = (Assignable) s.Get(typeof(Assignable), "foo");
@@ -1211,7 +1211,7 @@ namespace NHibernate.Test.Legacy
 			s.Flush();
 			s.Close();
 
-			sessions.EvictCollection("NHibernate.DomainModel.Assignable.Categories");
+			Sfi.EvictCollection("NHibernate.DomainModel.Assignable.Categories");
 
 			s = OpenSession();
 			a = (Assignable) s.Get(typeof(Assignable), "foo");
@@ -1224,7 +1224,7 @@ namespace NHibernate.Test.Legacy
 			Assert.AreEqual(3, a.Categories.Count);
 			s.Close();
 
-			sessions.EvictCollection("NHibernate.DomainModel.Assignable.Categories");
+			Sfi.EvictCollection("NHibernate.DomainModel.Assignable.Categories");
 
 			s = OpenSession();
 			a = (Assignable) s.Get(typeof(Assignable), "foo");
@@ -1259,7 +1259,7 @@ namespace NHibernate.Test.Legacy
 		public void ToStringWithNoIdentifier()
 		{
 			NHibernateUtil.Entity(typeof(Master)).ToLoggableString(new Master(),
-			                                                       (ISessionFactoryImplementor) sessions);
+			                                                       (ISessionFactoryImplementor) Sfi);
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Legacy/MultiTableTest.cs
+++ b/src/NHibernate.Test/Legacy/MultiTableTest.cs
@@ -79,7 +79,7 @@ namespace NHibernate.Test.Legacy
 			s.Flush();
 			s.Close();
 
-			sessions.Evict(typeof(SubMulti));
+			Sfi.Evict(typeof(SubMulti));
 
 			s = OpenSession();
 			// TODO: I don't understand why h2.0.3/h2.1 issues a select statement here

--- a/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
@@ -534,7 +534,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -548,7 +548,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -562,7 +562,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -693,7 +693,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -707,7 +707,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -721,7 +721,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -735,7 +735,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -749,7 +749,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -763,7 +763,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -777,7 +777,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -791,7 +791,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");
@@ -805,7 +805,7 @@ namespace NHibernate.Test.Linq.ByMethod
 		{
 			if (Dialect is FirebirdDialect)
 				Assert.Ignore("Firebird does not support complex group by expressions");
-			if (sessions.ConnectionProvider.Driver is OdbcDriver)
+			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
 			if (Dialect is MsSqlCeDialect)
 				Assert.Ignore("SQL Server CE does not support complex group by expressions.");

--- a/src/NHibernate.Test/Linq/ParameterisedQueries.cs
+++ b/src/NHibernate.Test/Linq/ParameterisedQueries.cs
@@ -25,8 +25,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable<Customer>>> london2 =
 					() => from c in db.Customers where c.Address.City == "London" select c;
 
-				var nhLondon1 = new NhLinqExpression(london1.Body, sessions);
-				var nhLondon2 = new NhLinqExpression(london2.Body, sessions);
+				var nhLondon1 = new NhLinqExpression(london1.Body, Sfi);
+				var nhLondon2 = new NhLinqExpression(london2.Body, Sfi);
 
 				Assert.AreEqual(nhLondon1.Key, nhLondon2.Key);
 			}
@@ -45,8 +45,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable<Customer>>> newYork =
 					() => from c in db.Customers where c.Address.City == "New York" select c;
 
-				var nhLondon = new NhLinqExpression(london.Body, sessions);
-				var nhNewYork = new NhLinqExpression(newYork.Body, sessions);
+				var nhLondon = new NhLinqExpression(london.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(newYork.Body, Sfi);
 
 				Assert.AreEqual(nhLondon.Key, nhNewYork.Key);
 				Assert.AreEqual(1, nhLondon.ParameterValuesByName.Count);
@@ -69,8 +69,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable<Customer>>> newYork =
 					() => from c in db.Customers where c.Address.City == "New York".MappedAs(NHibernateUtil.AnsiString) select c;
 
-				var nhLondon = new NhLinqExpression(london.Body, sessions);
-				var nhNewYork = new NhLinqExpression(newYork.Body, sessions);
+				var nhLondon = new NhLinqExpression(london.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(newYork.Body, Sfi);
 
 				var londonParameter = nhLondon.ParameterValuesByName.Single().Value;
 				Assert.That(londonParameter.Item1, Is.EqualTo("London"));
@@ -94,8 +94,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable<Customer>>> company =
 					() => from c in db.Customers where c.CompanyName == "Acme" select c;
 
-				var nhLondon = new NhLinqExpression(london.Body, sessions);
-				var nhNewYork = new NhLinqExpression(company.Body, sessions);
+				var nhLondon = new NhLinqExpression(london.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(company.Body, Sfi);
 
 				Assert.AreNotEqual(nhLondon.Key, nhNewYork.Key);
 			}
@@ -113,8 +113,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable<string>>> title =
 					() => from c in db.Customers select c.ContactTitle;
 
-				var nhLondon = new NhLinqExpression(customerId.Body, sessions);
-				var nhNewYork = new NhLinqExpression(title.Body, sessions);
+				var nhLondon = new NhLinqExpression(customerId.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(title.Body, Sfi);
 
 				Assert.AreNotEqual(nhLondon.Key, nhNewYork.Key);
 			}
@@ -132,8 +132,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable>> customerId =
 					() => from c in db.Customers select c.CustomerId;
 
-				var nhLondon = new NhLinqExpression(newCustomerId.Body, sessions);
-				var nhNewYork = new NhLinqExpression(customerId.Body, sessions);
+				var nhLondon = new NhLinqExpression(newCustomerId.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(customerId.Body, Sfi);
 
 				Assert.AreNotEqual(nhLondon.Key, nhNewYork.Key);
 			}
@@ -151,8 +151,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable>> customerId =
 					() => from c in db.Customers select new { Title = c.ContactTitle, Id = c.CustomerId };
 
-				var nhLondon = new NhLinqExpression(newCustomerId.Body, sessions);
-				var nhNewYork = new NhLinqExpression(customerId.Body, sessions);
+				var nhLondon = new NhLinqExpression(newCustomerId.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(customerId.Body, Sfi);
 
 				Assert.AreNotEqual(nhLondon.Key, nhNewYork.Key);
 			}
@@ -170,8 +170,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable>> customerId =
 					() => from c in db.Customers select new { Desc = c.CustomerId != "1" ? "First" : "Not First" };
 
-				var nhLondon = new NhLinqExpression(newCustomerId.Body, sessions);
-				var nhNewYork = new NhLinqExpression(customerId.Body, sessions);
+				var nhLondon = new NhLinqExpression(newCustomerId.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(customerId.Body, Sfi);
 
 				Assert.AreNotEqual(nhLondon.Key, nhNewYork.Key);
 			}
@@ -189,8 +189,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable>> customerId =
 					() => from c in db.Customers where !(c.CustomerId == "1") select c;
 
-				var nhLondon = new NhLinqExpression(newCustomerId.Body, sessions);
-				var nhNewYork = new NhLinqExpression(customerId.Body, sessions);
+				var nhLondon = new NhLinqExpression(newCustomerId.Body, Sfi);
+				var nhNewYork = new NhLinqExpression(customerId.Body, Sfi);
 
 				Assert.AreNotEqual(nhLondon.Key, nhNewYork.Key);
 			}
@@ -204,8 +204,8 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable>> ofType1 = () => (from a in session.Query<Animal>().OfType<Cat>() where a.Pregnant select a.Id);
 				Expression<Func<IEnumerable>> ofType2 = () => (from a in session.Query<Animal>().OfType<Dog>() where a.Pregnant select a.Id);
 
-				var nhOfType1 = new NhLinqExpression(ofType1.Body, sessions);
-				var nhOfType2 = new NhLinqExpression(ofType2.Body, sessions);
+				var nhOfType1 = new NhLinqExpression(ofType1.Body, Sfi);
+				var nhOfType2 = new NhLinqExpression(ofType2.Body, Sfi);
 
 				Assert.AreNotEqual(nhOfType1.Key, nhOfType2.Key);
 			}
@@ -223,9 +223,9 @@ namespace NHibernate.Test.Linq
 				Expression<Func<IEnumerable>> null2 = () => (from a in session.Query<Animal>() where a.Description == nullVariable select a);
 				Expression<Func<IEnumerable>> notNull = () => (from a in session.Query<Animal>() where a.Description == notNullVariable select a);
 
-				var nhNull1 = new NhLinqExpression(null1.Body, sessions);
-				var nhNull2 = new NhLinqExpression(null2.Body, sessions);
-				var nhNotNull = new NhLinqExpression(notNull.Body, sessions);
+				var nhNull1 = new NhLinqExpression(null1.Body, Sfi);
+				var nhNull2 = new NhLinqExpression(null2.Body, Sfi);
+				var nhNotNull = new NhLinqExpression(notNull.Body, Sfi);
 
 				Assert.AreNotEqual(nhNull1.Key, nhNotNull.Key);
 				Assert.AreNotEqual(nhNull2.Key, nhNotNull.Key);

--- a/src/NHibernate.Test/NHSpecificTest/CollectionFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/CollectionFixture.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Test.NHSpecificTest
 
 		protected override void OnTearDown()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				session.Delete("from LLParent");
 				session.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/CriteriaFromHql/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/CriteriaFromHql/Fixture.cs
@@ -26,7 +26,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaFromHql
 			CreateData();
 
 			using (SqlLogSpy spy = new SqlLogSpy())
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tx = session.BeginTransaction())
 			{
 				Person result = session.CreateQuery(@"
@@ -42,7 +42,7 @@ where p.Parent is null")
 			}
 
 			using (SqlLogSpy spy = new SqlLogSpy())
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tx = session.BeginTransaction())
 			{
 				Person result = session.CreateCriteria(typeof(Person))
@@ -60,7 +60,7 @@ where p.Parent is null")
 
 		private void DeleteData()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tx = session.BeginTransaction())
 			{
 				session.Delete("from Person");
@@ -70,7 +70,7 @@ where p.Parent is null")
 
 		private void CreateData()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tx = session.BeginTransaction())
 			{
 				Person root = new Person();

--- a/src/NHibernate.Test/NHSpecificTest/CriteriaQueryOnComponentCollection/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/CriteriaQueryOnComponentCollection/Fixture.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 
 		protected override void OnSetUp()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			using (s.BeginTransaction())
 			{
 				var parent = new Employee
@@ -51,7 +51,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 
 		protected override void OnTearDown()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			using (s.BeginTransaction())
 			{
 				s.Delete("from System.Object");
@@ -63,7 +63,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 		[Test]
 		public void CanQueryByCriteriaOnSetOfCompositeElement()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var list = s.CreateCriteria<Employee>()
 				            .CreateCriteria("ManagedEmployees")
@@ -80,7 +80,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 		[Test]
 		public void CanQueryByCriteriaOnSetOfElement()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var list = s.CreateCriteria<Employee>()
 				            .CreateCriteria("Amounts")
@@ -99,7 +99,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 		[TestCase(JoinType.InnerJoin)]
 		public void CanQueryByCriteriaOnSetOfElementByCreateAlias(JoinType joinType)
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var list = s.CreateCriteria<Employee>("x")
 				            .CreateAlias("x.Amounts", "amount", joinType)
@@ -117,7 +117,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 		[Test]
 		public void CanQueryByCriteriaOnSetOfCompositeElement_UsingDetachedCriteria()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var list = s.CreateCriteria<Employee>()
 				            .Add(Subqueries.PropertyIn("id",

--- a/src/NHibernate.Test/NHSpecificTest/DtcFailures/DtcFailuresFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/DtcFailures/DtcFailuresFixture.cs
@@ -64,7 +64,7 @@ namespace NHibernate.Test.NHSpecificTest.DtcFailures
 		public void WillNotCrashOnDtcPrepareFailure()
 		{
 			var tx = new TransactionScope();
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = OpenSession())
 			{
 				s.Save(new Person {NotNullData = null});  // Cause a SQL not null constraint violation.
 			}
@@ -91,7 +91,7 @@ namespace NHibernate.Test.NHSpecificTest.DtcFailures
 				Assert.Ignore("Firebird driver does not support distributed transactions");
 
 			var tx = new TransactionScope();
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = OpenSession())
 			{
 				new ForceEscalationToDistributedTx(true); //will rollback tx
 				s.Save(new Person { CreatedAt = DateTime.Today });
@@ -120,7 +120,7 @@ namespace NHibernate.Test.NHSpecificTest.DtcFailures
 			{
 				using (var txscope = new TransactionScope())
 				{
-					using (ISession s = sessions.OpenSession())
+					using (ISession s = OpenSession())
 					{
 						var person = new Person { CreatedAt = DateTime.Now };
 						s.Save(person);
@@ -150,7 +150,7 @@ namespace NHibernate.Test.NHSpecificTest.DtcFailures
 			{
 				using (var txscope = new TransactionScope())
 				{
-					using (ISession s = sessions.OpenSession())
+					using (ISession s = OpenSession())
 					{
 						var person = new Person {CreatedAt = DateTime.Now};
 						s.Save(person);
@@ -178,7 +178,7 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 			object savedId;
 			using (var txscope = new TransactionScope())
 			{
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = OpenSession())
 				{
 					var person = new Person {CreatedAt = DateTime.Now};
 					savedId = s.Save(person);
@@ -189,7 +189,7 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 			{
 				using (var txscope = new TransactionScope())
 				{
-					using (ISession s = sessions.OpenSession())
+					using (ISession s = OpenSession())
 					{
 						var person = s.Get<Person>(savedId);
 						person.CreatedAt = DateTime.Now;
@@ -211,7 +211,7 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 			{
 				using (var txscope = new TransactionScope())
 				{
-					using (ISession s = sessions.OpenSession())
+					using (ISession s = OpenSession())
 					{
 						var person = s.Get<Person>(savedId);
 						s.Delete(person);
@@ -266,7 +266,7 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 			object id;
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = OpenSession())
 				{
 					id = s.Save(new Person {CreatedAt = DateTime.Today});
 
@@ -278,7 +278,7 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = OpenSession())
 				{
 					new ForceEscalationToDistributedTx();
 
@@ -295,12 +295,12 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 		{
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = OpenSession())
 				{
 					s.Flush();
 				}
 
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = OpenSession())
 				{
 					s.Flush();
 				}

--- a/src/NHibernate.Test/NHSpecificTest/EmptyMappingsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/EmptyMappingsFixture.cs
@@ -61,13 +61,13 @@ namespace NHibernate.Test.NHSpecificTest
 		public void NullInterceptor()
 		{
 			IInterceptor nullInterceptor = null;
-			Assert.Throws<ArgumentNullException>(() => sessions.WithOptions().Interceptor(nullInterceptor).OpenSession().Close());
+			Assert.Throws<ArgumentNullException>(() => Sfi.WithOptions().Interceptor(nullInterceptor).OpenSession().Close());
 		}
 
 		[Test]
 		public void DisconnectShouldNotCloseUserSuppliedConnection()
 		{
-			var conn = sessions.ConnectionProvider.GetConnection();
+			var conn = Sfi.ConnectionProvider.GetConnection();
 			try
 			{
 				using (ISession s = OpenSession())
@@ -80,7 +80,7 @@ namespace NHibernate.Test.NHSpecificTest
 			}
 			finally
 			{
-				sessions.ConnectionProvider.CloseConnection(conn);
+				Sfi.ConnectionProvider.CloseConnection(conn);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/Evicting/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Evicting/Fixture.cs
@@ -15,7 +15,7 @@ namespace NHibernate.Test.NHSpecificTest.Evicting
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var tx = session.BeginTransaction())
 			{
 				session.Save(new Employee
@@ -30,7 +30,7 @@ namespace NHibernate.Test.NHSpecificTest.Evicting
 
 		protected override void OnTearDown()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var tx = session.BeginTransaction())
 			{
 				session.Delete(session.Load<Employee>(1));
@@ -44,7 +44,7 @@ namespace NHibernate.Test.NHSpecificTest.Evicting
 		[Test]
 		public void Can_evict_entity_from_session()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var tx = session.BeginTransaction())
 			{
 				var employee = session.Load<Employee>(1);
@@ -62,7 +62,7 @@ namespace NHibernate.Test.NHSpecificTest.Evicting
 		public void Can_evict_non_persistent_object()
 		{
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var tx = session.BeginTransaction())
 			{
 				var employee = new Employee();
@@ -80,11 +80,11 @@ namespace NHibernate.Test.NHSpecificTest.Evicting
 		public void Can_evict_when_trying_to_evict_entity_from_another_session()
 		{
 
-			using (var session1 = sessions.OpenSession())
+			using (var session1 = Sfi.OpenSession())
 			using (var tx1 = session1.BeginTransaction())
 			{
 
-				using (var session2 = sessions.OpenSession())
+				using (var session2 = Sfi.OpenSession())
 				using (var tx2 = session2.BeginTransaction())
 				{
 					var employee = session2.Load<Employee>(1);

--- a/src/NHibernate.Test/NHSpecificTest/Futures/FallbackFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/FallbackFixture.cs
@@ -47,7 +47,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 
 		protected override void OnTearDown()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				session.Delete("from Person");
 				session.Flush();
@@ -59,7 +59,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void FutureOfCriteriaFallsBackToListImplementationWhenQueryBatchingIsNotSupported()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var results = session.CreateCriteria<Person>().Future<Person>();
 				results.GetEnumerator().MoveNext();
@@ -71,7 +71,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			int personId = CreatePerson();
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var futurePerson = session.CreateCriteria<Person>()
 					.Add(Restrictions.Eq("Id", personId))
@@ -85,7 +85,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			CreatePerson();
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var futureCount = session.CreateCriteria<Person>()
 					.SetProjection(Projections.RowCount())
@@ -97,7 +97,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void FutureOfQueryFallsBackToListImplementationWhenQueryBatchingIsNotSupported()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var results = session.CreateQuery("from Person").Future<Person>();
 				results.GetEnumerator().MoveNext();
@@ -109,7 +109,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			int personId = CreatePerson();
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var futurePerson = session.CreateQuery("from Person where Id = :id")
 					.SetInt32("id", personId)
@@ -123,7 +123,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			CreatePerson();
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var futureCount = session.CreateQuery("select count(*) from Person")
 					.FutureValue<long>();
@@ -134,7 +134,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void FutureOfLinqFallsBackToListImplementationWhenQueryBatchingIsNotSupported()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var results = session.Query<Person>().ToFuture();
 				results.GetEnumerator().MoveNext();
@@ -146,7 +146,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			var personId = CreatePerson();
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var futurePerson = session.Query<Person>()
 					.Where(x => x.Id == personId)
@@ -157,7 +157,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 
 		private int CreatePerson()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var person = new Person();
 				session.Save(person);

--- a/src/NHibernate.Test/NHSpecificTest/Futures/FutureCriteriaFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/FutureCriteriaFixture.cs
@@ -12,7 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		public void DefaultReadOnlyTest()
 		{
 			//NH-3575
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				s.DefaultReadOnly = true;
 
@@ -25,7 +25,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
         [Test]
         public void CanUseFutureCriteria()
         {
-            using (var s = sessions.OpenSession())
+            using (var s = Sfi.OpenSession())
             {
                 IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -57,7 +57,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
     	[Test]
         public void TwoFuturesRunInTwoRoundTrips()
         {
-            using (var s = sessions.OpenSession())
+            using (var s = Sfi.OpenSession())
             {
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -84,7 +84,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanCombineSingleFutureValueWithEnumerableFutures()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 

--- a/src/NHibernate.Test/NHSpecificTest/Futures/FutureFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/FutureFixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 
 		protected void IgnoreThisTestIfMultipleQueriesArentSupportedByDriver()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (driver.SupportsMultipleQueries == false)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 		}

--- a/src/NHibernate.Test/NHSpecificTest/Futures/FutureQueryFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/FutureQueryFixture.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		public void DefaultReadOnlyTest()
 		{
 			//NH-3575
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				s.DefaultReadOnly = true;
 
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanUseFutureQuery()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -59,7 +59,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void TwoFuturesRunInTwoRoundTrips()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -86,7 +86,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanCombineSingleFutureValueWithEnumerableFutures()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -114,7 +114,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanExecuteMultipleQueryWithSameParameterName()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 			

--- a/src/NHibernate.Test/NHSpecificTest/Futures/FutureQueryOverFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/FutureQueryOverFixture.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		public void DefaultReadOnlyTest()
 		{
 			//NH-3575
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				s.DefaultReadOnly = true;
 
@@ -48,7 +48,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanUseFutureCriteria()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -82,7 +82,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void TwoFuturesRunInTwoRoundTrips()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
@@ -110,7 +110,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanCombineSingleFutureValueWithEnumerableFutures()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 

--- a/src/NHibernate.Test/NHSpecificTest/Futures/LinqFutureFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Futures/LinqFutureFixture.cs
@@ -12,7 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		public void DefaultReadOnlyTest()
 		{
 			//NH-3575
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				s.DefaultReadOnly = true;
 
@@ -56,7 +56,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanUseToFutureWithContains()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var ids = new[] { 1, 2, 3 };
 				var persons10 = s.Query<Person>()
@@ -73,7 +73,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanUseToFutureWithContains2()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var ids = new[] { 1, 2, 3 };
 				var persons10 = s.Query<Person>()
@@ -90,7 +90,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			using (var tx = s.BeginTransaction())
 			{
 				var p1 = new Person { Name = "Parent" };
@@ -103,7 +103,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 				s.Clear(); // we don't want caching
 			}
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var persons10 = s.Query<Person>()
 					.FetchMany(p => p.Children)
@@ -138,7 +138,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var persons10 = s.Query<Person>()
 					.Take(10)
@@ -168,7 +168,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var persons = s.Query<Person>()
 					.Select(p => new { Id = p.Id, Name = p.Name })
@@ -194,7 +194,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 			
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			using (var tx = s.BeginTransaction())
 			{
 				var p1 = new Person { Name = "Parent" };
@@ -207,7 +207,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 				s.Clear(); // we don't want caching
 			}
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var persons = s.Query<Person>()
 					.FetchMany(p => p.Children)
@@ -241,7 +241,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				using (var logSpy = new SqlLogSpy())
 				{
@@ -268,7 +268,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 			
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var persons = s.Query<Person>()
 					.Take(10)
@@ -308,7 +308,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 				tx.Commit();
 			}
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var meContainer = s.Query<Person>()
 								   .Where(x => x.Id == personId)
@@ -329,7 +329,7 @@ namespace NHibernate.Test.NHSpecificTest.Futures
 		[Test]
 		public void CanExecuteMultipleQueriesOnSameExpression()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
 

--- a/src/NHibernate.Test/NHSpecificTest/GetTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GetTest.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Test.NHSpecificTest
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/HqlOnMapWithForumula/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/HqlOnMapWithForumula/Fixture.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Test.NHSpecificTest.HqlOnMapWithForumula
 		[Test]
 		public void TestBug()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.CreateQuery("from A a where 1 in elements(a.MyMaps)")
 					.List();

--- a/src/NHibernate.Test/NHSpecificTest/LazyLoadBugTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/LazyLoadBugTest.cs
@@ -84,7 +84,7 @@ namespace NHibernate.Test.NHSpecificTest
 				Assert.AreEqual(1, parent2.ChildrenNoAdd.Count);
 			}
 
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				session.Delete("from LLParent");
 				session.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/LoadingNullEntityInSet/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/LoadingNullEntityInSet/Fixture.cs
@@ -21,13 +21,13 @@ namespace NHibernate.Test.NHSpecificTest.LoadingNullEntityInSet
             get { return "NHibernate.Test"; }
         }
 
-		protected override void BuildSessionFactory()
+		protected override DebugSessionFactory BuildSessionFactory()
 		{
 			cfg.GetCollectionMapping(typeof (Employee).FullName + ".Primaries")
 				.CollectionTable.Name = "WantedProfessions";
 			cfg.GetCollectionMapping(typeof (Employee).FullName + ".Secondaries")
 				.CollectionTable.Name = "WantedProfessions";
-			base.BuildSessionFactory();
+			return base.BuildSessionFactory();
 		}
 
 		protected override void OnTearDown()

--- a/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 			ThreadContext.Properties["sessionId"] = new SessionIdCapturer();
 
 			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var sessionId = ((SessionImpl)s).SessionId;
 

--- a/src/NHibernate.Test/NHSpecificTest/MapFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/MapFixture.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Test.NHSpecificTest
 
 		protected override void OnTearDown()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				session.Delete("from Team");
 				session.Delete("from Child");

--- a/src/NHibernate.Test/NHSpecificTest/NH1001/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1001/Fixture.cs
@@ -47,7 +47,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1001
 
 			ExecuteStatement(string.Format("UPDATE EMPLOYEES SET DEPARTMENT_ID = 99999 WHERE EMPLOYEE_ID = {0}", employeeId));
 
-			IStatistics stat = sessions.Statistics;
+			IStatistics stat = Sfi.Statistics;
 			stat.Clear();
 			using (ISession sess = OpenSession())
 			using (ITransaction tx = sess.BeginTransaction())

--- a/src/NHibernate.Test/NHSpecificTest/NH1080/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1080/Fixture.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1080
             try
             {
 
-                using (ISession s = sessions.OpenSession())
+                using (ISession s = Sfi.OpenSession())
                 {
                     s.Save(c);
                     s.Save(b1);
@@ -68,7 +68,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1080
                     s.Close();
                 }
 
-                using (ISession s = sessions.OpenSession())
+                using (ISession s = Sfi.OpenSession())
                 {
                     /* If bug is present, throws:
                     NHibernate.Test.NHSpecificTest.NH1080.Fixture.TestBug : NHibernate.UnresolvableObjectException : No row with the given identifier exists: 1, of class: NHibernate.Test.NHSpecificTest.NH1080.B
@@ -78,7 +78,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1080
             }
             finally
             {
-                using (ISession s = sessions.OpenSession())
+                using (ISession s = Sfi.OpenSession())
                 {
                     
                     s.Delete(a);

--- a/src/NHibernate.Test/NHSpecificTest/NH1082/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1082/Fixture.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 			var c = new C {ID = 1, Value = "value"};
 
 			var sessionInterceptor = new SessionInterceptorThatThrowsExceptionAtBeforeTransactionCompletion();
-			using (var s = sessions.WithOptions().Interceptor(sessionInterceptor).OpenSession())
+			using (var s = Sfi.WithOptions().Interceptor(sessionInterceptor).OpenSession())
 			using (var t = s.BeginTransaction())
 			{
 				s.Save(c);
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 				Assert.Throws<BadException>(t.Commit);
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				var objectInDb = s.Get<C>(1);
 				Assert.IsNull(objectInDb);
@@ -41,7 +41,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 			var c = new C { ID = 1, Value = "value" };
 
 			var synchronization = new SynchronizationThatThrowsExceptionAtBeforeTransactionCompletion();
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				t.RegisterSynchronization(synchronization);
@@ -51,7 +51,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1082
 				Assert.Throws<BadException>(t.Commit);
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				var objectInDb = s.Get<C>(1);
 				Assert.IsNull(objectInDb);

--- a/src/NHibernate.Test/NHSpecificTest/NH1093/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1093/Fixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1093
 
 		private void Cleanup()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = OpenSession())
 			{
 				using (s.BeginTransaction())
 				{
@@ -34,7 +34,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1093
 
 		private void FillDb()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = OpenSession())
 			{
 				using (ITransaction tx = s.BeginTransaction())
 				{
@@ -80,13 +80,14 @@ namespace NHibernate.Test.NHSpecificTest.NH1093
 			}
 		}
 
-		protected override void BuildSessionFactory()
+		protected override DebugSessionFactory BuildSessionFactory()
 		{
 			// Without configured cache, should log warn.
 			using (var ls = new LogSpy(LogManager.GetLogger(typeof(Fixture).Assembly, "NHibernate"), Level.Warn))
 			{
-				base.BuildSessionFactory();
+				var factory = base.BuildSessionFactory();
 				Assert.That(ls.GetWholeLog(), Does.Contain("Fake cache used"));
+				return factory;
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1101/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1101/Fixture.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1101
 			{
 				a = s.Get<A>(savedId);
 
-				IStatistics statistics = sessions.Statistics;
+				IStatistics statistics = Sfi.Statistics;
 				statistics.Clear();
 
 				Assert.IsNotNull(a.B); // an instance of B was created
@@ -47,7 +47,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1101
 			{
 				a = s.Load<A>(savedId);
 
-				IStatistics statistics = sessions.Statistics;
+				IStatistics statistics = Sfi.Statistics;
 				statistics.Clear();
 
 				Assert.IsNotNull(a.B); // an instance of B was created

--- a/src/NHibernate.Test/NHSpecificTest/NH1253/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1253/Fixture.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1253
 		[Test]
 		public void MultiQuerySingleInList()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (!driver.SupportsMultipleQueries)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 

--- a/src/NHibernate.Test/NHSpecificTest/NH1553/MsSQL/SnapshotIsolationUpdateConflictTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1553/MsSQL/SnapshotIsolationUpdateConflictTest.cs
@@ -66,7 +66,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 			SavePerson(p1);
 			Assert.That(p1.Version, Is.EqualTo(person.Version + 1));
 
-			var expectedException = sessions.Settings.IsBatchVersionedDataEnabled
+			var expectedException = Sfi.Settings.IsBatchVersionedDataEnabled
 				? (IResolveConstraint) Throws.InstanceOf<StaleStateException>()
 				: Throws.InstanceOf<StaleObjectStateException>()
 				        .And.Property("EntityName").EqualTo(typeof(Person).FullName)
@@ -103,7 +103,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 
 					session2.SaveOrUpdate(p2);
 
-					var expectedException = sessions.Settings.IsBatchVersionedDataEnabled
+					var expectedException = Sfi.Settings.IsBatchVersionedDataEnabled
 						? (IConstraint) Throws.InstanceOf<StaleStateException>()
 						: Throws.InstanceOf<StaleObjectStateException>()
 						        .And.Property("EntityName").EqualTo(typeof(Person).FullName)

--- a/src/NHibernate.Test/NHSpecificTest/NH1574/StatelessTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1574/StatelessTest.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1574
 				session.Flush();
 			}
 
-			using (IStatelessSession session = sessions.OpenStatelessSession())
+			using (IStatelessSession session = Sfi.OpenStatelessSession())
 			{
 				IQuery query = session.CreateQuery("from SpecializedPrincipal p");
 				IList<Principal> principals = query.List<Principal>();

--- a/src/NHibernate.Test/NHSpecificTest/NH1609/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1609/Fixture.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1609
 		[Test]
 		public void Test()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (session.BeginTransaction())
 			{
 				EntityA a1 = CreateEntityA(session);

--- a/src/NHibernate.Test/NHSpecificTest/NH1632/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1632/Fixture.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 		{
 			object scalar1, scalar2;
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var command = session.Connection.CreateCommand())
 			{
 				command.CommandText = "select next_hi from hibernate_unique_key";
@@ -37,10 +37,10 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 
 			using (var tx = new TransactionScope())
 			{
-				var generator = sessions.GetIdentifierGenerator(typeof(Person).FullName);
+				var generator = Sfi.GetIdentifierGenerator(typeof(Person).FullName);
 				Assert.That(generator, Is.InstanceOf<TableHiLoGenerator>());
 
-				using(var session = sessions.OpenSession())
+				using(var session = Sfi.OpenSession())
 				{
 					var id = generator.Generate((ISessionImplementor) session, new Person());
 				}
@@ -49,7 +49,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 				tx.Dispose();
 			}
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var command = session.Connection.CreateCommand())
 			{
 				command.CommandText = "select next_hi from hibernate_unique_key";
@@ -66,7 +66,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 
 			using (var tx = new TransactionScope())
 			{
-				using (s = sessions.OpenSession())
+				using (s = Sfi.OpenSession())
 				{
 
 				}
@@ -82,7 +82,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 		{
 			using (var tx = new TransactionScope())
 			{
-				using (var s = sessions.OpenSession())
+				using (var s = Sfi.OpenSession())
 				{
 					s.Save(new Nums {ID = 29, NumA = 1, NumB = 3});
 				}
@@ -91,7 +91,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 
 			using (var tx = new TransactionScope())
 			{
-				using (var s = sessions.OpenSession())
+				using (var s = Sfi.OpenSession())
 				{
 					var nums = s.Load<Nums>(29);
 					Assert.AreEqual(1, nums.NumA);
@@ -101,12 +101,12 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 			}
 
 			//closing the connection to ensure we can't really use it.
-			var connection = sessions.ConnectionProvider.GetConnection();
-			sessions.ConnectionProvider.CloseConnection(connection);
+			var connection = Sfi.ConnectionProvider.GetConnection();
+			Sfi.ConnectionProvider.CloseConnection(connection);
 
 			using (var tx = new TransactionScope())
 			{
-				using (var s = sessions.WithOptions().Connection(connection).OpenSession())
+				using (var s = Sfi.WithOptions().Connection(connection).OpenSession())
 				{
 					var nums = s.Load<Nums>(29);
 					Assert.AreEqual(1, nums.NumA);
@@ -115,7 +115,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 				tx.Complete();
 			}
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			using (var tx = s.BeginTransaction())
 			{
 				var nums = s.Load<Nums>(29);
@@ -130,14 +130,14 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 			object id;
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = Sfi.OpenSession())
 				{
 					id = s.Save(new Nums { NumA = 1, NumB = 2, ID = 5 });
 				}
 				tx.Complete();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				Nums nums = s.Get<Nums>(id);
@@ -154,7 +154,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 			object id;
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s = sessions.OpenSession())
+				using (ISession s = Sfi.OpenSession())
 				{
 					s.FlushMode = FlushMode.Manual;
 					id = s.Save(new Nums { NumA = 1, NumB = 2, ID = 5 });
@@ -162,7 +162,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 				tx.Complete();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				Nums nums = s.Get<Nums>(id);
@@ -180,8 +180,8 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 			object id1, id2;
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s1 = sessions.OpenSession())
-				using (ISession s2 = sessions.OpenSession())
+				using (ISession s1 = Sfi.OpenSession())
+				using (ISession s2 = Sfi.OpenSession())
 				{
 
 					id1 = s1.Save(new Nums { NumA = 1, NumB = 2, ID = 5 });
@@ -194,7 +194,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 				}
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				Nums nums = s.Get<Nums>(id1);
@@ -218,8 +218,8 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 			object id1, id2;
 			using (var tx = new TransactionScope())
 			{
-				using (ISession s1 = sessions.OpenSession())
-				using (ISession s2 = sessions.OpenSession())
+				using (ISession s1 = Sfi.OpenSession())
+				using (ISession s2 = Sfi.OpenSession())
 				{
 
 					id1 = s1.Save(new Nums { NumA = 1, NumB = 2, ID = 5 });
@@ -230,7 +230,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1632
 				}
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				Nums nums = s.Get<Nums>(id1);

--- a/src/NHibernate.Test/NHSpecificTest/NH1640/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1640/Fixture.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1640
 				}
 			}
 
-			using (IStatelessSession session = sessions.OpenStatelessSession())
+			using (IStatelessSession session = Sfi.OpenStatelessSession())
 			{
 				var parent =
 					session.CreateQuery("from Entity p join fetch p.Child where p.Id=:pId").SetInt32("pId", savedId).UniqueResult

--- a/src/NHibernate.Test/NHSpecificTest/NH1741/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1741/Fixture.cs
@@ -100,7 +100,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1741
 		public void Bug()
 		{
 			var dq = new DetachedNamedQueryCrack(QueryName);
-			ISession s = sessions.OpenSession();
+			ISession s = Sfi.OpenSession();
 			dq.GetExecutableQuery(s);
 			s.Close();
 
@@ -121,7 +121,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1741
 			var dq = new DetachedNamedQueryCrack(QueryName);
 			dq.SetCacheable(false).SetCacheRegion("another region").SetReadOnly(false).SetTimeout(20).SetCacheMode(
 				CacheMode.Refresh).SetFetchSize(22).SetComment("another comment").SetFlushMode(FlushMode.Commit);
-			ISession s = sessions.OpenSession();
+			ISession s = Sfi.OpenSession();
 			dq.GetExecutableQuery(s);
 			s.Close();
 

--- a/src/NHibernate.Test/NHSpecificTest/NH1835/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1835/Fixture.cs
@@ -9,9 +9,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1835
 		[Test]
 		public void ColumnTypeBinaryBlob()
 		{
-			var pc = sessions.GetEntityPersister(typeof (Document).FullName);
+			var pc = Sfi.GetEntityPersister(typeof (Document).FullName);
 			var type = pc.GetPropertyType("Contents");
-			Assert.That(type.SqlTypes(sessions)[0], Is.InstanceOf<BinaryBlobSqlType>());
+			Assert.That(type.SqlTypes(Sfi)[0], Is.InstanceOf<BinaryBlobSqlType>());
 		}
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH1837/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1837/Fixture.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1837
 	{
 		protected override void OnSetUp()
 		{
-			sessions.Statistics.IsStatisticsEnabled = true;
+			Sfi.Statistics.IsStatisticsEnabled = true;
 			using(ISession session=this.OpenSession())
 			using(ITransaction tran=session.BeginTransaction())
 			{
@@ -38,7 +38,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1837
 		public void ExecutesOneQueryWithUniqueResultWithChildCriteriaNonGeneric()
 		{
 	
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			using (ISession session = this.OpenSession())
 			{
 				var criteria = session.CreateCriteria(typeof(Order),"o");
@@ -46,13 +46,13 @@ namespace NHibernate.Test.NHSpecificTest.NH1837
 					.Add(Restrictions.Eq("c.Id", 1))
 					.SetProjection(Projections.RowCount())
 					.UniqueResult();
-				Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
 			}
 		}
 		[Test]
 		public void ExecutesOneQueryWithUniqueResultWithChildCriteriaGeneric()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			using (ISession session = this.OpenSession())
 			{
 				session.CreateCriteria(typeof (Order), "o")
@@ -60,32 +60,32 @@ namespace NHibernate.Test.NHSpecificTest.NH1837
 					.Add(Restrictions.Eq("c.Id", 1))
 					.SetProjection(Projections.RowCount())
 					.UniqueResult<int>();
-				Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
 			}
 		}
 		[Test]
 		public void ExecutesOneQueryWithUniqueResultWithCriteriaNonGeneric()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			using (ISession session = this.OpenSession())
 			{
 				session.CreateCriteria(typeof (Order), "o")
 					.SetProjection(Projections.RowCount())
 					.UniqueResult();
-				Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
 			}
 		}
 
 		[Test]
 		public void ExecutesOneQueryWithUniqueResultWithCriteriaGeneric()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 			using (ISession session = this.OpenSession())
 			{
 				session.CreateCriteria(typeof (Order), "o")
 					.SetProjection(Projections.RowCount())
 					.UniqueResult<int>();
-				Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1849/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1849/Fixture.cs
@@ -46,7 +46,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1849
 		{
 		 string hql = @"from Customer c where contains(c.Name, :smth)";
 
-		 HQLQueryPlan plan = new QueryExpressionPlan(new StringQueryExpression(hql), false, new CollectionHelper.EmptyMapClass<string, IFilter>(), sessions);
+		 HQLQueryPlan plan = new QueryExpressionPlan(new StringQueryExpression(hql), false, new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
 
 		 Assert.AreEqual(1, plan.ParameterMetadata.NamedParameterNames.Count);
 		 Assert.AreEqual(1, plan.QuerySpaces.Count);

--- a/src/NHibernate.Test/NHSpecificTest/NH1869/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1869/Fixture.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1869
 
 		protected override void OnTearDown()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
 				session.Delete("from NodeKeyword");
@@ -29,7 +29,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1869
 		[Test]
 		public void Test()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
 				_keyword = new Keyword();
@@ -43,7 +43,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1869
 				transaction.Commit();
 			}
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				//If uncomment the line below the test will pass
 				//GetResult(session);

--- a/src/NHibernate.Test/NHSpecificTest/NH1908ThreadSafety/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1908ThreadSafety/Fixture.cs
@@ -30,9 +30,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1908ThreadSafety
 			// By clearing the connection pool the tables will get dropped. This is done by the following code.
 			var fbConnectionType = ReflectHelper.TypeFromAssembly("FirebirdSql.Data.FirebirdClient.FbConnection", "FirebirdSql.Data.FirebirdClient", false);
 			var clearPool = fbConnectionType.GetMethod("ClearPool");
-			var sillyConnection = sessions.ConnectionProvider.GetConnection();
+			var sillyConnection = Sfi.ConnectionProvider.GetConnection();
 			clearPool.Invoke(null, new object[] { sillyConnection });
-			sessions.ConnectionProvider.CloseConnection(sillyConnection);
+			Sfi.ConnectionProvider.CloseConnection(sillyConnection);
 		}
 
 		[Test]
@@ -72,7 +72,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1908ThreadSafety
 
 		private void ScenarioRunningWithMultiThreading()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				session
 					.EnableFilter("CurrentOnly")

--- a/src/NHibernate.Test/NHSpecificTest/NH1922/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1922/Fixture.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1922
         [Test]
         public void CanExecuteQueryOnStatelessSessionUsingDetachedCriteria()
         {
-            using(var stateless = sessions.OpenStatelessSession())
+            using(var stateless = Sfi.OpenStatelessSession())
             {
             	var dc = DetachedCriteria.For<Customer>()
             		.Add(Restrictions.Eq("ValidUntil", new DateTime(2000,1,1)));

--- a/src/NHibernate.Test/NHSpecificTest/NH1989/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1989/Fixture.cs
@@ -17,11 +17,17 @@ namespace NHibernate.Test.NHSpecificTest.NH1989
 			return factory.ConnectionProvider.Driver.SupportsMultipleQueries;
 		}
 
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.Properties[Environment.CacheProvider] = typeof(HashtableCacheProvider).AssemblyQualifiedName;
+			configuration.Properties[Environment.UseQueryCache] = "true";
+		}
+
 		protected override void OnSetUp()
 		{
-			cfg.Properties[Environment.CacheProvider] = typeof(HashtableCacheProvider).AssemblyQualifiedName;
-			cfg.Properties[Environment.UseQueryCache] = "true";
-			sessions = (ISessionFactoryImplementor)cfg.BuildSessionFactory();
+			// Clear cache at each test.
+			RebuildSessionFactory();
 		}
 
 		protected override void OnTearDown()

--- a/src/NHibernate.Test/NHSpecificTest/NH2031/HqlModFuctionForMsSqlTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2031/HqlModFuctionForMsSqlTest.cs
@@ -26,7 +26,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2031
 
 		public string GetSql(string query)
 		{
-			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, sessions).Parse(), new CollectionHelper.EmptyMapClass<string, IFilter>(), sessions);
+			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, Sfi).Parse(), new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
 			qt.Compile(null, false);
 			return qt.SQLString;
 		}

--- a/src/NHibernate.Test/NHSpecificTest/NH2043/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2043/Fixture.cs
@@ -1,3 +1,4 @@
+using NHibernate.Cfg;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH2043
@@ -16,11 +17,11 @@ namespace NHibernate.Test.NHSpecificTest.NH2043
             }
         }
 
-        protected override void  BuildSessionFactory()
-        {
-            cfg.SetInterceptor(new Namer());
- 	        base.BuildSessionFactory();
-        }
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.SetInterceptor(new Namer());
+		}
 
         [Test]
 		public void Test()

--- a/src/NHibernate.Test/NHSpecificTest/NH2055/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2055/Fixture.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2055
 		[Test] 
 		public void CanCreateAndDropSchema() 
 		{
-            using(var s = sessions.OpenSession())
+            using(var s = Sfi.OpenSession())
             {
                 using(var cmd = s.Connection.CreateCommand())
                 {

--- a/src/NHibernate.Test/NHSpecificTest/NH2056/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2056/Fixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2056
 		public void CanUpdateInheritedClass()
 		{
 			object savedId;
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var t = session.BeginTransaction())
 			{
 				IDictionary address = new Dictionary<string, object>();
@@ -32,7 +32,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2056
 				t.Commit();
 			}
 
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var t = session.BeginTransaction())
 			{
 				var query = session.CreateQuery("Update Address address set address.AddressF1 = :val1, address.AddressF2 = :val2 where ID=:theID");
@@ -46,7 +46,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2056
 
 				t.Commit();
 			}
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var t = session.BeginTransaction())
 			{
 				var updated = (IDictionary) session.Get("Address", savedId);

--- a/src/NHibernate.Test/NHSpecificTest/NH2111/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2111/Fixture.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2111
 	{
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from A" );
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2112/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2112/Fixture.cs
@@ -56,22 +56,22 @@ namespace NHibernate.Test.NHSpecificTest.NH2112
         }
         protected void ClearCounts()
         {
-            sessions.Statistics.Clear();
+            Sfi.Statistics.Clear();
         }
 
         protected void AssertInsertCount(long expected)
         {
-            Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(expected), "unexpected insert count");
+            Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(expected), "unexpected insert count");
         }
 
         protected void AssertUpdateCount(int expected)
         {
-            Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(expected), "unexpected update count");
+            Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(expected), "unexpected update count");
         }
 
         protected void AssertDeleteCount(int expected)
         {
-            Assert.That(sessions.Statistics.EntityDeleteCount, Is.EqualTo(expected), "unexpected delete count");
+            Assert.That(Sfi.Statistics.EntityDeleteCount, Is.EqualTo(expected), "unexpected delete count");
         }
 
     }

--- a/src/NHibernate.Test/NHSpecificTest/NH2118/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2118/Fixture.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2118
 		{
 			base.OnSetUp();
 
-			using(var s = sessions.OpenStatelessSession())
+			using(var s = Sfi.OpenStatelessSession())
 			using(var tx = s.BeginTransaction())
 			{
 				s.Insert(new Person {FirstName = "Bart", LastName = "Simpson"});
@@ -32,7 +32,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2118
 		[Test]
 		public void CanGroupByWithoutSelect()
 		{
-			using(var s = sessions.OpenSession())
+			using(var s = Sfi.OpenSession())
 			using (s.BeginTransaction())
 			{
 				var groups = s.Query<Person>().GroupBy(p => p.LastName).ToList();
@@ -44,7 +44,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2118
 		protected override void OnTearDown()
 		{
 			base.OnTearDown();
-			using(var s = sessions.OpenStatelessSession())
+			using(var s = Sfi.OpenStatelessSession())
 			using (var tx = s.BeginTransaction())
 			{
 				s.CreateQuery("delete from Person").ExecuteUpdate();

--- a/src/NHibernate.Test/NHSpecificTest/NH2189/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2189/Fixture.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2189
 		{
 			base.OnSetUp();
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				TeamMember tm1 = new TeamMember() { Name = "Joe" };
@@ -42,7 +42,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2189
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				s.Delete("FROM Task");
@@ -57,7 +57,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2189
 		[Test]
 		public void FutureQueryReturnsExistingProxy()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				Policy policyProxy = s.Load<Policy>(_policy2Id);
@@ -77,7 +77,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2189
 		[Test]
 		public void FutureCriteriaReturnsExistingProxy()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				Policy policyProxy = s.Load<Policy>(_policy2Id);
@@ -97,7 +97,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2189
 		[Test]
 		public void FutureQueryEagerLoadUsesAlreadyLoadedEntity()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				Policy policy2 = s.CreateQuery("SELECT p FROM Policy p " +
@@ -125,7 +125,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2189
 		[Test]
 		public void FutureCriteriaEagerLoadUsesAlreadyLoadedEntity()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				Policy policy2 =

--- a/src/NHibernate.Test/NHSpecificTest/NH2195/SQLiteMultiCriteriaTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2195/SQLiteMultiCriteriaTest.cs
@@ -94,7 +94,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2195
 		[Test]
 		public void MultiCriteriaQueriesWithIntsShouldExecuteCorrectly()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (!driver.SupportsMultipleQueries)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 
@@ -123,7 +123,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2195
 		[Test]
 		public void MultiCriteriaQueriesWithStringsShouldExecuteCorrectly()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (!driver.SupportsMultipleQueries)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2203/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2203/Fixture.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2203
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			using (var session = sessions.OpenStatelessSession())
+			using (var session = Sfi.OpenStatelessSession())
 			using (var tx = session.BeginTransaction())
 			{
 				foreach (var artistName in new[] { "Foo", "Bar", "Baz", "Soz", "Tiz", "Fez" })
@@ -25,7 +25,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2203
 		[Test]
 		public void QueryShouldWork()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using(session.BeginTransaction())
 			{
 				var actual = session.Query<Artist>()
@@ -40,7 +40,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2203
 
 		protected override void OnTearDown()
 		{
-			using(var session = sessions.OpenStatelessSession())
+			using(var session = Sfi.OpenStatelessSession())
 			using (var tx = session.BeginTransaction())
 			{
 				session.CreateQuery("delete Artist").ExecuteUpdate();

--- a/src/NHibernate.Test/NHSpecificTest/NH2218/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2218/Fixture.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2218
 		[Test]
 		public void SelectEntitiesByEntityNameFromStatelessSession()
 		{
-			using (var session = sessions.OpenStatelessSession())
+			using (var session = Sfi.OpenStatelessSession())
 			using (session.BeginTransaction())
 			{
 				// verify the instance count for both mappings

--- a/src/NHibernate.Test/NHSpecificTest/NH2244/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2244/Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2244
 	{
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2278/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2278/Fixture.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2278
 	{
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from CustomA" );
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2279/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2279/Fixture.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2279
 	{
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from A" );
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2317/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2317/Fixture.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2317
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			using (var session = sessions.OpenStatelessSession())
+			using (var session = Sfi.OpenStatelessSession())
 			using (var tx = session.BeginTransaction())
 			{
 				foreach (var artistName in new[] { "Foo", "Bar", "Baz", "Soz", "Tiz", "Fez" })
@@ -24,7 +24,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2317
 		[Test]
 		public void QueryShouldWork()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using(session.BeginTransaction())
 			{
 				// The HQL : "select a.id from Artist a where a in (from Artist take 3)"
@@ -40,7 +40,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2317
 
 		protected override void OnTearDown()
 		{
-			using(var session = sessions.OpenStatelessSession())
+			using(var session = Sfi.OpenStatelessSession())
 			using (var tx = session.BeginTransaction())
 			{
 				session.CreateQuery("delete Artist").ExecuteUpdate();

--- a/src/NHibernate.Test/NHSpecificTest/NH2318/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2318/Fixture.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2318
 
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
 				s.Delete( "from A" );
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2392/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2392/Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2392
 	{
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2394/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2394/Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2394
 	{
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2412/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2412/Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2412
 	{
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from Order");
 				s.Delete("from Customer");

--- a/src/NHibernate.Test/NHSpecificTest/NH2420/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2420/Fixture.cs
@@ -65,7 +65,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2420
 					EnlistmentOptions.None);
 
 				DbConnection connection;
-				if (sessions.ConnectionProvider.Driver.GetType() == typeof(OdbcDriver))
+				if (Sfi.ConnectionProvider.Driver.GetType() == typeof(OdbcDriver))
 					connection = new OdbcConnection(connectionString);
 				else
 					connection = new SqlConnection(connectionString);

--- a/src/NHibernate.Test/NHSpecificTest/NH2477/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2477/Fixture.cs
@@ -57,7 +57,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2477
 		{
 			using (new Scenario(Sfi))
 			{
-				using (var session = sessions.OpenSession())
+				using (var session = Sfi.OpenSession())
 				using (session.BeginTransaction())
 				{
 					// This is another case where we have to work with subqueries and we have to write a specific query rewriter for Skip/Take instead flat the query in QueryReferenceExpressionFlattener

--- a/src/NHibernate.Test/NHSpecificTest/NH2664/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2664/Fixture.cs
@@ -120,8 +120,8 @@ namespace NHibernate.Test.NHSpecificTest.NH2664
 				Expression<Func<IEnumerable>> key1 = () => (from a in session.Query<Product>() where a.Properties["Name"] == "val" select a);
 				Expression<Func<IEnumerable>> key2 = () => (from a in session.Query<Product>() where a.Properties["Description"] == "val" select a);
 
-				var nhKey1 = new NhLinqExpression(key1.Body, sessions);
-				var nhKey2 = new NhLinqExpression(key2.Body, sessions);
+				var nhKey1 = new NhLinqExpression(key1.Body, Sfi);
+				var nhKey2 = new NhLinqExpression(key2.Body, Sfi);
 
 				Assert.AreNotEqual(nhKey1.Key, nhKey2.Key);
 			}

--- a/src/NHibernate.Test/NHSpecificTest/NH2721/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2721/Fixture.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2721
 	{
 		protected override void OnTearDown()
 		{
-			using( ISession s = sessions.OpenSession() )
+			using( ISession s = Sfi.OpenSession() )
 			{
                 s.Delete("from A");
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH2812/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2812/Fixture.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2812
 		[Test]
 		public void PerformingAQueryOnAByteColumnShouldNotThrowEqualityOperator()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var query = (from e in session.Query<EntityWithAByteValue>()
 							 where e.ByteValue == 1
@@ -47,7 +47,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2812
 		[Test]
 		public void PerformingAQueryOnAByteColumnShouldNotThrowEquals()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			{
 				var query = (from e in session.Query<EntityWithAByteValue>()
 							 where e.ByteValue.Equals(1)

--- a/src/NHibernate.Test/NHSpecificTest/NH2828/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2828/Fixture.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2828
 			//Now in a second transaction i remove the address and persist Company: for a cascade option the Address will be removed
 			using (var sl = new SqlLogSpy())
 			{
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					using (ITransaction tx = session.BeginTransaction())
 					{
@@ -37,7 +37,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2828
 
 		private void Cleanup(Guid companyId)
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				using (ITransaction tx = session.BeginTransaction())
 				{
@@ -54,7 +54,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2828
 			var bankAccount = new BankAccount() {Name = "Bank test"};
 			company.AddAddress(address);
 			company.AddBank(bankAccount);
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				using (ITransaction tx = session.BeginTransaction())
 				{

--- a/src/NHibernate.Test/NHSpecificTest/NH2856/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2856/Fixture.cs
@@ -45,21 +45,21 @@ namespace NHibernate.Test.NHSpecificTest.NH2856
 					.Fetch(p => p.Address)
 					.Cacheable();
 
-				sessions.Statistics.Clear();
+				Sfi.Statistics.Clear();
 
 				var result = query.ToList(); // Execute the query
 
 				Assert.That(result.Count, Is.EqualTo(1));
-				Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
-				Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(0));
+				Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
 
-				sessions.Statistics.Clear();
+				Sfi.Statistics.Clear();
 
 				var cachedResult = query.ToList(); // Re-execute the query
 
 				Assert.That(cachedResult.Count, Is.EqualTo(1));
-				Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(0));
-				Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+				Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0));
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2880/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2880/Fixture.cs
@@ -12,7 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2880
 
 		protected override void OnSetUp()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				using (ITransaction t = s.BeginTransaction())
 				{
@@ -36,7 +36,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2880
 		{
 			MemoryStream sessionMemoryStream;
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				using (ITransaction t = s.BeginTransaction())
 				{
@@ -66,7 +66,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2880
 		{
 			MemoryStream sessionMemoryStream;
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.EnableFilter("myFilter");
 
@@ -86,7 +86,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2880
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				using (ITransaction t = s.BeginTransaction())
 				{

--- a/src/NHibernate.Test/NHSpecificTest/NH2898/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2898/Fixture.cs
@@ -1,6 +1,5 @@
 using NHibernate.Cfg;
 using NHibernate.Criterion;
-using NHibernate.Engine;
 using NHibernate.Intercept;
 using NHibernate.Properties;
 using NUnit.Framework;
@@ -10,12 +9,17 @@ namespace NHibernate.Test.NHSpecificTest.NH2898
 	[TestFixture]
 	public class Fixture : BugTestCase
 	{
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.Properties[Environment.CacheProvider] = typeof(BinaryFormatterCacheProvider).AssemblyQualifiedName;
+			configuration.Properties[Environment.UseQueryCache] = "true";
+		}
+
 		protected override void OnSetUp()
 		{
-			cfg.Properties[Environment.CacheProvider] = typeof (BinaryFormatterCacheProvider).AssemblyQualifiedName;
-			cfg.Properties[Environment.UseQueryCache] = "true";
-			sessions = (ISessionFactoryImplementor) cfg.BuildSessionFactory();
-
+			// Clear cache at each test.
+			RebuildSessionFactory();
 			using (var session = OpenSession())
 			using (var tx = session.BeginTransaction())
 			{

--- a/src/NHibernate.Test/NHSpecificTest/NH2985/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2985/Fixture.cs
@@ -39,8 +39,8 @@ namespace NHibernate.Test.NHSpecificTest.NH2985
 			}
 
 			// Clear the cache
-			sessions.Evict(typeof (ClassA));
-			sessions.Evict(typeof (WebImage));
+			Sfi.Evict(typeof (ClassA));
+			Sfi.Evict(typeof (WebImage));
 
 			using (ISession s = OpenSession())
 			using (ITransaction tx = s.BeginTransaction())

--- a/src/NHibernate.Test/NHSpecificTest/NH3050/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3050/Fixture.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3050
 			// get the planCache field on the QueryPlanCache and overwrite it with the restricted cache
 			queryPlanCacheType
 				.GetField("planCache", BindingFlags.Instance | BindingFlags.NonPublic)
-				.SetValue(sessions.QueryPlanCache, cache);
+				.SetValue(Sfi.QueryPlanCache, cache);
 
 			// Initiate a LINQ query with a contains with one item in it, of which we know that the underlying IQueryExpression implementations
 			// aka NhLinqExpression and the ExpandedQueryExpression generate the same key.
@@ -82,7 +82,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3050
 				// This will constantly interact with the cache (Once in the PrepareQuery method of the DefaultQueryProvider and once in the Execute)
 				System.Action queryExecutor = () =>
 					{
-						var sessionToUse = sessions.OpenSession();
+						var sessionToUse = Sfi.OpenSession();
 
 						try
 						{

--- a/src/NHibernate.Test/NHSpecificTest/NH3050/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3050/FixtureByCode.cs
@@ -102,20 +102,20 @@ namespace NHibernate.Test.NHSpecificTest.NH3050
 		/// <param name="factory"></param>
 		/// <param name="size"></param>
 		/// <returns></returns>
-		private static bool TrySetQueryPlanCacheSize(NHibernate.ISessionFactory factory, int size)
+		private static bool TrySetQueryPlanCacheSize(ISessionFactory factory, int size)
 		{
-			var factoryImpl = factory as NHibernate.Impl.SessionFactoryImpl;
+			var factoryImpl = (factory as DebugSessionFactory)?.ActualFactory as Impl.SessionFactoryImpl;
 			if (factoryImpl != null)
 			{
-				var queryPlanCacheFieldInfo = typeof(NHibernate.Impl.SessionFactoryImpl).GetField("queryPlanCache", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+				var queryPlanCacheFieldInfo = typeof(Impl.SessionFactoryImpl).GetField("queryPlanCache", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 				if (queryPlanCacheFieldInfo != null)
 				{
-					var queryPlanCache = (NHibernate.Engine.Query.QueryPlanCache)queryPlanCacheFieldInfo.GetValue(factoryImpl);
+					var queryPlanCache = (Engine.Query.QueryPlanCache)queryPlanCacheFieldInfo.GetValue(factoryImpl);
 
-					var planCacheFieldInfo = typeof(NHibernate.Engine.Query.QueryPlanCache).GetField("planCache", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+					var planCacheFieldInfo = typeof(Engine.Query.QueryPlanCache).GetField("planCache", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 					if (planCacheFieldInfo != null)
 					{
-						var softLimitMRUCache = new NHibernate.Util.SoftLimitMRUCache(size);
+						var softLimitMRUCache = new Util.SoftLimitMRUCache(size);
 
 						planCacheFieldInfo.SetValue(queryPlanCache, softLimitMRUCache);
 						return true;

--- a/src/NHibernate.Test/NHSpecificTest/NH3058/SampleTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3058/SampleTest.cs
@@ -1,5 +1,4 @@
 ﻿using NHibernate.Context;
-using NHibernate.Engine;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3058
@@ -7,15 +6,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3058
 	[TestFixture]
 	public class SampleTest : BugTestCase
 	{
-		public static ISessionFactoryImplementor AmbientSfi { get; private set; }
-
-		protected override void BuildSessionFactory()
-		{
-			base.BuildSessionFactory();
-
-			AmbientSfi = Sfi;
-		}
-
 		protected override void Configure(Cfg.Configuration configuration)
 		{
 			base.Configure(configuration);

--- a/src/NHibernate.Test/NHSpecificTest/NH3121/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3121/Fixture.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3121
 			// For SQL Server only the SqlClientDriver sets parameter lengths
 			// even when there is no length specified in the mapping. The ODBC
 			// driver won't cause the truncation issue and hence not the exception.
-			if (!(sessions.ConnectionProvider.Driver is SqlClientDriver))
+			if (!(Sfi.ConnectionProvider.Driver is SqlClientDriver))
 				Assert.Ignore("Test limited to drivers that sets parameter length even with no length specified in the mapping.");
 
 			const int reportSize = 17158;

--- a/src/NHibernate.Test/NHSpecificTest/NH3234/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3234/Fixture.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3234
 		private void Evict(ISession session, GridWidget widget)
 		{
 			session.Evict(widget);
-			sessions.Evict(widget.GetType());
+			Sfi.Evict(widget.GetType());
 		}
 
 		private static void Save(ISession session, GridWidget widget)

--- a/src/NHibernate.Test/NHSpecificTest/NH3436/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3436/Fixture.cs
@@ -98,7 +98,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3436
 
 		private void Run(ICollection<Guid> ids)
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (session.BeginTransaction())
 			{
 				var result = session.Query<TestEntity>()

--- a/src/NHibernate.Test/NHSpecificTest/NH3505/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3505/Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3505
 	{
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from Student");
 			    s.Delete("from Teacher");

--- a/src/NHibernate.Test/NHSpecificTest/NH3518/XmlColumnTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3518/XmlColumnTest.cs
@@ -12,7 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3518
 	{
 		protected override void OnTearDown()
 		{
-			using (var session = sessions.OpenSession())
+			using (var session = Sfi.OpenSession())
 			using (var t = session.BeginTransaction())
 			{
 				session.Delete("from ClassWithXmlMember");
@@ -43,7 +43,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3518
 			xmlDocument.AppendChild(xmlElement);
 			var parentA = new ClassWithXmlMember("A", xmlDocument);
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			using (var t = s.BeginTransaction())
 			{
 				s.Save(parentA);

--- a/src/NHibernate.Test/NHSpecificTest/NH3571/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3571/Fixture.cs
@@ -124,8 +124,8 @@ namespace NHibernate.Test.NHSpecificTest.NH3571
 				Expression<Func<IEnumerable>> key2 = () => (from a in session.Query<Product>() where (string) a.Details.Properties["Description"] == "val" select a);
 // ReSharper restore AccessToDisposedClosure
 
-				var nhKey1 = new NhLinqExpression(key1.Body, sessions);
-				var nhKey2 = new NhLinqExpression(key2.Body, sessions);
+				var nhKey1 = new NhLinqExpression(key1.Body, Sfi);
+				var nhKey2 = new NhLinqExpression(key2.Body, Sfi);
 
 				Assert.AreNotEqual(nhKey1.Key, nhKey2.Key);
 			}

--- a/src/NHibernate.Test/NHSpecificTest/NH3771/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3771/Fixture.cs
@@ -25,10 +25,10 @@ namespace NHibernate.Test.NHSpecificTest.NH3771
 		[Description("Should be two batchs with two sentences each.")]
 		public void InsertAndUpdateWithBatch()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			using (var sqlLog = new SqlLogSpy())
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				Singer vs1 = new Singer();
@@ -71,7 +71,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3771
 				Assert.AreEqual(2, batchs);
 				Assert.AreEqual(0, sqls);
 				Assert.AreEqual(4, batchCommands);
-				Assert.AreEqual(2, sessions.Statistics.PrepareStatementCount);
+				Assert.AreEqual(2, Sfi.Statistics.PrepareStatementCount);
 
 				tx.Rollback();
 			}

--- a/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3795/Fixture.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		[Test]
 		public void TestFieldAliasInQueryOver()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				A rowalias = null;
 				s.QueryOver(() => AAliasField)
@@ -35,7 +35,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		[Test]
 		public void TestFieldAliasInQueryOverWithConversion()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				B rowalias = null;
 				s.QueryOver(() => AAliasField)
@@ -49,7 +49,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		[Test]
 		public void TestFieldAliasInJoinAlias()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				Child rowalias = null;
 				s.QueryOver<Parent>()
@@ -64,7 +64,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		[Test]
 		public void TestFieldAliasInJoinQueryOver()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				Child rowalias = null;
 				s.QueryOver<Parent>()
@@ -80,7 +80,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		public void TestAliasInQueryOver()
 		{
 			A aAlias = null;
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				A rowalias = null;
 				s.QueryOver(() => aAlias)
@@ -96,7 +96,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		public void TestAliasInQueryOverWithConversion()
 		{
 			A aAlias = null;
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				B rowalias = null;
 				s.QueryOver(() => aAlias)
@@ -112,7 +112,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		{
 			Child childAlias = null;
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				Child rowalias = null;
 				s.QueryOver<Parent>()
@@ -129,7 +129,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3795
 		{
 			Child childAlias = null;
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				Child rowalias = null;
 				s.QueryOver<Parent>()

--- a/src/NHibernate.Test/NHSpecificTest/NH392/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH392/Fixture.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Test.NHSpecificTest.NH392
 
         protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from UnsavedValueMinusOne");
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH3932/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3932/Fixture.cs
@@ -189,7 +189,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3932
 
 		protected override void OnTearDown()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				using (var tx = s.BeginTransaction())
 				{

--- a/src/NHibernate.Test/NHSpecificTest/NH508/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH508/Fixture.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.NH508
 
 			object userId = null;
 
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tran = session.BeginTransaction())
 			{
 				session.Save(friend1);
@@ -38,7 +38,7 @@ namespace NHibernate.Test.NHSpecificTest.NH508
 			}
 
 			// reload the user and remove one of the 3 friends
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tran = session.BeginTransaction())
 			{
 				User reloadedFriend = (User) session.Load(typeof(User), friend1.UserId);
@@ -47,7 +47,7 @@ namespace NHibernate.Test.NHSpecificTest.NH508
 				tran.Commit();
 			}
 
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (ITransaction tx = session.BeginTransaction())
 			{
 				User admin = (User) session.Get(typeof(User), userId);

--- a/src/NHibernate.Test/NHSpecificTest/NH687/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH687/Fixture.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Test.NHSpecificTest.NH687
 			try
 			{
 				int child1Id, child2Id;
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					session.Save(foo);
 
@@ -41,7 +41,7 @@ namespace NHibernate.Test.NHSpecificTest.NH687
 					session.Flush();
 				}
 
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					Foo r = session.Get<Foo>(foo.Id);
 					Assert.IsNotNull(r);

--- a/src/NHibernate.Test/NHSpecificTest/NH719/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH719/Fixture.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.NHSpecificTest.NH719
 
 			try
 			{
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					session.Save(a);
 					session.Save(b);
@@ -31,7 +31,7 @@ namespace NHibernate.Test.NHSpecificTest.NH719
 					session.Flush();
 				}
 
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					// runs OK, since it's not cached
 					NotCached nc = (NotCached) session.Load(typeof(NotCached), 1);
@@ -43,7 +43,7 @@ namespace NHibernate.Test.NHSpecificTest.NH719
 				}
 
 				// 2nd run fails, when data is read from the cache
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					// runs OK, since it's not cached
 					NotCached nc = (NotCached) session.Load(typeof(NotCached), 1);

--- a/src/NHibernate.Test/NHSpecificTest/NH734/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH734/Fixture.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.NHSpecificTest.NH734
 		[TestAttribute]
 		public void LimitProblem()
 		{
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			{
 				ICriteria criteria = session.CreateCriteria(typeof(MyClass));
 				criteria.SetMaxResults(100);

--- a/src/NHibernate.Test/NHSpecificTest/NH750/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/Fixture.cs
@@ -8,7 +8,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 	{
 		protected override void OnTearDown()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete("from Device");
 				s.Delete("from Drive");
@@ -25,7 +25,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			Drive dr3 = new Drive("Drive 3");
 			Device dv1 = new Device("Device 1");
 			Device dv2 = new Device("Device 2");
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Save(dr1);
 				s.Save(dr2);
@@ -39,7 +39,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			dv1.Drives.Add(dr2);
 			dv2.Drives.Add(dr1);
 			dv2.Drives.Add(dr3);
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				dvSavedId[0] = (int) s.Save(dv1);
 				dvSavedId[1] = (int) s.Save(dv2);
@@ -47,7 +47,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			}
 			dv1 = null;
 			dv2 = null;
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.Delete(dr3);
 				s.Flush();

--- a/src/NHibernate.Test/NHSpecificTest/NH776/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH776/Fixture.cs
@@ -18,14 +18,14 @@ namespace NHibernate.Test.NHSpecificTest.NH776
 
 			try
 			{
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					session.Save(a);
 
 					session.Flush();
 				}
 
-				using (ISession session = sessions.OpenSession())
+				using (ISession session = Sfi.OpenSession())
 				{
 					A loadedA = (A) session.Load(typeof(A), 1);
 					Assert.IsNull(loadedA.NotProxied);

--- a/src/NHibernate.Test/NHSpecificTest/NH995/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH995/Fixture.cs
@@ -55,9 +55,9 @@ namespace NHibernate.Test.NHSpecificTest.NH995
 			}
 
 			// Clear the cache
-			sessions.Evict(typeof(ClassA));
-			sessions.Evict(typeof(ClassB));
-			sessions.Evict(typeof(ClassC));
+			Sfi.Evict(typeof(ClassA));
+			Sfi.Evict(typeof(ClassB));
+			Sfi.Evict(typeof(ClassC));
 			
 			using(ISession s = OpenSession())
 			using (ITransaction tx = s.BeginTransaction())

--- a/src/NHibernate.Test/NHSpecificTest/OptimisticConcurrencyFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/OptimisticConcurrencyFixture.cs
@@ -56,7 +56,7 @@ namespace NHibernate.Test.NHSpecificTest
 
 					top.Name = "new name";
 
-					var expectedException = sessions.Settings.IsBatchVersionedDataEnabled
+					var expectedException = Sfi.Settings.IsBatchVersionedDataEnabled
 						? Throws.InstanceOf<StaleStateException>()
 						: Throws.InstanceOf<StaleObjectStateException>();
 
@@ -95,7 +95,7 @@ namespace NHibernate.Test.NHSpecificTest
 
 					optimistic.String = "new string";
 
-					var expectedException = sessions.Settings.IsBatchVersionedDataEnabled
+					var expectedException = Sfi.Settings.IsBatchVersionedDataEnabled
 						? Throws.InstanceOf<StaleStateException>()
 						: Throws.InstanceOf<StaleObjectStateException>();
 

--- a/src/NHibernate.Test/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 		[Test]
 		public void MultiHqlShouldThrowUserException()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (!driver.SupportsMultipleQueries)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 
@@ -57,7 +57,7 @@ namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 		[Test]
 		public void MultiCriteriaShouldThrowUserException()
 		{
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (!driver.SupportsMultipleQueries)
 				Assert.Ignore("Driver {0} does not support multi-queries", driver.GetType().FullName);
 

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Criteria\ProjectionsTest.cs" />
     <Compile Include="Criteria\Reptile.cs" />
     <Compile Include="CrossThreadTestRunner.cs" />
+    <Compile Include="DebugSessionFactory.cs" />
     <Compile Include="DialectTest\FunctionTests\SubstringSupportFixture.cs" />
     <Compile Include="DialectTest\FunctionTests\SequenceSupportFixture.cs" />
     <Compile Include="DialectTest\Ingres9DialectFixture.cs" />

--- a/src/NHibernate.Test/Naturalid/Immutable/ImmutableNaturalIdFixture.cs
+++ b/src/NHibernate.Test/Naturalid/Immutable/ImmutableNaturalIdFixture.cs
@@ -89,7 +89,7 @@ namespace NHibernate.Test.Naturalid.Immutable
 			s.Transaction.Commit();
 			s.Close();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			s.BeginTransaction();
@@ -101,9 +101,9 @@ namespace NHibernate.Test.Naturalid.Immutable
 			s.Transaction.Commit();
 			s.Close();
 
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCachePutCount);
 
 			s = OpenSession();
 			s.BeginTransaction();
@@ -112,7 +112,7 @@ namespace NHibernate.Test.Naturalid.Immutable
 			s.Transaction.Commit();
 			s.Close();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			s.BeginTransaction();
@@ -121,15 +121,15 @@ namespace NHibernate.Test.Naturalid.Immutable
 				s.CreateCriteria(typeof(User)).Add(Restrictions.NaturalId().Set("UserName", "steve")).SetCacheable(true).
 					UniqueResult();
 			Assert.That(u, Is.Not.Null);
-			Assert.AreEqual(0, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCacheHitCount);
 			u =
 				(User)
 				s.CreateCriteria(typeof(User)).Add(Restrictions.NaturalId().Set("UserName", "steve")).SetCacheable(true).
 					UniqueResult();
 			Assert.That(u, Is.Not.Null);
-			Assert.AreEqual(0, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(2, sessions.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(2, Sfi.Statistics.QueryCacheHitCount);
 			s.Transaction.Commit();
 			s.Close();
 

--- a/src/NHibernate.Test/Naturalid/Mutable/MutableNaturalIdFixture.cs
+++ b/src/NHibernate.Test/Naturalid/Mutable/MutableNaturalIdFixture.cs
@@ -71,7 +71,7 @@ namespace NHibernate.Test.Naturalid.Mutable
 		[Test]
 		public void NonexistentNaturalIdCache()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			ISession s = OpenSession();
 			ITransaction t = s.BeginTransaction();
@@ -85,9 +85,9 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCachePutCount);
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -98,7 +98,7 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -113,11 +113,11 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCachePutCount);
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -132,10 +132,10 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			Assert.AreEqual(0, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCacheHitCount);
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -149,9 +149,9 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCachePutCount);
 		}
 
 		[Test]
@@ -166,7 +166,7 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -180,9 +180,9 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCachePutCount);
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -193,7 +193,7 @@ namespace NHibernate.Test.Naturalid.Mutable
 			t.Commit();
 			s.Close();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			s = OpenSession();
 			t = s.BeginTransaction();
@@ -203,15 +203,15 @@ namespace NHibernate.Test.Naturalid.Mutable
 				.SetCacheable(true).UniqueResult();
 
 			Assert.That(u, Is.Not.Null);
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
 
 			u = (User)s.CreateCriteria(typeof(User))
 				.Add(Restrictions.NaturalId().Set("name", "gavin").Set("org", "hb"))
 				.SetCacheable(true).UniqueResult();
 			Assert.That(u, Is.Not.Null);
-			Assert.AreEqual(1, sessions.Statistics.QueryExecutionCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryExecutionCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCacheHitCount);
 
 			t.Commit();
 			s.Close();

--- a/src/NHibernate.Test/Ondelete/JoinedSubclassFixture.cs
+++ b/src/NHibernate.Test/Ondelete/JoinedSubclassFixture.cs
@@ -36,7 +36,7 @@ namespace NHibernate.Test.Ondelete
 			t.Commit();
 			s.Close();
 
-			IStatistics statistics = sessions.Statistics;
+			IStatistics statistics = Sfi.Statistics;
 			statistics.Clear();
 
 			s = OpenSession();

--- a/src/NHibernate.Test/Ondelete/OnDeleteFixture.cs
+++ b/src/NHibernate.Test/Ondelete/OnDeleteFixture.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Test.Ondelete
 		[Test]
 		public void JoinedSubclass()
 		{
-			IStatistics statistics = sessions.Statistics;
+			IStatistics statistics = Sfi.Statistics;
 			statistics.Clear();
 
 			ISession s = OpenSession();

--- a/src/NHibernate.Test/Ondelete/ParentChildFixture.cs
+++ b/src/NHibernate.Test/Ondelete/ParentChildFixture.cs
@@ -40,7 +40,7 @@ namespace NHibernate.Test.Ondelete
 			t.Commit();
 			s.Close();
 
-			IStatistics statistics = sessions.Statistics;
+			IStatistics statistics = Sfi.Statistics;
 			statistics.Clear();
 
 			s = OpenSession();

--- a/src/NHibernate.Test/Operations/AbstractOperationTestCase.cs
+++ b/src/NHibernate.Test/Operations/AbstractOperationTestCase.cs
@@ -36,22 +36,22 @@ namespace NHibernate.Test.Operations
 
 		protected void ClearCounts()
 		{
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 		}
 
 		protected void AssertInsertCount(long expected)
 		{
-			Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(expected), "unexpected insert count");
+			Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(expected), "unexpected insert count");
 		}
 
 		protected void AssertUpdateCount(int expected)
 		{
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(expected), "unexpected update count");
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(expected), "unexpected update count");
 		}
 
 		protected void AssertDeleteCount(int expected)
 		{
-			Assert.That(sessions.Statistics.EntityDeleteCount, Is.EqualTo(expected), "unexpected delete count");
+			Assert.That(Sfi.Statistics.EntityDeleteCount, Is.EqualTo(expected), "unexpected delete count");
 		}
 	}
 }

--- a/src/NHibernate.Test/Operations/MergeFixture.cs
+++ b/src/NHibernate.Test/Operations/MergeFixture.cs
@@ -257,7 +257,7 @@ namespace NHibernate.Test.Operations
 			AssertUpdateCount(1);
 			ClearCounts();
 
-			sessions.Evict(typeof (NumberedNode));
+			Sfi.Evict(typeof (NumberedNode));
 
 			var child2 = new NumberedNode("child2");
 			var grandchild3 = new NumberedNode("grandchild3");

--- a/src/NHibernate.Test/ProjectionFixtures/Fixture.cs
+++ b/src/NHibernate.Test/ProjectionFixtures/Fixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.ProjectionFixtures
 
         protected override void OnSetUp()
         {
-            using(var s = sessions.OpenSession())
+            using(var s = Sfi.OpenSession())
             using(var tx = s.BeginTransaction())
             {
                 var root = new TreeNode
@@ -55,7 +55,7 @@ namespace NHibernate.Test.ProjectionFixtures
 
         protected override void OnTearDown()
         {
-            using(var s = sessions.OpenSession())
+            using(var s = Sfi.OpenSession())
             using (var tx = s.BeginTransaction())
             {
                 s.Delete("from TreeNode");
@@ -72,7 +72,7 @@ namespace NHibernate.Test.ProjectionFixtures
 			    Assert.Ignore(
 				    "Test checks for exact sql and expects an error to occur in a case which is not erroneous on all databases.");
 
-		    string pName = ((ISqlParameterFormatter) sessions.ConnectionProvider.Driver).GetParameterName(0);
+		    string pName = ((ISqlParameterFormatter) Sfi.ConnectionProvider.Driver).GetParameterName(0);
 		    string expectedMessagePart0 =
 			    string.Format("could not execute query" + Environment.NewLine +
 			                  "[ SELECT this_.Id as y0_, count(this_.Area) as y1_ FROM TreeNode this_ WHERE this_.Id = {0} ]",
@@ -92,7 +92,7 @@ namespace NHibernate.Test.ProjectionFixtures
 
 		    var e = Assert.Throws<GenericADOException>(() =>
 		    {
-			    using (var s = sessions.OpenSession())
+			    using (var s = Sfi.OpenSession())
 			    using (var tx = s.BeginTransaction())
 			    {
 				    var criteria = projection.GetExecutableCriteria(s);
@@ -122,7 +122,7 @@ namespace NHibernate.Test.ProjectionFixtures
                     .Add(Projections.Count(Projections.Property("grandchild.Key.Id")))
                 );
 
-            using(var s = sessions.OpenSession())
+            using(var s = Sfi.OpenSession())
             using(var tx = s.BeginTransaction())
             {
                 var criteria = projection.GetExecutableCriteria(s);

--- a/src/NHibernate.Test/QueryTest/MultiCriteriaFixture.cs
+++ b/src/NHibernate.Test/QueryTest/MultiCriteriaFixture.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Test.QueryTest
 		{
 			base.OnSetUp();
 
-			this.sessions.Statistics.Clear();
+			this.Sfi.Statistics.Clear();
 		}
 
 		protected override void OnTearDown()
@@ -122,7 +122,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void CanUseSecondLevelCacheWithPositionalParameters()
 		{
-			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(sessions);
+			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(Sfi);
 			cacheHashtable.Clear();
 
 			CreateItems();
@@ -139,7 +139,7 @@ namespace NHibernate.Test.QueryTest
 			//set the query in the cache
 			DoMutiQueryAndAssert();
 
-			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(sessions);
+			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(Sfi);
 			var cachedListEntry = (IList)new ArrayList(cacheHashtable.Values)[0];
 			var cachedQuery = (IList)cachedListEntry[1];
 
@@ -151,7 +151,7 @@ namespace NHibernate.Test.QueryTest
 			var secondQueryResults = (IList)cachedQuery[1];
 			secondQueryResults[0] = 2;
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var criteria = s.CreateCriteria(typeof(Item))
 					.Add(Restrictions.Gt("id", 50));
@@ -173,14 +173,14 @@ namespace NHibernate.Test.QueryTest
 			CreateItems();
 
 			DoMutiQueryAndAssert();
-			Assert.AreEqual(0, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCacheMissCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(0, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCacheMissCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCachePutCount);
 
 			DoMutiQueryAndAssert();
-			Assert.AreEqual(1, sessions.Statistics.QueryCacheHitCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCacheMissCount);
-			Assert.AreEqual(1, sessions.Statistics.QueryCachePutCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCacheHitCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCacheMissCount);
+			Assert.AreEqual(1, Sfi.Statistics.QueryCachePutCount);
 		}
 
 		[Test]

--- a/src/NHibernate.Test/QueryTest/MultipleMixedQueriesFixture.cs
+++ b/src/NHibernate.Test/QueryTest/MultipleMixedQueriesFixture.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void NH_1085_WillIgnoreParametersIfDoesNotAppearInQuery()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var multiQuery = s.CreateMultiQuery()
 					.Add(s.CreateSQLQuery("select * from ITEM where Id in (:ids)").AddEntity(typeof (Item)))
@@ -52,7 +52,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void NH_1085_WillGiveReasonableErrorIfBadParameterName()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var multiQuery = s.CreateMultiQuery()
 					.Add(s.CreateSQLQuery("select * from ITEM where Id in (:ids)").AddEntity(typeof(Item)))
@@ -69,7 +69,7 @@ namespace NHibernate.Test.QueryTest
 			//set the query in the cache
 			DoMutiQueryAndAssert();
 
-			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(sessions);
+			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(Sfi);
 			var cachedListEntry = (IList)new ArrayList(cacheHashtable.Values)[0];
 			var cachedQuery = (IList)cachedListEntry[1];
 
@@ -81,7 +81,7 @@ namespace NHibernate.Test.QueryTest
 			var secondQueryResults = (IList)cachedQuery[1];
 			secondQueryResults[0] = 2L;
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var multiQuery = s.CreateMultiQuery()
 					.Add(s.CreateSQLQuery("select * from ITEM where Id > ?").AddEntity(typeof(Item))
@@ -168,7 +168,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void CanUseSecondLevelCacheWithPositionalParameters()
 		{
-			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(sessions);
+			var cacheHashtable = MultipleQueriesFixture.GetHashTableUsedAsQueryCache(Sfi);
 			cacheHashtable.Clear();
 
 			CreateItems();

--- a/src/NHibernate.Test/QueryTest/MultipleQueriesFixture.cs
+++ b/src/NHibernate.Test/QueryTest/MultipleQueriesFixture.cs
@@ -41,7 +41,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void NH_1085_WillIgnoreParametersIfDoesNotAppearInQuery()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var multiQuery = s.CreateMultiQuery()
 					.Add("from Item i where i.Id in (:ids)")
@@ -55,7 +55,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void NH_1085_WillGiveReasonableErrorIfBadParameterName()
 		{
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var multiQuery = s.CreateMultiQuery()
 					.Add("from Item i where i.Id in (:ids)")
@@ -72,7 +72,7 @@ namespace NHibernate.Test.QueryTest
 			//set the query in the cache
 			DoMutiQueryAndAssert();
 
-			var cacheHashtable = GetHashTableUsedAsQueryCache(sessions);
+			var cacheHashtable = GetHashTableUsedAsQueryCache(Sfi);
 			var cachedListEntry = (IList)new ArrayList(cacheHashtable.Values)[0];
 			var cachedQuery = (IList)cachedListEntry[1];
 
@@ -84,7 +84,7 @@ namespace NHibernate.Test.QueryTest
 			var secondQueryResults = (IList)cachedQuery[1];
 			secondQueryResults[0] = 2L;
 
-			using (var s = sessions.OpenSession())
+			using (var s = Sfi.OpenSession())
 			{
 				var multiQuery = s.CreateMultiQuery()
 					.Add(s.CreateQuery("from Item i where i.Id > ?")
@@ -170,7 +170,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void CanUseSecondLevelCacheWithPositionalParameters()
 		{
-			var cacheHashtable = GetHashTableUsedAsQueryCache(sessions);
+			var cacheHashtable = GetHashTableUsedAsQueryCache(Sfi);
 			cacheHashtable.Clear();
 
 			CreateItems();

--- a/src/NHibernate.Test/QueryTest/NamedParametersFixture.cs
+++ b/src/NHibernate.Test/QueryTest/NamedParametersFixture.cs
@@ -45,7 +45,7 @@ namespace NHibernate.Test.QueryTest
 		[Test]
 		public void TestNullNamedParameter()
 		{
-			if (sessions.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory)
+			if (Sfi.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory)
 			{
 				Assert.Ignore("Not supported; The AST parser can guess the type.");
 			}

--- a/src/NHibernate.Test/ReadOnly/ReadOnlyCriteriaQueryTest.cs
+++ b/src/NHibernate.Test/ReadOnly/ReadOnlyCriteriaQueryTest.cs
@@ -71,10 +71,10 @@ namespace NHibernate.Test.ReadOnly
 				t.Commit();
 			}
 			
-			Assert.That(sessions.Statistics.EntityInsertCount, Is.EqualTo(4));
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(4));
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(0));
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 				
 			using (ISession s = OpenSession())
 			using (ITransaction t = s.BeginTransaction())
@@ -119,10 +119,10 @@ namespace NHibernate.Test.ReadOnly
 				t.Commit();
 			}
 
-			Assert.That(sessions.Statistics.EntityUpdateCount, Is.EqualTo(1));
-			Assert.That(sessions.Statistics.EntityDeleteCount, Is.EqualTo(4));
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.EntityDeleteCount, Is.EqualTo(4));
 			
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 		}
 		
 		[Test]

--- a/src/NHibernate.Test/SecondLevelCacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/SecondLevelCacheTest/QueryCacheFixture.cs
@@ -52,7 +52,7 @@ namespace NHibernate.Test.SecondLevelCacheTests
 		public void ShouldHitCacheUsingNamedQueryWithProjection()
 		{
 			FillDb(1);
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			using (ISession s = OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
@@ -61,11 +61,11 @@ namespace NHibernate.Test.SecondLevelCacheTests
 				tx.Commit();
 			}
 
-			Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
-			Assert.That(sessions.Statistics.QueryCachePutCount, Is.EqualTo(1));
-			Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			using (ISession s = OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
@@ -74,10 +74,10 @@ namespace NHibernate.Test.SecondLevelCacheTests
 				tx.Commit();
 			}
 
-			Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(0));
-			Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
 
-			sessions.Statistics.LogSummary();
+			Sfi.Statistics.LogSummary();
 			CleanUp();
 		}
 
@@ -85,7 +85,7 @@ namespace NHibernate.Test.SecondLevelCacheTests
 		public void ShouldHitCacheUsingQueryWithProjection()
 		{
 			FillDb(1);
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			int resultCount;
 			using (ISession s = OpenSession())
@@ -97,11 +97,11 @@ namespace NHibernate.Test.SecondLevelCacheTests
 				tx.Commit();
 			}
 
-			Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(1));
-			Assert.That(sessions.Statistics.QueryCachePutCount, Is.EqualTo(1));
-			Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			int secondResultCount;
 			using (ISession s = OpenSession())
@@ -112,26 +112,26 @@ namespace NHibernate.Test.SecondLevelCacheTests
 				tx.Commit();
 			}
 
-			Assert.That(sessions.Statistics.QueryExecutionCount, Is.EqualTo(0));
-			Assert.That(sessions.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0));
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
 			Assert.That(secondResultCount, Is.EqualTo(resultCount));
 
-			sessions.Statistics.LogSummary();
+			Sfi.Statistics.LogSummary();
 			CleanUp();
 		}
 
 		[Test]
 		public void QueryCacheInvalidation()
 		{
-			sessions.EvictQueries();
-			sessions.Statistics.Clear();
+			Sfi.EvictQueries();
+			Sfi.Statistics.Clear();
 
 			const string queryString = "from Item i where i.Name='widget'";
 
 			object savedId = CreateItem(queryString);
 
-			QueryStatistics qs = sessions.Statistics.GetQueryStatistics(queryString);
-			EntityStatistics es = sessions.Statistics.GetEntityStatistics(typeof(Item).FullName);
+			QueryStatistics qs = Sfi.Statistics.GetQueryStatistics(queryString);
+			EntityStatistics es = Sfi.Statistics.GetEntityStatistics(typeof(Item).FullName);
 
 			Thread.Sleep(200);
 
@@ -211,8 +211,8 @@ namespace NHibernate.Test.SecondLevelCacheTests
 		public void SimpleProjections()
 		{
 			var transformer = new CustomTransformer();
-			sessions.EvictQueries();
-			sessions.Statistics.Clear();
+			Sfi.EvictQueries();
+			Sfi.Statistics.Clear();
 
 			const string queryString = "select i.Name, i.Description from AnotherItem i where i.Name='widget'";
 
@@ -226,8 +226,8 @@ namespace NHibernate.Test.SecondLevelCacheTests
 				tx.Commit();
 			}
 
-			QueryStatistics qs = sessions.Statistics.GetQueryStatistics(queryString);
-			EntityStatistics es = sessions.Statistics.GetEntityStatistics(typeof(AnotherItem).FullName);
+			QueryStatistics qs = Sfi.Statistics.GetQueryStatistics(queryString);
+			EntityStatistics es = Sfi.Statistics.GetEntityStatistics(typeof(AnotherItem).FullName);
 
 			Thread.Sleep(200);
 

--- a/src/NHibernate.Test/SecondLevelCacheTest/SecondLevelCacheTest.cs
+++ b/src/NHibernate.Test/SecondLevelCacheTest/SecondLevelCacheTest.cs
@@ -22,14 +22,19 @@ namespace NHibernate.Test.SecondLevelCacheTests
 			get { return new string[] { "SecondLevelCacheTest.Item.hbm.xml" }; }
 		}
 
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.Properties[Environment.CacheProvider] = typeof(HashtableCacheProvider).AssemblyQualifiedName;
+			configuration.Properties[Environment.UseQueryCache] = "true";
+		}
+
 		protected override void OnSetUp()
 		{
-			cfg.Properties[Environment.CacheProvider] = typeof(HashtableCacheProvider).AssemblyQualifiedName;
-			cfg.Properties[Environment.UseQueryCache] = "true";
-			sessions = (ISessionFactoryImplementor)cfg.BuildSessionFactory();
-
+			// Clear cache at each test.
+			RebuildSessionFactory();
 			using (ISession session = OpenSession())
-			using(ITransaction tx = session.BeginTransaction())
+			using (ITransaction tx = session.BeginTransaction())
 			{
 				Item item = new Item();
 				item.Id = 1;
@@ -46,15 +51,15 @@ namespace NHibernate.Test.SecondLevelCacheTests
 				for (int i = 0; i < 5; i++)
 				{
 					AnotherItem obj = new AnotherItem("Item #" + i);
-					obj.Id = i+1;
+					obj.Id = i + 1;
 					session.Save(obj);
 				}
 
 				tx.Commit();
 			}
 
-			sessions.Evict(typeof(Item));
-			sessions.EvictCollection(typeof(Item).FullName + ".Children");
+			Sfi.Evict(typeof(Item));
+			Sfi.EvictCollection(typeof(Item).FullName + ".Children");
 		}
 
 		protected override void OnTearDown()

--- a/src/NHibernate.Test/SessionBuilder/Fixture.cs
+++ b/src/NHibernate.Test/SessionBuilder/Fixture.cs
@@ -11,11 +11,7 @@ namespace NHibernate.Test.SessionBuilder
 	{
 		protected override string MappingsAssembly => "NHibernate.Test";
 
-		protected override IList Mappings =>
-			new string[]
-			{
-				"SessionBuilder.Mappings.hbm.xml"
-			};
+		protected override IList Mappings => new [] { "SessionBuilder.Mappings.hbm.xml" };
 
 		protected override void Configure(Configuration configuration)
 		{
@@ -26,7 +22,7 @@ namespace NHibernate.Test.SessionBuilder
 		[Test]
 		public void CanSetAutoClose()
 		{
-			var sb = sessions.WithOptions();
+			var sb = Sfi.WithOptions();
 			CanSetAutoClose(sb);
 			using (var s = sb.OpenSession())
 			{
@@ -36,7 +32,7 @@ namespace NHibernate.Test.SessionBuilder
 
 		private void CanSetAutoClose<T>(T sb) where T : ISessionBuilder<T>
 		{
-			var options = (ISessionCreationOptions)sb;
+			var options = DebugSessionFactory.GetCreationOptions(sb);
 			CanSet(sb, sb.AutoClose, () => options.ShouldAutoClose,
 				sb is ISharedSessionBuilder ssb ? ssb.AutoClose : default(Func<ISharedSessionBuilder>),
 				// initial values
@@ -48,7 +44,7 @@ namespace NHibernate.Test.SessionBuilder
 		[Test]
 		public void CanSetConnection()
 		{
-			var sb = sessions.WithOptions();
+			var sb = Sfi.WithOptions();
 			CanSetConnection(sb);
 			using (var s = sb.OpenSession())
 			{
@@ -59,10 +55,10 @@ namespace NHibernate.Test.SessionBuilder
 		private void CanSetConnection<T>(T sb) where T : ISessionBuilder<T>
 		{
 			var sbType = sb.GetType().Name;
-			var conn = sessions.ConnectionProvider.GetConnection();
+			var conn = Sfi.ConnectionProvider.GetConnection();
 			try
 			{
-				var options = (ISessionCreationOptions)sb;
+				var options = DebugSessionFactory.GetCreationOptions(sb);
 				Assert.IsNull(options.UserSuppliedConnection, $"{sbType}: Initial value");
 				var fsb = sb.Connection(conn);
 				Assert.AreEqual(conn, options.UserSuppliedConnection, $"{sbType}: After call with a connection");
@@ -96,19 +92,19 @@ namespace NHibernate.Test.SessionBuilder
 			}
 			finally
 			{
-				sessions.ConnectionProvider.CloseConnection(conn);
+				Sfi.ConnectionProvider.CloseConnection(conn);
 			}
 		}
 
 		[Test]
 		public void CanSetConnectionOnStateless()
 		{
-			var sb = sessions.WithStatelessOptions();
+			var sb = Sfi.WithStatelessOptions();
 			var sbType = sb.GetType().Name;
-			var conn = sessions.ConnectionProvider.GetConnection();
+			var conn = Sfi.ConnectionProvider.GetConnection();
 			try
 			{
-				var options = (ISessionCreationOptions)sb;
+				var options = DebugSessionFactory.GetCreationOptions(sb);
 				Assert.IsNull(options.UserSuppliedConnection, $"{sbType}: Initial value");
 				var fsb = sb.Connection(conn);
 				Assert.AreEqual(conn, options.UserSuppliedConnection, $"{sbType}: After call with a connection");
@@ -120,14 +116,14 @@ namespace NHibernate.Test.SessionBuilder
 			}
 			finally
 			{
-				sessions.ConnectionProvider.CloseConnection(conn);
+				Sfi.ConnectionProvider.CloseConnection(conn);
 			}
 		}
 
 		[Test]
 		public void CanSetConnectionReleaseMode()
 		{
-			var sb = sessions.WithOptions();
+			var sb = Sfi.WithOptions();
 			CanSetConnectionReleaseMode(sb);
 			using (var s = sb.OpenSession())
 			{
@@ -137,11 +133,11 @@ namespace NHibernate.Test.SessionBuilder
 
 		private void CanSetConnectionReleaseMode<T>(T sb) where T : ISessionBuilder<T>
 		{
-			var options = (ISessionCreationOptions)sb;
+			var options = DebugSessionFactory.GetCreationOptions(sb);
 			CanSet(sb, sb.ConnectionReleaseMode, () => options.SessionConnectionReleaseMode,
 				sb is ISharedSessionBuilder ssb ? ssb.ConnectionReleaseMode : default(Func<ISharedSessionBuilder>),
 				// initial values
-				sessions.Settings.ConnectionReleaseMode,
+				Sfi.Settings.ConnectionReleaseMode,
 				// values
 				ConnectionReleaseMode.OnClose, ConnectionReleaseMode.AfterStatement, ConnectionReleaseMode.AfterTransaction);
 		}
@@ -149,7 +145,7 @@ namespace NHibernate.Test.SessionBuilder
 		[Test]
 		public void CanSetFlushMode()
 		{
-			var sb = sessions.WithOptions();
+			var sb = Sfi.WithOptions();
 			CanSetFlushMode(sb);
 			using (var s = sb.OpenSession())
 			{
@@ -159,11 +155,11 @@ namespace NHibernate.Test.SessionBuilder
 
 		private void CanSetFlushMode<T>(T sb) where T : ISessionBuilder<T>
 		{
-			var options = (ISessionCreationOptions)sb;
+			var options = DebugSessionFactory.GetCreationOptions(sb);
 			CanSet(sb, sb.FlushMode, () => options.InitialSessionFlushMode,
 				sb is ISharedSessionBuilder ssb ? ssb.FlushMode : default(Func<ISharedSessionBuilder>),
 				// initial values
-				sessions.Settings.DefaultFlushMode,
+				Sfi.Settings.DefaultFlushMode,
 				// values
 				FlushMode.Always, FlushMode.Auto, FlushMode.Commit, FlushMode.Manual);
 		}
@@ -171,7 +167,7 @@ namespace NHibernate.Test.SessionBuilder
 		[Test]
 		public void CanSetInterceptor()
 		{
-			var sb = sessions.WithOptions();
+			var sb = Sfi.WithOptions();
 			CanSetInterceptor(sb);
 			using (var s = sb.OpenSession())
 			{
@@ -184,9 +180,9 @@ namespace NHibernate.Test.SessionBuilder
 			var sbType = sb.GetType().Name;
 			// Do not use .Instance here, we want another instance.
 			var interceptor = new EmptyInterceptor();
-			var options = (ISessionCreationOptions)sb;
+			var options = DebugSessionFactory.GetCreationOptions(sb);
 
-			Assert.AreEqual(sessions.Interceptor, options.SessionInterceptor, $"{sbType}: Initial value");
+			Assert.AreEqual(Sfi.Interceptor, options.SessionInterceptor, $"{sbType}: Initial value");
 			var fsb = sb.Interceptor(interceptor);
 			Assert.AreEqual(interceptor, options.SessionInterceptor, $"{sbType}: After call with an interceptor");
 			Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with an interceptor");

--- a/src/NHibernate.Test/SqlTest/Custom/CustomSQLSupportTest.cs
+++ b/src/NHibernate.Test/SqlTest/Custom/CustomSQLSupportTest.cs
@@ -40,9 +40,9 @@ namespace NHibernate.Test.SqlTest.Custom
 			t.Commit();
 			s.Close();
 
-			sessions.Evict(typeof(Organization));
-			sessions.Evict(typeof(Person));
-			sessions.Evict(typeof(Employment));
+			Sfi.Evict(typeof(Organization));
+			Sfi.Evict(typeof(Person));
+			Sfi.Evict(typeof(Employment));
 
 			s = OpenSession();
 			t = s.BeginTransaction();

--- a/src/NHibernate.Test/Stateless/Fetching/StatelessSessionFetchingTest.cs
+++ b/src/NHibernate.Test/Stateless/Fetching/StatelessSessionFetchingTest.cs
@@ -41,7 +41,7 @@ namespace NHibernate.Test.Stateless.Fetching
 				tx.Commit();
 			}
 
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			using (ITransaction tx = ss.BeginTransaction())
 			{
 				ss.BeginTransaction();

--- a/src/NHibernate.Test/Stateless/FetchingLazyCollections/LazyCollectionFetchTests.cs
+++ b/src/NHibernate.Test/Stateless/FetchingLazyCollections/LazyCollectionFetchTests.cs
@@ -77,7 +77,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 			const string crocodileFather = "Crocodile father";
 			const string crocodileMother = "Crocodile mother";
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var rf = new Reptile { Description = crocodileFather };
@@ -96,7 +96,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 
 			const string humanFather = "Fred";
 			const string humanMother = "Wilma";
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var hf = new Human { Description = "Flinstone", Name = humanFather };
@@ -112,7 +112,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 				tx.Commit();
 			}
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				IList<Family<Human>> hf = s.CreateQuery("from HumanFamily").List<Family<Human>>();
@@ -130,7 +130,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 				tx.Commit();
 			}
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				IList<Family<Human>> hf = s.Query<Family<Human>>().FetchMany(f => f.Childs).ToList();
@@ -150,7 +150,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 				tx.Commit();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				s.Delete("from HumanFamily");

--- a/src/NHibernate.Test/Stateless/FetchingLazyCollections/TreeFetchTests.cs
+++ b/src/NHibernate.Test/Stateless/FetchingLazyCollections/TreeFetchTests.cs
@@ -31,7 +31,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 		[Test]
 		public void FetchMultipleHierarchies()
 		{
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var root = new TreeNode {Content = "Root"};
@@ -44,7 +44,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 				tx.Commit();
 			}
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				IList<TreeNode> rootNodes = s.Query<TreeNode>().Where(t => t.Content == "Root")
@@ -56,7 +56,7 @@ namespace NHibernate.Test.Stateless.FetchingLazyCollections
 				tx.Commit();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				s.Delete("from TreeNode");

--- a/src/NHibernate.Test/Stateless/StatelessSessionFixture.cs
+++ b/src/NHibernate.Test/Stateless/StatelessSessionFixture.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Test.Stateless
 			Document doc;
 			DateTime? initVersion;
 
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				ITransaction tx;
 				using (tx = ss.BeginTransaction())
@@ -93,7 +93,7 @@ namespace NHibernate.Test.Stateless
 		[Test]
 		public void HqlBulk()
 		{
-			IStatelessSession ss = sessions.OpenStatelessSession();
+			IStatelessSession ss = Sfi.OpenStatelessSession();
 			ITransaction tx = ss.BeginTransaction();
 			var doc = new Document("blah blah blah", "Blahs");
 			ss.Insert(doc);
@@ -124,7 +124,7 @@ namespace NHibernate.Test.Stateless
 		{
 			Paper paper;
 
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				ITransaction tx;
 				using (tx = ss.BeginTransaction())
@@ -147,7 +147,7 @@ namespace NHibernate.Test.Stateless
 		{
 			Paper paper;
 
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				using (ITransaction tx = ss.BeginTransaction())
 				{
@@ -156,7 +156,7 @@ namespace NHibernate.Test.Stateless
 					tx.Commit();
 				}
 			}
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				using (ITransaction tx = ss.BeginTransaction())
 				{
@@ -166,7 +166,7 @@ namespace NHibernate.Test.Stateless
 					tx.Commit();
 				}
 			}
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				using (ITransaction tx = ss.BeginTransaction())
 				{
@@ -185,7 +185,7 @@ namespace NHibernate.Test.Stateless
 			if (!Dialect.SupportsSqlBatches)
 				Assert.Ignore("Dialect does not support sql batches.");
 
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				ss.SetBatchSize(37);
 				var impl = (ISessionImplementor)ss;
@@ -196,7 +196,7 @@ namespace NHibernate.Test.Stateless
 		[Test]
 		public void CanGetImplementor()
 		{
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				Assert.That(ss.GetSessionImplementation(), Is.SameAs(ss));
 			}
@@ -206,7 +206,7 @@ namespace NHibernate.Test.Stateless
 		public void HavingDetachedCriteriaThenCanGetExecutableCriteriaFromStatelessSession()
 		{
 			var dc = DetachedCriteria.For<Paper>();
-			using (IStatelessSession ss = sessions.OpenStatelessSession())
+			using (IStatelessSession ss = Sfi.OpenStatelessSession())
 			{
 				ICriteria criteria = null;
 				Assert.That(() => criteria = dc.GetExecutableCriteria(ss), Throws.Nothing);
@@ -219,7 +219,7 @@ namespace NHibernate.Test.Stateless
 		{
 			try
 			{
-				IStatelessSession ss = sessions.OpenStatelessSession();
+				IStatelessSession ss = Sfi.OpenStatelessSession();
 				ss.Close();
 				ss.Dispose();
 			}

--- a/src/NHibernate.Test/Stateless/StatelessSessionQueryFixture.cs
+++ b/src/NHibernate.Test/Stateless/StatelessSessionQueryFixture.cs
@@ -76,10 +76,10 @@ namespace NHibernate.Test.Stateless
 		[Test]
 		public void Criteria()
 		{
-			var testData = new TestData(sessions);
+			var testData = new TestData(Sfi);
 			testData.createData();
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			{
 				Assert.AreEqual(1, s.CreateCriteria<Contact>().List().Count);
 			}
@@ -90,10 +90,10 @@ namespace NHibernate.Test.Stateless
 		[Test]
 		public void CriteriaWithSelectFetchMode()
 		{
-			var testData = new TestData(sessions);
+			var testData = new TestData(Sfi);
 			testData.createData();
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			{
 				Assert.AreEqual(1, s.CreateCriteria<Contact>().SetFetchMode("Org", FetchMode.Select).List().Count);
 			}
@@ -104,10 +104,10 @@ namespace NHibernate.Test.Stateless
 		[Test]
 		public void Hql()
 		{
-			var testData = new TestData(sessions);
+			var testData = new TestData(Sfi);
 			testData.createData();
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			{
 				Assert.AreEqual(1, s.CreateQuery("from Contact c join fetch c.Org join fetch c.Org.Country").List<Contact>().Count);
 			}

--- a/src/NHibernate.Test/Stateless/StatelessWithRelationsFixture.cs
+++ b/src/NHibernate.Test/Stateless/StatelessWithRelationsFixture.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Test.Stateless
 			const string crocodileFather = "Crocodile father";
 			const string crocodileMother = "Crocodile mother";
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var rf = new Reptile { Description = crocodileFather };
@@ -42,7 +42,7 @@ namespace NHibernate.Test.Stateless
 
 			const string humanFather = "Fred";
 			const string humanMother = "Wilma";
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				var hf = new Human { Description = "Flinstone", Name = humanFather };
@@ -58,7 +58,7 @@ namespace NHibernate.Test.Stateless
 				tx.Commit();
 			}
 
-			using (IStatelessSession s = sessions.OpenStatelessSession())
+			using (IStatelessSession s = Sfi.OpenStatelessSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				IList<Family<Human>> hf = s.CreateQuery("from HumanFamily").List<Family<Human>>();
@@ -78,7 +78,7 @@ namespace NHibernate.Test.Stateless
 				tx.Commit();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction tx = s.BeginTransaction())
 			{
 				s.Delete("from HumanFamily");

--- a/src/NHibernate.Test/Stats/SessionStatsFixture.cs
+++ b/src/NHibernate.Test/Stats/SessionStatsFixture.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Test.Stats
 		[Test]
 		public void Can_use_cached_query_that_return_no_results()
 		{
-			Assert.IsTrue(sessions.Settings.IsQueryCacheEnabled);
+			Assert.IsTrue(Sfi.Settings.IsQueryCacheEnabled);
 
 			using(ISession s = OpenSession())
 			{
@@ -70,7 +70,7 @@ namespace NHibernate.Test.Stats
 		{
 			ISession s = OpenSession();
 			ITransaction tx = s.BeginTransaction();
-			IStatistics stats = sessions.Statistics;
+			IStatistics stats = Sfi.Statistics;
 			stats.Clear();
 			bool isStats = stats.IsStatisticsEnabled;
 			stats.IsStatisticsEnabled = true;

--- a/src/NHibernate.Test/Stats/StatsFixture.cs
+++ b/src/NHibernate.Test/Stats/StatsFixture.cs
@@ -47,7 +47,7 @@ namespace NHibernate.Test.Stats
 		[Test]
 		public void CollectionFetchVsLoad()
 		{
-			IStatistics stats = sessions.Statistics;
+			IStatistics stats = Sfi.Statistics;
 			stats.Clear();
 
 			ISession s = OpenSession();
@@ -139,7 +139,7 @@ namespace NHibernate.Test.Stats
 		[Test]
 		public void QueryStatGathering()
 		{
-			IStatistics stats = sessions.Statistics;
+			IStatistics stats = Sfi.Statistics;
 			stats.Clear();
 
 			ISession s = OpenSession();
@@ -221,7 +221,7 @@ namespace NHibernate.Test.Stats
 				tx.Commit();
 			}
 
-			IStatistics stats = sessions.Statistics;
+			IStatistics stats = Sfi.Statistics;
 			stats.Clear();
 			using (ISession s = OpenSession())
 			{
@@ -238,7 +238,7 @@ namespace NHibernate.Test.Stats
 
 			stats.Clear();
 
-			var driver = sessions.ConnectionProvider.Driver;
+			var driver = Sfi.ConnectionProvider.Driver;
 			if (driver.SupportsMultipleQueries)
 			{
 				using (var s = OpenSession())

--- a/src/NHibernate.Test/SubselectFetchTest/SubselectFetchFixture.cs
+++ b/src/NHibernate.Test/SubselectFetchTest/SubselectFetchFixture.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Test.SubselectFetchTest
 			s = OpenSession();
 			t = s.BeginTransaction();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			IList parents = s.CreateQuery("from Parent where name between 'bar' and 'foo' order by name desc")
 				.List();
@@ -65,7 +65,7 @@ namespace NHibernate.Test.SubselectFetchTest
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
-			Assert.AreEqual(3, sessions.Statistics.PrepareStatementCount);
+			Assert.AreEqual(3, Sfi.Statistics.PrepareStatementCount);
 
 			Child c = (Child) p.Children[0];
 			NHibernateUtil.Initialize(c.Friends);
@@ -97,7 +97,7 @@ namespace NHibernate.Test.SubselectFetchTest
 			s = OpenSession();
 			t = s.BeginTransaction();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			IList parents = s.CreateQuery("from Parent where name between :bar and :foo order by name desc")
 				.SetParameter("bar", "bar")
@@ -130,7 +130,7 @@ namespace NHibernate.Test.SubselectFetchTest
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
-			Assert.AreEqual(3, sessions.Statistics.PrepareStatementCount);
+			Assert.AreEqual(3, Sfi.Statistics.PrepareStatementCount);
 
 			Child c = (Child) p.Children[0];
 			NHibernateUtil.Initialize(c.Friends);
@@ -162,7 +162,7 @@ namespace NHibernate.Test.SubselectFetchTest
 			s = OpenSession();
 			t = s.BeginTransaction();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			IList parents = s.CreateQuery("from Parent where name between ? and ? order by name desc")
 				.SetParameter(0, "bar")
@@ -195,7 +195,7 @@ namespace NHibernate.Test.SubselectFetchTest
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
-			Assert.AreEqual(3, sessions.Statistics.PrepareStatementCount);
+			Assert.AreEqual(3, Sfi.Statistics.PrepareStatementCount);
 
 			Child c = (Child) p.Children[0];
 			NHibernateUtil.Initialize(c.Friends);
@@ -229,7 +229,7 @@ namespace NHibernate.Test.SubselectFetchTest
 			s = OpenSession();
 			t = s.BeginTransaction();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			IList parents = s.CreateQuery("from Parent order by name desc")
 				.SetMaxResults(2)
@@ -245,7 +245,7 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(3, sessions.Statistics.PrepareStatementCount);
+			Assert.AreEqual(3, Sfi.Statistics.PrepareStatementCount);
 
 			r = (Parent) s.Get(typeof(Parent), r.Name);
 			Assert.IsTrue(NHibernateUtil.IsInitialized(r.Children)); // The test for True is the test of H3.2
@@ -321,7 +321,7 @@ namespace NHibernate.Test.SubselectFetchTest
 			s = OpenSession();
 			t = s.BeginTransaction();
 
-			sessions.Statistics.Clear();
+			Sfi.Statistics.Clear();
 
 			IList parents = s.CreateCriteria(typeof(Parent))
 				.Add(Expression.Between("Name", "bar", "foo"))
@@ -354,7 +354,7 @@ namespace NHibernate.Test.SubselectFetchTest
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
-			Assert.AreEqual(3, sessions.Statistics.PrepareStatementCount);
+			Assert.AreEqual(3, Sfi.Statistics.PrepareStatementCount);
 
 			Child c = (Child) p.Children[0];
 			NHibernateUtil.Initialize(c.Friends);

--- a/src/NHibernate.Test/SystemTransactions/TransactionFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/TransactionFixture.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void CanUseSystemTransactionsToCommit()
 		{
 			object identifier;
-			using(ISession session = sessions.OpenSession())
+			using(ISession session = Sfi.OpenSession())
 			using(TransactionScope tx = new TransactionScope())
 			{
 				W s = new W();
@@ -26,7 +26,7 @@ namespace NHibernate.Test.SystemTransactions
 				tx.Complete();
 			}
 
-			using (ISession session = sessions.OpenSession())
+			using (ISession session = Sfi.OpenSession())
 			using (TransactionScope tx = new TransactionScope())
 			{
 				W w = session.Get<W>(identifier);

--- a/src/NHibernate.Test/SystemTransactions/TransactionNotificationFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/TransactionNotificationFixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void NoTransaction()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				Assert.AreEqual(0, interceptor.afterTransactionBeginCalled);
 				Assert.AreEqual(0, interceptor.beforeTransactionCompletionCalled);
@@ -33,7 +33,7 @@ namespace NHibernate.Test.SystemTransactions
 		{
 			var interceptor = new RecordingInterceptor();
 			using (new TransactionScope()) 
-			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				Assert.AreEqual(1, interceptor.afterTransactionBeginCalled);
 				Assert.AreEqual(0, interceptor.beforeTransactionCompletionCalled);
@@ -48,7 +48,7 @@ namespace NHibernate.Test.SystemTransactions
 			ISession session;
 			using(var scope = new TransactionScope())
 			{
-				session = sessions.WithOptions().Interceptor(interceptor).OpenSession();
+				session = Sfi.WithOptions().Interceptor(interceptor).OpenSession();
 				scope.Complete();
 			}
 			session.Dispose();
@@ -62,7 +62,7 @@ namespace NHibernate.Test.SystemTransactions
 		{
 			var interceptor = new RecordingInterceptor();
 			using (new TransactionScope())
-			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 			}
 			Assert.AreEqual(0, interceptor.beforeTransactionCompletionCalled);
@@ -73,7 +73,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void TwoTransactionScopesInsideOneSession()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (var session = Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				using (var scope = new TransactionScope())
 				{
@@ -96,7 +96,7 @@ namespace NHibernate.Test.SystemTransactions
 		public void OneTransactionScopesInsideOneSession()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (var session = Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				using (var scope = new TransactionScope())
 				{
@@ -161,11 +161,11 @@ namespace NHibernate.Test.SystemTransactions
 
 			using (var tx = new TransactionScope())
 			{
-				var ownConnection1 = sessions.ConnectionProvider.GetConnection();
+				var ownConnection1 = Sfi.ConnectionProvider.GetConnection();
 
 				try
 				{
-					using (s1 = sessions.WithOptions().Connection(ownConnection1).Interceptor(interceptor).OpenSession())
+					using (s1 = Sfi.WithOptions().Connection(ownConnection1).Interceptor(interceptor).OpenSession())
 					{
 						s1.CreateCriteria<object>().List();
 					}
@@ -175,7 +175,7 @@ namespace NHibernate.Test.SystemTransactions
 				}
 				finally
 				{
-					sessions.ConnectionProvider.CloseConnection(ownConnection1);
+					Sfi.ConnectionProvider.CloseConnection(ownConnection1);
 				}
 			}
 

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -12,12 +12,8 @@ using NHibernate.Tool.hbm2ddl;
 using NHibernate.Type;
 using NUnit.Framework;
 using NHibernate.Hql.Ast.ANTLR;
-using System.Collections.Concurrent;
-using System.IO;
 using NUnit.Framework.Interfaces;
 using System.Text;
-using log4net.Util;
-using static NUnit.Framework.TestContext;
 
 namespace NHibernate.Test
 {
@@ -25,7 +21,7 @@ namespace NHibernate.Test
 	{
 		private const bool OutputDdl = false;
 		protected Configuration cfg;
-		protected ISessionFactoryImplementor sessions;
+		private DebugSessionFactory _sessionFactory;
 
 		private static readonly ILog log = LogManager.GetLogger(typeof(TestCase));
 
@@ -42,17 +38,7 @@ namespace NHibernate.Test
 		/// <summary>
 		/// To use in in-line test
 		/// </summary>
-		protected bool IsAntlrParser
-		{
-			get
-			{
-				return sessions.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory;
-			}
-		}
-
-		private ConcurrentBag<ISession> _openedSessions = new ConcurrentBag<ISession>();
-		private ISession _lastOpenedSession;
-		private DebugConnectionProvider connectionProvider;
+		protected bool IsAntlrParser => Sfi.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory;
 
 		/// <summary>
 		/// Mapping files used in the TestCase
@@ -90,8 +76,8 @@ namespace NHibernate.Test
 				CreateSchema();
 				try
 				{
-					BuildSessionFactory();
-					if (!AppliesTo(sessions))
+					_sessionFactory = BuildSessionFactory();
+					if (!AppliesTo(_sessionFactory))
 					{
 						Assert.Ignore(GetType() + " does not apply with the current session-factory configuration");
 					}
@@ -108,6 +94,11 @@ namespace NHibernate.Test
 				log.Error("Error while setting up the test fixture", e);
 				throw;
 			}
+		}
+
+		protected void RebuildSessionFactory()
+		{
+			_sessionFactory = BuildSessionFactory();
 		}
 
 		/// <summary>
@@ -166,7 +157,7 @@ namespace NHibernate.Test
 			try
 			{
 				OnTearDown();
-				var wereClosed = CheckSessionsWereClosed();
+				var wereClosed = _sessionFactory.CheckSessionsWereClosed();
 				var wasCleaned = CheckDatabaseWasCleaned();
 				var wereConnectionsClosed = CheckConnectionsWereClosed();
 				fail = !wereClosed || !wasCleaned || !wereConnectionsClosed;
@@ -200,7 +191,7 @@ namespace NHibernate.Test
 			}
 		}
 
-		private string GetCombinedFailureMessage(ResultAdapter result, string tearDownFailure, string tearDownStackTrace)
+		private string GetCombinedFailureMessage(TestContext.ResultAdapter result, string tearDownFailure, string tearDownStackTrace)
 		{
 			var message = new StringBuilder()
 				.Append("The test failed and then failed to cleanup. Test failure is: ")
@@ -217,26 +208,9 @@ namespace NHibernate.Test
 			return message.ToString();
 		}
 
-		// Factory is exposed to descendant, any session opened directly from it will not be handled by following check.
-		private bool CheckSessionsWereClosed()
-		{
-			var allClosed = true;
-			foreach (var session in _openedSessions)
-			{
-				if (session.IsOpen)
-				{
-					log.Error($"Test case didn't close session {session.GetSessionImplementation().SessionId}, closing");
-					allClosed = false;
-					session.Close();
-				}
-			}
-
-			return allClosed;
-		}
-
 		protected virtual bool CheckDatabaseWasCleaned()
 		{
-			if (sessions.GetAllClassMetadata().Count == 0)
+			if (Sfi.GetAllClassMetadata().Count == 0)
 			{
 				// Return early in the case of no mappings, also avoiding
 				// a warning when executing the HQL below.
@@ -244,7 +218,7 @@ namespace NHibernate.Test
 			}
 
 			bool empty;
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				IList objects = s.CreateQuery("from System.Object o").List();
 				empty = objects.Count == 0;
@@ -262,13 +236,13 @@ namespace NHibernate.Test
 
 		private bool CheckConnectionsWereClosed()
 		{
-			if (connectionProvider == null || !connectionProvider.HasOpenConnections)
+			if (_sessionFactory?.ConnectionProvider?.HasOpenConnections != true)
 			{
 				return true;
 			}
 
 			log.Error("Test case didn't close all open connections, closing");
-			connectionProvider.CloseAllConnections();
+			_sessionFactory.ConnectionProvider.CloseAllConnections();
 			return false;
 		}
 
@@ -303,22 +277,15 @@ namespace NHibernate.Test
 			new SchemaExport(cfg).Drop(OutputDdl, true);
 		}
 
-		protected virtual void BuildSessionFactory()
+		protected virtual DebugSessionFactory BuildSessionFactory()
 		{
-			sessions = (ISessionFactoryImplementor)cfg.BuildSessionFactory();
-			connectionProvider = sessions.ConnectionProvider as DebugConnectionProvider;
+			return new DebugSessionFactory(cfg.BuildSessionFactory());
 		}
 
 		private void Cleanup()
 		{
-			if (sessions != null)
-			{
-				sessions.Close();
-			}
-			sessions = null;
-			connectionProvider = null;
-			_lastOpenedSession = null;
-			_openedSessions = new ConcurrentBag<ISession>();
+			Sfi?.Close();
+			_sessionFactory = null;
 			cfg = null;
 		}
 
@@ -364,23 +331,16 @@ namespace NHibernate.Test
 			}
 		}
 
-		protected ISessionFactoryImplementor Sfi
-		{
-			get { return sessions; }
-		}
+		protected ISessionFactoryImplementor Sfi => _sessionFactory;
 
 		protected virtual ISession OpenSession()
 		{
-			_lastOpenedSession = sessions.OpenSession();
-			_openedSessions.Add(_lastOpenedSession);
-			return _lastOpenedSession;
+			return Sfi.OpenSession();
 		}
 
 		protected virtual ISession OpenSession(IInterceptor sessionLocalInterceptor)
 		{
-			_lastOpenedSession = sessions.WithOptions().Interceptor(sessionLocalInterceptor).OpenSession();
-			_openedSessions.Add(_lastOpenedSession);
-			return _lastOpenedSession;
+			return Sfi.WithOptions().Interceptor(sessionLocalInterceptor).OpenSession();
 		}
 
 		protected virtual void ApplyCacheSettings(Configuration configuration)
@@ -398,7 +358,7 @@ namespace NHibernate.Test
 					if (prop.Value.IsSimpleValue)
 					{
 						IType type = ((SimpleValue)prop.Value).Type;
-						if (type == NHibernateUtil.BinaryBlob)
+						if (ReferenceEquals(type, NHibernateUtil.BinaryBlob))
 						{
 							hasLob = true;
 						}

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -36,11 +36,6 @@ namespace NHibernate.Test
 		}
 
 		/// <summary>
-		/// To use in in-line test
-		/// </summary>
-		protected bool IsAntlrParser => Sfi.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory;
-
-		/// <summary>
 		/// Mapping files used in the TestCase
 		/// </summary>
 		protected abstract IList Mappings { get; }

--- a/src/NHibernate.Test/TransactionTest/TransactionNotificationFixture.cs
+++ b/src/NHibernate.Test/TransactionTest/TransactionNotificationFixture.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Test.TransactionTest
 		public void NoTransaction()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				Assert.That(interceptor.afterTransactionBeginCalled, Is.EqualTo(0));
 				Assert.That(interceptor.beforeTransactionCompletionCalled, Is.EqualTo(0));
@@ -29,7 +29,7 @@ namespace NHibernate.Test.TransactionTest
 		public void AfterBegin()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (var session = Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			using (session.BeginTransaction())
 			{
 				Assert.That(interceptor.afterTransactionBeginCalled, Is.EqualTo(1));
@@ -42,7 +42,7 @@ namespace NHibernate.Test.TransactionTest
 		public void Commit()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (var session = Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				ITransaction tx = session.BeginTransaction();
 				tx.Commit();
@@ -56,7 +56,7 @@ namespace NHibernate.Test.TransactionTest
 		public void Rollback()
 		{
 			var interceptor = new RecordingInterceptor();
-			using (var session = sessions.WithOptions().Interceptor(interceptor).OpenSession())
+			using (var session = Sfi.WithOptions().Interceptor(interceptor).OpenSession())
 			{
 				ITransaction tx = session.BeginTransaction();
 				tx.Rollback();
@@ -96,9 +96,9 @@ namespace NHibernate.Test.TransactionTest
 			var interceptor = new RecordingInterceptor();
 			ISession s;
 
-			using (var ownConnection = sessions.ConnectionProvider.GetConnection())
+			using (var ownConnection = Sfi.ConnectionProvider.GetConnection())
 			{
-				using (s = sessions.WithOptions().Connection(ownConnection).Interceptor(interceptor).OpenSession())
+				using (s = Sfi.WithOptions().Connection(ownConnection).Interceptor(interceptor).OpenSession())
 				using (s.BeginTransaction())
 				{
 					s.CreateCriteria<object>().List();

--- a/src/NHibernate.Test/TypeParameters/TypeParameterTest.cs
+++ b/src/NHibernate.Test/TypeParameters/TypeParameterTest.cs
@@ -54,7 +54,7 @@ namespace NHibernate.Test.TypeParameters
 			s = OpenSession();
 			t = s.BeginTransaction();
 
-			IDriver driver = sessions.ConnectionProvider.Driver;
+			IDriver driver = Sfi.ConnectionProvider.Driver;
 
 			var connection = s.Connection;
 			var statement = driver.GenerateCommand(

--- a/src/NHibernate.Test/TypedManyToOne/TypedManyToOneTest.cs
+++ b/src/NHibernate.Test/TypedManyToOne/TypedManyToOneTest.cs
@@ -42,14 +42,14 @@ namespace NHibernate.Test.TypedManyToOne
 			cust.BillingAddress = bill;
 			cust.ShippingAddress = ship;
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.Persist(cust);
 				t.Commit();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				IList results = s.CreateQuery("from Customer cust left join fetch cust.BillingAddress where cust.CustomerId='abc123'").List();
@@ -64,7 +64,7 @@ namespace NHibernate.Test.TypedManyToOne
 				t.Commit();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.SaveOrUpdate(cust);
@@ -87,14 +87,14 @@ namespace NHibernate.Test.TypedManyToOne
 			cust.CustomerId = "xyz123";
 			cust.Name = "Matt";
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.Persist(cust);
 				t.Commit();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				IList results = s.CreateQuery("from Customer cust left join fetch cust.BillingAddress where cust.CustomerId='xyz123'").List();

--- a/src/NHibernate.Test/TypesTest/EntityTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/EntityTypeFixture.cs
@@ -45,9 +45,9 @@ namespace NHibernate.Test.TypesTest
 			EntityClass b = new EntityClass(2);
 			EntityClass c = new EntityClass(1);
 
-			Assert.IsTrue(type.IsEqual(a, a, (ISessionFactoryImplementor) sessions));
-			Assert.IsFalse(type.IsEqual(a, b, (ISessionFactoryImplementor) sessions));
-			Assert.IsTrue(type.IsEqual(a, c, (ISessionFactoryImplementor) sessions));
+			Assert.IsTrue(type.IsEqual(a, a, (ISessionFactoryImplementor) Sfi));
+			Assert.IsFalse(type.IsEqual(a, b, (ISessionFactoryImplementor) Sfi));
+			Assert.IsTrue(type.IsEqual(a, c, (ISessionFactoryImplementor) Sfi));
 		}
 	}
 }

--- a/src/NHibernate.Test/TypesTest/PersistentEnumTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/PersistentEnumTypeFixture.cs
@@ -84,7 +84,7 @@ namespace NHibernate.Test.TypesTest
 				s.Flush();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				s.CreateQuery("select new PersistentEnumHolder(p.A, p.B) from PersistentEnumClass p").List();
 				s.Delete("from PersistentEnumClass");
@@ -101,7 +101,7 @@ namespace NHibernate.Test.TypesTest
 				s.Flush();
 			}
 
-			ISession s2 = sessions.OpenSession();
+			ISession s2 = Sfi.OpenSession();
 			try
 			{
 				Assert.Throws<QueryException>(
@@ -125,7 +125,7 @@ namespace NHibernate.Test.TypesTest
 				s.Flush();
 			}
 
-			using (ISession s = sessions.OpenSession())
+			using (ISession s = Sfi.OpenSession())
 			{
 				var saved = s.Get<PersistentEnumClass>(1);
 				Assert.That(saved.A, Is.EqualTo(A.Two));

--- a/src/NHibernate.Test/TypesTest/StringTypeWithLengthFixture.cs
+++ b/src/NHibernate.Test/TypesTest/StringTypeWithLengthFixture.cs
@@ -171,7 +171,7 @@ namespace NHibernate.Test.TypesTest
 			// This test fails against the ODBC driver. The driver would need to be override to allow longer parameter sizes than the column.
 			AssertExpectedFailureOrNoException(
 				exception,
-				(sessions.ConnectionProvider.Driver is OdbcDriver));
+				(Sfi.ConnectionProvider.Driver is OdbcDriver));
 		}
 
 		[Test]
@@ -199,7 +199,7 @@ namespace NHibernate.Test.TypesTest
 			// This test fails against the ODBC driver. The driver would need to be override to allow longer parameter sizes than the column.
 			AssertExpectedFailureOrNoException(
 				exception,
-				(sessions.ConnectionProvider.Driver is OdbcDriver));
+				(Sfi.ConnectionProvider.Driver is OdbcDriver));
 		}
 
 
@@ -231,7 +231,7 @@ namespace NHibernate.Test.TypesTest
 			// This test fails against the ODBC driver. The driver would need to be override to allow longer parameter sizes than the column.
 			AssertExpectedFailureOrNoException(
 				exception,
-				(Dialect is FirebirdDialect) || (sessions.ConnectionProvider.Driver is OdbcDriver));
+				(Dialect is FirebirdDialect) || (Sfi.ConnectionProvider.Driver is OdbcDriver));
 		}
 
 
@@ -263,7 +263,7 @@ namespace NHibernate.Test.TypesTest
 			// This test fails against the ODBC driver. The driver would need to be override to allow longer parameter sizes than the column.
 			AssertExpectedFailureOrNoException(
 				exception,
-				(Dialect is FirebirdDialect) || (sessions.ConnectionProvider.Driver is OdbcDriver));
+				(Dialect is FirebirdDialect) || (Sfi.ConnectionProvider.Driver is OdbcDriver));
 		}
 
 

--- a/src/NHibernate.Test/TypesTest/UriTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/UriTypeFixture.cs
@@ -94,7 +94,7 @@ namespace NHibernate.Test.TypesTest
 		public void AutoDiscoverFromNetType()
 		{
 			// integration test to be 100% sure
-			var propertyType = sessions.GetEntityPersister(typeof(UriClass).FullName).GetPropertyType("AutoUri");
+			var propertyType = Sfi.GetEntityPersister(typeof(UriClass).FullName).GetPropertyType("AutoUri");
 			Assert.That(propertyType, Is.InstanceOf<UriType>());
 		}
 

--- a/src/NHibernate.Test/TypesTest/XDocTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/XDocTypeFixture.cs
@@ -75,7 +75,7 @@ namespace NHibernate.Test.TypesTest
 		public void AutoDiscoverFromNetType()
 		{
 			// integration test to be 100% sure
-			var propertyType = sessions.GetEntityPersister(typeof (XDocClass).FullName).GetPropertyType("AutoDocument");
+			var propertyType = Sfi.GetEntityPersister(typeof (XDocClass).FullName).GetPropertyType("AutoDocument");
 			Assert.That(propertyType, Is.InstanceOf<XDocType>());
 		}
 	}

--- a/src/NHibernate.Test/TypesTest/XmlDocTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/XmlDocTypeFixture.cs
@@ -75,7 +75,7 @@ namespace NHibernate.Test.TypesTest
 		public void AutoDiscoverFromNetType()
 		{
 			// integration test to be 100% sure
-			var propertyType = sessions.GetEntityPersister(typeof (XmlDocClass).FullName).GetPropertyType("AutoDocument");
+			var propertyType = Sfi.GetEntityPersister(typeof (XmlDocClass).FullName).GetPropertyType("AutoDocument");
 			Assert.That(propertyType, Is.InstanceOf<XmlDocType>());
 		}
 	}

--- a/src/NHibernate.Test/Unconstrained/UnconstrainedNoLazyTest.cs
+++ b/src/NHibernate.Test/Unconstrained/UnconstrainedNoLazyTest.cs
@@ -31,7 +31,7 @@ namespace NHibernate.Test.Unconstrained
 			tx.Commit();
 			session.Close();
 
-			sessions.Evict(typeof(Person));
+			Sfi.Evict(typeof(Person));
 
 			session = OpenSession();
 			tx = session.BeginTransaction();
@@ -41,7 +41,7 @@ namespace NHibernate.Test.Unconstrained
 			tx.Commit();
 			session.Close();
 
-			sessions.Evict(typeof(Person));
+			Sfi.Evict(typeof(Person));
 
 			session = OpenSession();
 			tx = session.BeginTransaction();
@@ -64,7 +64,7 @@ namespace NHibernate.Test.Unconstrained
 			tx.Commit();
 			session.Close();
 
-			sessions.Evict(typeof(Person));
+			Sfi.Evict(typeof(Person));
 
 			session = OpenSession();
 			tx = session.BeginTransaction();
@@ -77,7 +77,7 @@ namespace NHibernate.Test.Unconstrained
 			tx.Commit();
 			session.Close();
 
-			sessions.Evict(typeof(Person));
+			Sfi.Evict(typeof(Person));
 
 			session = OpenSession();
 			tx = session.BeginTransaction();

--- a/src/NHibernate.Test/VersionTest/Db/MsSQL/GeneratedBinaryVersionFixture.cs
+++ b/src/NHibernate.Test/VersionTest/Db/MsSQL/GeneratedBinaryVersionFixture.cs
@@ -100,7 +100,7 @@ namespace NHibernate.Test.VersionTest.Db.MsSQL
 
 					versioned.Something = "new string";
 
-					var expectedException = sessions.Settings.IsBatchVersionedDataEnabled
+					var expectedException = Sfi.Settings.IsBatchVersionedDataEnabled
 						? Throws.InstanceOf<StaleStateException>()
 						: Throws.InstanceOf<StaleObjectStateException>();
 


### PR DESCRIPTION
[NH-4021](https://nhibernate.jira.com/browse/NH-4021) - Track all opened session in tests

As illustrated with DtcFailuresFixture, some session "leaks" (indeed delayed releases) are going unnoticed due to the test by-passing the session tracking.
Adapt the base test class for ensuring this is no more possible, at least for sessions opened from session factory.

This is done by wrapping the session factory in delegating session factory. Some tests doing assumptions on the concrete session factory had to be adapted.

Lot of tests which were directly using the `TestBase` session factory field have been changed for using the property instead. Some tests which were changing the session factory were adapted too.

This does not handle sessions opened from other sessions. It would require a similar wrapping, and much more tests could be impacted by it.