### PR TITLE
NH-4027 - Missing disposals of enumerators.

### DIFF
--- a/src/NHibernate/AdoNet/Util/BasicFormatter.cs
+++ b/src/NHibernate/AdoNet/Util/BasicFormatter.cs
@@ -59,14 +59,15 @@ namespace NHibernate.AdoNet.Util
 
 		public virtual string Format(string source)
 		{
-			return new FormatProcess(source).Perform();
+			using (var fp = new FormatProcess(source))
+				return fp.Perform();
 		}
 
 		#endregion
 
 		#region Nested type: FormatProcess
 
-		private class FormatProcess
+		private class FormatProcess : IDisposable
 		{
 			private readonly List<bool> afterByOrFromOrSelects = new List<bool>();
 			private readonly List<int> parenCounts = new List<int>();
@@ -440,6 +441,11 @@ namespace NHibernate.AdoNet.Util
 					result.Append(IndentString);
 				}
 				beginLine = true;
+			}
+
+			public void Dispose()
+			{
+				tokens.Dispose();
 			}
 		}
 

--- a/src/NHibernate/AdoNet/Util/DdlFormatter.cs
+++ b/src/NHibernate/AdoNet/Util/DdlFormatter.cs
@@ -38,13 +38,10 @@ namespace NHibernate.AdoNet.Util
 
 		protected virtual string FormatCommentOn(string sql)
 		{
-			StringBuilder result = new StringBuilder(60).Append(Indent1);
-			IEnumerator<string> tokens = (new StringTokenizer(sql, " '[]\"", true)).GetEnumerator();
-
-			bool quoted = false;
-			while (tokens.MoveNext())
+			var result = new StringBuilder(60).Append(Indent1);
+			var quoted = false;
+			foreach (var token in new StringTokenizer(sql, " '[]\"", true))
 			{
-				string token = tokens.Current;
 				result.Append(token);
 				if (IsQuote(token))
 				{
@@ -64,13 +61,10 @@ namespace NHibernate.AdoNet.Util
 
 		protected virtual string FormatAlterTable(string sql)
 		{
-			StringBuilder result = new StringBuilder(60).Append(Indent1);
-			IEnumerator<string> tokens = (new StringTokenizer(sql, " (,)'[]\"", true)).GetEnumerator();
-
-			bool quoted = false;
-			while (tokens.MoveNext())
+			var result = new StringBuilder(60).Append(Indent1);
+			var quoted = false;
+			foreach (var token in new StringTokenizer(sql, " (,)'[]\"", true))
 			{
-				string token = tokens.Current;
 				if (IsQuote(token))
 				{
 					quoted = !quoted;
@@ -90,14 +84,11 @@ namespace NHibernate.AdoNet.Util
 
 		protected virtual string FormatCreateTable(string sql)
 		{
-			StringBuilder result = new StringBuilder(60).Append(Indent1);
-			IEnumerator<string> tokens = (new StringTokenizer(sql, "(,)'[]\"", true)).GetEnumerator();
-
-			int depth = 0;
-			bool quoted = false;
-			while (tokens.MoveNext())
+			var result = new StringBuilder(60).Append(Indent1);
+			var depth = 0;
+			var quoted = false;
+			foreach (var token in new StringTokenizer(sql, "(,)'[]\"", true))
 			{
-				string token = tokens.Current;
 				if (IsQuote(token))
 				{
 					quoted = !quoted;

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -343,11 +343,13 @@ namespace NHibernate.Dialect
 
 		public override SqlString GetLimitString(SqlString querySqlString, SqlString offset, SqlString limit)
 		{
-			var tokenEnum = new SqlTokenizer(querySqlString).GetEnumerator();
-			if (!tokenEnum.TryParseUntilFirstMsSqlSelectColumn()) return null;
+			using (var tokenEnum = new SqlTokenizer(querySqlString).GetEnumerator())
+			{
+				if (!tokenEnum.TryParseUntilFirstMsSqlSelectColumn()) return null;
 
-			int insertPoint = tokenEnum.Current.SqlIndex;
-			return querySqlString.Insert(insertPoint, new SqlString("top ", limit, " "));
+				var insertPoint = tokenEnum.Current.SqlIndex;
+				return querySqlString.Insert(insertPoint, new SqlString("top ", limit, " "));
+			}
 		}
 
 		/// <summary>

--- a/src/NHibernate/Dialect/MsSql2005DialectQueryPager.cs
+++ b/src/NHibernate/Dialect/MsSql2005DialectQueryPager.cs
@@ -33,11 +33,13 @@ namespace NHibernate.Dialect
 
 		private SqlString PageByLimitOnly(SqlString limit)
 		{
-			var tokenEnum = new SqlTokenizer(_sourceQuery).GetEnumerator();
-			if (!tokenEnum.TryParseUntilFirstMsSqlSelectColumn()) return null;
-			
-			int insertPoint = tokenEnum.Current.SqlIndex;
-			return _sourceQuery.Insert(insertPoint, new SqlString("TOP (", limit, ") "));
+			using (var tokenEnum = new SqlTokenizer(_sourceQuery).GetEnumerator())
+			{
+				if (!tokenEnum.TryParseUntilFirstMsSqlSelectColumn()) return null;
+
+				var insertPoint = tokenEnum.Current.SqlIndex;
+				return _sourceQuery.Insert(insertPoint, new SqlString("TOP (", limit, ") "));
+			}
 		}
 
 		private SqlString PageByLimitAndOffset(SqlString offset, SqlString limit)

--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -58,31 +58,33 @@ namespace NHibernate.Dialect
 
 		public override SqlString GetLimitString(SqlString querySqlString, SqlString offset, SqlString limit)
 		{
-			var tokenEnum = new SqlTokenizer(querySqlString).GetEnumerator();
-			if (!tokenEnum.TryParseUntilFirstMsSqlSelectColumn()) return null;
-
-			var result = new SqlStringBuilder(querySqlString);
-			if (!tokenEnum.TryParseUntil("order"))
+			using (var tokenEnum = new SqlTokenizer(querySqlString).GetEnumerator())
 			{
-				result.Add(" ORDER BY CURRENT_TIMESTAMP");
-			}
+				if (!tokenEnum.TryParseUntilFirstMsSqlSelectColumn()) return null;
 
-			result.Add(" OFFSET ");
-			if (offset != null)
-			{
-				result.Add(offset).Add(" ROWS");
-			}
-			else
-			{
-				result.Add("0 ROWS");
-			}
+				var result = new SqlStringBuilder(querySqlString);
+				if (!tokenEnum.TryParseUntil("order"))
+				{
+					result.Add(" ORDER BY CURRENT_TIMESTAMP");
+				}
 
-			if (limit != null)
-			{
-				result.Add(" FETCH FIRST ").Add(limit).Add(" ROWS ONLY");
-			}
+				result.Add(" OFFSET ");
+				if (offset != null)
+				{
+					result.Add(offset).Add(" ROWS");
+				}
+				else
+				{
+					result.Add("0 ROWS");
+				}
 
-			return result.ToSqlString();
+				if (limit != null)
+				{
+					result.Add(" FETCH FIRST ").Add(limit).Add(" ROWS ONLY");
+				}
+
+				return result.ToSqlString();
+			}
 		}
 	}
 }

--- a/src/NHibernate/Engine/TypedValue.cs
+++ b/src/NHibernate/Engine/TypedValue.cs
@@ -101,14 +101,21 @@ namespace NHibernate.Engine
 				if (x.Count != y.Count)
 					return false;
 
-				IEnumerator xe = x.GetEnumerator();
-				IEnumerator ye = y.GetEnumerator();
-
-				while (xe.MoveNext())
+				var ye = y.GetEnumerator();
+				try
 				{
-					ye.MoveNext();
-					if (!type.IsEqual(xe.Current, ye.Current))
-						return false;
+					foreach (var xItem in x)
+					{
+						ye.MoveNext();
+						if (!type.IsEqual(xItem, ye.Current))
+							return false;
+					}
+				}
+				finally
+				{
+					// The old non generic IEnumerator is not disposable, but in most cases the concrete enumerator
+					// will be a generic one, disposable. https://stackoverflow.com/a/11179175/1178314
+					(ye as IDisposable)?.Dispose();
 				}
 
 				return true;

--- a/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
@@ -81,7 +81,7 @@ namespace NHibernate.Event.Default
 					.Append(" removals to ").Append(persistenceContext.CollectionEntries.Count).Append(" collections");
 
 				log.Debug(sb.ToString());
-				new Printer(session.Factory).ToString(persistenceContext.EntitiesByKey.Values.ToArray().GetEnumerator());
+				new Printer(session.Factory).ToString(persistenceContext.EntitiesByKey.Values.ToArray());
 			}
 		}
 

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/FromClause.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/FromClause.cs
@@ -363,11 +363,10 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		public virtual void Resolve()
 		{
 			// Make sure that all from elements registered with this FROM clause are actually in the AST.
-			var iter = (new ASTIterator(GetFirstChild())).GetEnumerator();
 			var childrenInTree = new HashSet<IASTNode>();
-			while (iter.MoveNext())
+			foreach (var ast in new ASTIterator(GetFirstChild()))
 			{
-				childrenInTree.Add(iter.Current);
+				childrenInTree.Add(ast);
 			}
 			foreach (var fromElement in _fromElements)
 			{

--- a/src/NHibernate/Hql/QuerySplitter.cs
+++ b/src/NHibernate/Hql/QuerySplitter.cs
@@ -113,7 +113,7 @@ namespace NHibernate.Hql
 				templateQuery.Append(token);
 			}
 			string[] results =
-				StringHelper.Multiply(templateQuery.ToString(), placeholders.GetEnumerator(), replacements.GetEnumerator());
+				StringHelper.Multiply(templateQuery.ToString(), placeholders, replacements);
 			if (results.Length == 0)
 			{
 				log.Warn("no persistent classes found for query class: " + query);

--- a/src/NHibernate/IFilter.cs
+++ b/src/NHibernate/IFilter.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using NHibernate.Engine;
 
 namespace NHibernate
@@ -10,7 +11,7 @@ namespace NHibernate
 	public interface IFilter
 	{
 		/// <summary>
-		/// Get the name of this filter. 
+		/// Get the name of this filter.
 		/// </summary>
 		/// <returns>This filter's name.</returns>
 		string Name { get; }
@@ -23,7 +24,7 @@ namespace NHibernate
 		FilterDefinition FilterDefinition { get; }
 
 		/// <summary>
-		/// Set the named parameter's value list for this filter. 
+		/// Set the named parameter's value list for this filter.
 		/// </summary>
 		/// <param name="name">The parameter's name.</param>
 		/// <param name="value">The values to be applied.</param>
@@ -31,26 +32,18 @@ namespace NHibernate
 		IFilter SetParameter(string name, object value);
 
 		/// <summary>
-		/// Set the named parameter's value list for this filter.  Used
-		/// in conjunction with IN-style filter criteria.        
+		/// Set the named parameter's value list for this filter. Used
+		/// in conjunction with IN-style filter criteria.
 		/// </summary>
 		/// <param name="name">The parameter's name.</param>
 		/// <param name="values">The values to be expanded into an SQL IN list.</param>
+		/// <typeparam name="T">The type of the values.</typeparam>
 		/// <returns>This FilterImpl instance (for method chaining).</returns>
-		IFilter SetParameterList(string name, ICollection values);
-
-		/// <summary>
-		/// Set the named parameter's value list for this filter.  Used
-		/// in conjunction with IN-style filter criteria.        
-		/// </summary>
-		/// <param name="name">The parameter's name.</param>
-		/// <param name="values">The values to be expanded into an SQL IN list.</param>
-		/// <returns>This FilterImpl instance (for method chaining).</returns>
-		IFilter SetParameterList(string name, object[] values);
+		IFilter SetParameterList<T>(string name, ICollection<T> values);
 
 		/// <summary>
 		/// Perform validation of the filter state.  This is used to verify the
-		/// state of the filter after its enablement and before its use.
+		/// state of the filter after its activation and before its use.
 		/// </summary>
 		/// <returns></returns>
 		void Validate();

--- a/src/NHibernate/Impl/EnumerableImpl.cs
+++ b/src/NHibernate/Impl/EnumerableImpl.cs
@@ -17,8 +17,8 @@ namespace NHibernate.Impl
 	/// <remarks>
 	/// <para>This is the IteratorImpl in H2.0.3</para>
 	/// <para>This thing is scary. It is an <see cref="IEnumerable" /> which returns itself as a <see cref="IEnumerator" />
-	/// when <c>GetEnumerator</c> is called, and EnumerableImpl is disposable. Iterating over it with a <c>foreach</c>
-	/// will cause it to be disposed, probably unexpectedly. (https://stackoverflow.com/a/11179175/1178314)
+	/// when <c>GetEnumerator</c> is called, and <c>EnumerableImpl</c> is disposable. Iterating over it with a <c>foreach</c>
+	/// will cause it to be disposed, probably unexpectedly for the developer. (https://stackoverflow.com/a/11179175/1178314)
 	/// "Fortunately", it does not currently support multiple iterations anyway.</para>
 	/// </remarks>
 	public class EnumerableImpl : IEnumerable, IEnumerator, IDisposable

--- a/src/NHibernate/Impl/EnumerableImpl.cs
+++ b/src/NHibernate/Impl/EnumerableImpl.cs
@@ -15,7 +15,11 @@ namespace NHibernate.Impl
 	/// Provides an <see cref="IEnumerable"/> wrapper over the results of an <see cref="IQuery"/>.
 	/// </summary>
 	/// <remarks>
-	/// This is the IteratorImpl in H2.0.3
+	/// <para>This is the IteratorImpl in H2.0.3</para>
+	/// <para>This thing is scary. It is an <see cref="IEnumerable" /> which returns itself as a <see cref="IEnumerator" />
+	/// when <c>GetEnumerator</c> is called, and EnumerableImpl is disposable. Iterating over it with a <c>foreach</c>
+	/// will cause it to be disposed, probably unexpectedly. (https://stackoverflow.com/a/11179175/1178314)
+	/// "Fortunately", it does not currently support multiple iterations anyway.</para>
 	/// </remarks>
 	public class EnumerableImpl : IEnumerable, IEnumerator, IDisposable
 	{

--- a/src/NHibernate/Impl/FilterImpl.cs
+++ b/src/NHibernate/Impl/FilterImpl.cs
@@ -93,10 +93,19 @@ namespace NHibernate.Impl
 			if (values.Count > 0)
 			{
 				var e = values.GetEnumerator();
-				e.MoveNext();
-				if (!type.ReturnedClass.IsInstanceOfType(e.Current))
+				try
 				{
-					throw new HibernateException("Incorrect type for parameter [" + name + "]");
+					e.MoveNext();
+					if (!type.ReturnedClass.IsInstanceOfType(e.Current))
+					{
+						throw new HibernateException("Incorrect type for parameter [" + name + "]");
+					}
+				}
+				finally
+				{
+					// Most enumerators are indeed disposable. foreach takes care of disposing them, but
+					// when using them directly, we have to do it.
+					(e as IDisposable)?.Dispose();
 				}
 			}
 			parameters[name] = values;

--- a/src/NHibernate/Impl/FilterImpl.cs
+++ b/src/NHibernate/Impl/FilterImpl.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using NHibernate.Engine;
 using NHibernate.Type;
 using System.Collections.Generic;
@@ -76,52 +75,21 @@ namespace NHibernate.Impl
 		/// <param name="name">The parameter's name.</param>
 		/// <param name="values">The values to be expanded into an SQL IN list.</param>
 		/// <returns>This FilterImpl instance (for method chaining).</returns>
-		public IFilter SetParameterList(string name, ICollection values)
+		public IFilter SetParameterList<T>(string name, ICollection<T> values)
 		{
-			// Make sure this is a defined parameter and check the incoming value type
-			if (values == null)
-			{
-				throw new ArgumentException("Collection must be not null!", "values");
-			}
-
 			var type = definition.GetParameterType(name);
 			if (type == null)
 			{
 				throw new HibernateException("Undefined filter parameter [" + name + "]");
 			}
 
-			if (values.Count > 0)
+			if (!type.ReturnedClass.IsAssignableFrom(typeof(T)))
 			{
-				var e = values.GetEnumerator();
-				try
-				{
-					e.MoveNext();
-					if (!type.ReturnedClass.IsInstanceOfType(e.Current))
-					{
-						throw new HibernateException("Incorrect type for parameter [" + name + "]");
-					}
-				}
-				finally
-				{
-					// Most enumerators are indeed disposable. foreach takes care of disposing them, but
-					// when using them directly, we have to do it.
-					(e as IDisposable)?.Dispose();
-				}
+				throw new HibernateException("Incorrect type for parameter [" + name + "]");
 			}
-			parameters[name] = values;
-			return this;
-		}
 
-		/// <summary>
-		/// Set the named parameter's value list for this filter.  Used
-		/// in conjunction with IN-style filter criteria.        
-		/// </summary>
-		/// <param name="name">The parameter's name.</param>
-		/// <param name="values">The values to be expanded into an SQL IN list.</param>
-		/// <returns>This FilterImpl instance (for method chaining).</returns>
-		public IFilter SetParameterList(string name, object[] values)
-		{
-			return SetParameterList(name, new List<object>(values));
+			parameters[name] = values ?? throw new ArgumentException("Collection must be not null!", nameof(values));
+			return this;
 		}
 
 		public object GetParameter(string name)

--- a/src/NHibernate/Impl/FutureValue.cs
+++ b/src/NHibernate/Impl/FutureValue.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,12 +26,7 @@ namespace NHibernate.Impl
 					// yields the scalar result when the query is scalar.
 					return (T)ExecuteOnEval.DynamicInvoke(result.AsQueryable());
 
-				var enumerator = result.GetEnumerator();
-
-				if (!enumerator.MoveNext())
-					return default(T);
-
-				return enumerator.Current;
+				return result.FirstOrDefault();
 			}
 		}
 

--- a/src/NHibernate/Impl/Printer.cs
+++ b/src/NHibernate/Impl/Printer.cs
@@ -83,25 +83,25 @@ namespace NHibernate.Impl
 			return CollectionPrinter.ToString(result);
 		}
 
-		public void ToString(IEnumerator enumerator)
+		public void ToString(object[] entities)
 		{
-			if (!log.IsDebugEnabled || !enumerator.MoveNext())
+			if (!log.IsDebugEnabled || entities.Length == 0)
 			{
 				return;
 			}
 
 			log.Debug("listing entities:");
-			int i = 0;
+			var i = 0;
 
-			do
+			foreach(var entity in entities)
 			{
 				if (i++ > 20)
 				{
 					log.Debug("more......");
 					break;
 				}
-				log.Debug(ToString(enumerator.Current));
-			} while (enumerator.MoveNext());
+				log.Debug(ToString(entity));
+			}
 		}
 
 		public Printer(ISessionFactoryImplementor factory)

--- a/src/NHibernate/Mapping/ForeignKey.cs
+++ b/src/NHibernate/Mapping/ForeignKey.cs
@@ -122,12 +122,14 @@ namespace NHibernate.Mapping
 				sb.Append("])");
 				throw new FKUnmatchingColumnsException(sb.ToString());
 			}
-			IEnumerator<Column> fkCols = ColumnIterator.GetEnumerator();
-			IEnumerator<Column> pkCols = referencedTable.PrimaryKey.ColumnIterator.GetEnumerator();
 
-			while (fkCols.MoveNext() && pkCols.MoveNext())
+			using (var fkCols = ColumnIterator.GetEnumerator())
+			using (var pkCols = referencedTable.PrimaryKey.ColumnIterator.GetEnumerator())
 			{
-				fkCols.Current.Length = pkCols.Current.Length;
+				while (fkCols.MoveNext() && pkCols.MoveNext())
+				{
+					fkCols.Current.Length = pkCols.Current.Length;
+				}
 			}
 		}
 

--- a/src/NHibernate/Mapping/ManyToOne.cs
+++ b/src/NHibernate/Mapping/ManyToOne.cs
@@ -80,13 +80,15 @@ namespace NHibernate.Mapping
 
 					// NH : The four lines below was added to ensure that related columns have same length,
 					// like ForeignKey.AlignColumns() do
-					IEnumerator<Column> fkCols = ConstraintColumns.GetEnumerator();
-					IEnumerator<Column> pkCols = ce.GetEnumerator();
-					while (fkCols.MoveNext() && pkCols.MoveNext())
-						fkCols.Current.Length = pkCols.Current.Length;
+					using (var fkCols = ConstraintColumns.GetEnumerator())
+					using (var pkCols = ce.GetEnumerator())
+					{
+						while (fkCols.MoveNext() && pkCols.MoveNext())
+							fkCols.Current.Length = pkCols.Current.Length;
+					}
 
 					ForeignKey fk =
-						Table.CreateForeignKey(ForeignKeyName, ConstraintColumns, ((EntityType) Type).GetAssociatedEntityName(), ce);
+						Table.CreateForeignKey(ForeignKeyName, ConstraintColumns, ((EntityType)Type).GetAssociatedEntityName(), ce);
 					fk.CascadeDeleteEnabled = IsCascadeDeleteEnabled;
 				}
 			}

--- a/src/NHibernate/Mapping/SimpleValue.cs
+++ b/src/NHibernate/Mapping/SimpleValue.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.Id;

--- a/src/NHibernate/Mapping/SimpleValue.cs
+++ b/src/NHibernate/Mapping/SimpleValue.cs
@@ -168,9 +168,7 @@ namespace NHibernate.Mapping
 			@params[PersistentIdGeneratorParmsNames.Table] = tableName;
 
 			//pass the column name (a generated id almost always has a single column and is not a formula)
-			IEnumerator enu = ColumnIterator.GetEnumerator();
-			enu.MoveNext();
-			string columnName = ((Column)enu.Current).GetQuotedName(dialect);
+			string columnName = ((Column)ColumnIterator.First()).GetQuotedName(dialect);
 
 			@params[PersistentIdGeneratorParmsNames.PK] = columnName;
 

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Dialect.Schema;
 using NHibernate.Engine;
@@ -564,12 +565,7 @@ namespace NHibernate.Mapping
 		/// </returns>
 		public Column GetColumn(int n)
 		{
-			IEnumerator<Column> iter = columns.Values.GetEnumerator();
-			for (int i = 0; i <= n; i++)
-			{
-				iter.MoveNext();
-			}
-			return iter.Current;
+			return columns.Values.Skip(n).First();
 		}
 
 		/// <summary>

--- a/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
@@ -130,21 +130,23 @@ namespace NHibernate.Persister.Entity
 			List<string> tables = new List<string>();
 			List<string[]> keyColumns = new List<string[]>();
 			List<bool> cascadeDeletes = new List<bool>();
-			IEnumerator<IKeyValue> kiter = persistentClass.KeyClosureIterator.GetEnumerator();
-			foreach (Table tab in persistentClass.TableClosureIterator)
+			using (var kiter = persistentClass.KeyClosureIterator.GetEnumerator())
 			{
-				kiter.MoveNext();
-				IKeyValue key = kiter.Current;
-				string tabname = tab.GetQualifiedName(factory.Dialect, factory.Settings.DefaultCatalogName, factory.Settings.DefaultSchemaName);
-				tables.Add(tabname);
+				foreach (var tab in persistentClass.TableClosureIterator)
+				{
+					kiter.MoveNext();
+					var key = kiter.Current;
+					var tabname = tab.GetQualifiedName(factory.Dialect, factory.Settings.DefaultCatalogName, factory.Settings.DefaultSchemaName);
+					tables.Add(tabname);
 
-				List<string> keyCols = new List<string>(idColumnSpan);
-				IEnumerable<Column> enumerableKCols = new SafetyEnumerable<Column>(key.ColumnIterator);
-				foreach (Column kcol in enumerableKCols)
-					keyCols.Add(kcol.GetQuotedName(factory.Dialect));
+					var keyCols = new List<string>(idColumnSpan);
+					var enumerableKCols = new SafetyEnumerable<Column>(key.ColumnIterator);
+					foreach (var kcol in enumerableKCols)
+						keyCols.Add(kcol.GetQuotedName(factory.Dialect));
 
-				keyColumns.Add(keyCols.ToArray());
-				cascadeDeletes.Add(key.IsCascadeDeleteEnabled && factory.Dialect.SupportsCascadeDelete);				
+					keyColumns.Add(keyCols.ToArray());
+					cascadeDeletes.Add(key.IsCascadeDeleteEnabled && factory.Dialect.SupportsCascadeDelete);
+				}
 			}
 			naturalOrderTableNames = tables.ToArray();
 			naturalOrderTableKeyColumns = keyColumns.ToArray();

--- a/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
@@ -247,9 +247,7 @@ namespace NHibernate.Persister.Entity
 					throw new MappingException("Discriminator mapping required for single table polymorphic persistence");
 
 				forceDiscriminator = persistentClass.IsForceDiscriminator;
-				IEnumerator<ISelectable> iSel = discrimValue.ColumnIterator.GetEnumerator();
-				iSel.MoveNext();
-				ISelectable selectable = iSel.Current;
+				var selectable = discrimValue.ColumnIterator.First();
 				if (discrimValue.HasFormula)
 				{
 					Formula formula = (Formula)selectable;

--- a/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
@@ -110,11 +110,13 @@ namespace NHibernate.Persister.Entity
 			int spacesSize = 1 + persistentClass.SynchronizedTables.Count;
 			spaces = new string[spacesSize];
 			spaces[0] = tableName;
-			IEnumerator<string> iSyncTab = persistentClass.SynchronizedTables.GetEnumerator();
-			for (int i = 1; i < spacesSize; i++)
+			using (var iSyncTab = persistentClass.SynchronizedTables.GetEnumerator())
 			{
-				iSyncTab.MoveNext();
-				spaces[i] = iSyncTab.Current;
+				for (var i = 1; i < spacesSize; i++)
+				{
+					iSyncTab.MoveNext();
+					spaces[i] = iSyncTab.Current;
+				}
 			}
 
 			subclassSpaces = persistentClass.SubclassTableClosureIterator

--- a/src/NHibernate/SqlCommand/SubselectClauseExtractor.cs
+++ b/src/NHibernate/SqlCommand/SubselectClauseExtractor.cs
@@ -76,22 +76,24 @@ namespace NHibernate.SqlCommand
 		/// statement.</returns>
 		public SqlString GetSqlString()
 		{
-			IEnumerator partEnumerator = sql.GetEnumerator();
-			parenNestCount = 0;
-			// Process the parts until FROM is found
-			while (partEnumerator.MoveNext())
+			using (var partEnumerator = sql.GetEnumerator())
 			{
-				object part = partEnumerator.Current;
-				if (ProcessPartBeforeFrom(part))
+				parenNestCount = 0;
+				// Process the parts until FROM is found
+				while (partEnumerator.MoveNext())
 				{
-					break;
+					var part = partEnumerator.Current;
+					if (ProcessPartBeforeFrom(part))
+					{
+						break;
+					}
 				}
-			}
 
-			// Process the rest
-			while (partEnumerator.MoveNext())
-			{
-				AddPart(partEnumerator.Current);
+				// Process the rest
+				while (partEnumerator.MoveNext())
+				{
+					AddPart(partEnumerator.Current);
+				}
 			}
 
 			RemoveLastOrderByClause();

--- a/src/NHibernate/SqlCommand/Template.cs
+++ b/src/NHibernate/SqlCommand/Template.cs
@@ -87,117 +87,117 @@ namespace NHibernate.SqlCommand
 			bool inFromClause = false;
 			bool afterFromTable = false;
 
-			IEnumerator<string> tokensEnum = tokens.GetEnumerator();
-			bool hasMore = tokensEnum.MoveNext();
-			string nextToken = hasMore ? tokensEnum.Current : null;
-			string lastToken = string.Empty;
-			while (hasMore)
+			using (var tokensEnum = tokens.GetEnumerator())
 			{
-				string token = nextToken;
-				string lcToken = token.ToLowerInvariant();
-				hasMore = tokensEnum.MoveNext();
-				nextToken = hasMore ? tokensEnum.Current : null;
-
-				bool isQuoteCharacter = false;
-
-				if (!quotedIdentifier && "'".Equals(token))
+				var hasMore = tokensEnum.MoveNext();
+				var nextToken = hasMore ? tokensEnum.Current : null;
+				var lastToken = string.Empty;
+				while (hasMore)
 				{
-					quoted = !quoted;
-					isQuoteCharacter = true;
-				}
+					var token = nextToken;
+					var lcToken = token.ToLowerInvariant();
+					hasMore = tokensEnum.MoveNext();
+					nextToken = hasMore ? tokensEnum.Current : null;
 
-				if (!quoted)
-				{
-					bool isOpenQuote;
-					if ("`".Equals(token))
+					var isQuoteCharacter = false;
+
+					if (!quotedIdentifier && "'".Equals(token))
 					{
-						isOpenQuote = !quotedIdentifier;
-						token = lcToken = isOpenQuote ?
-						                  dialect.OpenQuote.ToString() :
-						                  dialect.CloseQuote.ToString();
-						quotedIdentifier = isOpenQuote;
+						quoted = !quoted;
 						isQuoteCharacter = true;
 					}
-					else if (!quotedIdentifier && (dialect.OpenQuote == token[0]))
+
+					if (!quoted)
 					{
-						isOpenQuote = true;
-						quotedIdentifier = true;
-						isQuoteCharacter = true;
+						bool isOpenQuote;
+						if ("`".Equals(token))
+						{
+							isOpenQuote = !quotedIdentifier;
+							token = lcToken = isOpenQuote ? dialect.OpenQuote.ToString() : dialect.CloseQuote.ToString();
+							quotedIdentifier = isOpenQuote;
+							isQuoteCharacter = true;
+						}
+						else if (!quotedIdentifier && (dialect.OpenQuote == token[0]))
+						{
+							isOpenQuote = true;
+							quotedIdentifier = true;
+							isQuoteCharacter = true;
+						}
+						else if (quotedIdentifier && (dialect.CloseQuote == token[0]))
+						{
+							quotedIdentifier = false;
+							isQuoteCharacter = true;
+							isOpenQuote = false;
+						}
+						else
+						{
+							isOpenQuote = false;
+						}
+
+						if (isOpenQuote && !inFromClause && !lastToken.EndsWith("."))
+						{
+							result.Append(placeholder).Append('.');
+						}
 					}
-					else if (quotedIdentifier && (dialect.CloseQuote == token[0]))
+
+					var quotedOrWhitespace = quoted ||
+						quotedIdentifier ||
+						isQuoteCharacter ||
+						char.IsWhiteSpace(token[0]);
+
+					if (quotedOrWhitespace)
 					{
-						quotedIdentifier = false;
-						isQuoteCharacter = true;
-						isOpenQuote = false;
+						result.Append(token);
+					}
+					else if (beforeTable)
+					{
+						result.Append(token);
+						beforeTable = false;
+						afterFromTable = true;
+					}
+					else if (afterFromTable)
+					{
+						if (!"as".Equals(lcToken))
+							afterFromTable = false;
+						result.Append(token);
+					}
+					else if (IsNamedParameter(token))
+					{
+						result.Append(token);
+					}
+					else if (
+						IsIdentifier(token, dialect) &&
+						!IsFunctionOrKeyword(lcToken, nextToken, dialect, functionRegistry)
+					)
+					{
+						result.Append(placeholder)
+							  .Append('.')
+							  .Append(token);
 					}
 					else
 					{
-						isOpenQuote = false;
+						if (BeforeTableKeywords.Contains(lcToken))
+						{
+							beforeTable = true;
+							inFromClause = true;
+						}
+						else if (inFromClause && ",".Equals(lcToken))
+						{
+							beforeTable = true;
+						}
+						result.Append(token);
 					}
 
-					if (isOpenQuote && !inFromClause && !lastToken.EndsWith("."))
-					{
-						result.Append(placeholder).Append('.');
-					}
-				}
-
-				bool quotedOrWhitespace = quoted ||
-				                          quotedIdentifier ||
-				                          isQuoteCharacter ||
-				                          char.IsWhiteSpace(token[0]);
-
-				if (quotedOrWhitespace)
-				{
-					result.Append(token);
-				}
-				else if (beforeTable)
-				{
-					result.Append(token);
-					beforeTable = false;
-					afterFromTable = true;
-				}
-				else if (afterFromTable)
-				{
-					if (!"as".Equals(lcToken))
-						afterFromTable = false;
-					result.Append(token);
-				}
-				else if (IsNamedParameter(token))
-				{
-					result.Append(token);
-				}
-				else if (
-					IsIdentifier(token, dialect) &&
-					!IsFunctionOrKeyword(lcToken, nextToken, dialect, functionRegistry)
+					if ( //Yuck:
+						inFromClause &&
+						Keywords.Contains(lcToken) && //"as" is not in Keywords
+						!BeforeTableKeywords.Contains(lcToken)
 					)
-				{
-					result.Append(placeholder)
-						.Append('.')
-						.Append(token);
-				}
-				else
-				{
-					if (BeforeTableKeywords.Contains(lcToken))
 					{
-						beforeTable = true;
-						inFromClause = true;
+						inFromClause = false;
 					}
-					else if (inFromClause && ",".Equals(lcToken))
-					{
-						beforeTable = true;
-					}
-					result.Append(token);
+					lastToken = token;
 				}
-
-				if ( //Yuck:
-					inFromClause &&
-					Keywords.Contains(lcToken) && //"as" is not in Keywords
-					!BeforeTableKeywords.Contains(lcToken)
-					)
-				{
-					inFromClause = false;
-				}
-				lastToken = token;
 			}
 			return result.ToString();
 		}
@@ -218,80 +218,80 @@ namespace NHibernate.SqlCommand
 			bool quoted = false;
 			bool quotedIdentifier = false;
 
-			IEnumerator<string> tokensEnum = tokens.GetEnumerator();
-			bool hasMore = tokensEnum.MoveNext();
-			string nextToken = hasMore ? tokensEnum.Current : null;
-			while (hasMore)
+			using (var tokensEnum = tokens.GetEnumerator())
 			{
-				string token = nextToken;
-				string lcToken = token.ToLowerInvariant();
-				hasMore = tokensEnum.MoveNext();
-				nextToken = hasMore ? tokensEnum.Current : null;
-
-				bool isQuoteCharacter = false;
-
-				if (!quotedIdentifier && "'".Equals(token))
+				var hasMore = tokensEnum.MoveNext();
+				var nextToken = hasMore ? tokensEnum.Current : null;
+				while (hasMore)
 				{
-					quoted = !quoted;
-					isQuoteCharacter = true;
-				}
+					var token = nextToken;
+					var lcToken = token.ToLowerInvariant();
+					hasMore = tokensEnum.MoveNext();
+					nextToken = hasMore ? tokensEnum.Current : null;
 
-				if (!quoted)
-				{
-					bool isOpenQuote;
-					if ("`".Equals(token))
+					var isQuoteCharacter = false;
+
+					if (!quotedIdentifier && "'".Equals(token))
 					{
-						isOpenQuote = !quotedIdentifier;
-						token = lcToken = isOpenQuote ?
-						                  dialect.OpenQuote.ToString() :
-						                  dialect.CloseQuote.ToString();
-						quotedIdentifier = isOpenQuote;
+						quoted = !quoted;
 						isQuoteCharacter = true;
 					}
-					else if (!quotedIdentifier && (dialect.OpenQuote == token[0]))
+
+					if (!quoted)
 					{
-						isOpenQuote = true;
-						quotedIdentifier = true;
-						isQuoteCharacter = true;
+						bool isOpenQuote;
+						if ("`".Equals(token))
+						{
+							isOpenQuote = !quotedIdentifier;
+							token = lcToken = isOpenQuote ? dialect.OpenQuote.ToString() : dialect.CloseQuote.ToString();
+							quotedIdentifier = isOpenQuote;
+							isQuoteCharacter = true;
+						}
+						else if (!quotedIdentifier && (dialect.OpenQuote == token[0]))
+						{
+							isOpenQuote = true;
+							quotedIdentifier = true;
+							isQuoteCharacter = true;
+						}
+						else if (quotedIdentifier && (dialect.CloseQuote == token[0]))
+						{
+							quotedIdentifier = false;
+							isQuoteCharacter = true;
+							isOpenQuote = false;
+						}
+						else
+						{
+							isOpenQuote = false;
+						}
+
+						if (isOpenQuote)
+						{
+							result.Append(Placeholder).Append('.');
+						}
 					}
-					else if (quotedIdentifier && (dialect.CloseQuote == token[0]))
+
+					var quotedOrWhitespace = quoted ||
+						quotedIdentifier ||
+						isQuoteCharacter ||
+						char.IsWhiteSpace(token[0]);
+
+					if (quotedOrWhitespace)
 					{
-						quotedIdentifier = false;
-						isQuoteCharacter = true;
-						isOpenQuote = false;
+						result.Append(token);
+					}
+					else if (
+						IsIdentifier(token, dialect) &&
+						!IsFunctionOrKeyword(lcToken, nextToken, dialect, functionRegistry)
+					)
+					{
+						result.Append(Placeholder)
+							  .Append('.')
+							  .Append(token);
 					}
 					else
 					{
-						isOpenQuote = false;
+						result.Append(token);
 					}
-
-					if (isOpenQuote)
-					{
-						result.Append(Placeholder).Append('.');
-					}
-				}
-
-				bool quotedOrWhitespace = quoted ||
-				                          quotedIdentifier ||
-				                          isQuoteCharacter ||
-				                          char.IsWhiteSpace(token[0]);
-
-				if (quotedOrWhitespace)
-				{
-					result.Append(token);
-				}
-				else if (
-					IsIdentifier(token, dialect) &&
-					!IsFunctionOrKeyword(lcToken, nextToken, dialect, functionRegistry)
-					)
-				{
-					result.Append(Placeholder)
-						.Append('.')
-						.Append(token);
-				}
-				else
-				{
-					result.Append(token);
 				}
 			}
 			return result.ToString();

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -244,16 +244,22 @@ namespace NHibernate.Util
 				return false;
 			}
 
-			IEnumerator e1 = c1.GetEnumerator();
-			IEnumerator e2 = c2.GetEnumerator();
-
-			while (e1.MoveNext())
+			var e2 = c2.GetEnumerator();
+			try
 			{
-				e2.MoveNext();
-				if (!Equals(e1.Current, e2.Current))
+				foreach (var item1 in c1)
 				{
-					return false;
+					e2.MoveNext();
+					if (!Equals(item1, e2.Current))
+					{
+						return false;
+					}
 				}
+			}
+			finally
+			{
+				// Most IEnumerator will have a disposable concrete implementation, must check it.
+				(e2 as IDisposable)?.Dispose();
 			}
 
 			return true;

--- a/src/NHibernate/Util/PropertiesHelper.cs
+++ b/src/NHibernate/Util/PropertiesHelper.cs
@@ -63,13 +63,14 @@ namespace NHibernate.Util
 			if (properties.TryGetValue(property, out propValue))
 			{
 				var tokens = new StringTokenizer(propValue, delim, false);
-				IEnumerator<string> en = tokens.GetEnumerator();
-				while (en.MoveNext())
+				using (var en = tokens.GetEnumerator())
 				{
-					string key = en.Current;
-
-					string value = en.MoveNext() ? en.Current : String.Empty;
-					map[key] = value;
+					while (en.MoveNext())
+					{
+						var key = en.Current;
+						var value = en.MoveNext() ? en.Current : string.Empty;
+						map[key] = value;
+					}
 				}
 			}
 			return map;

--- a/src/NHibernate/Util/SafetyEnumerable.cs
+++ b/src/NHibernate/Util/SafetyEnumerable.cs
@@ -21,10 +21,8 @@ namespace NHibernate.Util
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			var enumerator = _collection.GetEnumerator();
-			while (enumerator.MoveNext())
+			foreach (var element in _collection)
 			{
-				var element = enumerator.Current;
 				if (element == null)
 					yield return default(T);
 				else if (element is T)

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -398,13 +398,16 @@ namespace NHibernate.Util
 		/// <param name="placeholders"></param>
 		/// <param name="replacements"></param>
 		/// <returns></returns>
-		public static string[] Multiply(string str, IEnumerator placeholders, IEnumerator replacements)
+		public static string[] Multiply(string str, IEnumerable<object> placeholders, IEnumerable<object> replacements)
 		{
-			string[] result = new string[] { str };
-			while (placeholders.MoveNext())
+			var result = new [] { str };
+			using (var replacementsIterator = replacements.GetEnumerator())
 			{
-				replacements.MoveNext();
-				result = Multiply(result, placeholders.Current as string, replacements.Current as string[]);
+				foreach (var placeholder in placeholders)
+				{
+					replacementsIterator.MoveNext();
+					result = Multiply(result, placeholder as string, replacementsIterator.Current as string[]);
+				}
 			}
 			return result;
 		}


### PR DESCRIPTION
[NH-4027](https://nhibernate.jira.com/browse/NH-4027) - Missing disposals of enumerators.

It appears NHibernate heavily uses `IEnumerator` directly, and does not dispose them in many cases.
This is likely a side effect of Java porting code. But in .Net, many cases can be replaced by LINQ calls or `foreach` loops, and should be.
Otherwise, extra care must be taken in order to ensure their are disposed of.
`IEnumerator<T>` is directly disposable, but the old `IEnumerator` is not, while the underlying concrete type will be `IDisposable` most of the time. The `foreach` construct handles it by try-casting it to `IDisposable`, and we should do the same.

Done in NHibernate project. Test project also have many cases, not fixed.