### PR TITLE
NH-3374 - Merge detached entity failed when the instrumented lazy property is initialized

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3374/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3374/FixtureByCode.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3374
 {
-	[Ignore("Not fixed yet.")]
+	[TestFixture]
 	public class ByCodeFixture : TestCaseMappingByCode
 	{
 		protected override HbmMapping GetMappings()

--- a/src/NHibernate.Test/NHSpecificTest/NH3374/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3374/FixtureByCode.cs
@@ -27,11 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3374
 					map.Id(x => x.Id, idMapper => idMapper.Generator(Generators.Identity));
 					map.Property(x => x.Bytes, y =>
 						{
-							y.Column(x =>
-							{
-								x.SqlType("varbinary(max)");
-								x.Length(int.MaxValue);
-							});
+							y.Length(int.MaxValue);
 							y.Lazy(true);
 						});
 				});

--- a/src/NHibernate/Type/TypeHelper.cs
+++ b/src/NHibernate/Type/TypeHelper.cs
@@ -126,6 +126,25 @@ namespace NHibernate.Type
 				{
 					copied[i] = target[i];
 				}
+				else if (target[i] == LazyPropertyInitializer.UnfetchedProperty)
+				{
+					// Should be no need to check for target[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN
+					// because PropertyAccessStrategyBackRefImpl.get( object ) returns
+					// PropertyAccessStrategyBackRefImpl.UNKNOWN, so target[i] == original[i].
+					//
+					// We know from above that original[i] != LazyPropertyInitializer.UNFETCHED_PROPERTY &&
+					// original[i] != PropertyAccessStrategyBackRefImpl.UNKNOWN;
+					// This is a case where the entity being merged has a lazy property
+					// that has been initialized. Copy the initialized value from original.
+					if (types[i].IsMutable)
+					{
+						copied[i] = types[i].DeepCopy(original[i], session.Factory);
+					}
+					else
+					{
+						copied[i] = original[i];
+					}
+				}
 				else
 				{
 					copied[i] = types[i].Replace(original[i], target[i], session, owner, copiedAlready);


### PR DESCRIPTION
- Ported fix from https://github.com/hibernate/hibernate-orm/commit/c00d4609efa61b32c2cb470aa5785284870a71b6
