### PR TITLE
NH-4028 - Supports inconclusive tests in result comparison

### DIFF
--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -831,7 +831,6 @@ namespace NHibernate.Test.Linq
 
 					// Over floats.
 					TestRow(p => p.ShippingWeight.CompareTo((float) 4.98) <= 0, 17, false),
-					TestRow(p => p.ShippingWeight.CompareTo((float) 4.98) <= 0, 17, false),
 
 					// Over nullable decimals.
 					TestRow(p => p.UnitPrice.Value.CompareTo((decimal) 14.00) <= 0, 24, false),

--- a/teamcity.build
+++ b/teamcity.build
@@ -369,7 +369,7 @@
 				report.AppendLine("==================");
 
 				var before = Result.ParseFile(lastResult);
-				var beforeByName = before.ToDictionary(b => b.Name);
+				var beforeByName = before.GroupBy(b => b.Name).ToDictionary(g => g.Key, g => g.First());
 				var after = Result.ParseFile(currentResult);
 
 				var newFailingTests = new List<Result>();

--- a/teamcity.build
+++ b/teamcity.build
@@ -236,6 +236,7 @@
 	<script language="C#" prefix="testResult">
 		<references>
 			<include name="System.dll" />
+			<include name="System.Core.dll" />
 			<include name="System.Data.dll" />
 			<include name="System.Xml.dll" />
 		</references>

--- a/teamcity.build
+++ b/teamcity.build
@@ -362,14 +362,28 @@
 		{
 			try
 			{
-				var outputFile = Path.GetDirectoryName(currentResult) + "/Comparison.txt";
+				var outputFile = Path.Combine(Path.GetDirectoryName(currentResult), "Comparison.txt");
 				var report = new StringBuilder();
 
 				report.AppendLine("Comparison Results");
 				report.AppendLine("==================");
 
 				var before = Result.ParseFile(lastResult);
-				var beforeByName = before.GroupBy(b => b.Name).ToDictionary(g => g.Key, g => g.First());
+				var beforeByName = before
+					// Some multi-value tests may be duplicated
+					.GroupBy(b => b.Name)
+					.ToDictionary(
+						g => g.Key,
+						// Take one, preferably not failing first, thus ensuring an after failing test
+						// will be match as broken in case one of the dup was not failing.
+						g => g
+							// Succeeded
+							.OrderByDescending(r => r.Success)
+							// Else ignored
+							.ThenBy(r => r.Executed)
+							// Else inconclusive
+							.ThenBy(r => r.Status == ResultStatus.Success ? 0 : 1)
+							.First());
 				var after = Result.ParseFile(currentResult);
 
 				var newFailingTests = new List<Result>();
@@ -379,8 +393,10 @@
 				var ignoredTests = new List<Result>();
 				var brokenTests = new List<Result>();
 				var inconclusiveTests = new List<Result>();
+				var afterTestNames = new HashSet<string>();
 				foreach (var afterResult in after)
 				{
+					afterTestNames.Add(afterResult.Name);
 					Result beforeResult;
 					if (beforeByName.TryGetValue(afterResult.Name, out beforeResult))
 					{
@@ -412,8 +428,6 @@
 					}
 				}
 
-				var afterTestNames = new HashSet<string>();
-				foreach (var result in after) afterTestNames.Add(result.Name);
 				var missingTests = new List<Result>();
 				foreach (var result in before)
 					if (!afterTestNames.Contains(result.Name))
@@ -460,16 +474,6 @@
 					report.AppendLine("None");
 
 				report.AppendLine();
-				report.AppendLine("*** Tests new (not failing) since last recorded results ***");
-				if (newNotFailingTests.Count > 0)
-				{
-					foreach (var result in newNotFailingTests)
-						report.AppendLine(result.ToString());
-				}
-				else
-					report.AppendLine("None");
-
-				report.AppendLine();
 				report.AppendLine("*** Tests fixed since last recorded results ***");
 				if (fixedTests.Count > 0)
 				{
@@ -484,6 +488,16 @@
 				if (ignoredTests.Count > 0)
 				{
 					foreach (Result result in ignoredTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
+
+				report.AppendLine();
+				report.AppendLine("*** Tests new (not failing) since last recorded results ***");
+				if (newNotFailingTests.Count > 0)
+				{
+					foreach (var result in newNotFailingTests)
 						report.AppendLine(result.ToString());
 				}
 				else

--- a/teamcity.build
+++ b/teamcity.build
@@ -245,231 +245,267 @@
 			<import namespace="System.Data.Common"/>
 			<import namespace="System.Data.SqlClient"/>
 			<import namespace="System.IO"/>
+			<import namespace="System.Linq"/>
 			<import namespace="System.Xml"/>
 		</imports>
 		<code>
 			<![CDATA[
 
-						public static void StripAttributes(XmlDocument source, string xpath)
+		public static void StripAttributes(XmlDocument source, string xpath)
+		{
+			foreach (XmlAttribute att in source.SelectNodes(xpath))
+				att.OwnerElement.RemoveAttribute(att.Name);
+		}
+
+		public static void StripElements(XmlDocument source, string xpath)
+		{
+			foreach (XmlElement el in source.SelectNodes(xpath))
+				el.ParentNode.RemoveChild(el);
+		}
+
+		[Function("StripTimings")]
+		public static string StripTimings(string testResultFile, string outputFile)
+		{
+			try
+			{
+				XmlDocument testResults = new XmlDocument();
+				testResults.Load(testResultFile);
+
+				StripElements(testResults, "//stack-trace");
+				StripAttributes(testResults, "//@cwd");
+				StripAttributes(testResults, "//@total");
+				StripAttributes(testResults, "//@date");
+				StripAttributes(testResults, "//@time");
+				StripAttributes(testResults, "//@machine-name");
+				StripAttributes(testResults, "//@user");
+				StripAttributes(testResults, "//@user-domain");
+
+				outputFile = Path.GetDirectoryName(testResultFile) + "/" + outputFile;
+				testResults.Save(outputFile);
+				return outputFile;
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+				throw;
+			}
+		}
+
+		public enum ResultStatus
+		{
+			None,
+			Ignored,
+			Success,
+			Failure
+		}
+
+		public class Result
+		{
+			public string Name;
+			public ResultStatus Status;
+			public bool Executed;
+			public bool Success;
+			public bool Inconclusive => Executed && !Success && Status == ResultStatus.Success;
+
+			private static Result Parse(XmlNode testCase)
+			{
+				var result = new Result
+				{
+					Name = testCase.Attributes["name"].Value,
+					Executed = bool.Parse(testCase.Attributes["executed"].Value)
+				};
+
+				Enum.TryParse<ResultStatus>(testCase.Attributes["result"].Value, out var status);
+				result.Status = status;
+
+				if (result.Executed)
+					result.Success = bool.Parse(testCase.Attributes["success"].Value);
+
+				return result;
+			}
+
+			public override string ToString()
+			{
+				var prefix = "IGNORED - ";
+				if (Executed)
+					prefix = Success ? "PASS    - " :
+						Inconclusive ? "INCONCL - " : "FAIL    - ";
+				return prefix + Name;
+			}
+
+			public static IList<Result> ParseFile(string file)
+			{
+				var run1 = new XmlDocument();
+				run1.Load(file);
+
+				var results = new List<Result>();
+				foreach (XmlNode testCase in run1.SelectNodes("//test-case"))
+				{
+					var result = Parse(testCase);
+					results.Add(result);
+				}
+				return results;
+			}
+		}
+
+		[Function("CompareResults")]
+		public static string CompareResults(string currentResult, string lastResult)
+		{
+			try
+			{
+				var outputFile = Path.GetDirectoryName(currentResult) + "/Comparison.txt";
+				var report = new StringBuilder();
+
+				report.AppendLine("Comparison Results");
+				report.AppendLine("==================");
+
+				var before = Result.ParseFile(lastResult);
+				var beforeByName = before.ToDictionary(b => b.Name);
+				var after = Result.ParseFile(currentResult);
+
+				var newFailingTests = new List<Result>();
+				var newInconclusiveTests = new List<Result>();
+				var newNotFailingTests = new List<Result>();
+				var fixedTests = new List<Result>();
+				var ignoredTests = new List<Result>();
+				var brokenTests = new List<Result>();
+				var inconclusiveTests = new List<Result>();
+				foreach (var afterResult in after)
+					if (beforeByName.TryGetValue(afterResult.Name, out var beforeResult))
+					{
+						if (!beforeResult.Success && afterResult.Success)
+							fixedTests.Add(afterResult);
+						if (beforeResult.Executed && !afterResult.Executed)
+							ignoredTests.Add(afterResult);
+						if (beforeResult.Success && afterResult.Executed && !afterResult.Success)
 						{
-							foreach(XmlAttribute att in source.SelectNodes(xpath))
-								att.OwnerElement.RemoveAttribute(att.Name);
+							if (afterResult.Inconclusive)
+								inconclusiveTests.Add(afterResult);
+							else
+								brokenTests.Add(afterResult);
 						}
-						
-						public static void StripElements(XmlDocument source, string xpath)
+						if (beforeResult.Inconclusive && afterResult.Executed && !afterResult.Success && !afterResult.Inconclusive)
+							brokenTests.Add(afterResult);
+					}
+					else
+					{
+						if (afterResult.Executed && !afterResult.Success)
 						{
-							foreach(XmlElement el in source.SelectNodes(xpath))
-								el.ParentNode.RemoveChild(el);
+							if (afterResult.Inconclusive)
+								newInconclusiveTests.Add(afterResult);
+							else
+								newFailingTests.Add(afterResult);
 						}
-						
-            [Function("StripTimings")]
-            public static string StripTimings(string testResultFile, string outputFile)
-            {
-							try
-							{
-								XmlDocument testResults = new XmlDocument();
-								testResults.Load(testResultFile);
+						else
+							newNotFailingTests.Add(afterResult);
+					}
 
-								StripElements(testResults, "//stack-trace");
-								StripAttributes(testResults, "//@cwd");
-								StripAttributes(testResults, "//@total");
-								StripAttributes(testResults, "//@date");
-								StripAttributes(testResults, "//@time");
-								StripAttributes(testResults, "//@machine-name");
-								StripAttributes(testResults, "//@user");
-								StripAttributes(testResults, "//@user-domain");
-							
-								outputFile = Path.GetDirectoryName(testResultFile) + "/" + outputFile;
-								testResults.Save(outputFile);
-								return outputFile;
-							}
-							catch(Exception e)
-							{
-								Console.WriteLine(e);
-								throw;
-							}
-            }
-						
-						public class Result
-						{
-							public string Name;
-							public bool Executed;
-							public bool Success;
+				var afterTestNames = new HashSet<string>();
+				foreach (var result in after) afterTestNames.Add(result.Name);
+				var missingTests = new List<Result>();
+				foreach (var result in before)
+					if (!afterTestNames.Contains(result.Name))
+						missingTests.Add(result);
 
-							private static Result Parse(XmlNode testCase)
-							{
-								Result result = new Result();
+				report.AppendLine();
+				report.AppendLine("*** Tests broken since last recorded results ***");
+				if (brokenTests.Count > 0)
+				{
+					foreach (var result in brokenTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-								result.Name = testCase.Attributes["name"].Value;
-								result.Executed = bool.Parse(testCase.Attributes["executed"].Value);
+				report.AppendLine();
+				report.AppendLine("*** Tests new (failed) since last recorded results ***");
+				if (newFailingTests.Count > 0)
+				{
+					foreach (var result in newFailingTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-								if (result.Executed)
-									result.Success = bool.Parse(testCase.Attributes["success"].Value);
+				report.AppendLine();
+				report.AppendLine("*** Tests inconclusive since last recorded results ***");
+				if (brokenTests.Count > 0)
+				{
+					foreach (var result in inconclusiveTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-								return result;
-							}
-							
-							public override string ToString()
-							{
-								string prefix = "IGNORED - ";
-								if (Executed) prefix = Success ? "PASS    - " : "FAIL    - ";
-								return prefix + Name;
-							}
+				report.AppendLine();
+				report.AppendLine("*** Tests new (inconclusive) since last recorded results ***");
+				if (newFailingTests.Count > 0)
+				{
+					foreach (var result in newInconclusiveTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-							public static IList<Result> ParseFile(string file)
-							{
-								XmlDocument run1 = new XmlDocument();
-								run1.Load(file);
+				report.AppendLine();
+				report.AppendLine("*** Tests new (not failing) since last recorded results ***");
+				if (newNotFailingTests.Count > 0)
+				{
+					foreach (var result in newNotFailingTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-								IList<Result> results = new List<Result>();
-								foreach (XmlNode testCase in run1.SelectNodes("//test-case"))
-								{
-									Result result = Result.Parse(testCase);
-									results.Add(result);
-								}
-								return results;
-							}
-						}
+				report.AppendLine();
+				report.AppendLine("*** Tests fixed since last recorded results ***");
+				if (fixedTests.Count > 0)
+				{
+					foreach (Result result in fixedTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-						[Function("CompareResults")]
-						public static string CompareResults(string currentResult, string lastResult)
-						{
-							try
-							{
-								string outputFile = Path.GetDirectoryName(currentResult) + "/Comparison.txt";
-								StringBuilder report = new StringBuilder();
+				report.AppendLine();
+				report.AppendLine("*** Tests ignored since last recorded results ***");
+				if (ignoredTests.Count > 0)
+				{
+					foreach (Result result in ignoredTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-								report.AppendLine("Comparison Results");
-								report.AppendLine("==================");
-							
-								IList<Result> before = Result.ParseFile(lastResult);
-								IList<Result> after = Result.ParseFile(currentResult);
-							
-								IList<string> beforeTestNames = new List<string>();
-								IList<string> afterTestNames = new List<string>();
-							
-								foreach(Result result in before) beforeTestNames.Add(result.Name);
-								foreach(Result result in after) afterTestNames.Add(result.Name);
-							
-								IList<Result> afterExistingTests = new List<Result>();
-								foreach(Result result in after)
-									if (beforeTestNames.Contains(result.Name))
-										afterExistingTests.Add(result);
-							
-								IList<Result> newFailingTests = new List<Result>();
-								IList<Result> newNotFailingTests = new List<Result>();
-								foreach(Result result in after)
-									if (!beforeTestNames.Contains(result.Name))
-										if (result.Executed && !result.Success)
-											newFailingTests.Add(result);
-										else
-											newNotFailingTests.Add(result);
-									
-								report.AppendLine();
-								report.AppendLine("*** Tests new (not failing) since last recorded results ***");
-								if (newNotFailingTests.Count > 0)
-								{
-									foreach(Result result in newNotFailingTests)
-										report.AppendLine(result.ToString());
-								}
-								else
-									report.AppendLine("None");
-							
-								report.AppendLine();
-								report.AppendLine("*** Tests new (failed) since last recorded results ***");
-								if (newFailingTests.Count > 0)
-								{
-									foreach(Result result in newFailingTests)
-										report.AppendLine(result.ToString());
-								}
-								else
-									report.AppendLine("None");
-							
-								IList<Result> fixedTests = new List<Result>();
-								foreach(Result afterResult in afterExistingTests)
-									foreach(Result beforeResult in before)
-										if (beforeResult.Name == afterResult.Name)
-											if (!beforeResult.Success && afterResult.Success)
-												fixedTests.Add(afterResult);
-							
-								report.AppendLine();
-								report.AppendLine("*** Tests fixed since last recorded results ***");
-								if (fixedTests.Count > 0)
-								{
-									foreach(Result result in fixedTests)
-										report.AppendLine(result.ToString());
-								}
-								else
-									report.AppendLine("None");
-							
-								IList<Result> missingTests = new List<Result>();
-								foreach(Result result in before)
-									if (!afterTestNames.Contains(result.Name))
-										missingTests.Add(result);
+				report.AppendLine();
+				report.AppendLine("*** Tests missing since last recorded results ***");
+				if (missingTests.Count > 0)
+				{
+					foreach (var result in missingTests)
+						report.AppendLine(result.ToString());
+				}
+				else
+					report.AppendLine("None");
 
-								report.AppendLine();
-								report.AppendLine("*** Tests missing since last recorded results ***");
-								if (missingTests.Count > 0)
-								{
-									foreach(Result result in missingTests)
-										report.AppendLine(result.ToString());
-								}
-								else
-									report.AppendLine("None");
-									
-								IList<Result> ignoredTests = new List<Result>();
-								foreach(Result afterResult in afterExistingTests)
-									foreach(Result beforeResult in before)
-										if (beforeResult.Name == afterResult.Name)
-											if (beforeResult.Executed && !afterResult.Executed)
-												ignoredTests.Add(afterResult);
+				var output = report.ToString();
+				File.WriteAllText(outputFile, output);
 
-								report.AppendLine();
-								report.AppendLine("*** Tests ignored since last recorded results ***");
-								if (ignoredTests.Count > 0)
-								{
-									foreach(Result result in ignoredTests)
-										report.AppendLine(result.ToString());
-								}
-								else
-									report.AppendLine("None");
+				if (brokenTests.Count > 0)
+					throw new Exception("Previously passing tests have been broken\n\n" + output);
 
-								IList<Result> brokenTests = new List<Result>();
-								foreach(Result afterResult in afterExistingTests)
-									foreach(Result beforeResult in before)
-										if (beforeResult.Name == afterResult.Name)
-											if (beforeResult.Success && afterResult.Executed && !afterResult.Success)
-												brokenTests.Add(afterResult);
+				if (newFailingTests.Count > 0)
+					throw new Exception("New tests that fail have been added\n\n" + output);
 
-								report.AppendLine();
-								report.AppendLine("*** Tests broken since last recorded results ***");
-								if (brokenTests.Count > 0)
-								{
-									foreach(Result result in brokenTests)
-										report.AppendLine(result.ToString());
-								}
-								else
-									report.AppendLine("None");
+				return output;
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+				throw;
+			}
+		}
 
-								string output = report.ToString();
-								File.WriteAllText(outputFile, output);
-							
-								if (brokenTests.Count > 0)
-									throw new Exception("Previously passing tests have been broken\n\n" + output);
-							
-								if (newFailingTests.Count > 0)
-									throw new Exception("New tests that fail have been added\n\n" + output);
-							
-								return output;
-							}
-							catch(Exception e)
-							{
-								Console.WriteLine(e);
-								throw;
-							}
-						}
-
-            ]]>
+			]]>
 		</code>
 	</script>
 

--- a/teamcity.build
+++ b/teamcity.build
@@ -305,7 +305,14 @@
 			public ResultStatus Status;
 			public bool Executed;
 			public bool Success;
-			public bool Inconclusive => Executed && !Success && Status == ResultStatus.Success;
+
+			public bool Inconclusive
+			{
+				get
+				{
+					return Executed && !Success && Status == ResultStatus.Success;
+				}
+			}
 
 			private static Result Parse(XmlNode testCase)
 			{
@@ -371,7 +378,9 @@
 				var brokenTests = new List<Result>();
 				var inconclusiveTests = new List<Result>();
 				foreach (var afterResult in after)
-					if (beforeByName.TryGetValue(afterResult.Name, out var beforeResult))
+				{
+					Result beforeResult;
+					if (beforeByName.TryGetValue(afterResult.Name, out beforeResult))
 					{
 						if (!beforeResult.Success && afterResult.Success)
 							fixedTests.Add(afterResult);
@@ -399,6 +408,7 @@
 						else
 							newNotFailingTests.Add(afterResult);
 					}
+				}
 
 				var afterTestNames = new HashSet<string>();
 				foreach (var result in after) afterTestNames.Add(result.Name);

--- a/teamcity.build
+++ b/teamcity.build
@@ -323,7 +323,8 @@
 					Executed = bool.Parse(testCase.Attributes["executed"].Value)
 				};
 
-				Enum.TryParse<ResultStatus>(testCase.Attributes["result"].Value, out var status);
+				ResultStatus status;
+				Enum.TryParse<ResultStatus>(testCase.Attributes["result"].Value, out status);
 				result.Status = status;
 
 				if (result.Executed)


### PR DESCRIPTION
[NH-4028](https://nhibernate.jira.com/browse/NH-4028) - Supports inconclusive tests in result comparison

Within #627, I have started issuing NUnit warning about problematic database behaviors we cannot fix. This causes the test to be inconclusive: it executes without errors but exhibit abnormal behaviors.
Current comparison result logic classifies them as failing. Teamcity classifies them as succeeded. The build log contains their warning.
Adjust comparison result logic to classify them as inconclusive and report them accordingly in comparison result. Do not cause the build to fail on them.

An example of such behavior causing a test to be inconclusive is the delayed commit with Oracle when the transaction is distributed, occurring after transaction scope disposal, instead of being committed before the disposal is left. The commit succeeded, but a query done right after the scope may not be able to see it. The test in #627 sleep a bit to check if the data finally gets committed. If no, it fails, if yes, it warns about the delayed commit, causing the test to be inconclusive.