### PR TITLE
NH-4032 - Multiple factories in thread static context.

### DIFF
--- a/doc/reference/modules/architecture.xml
+++ b/doc/reference/modules/architecture.xml
@@ -259,7 +259,8 @@
             <listitem>
                 <para>
                     <literal>NHibernate.Context.ThreadStaticSessionContext</literal> - current session is
-                    stored in a thread-static variable. This context only supports one session factory.
+                    stored in a thread-static variable. This context supports multiple session factory only
+                    since NHibernate v5.
                     You are responsible to bind and unbind an <literal>ISession</literal> instance with
                     static methods of class <literal>CurrentSessionContext</literal>.
                 </para>

--- a/src/NHibernate.Test/ConnectionTest/ThreadStaticSessionContextFixture.cs
+++ b/src/NHibernate.Test/ConnectionTest/ThreadStaticSessionContextFixture.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Threading;
+using NHibernate.Cfg;
+using NHibernate.Context;
+using NHibernate.Engine;
+using NUnit.Framework;
+
+namespace NHibernate.Test.ConnectionTest
+{
+	[TestFixture]
+	public class ThreadStaticSessionContextFixture : ConnectionManagementTestCase
+	{
+		protected override ISession GetSessionUnderTest()
+		{
+			var session = OpenSession();
+			session.BeginTransaction();
+			return session;
+		}
+
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(cfg);
+			cfg.SetProperty(Environment.CurrentSessionContextClass, "thread_static");
+		}
+
+		[Test]
+		public void ThreadStaticIsolation()
+		{
+			using (var session1 = OpenSession())
+			using (var session2 = OpenSession())
+			{
+				var thread1 = new Thread(() =>
+				{
+					for (var i = 1; i <= 100; i++)
+					{
+						CurrentSessionContext.Bind(session1);
+						Thread.Sleep(1);
+						// Yes, NUnit catches asserts inside threads.
+						AssertCurrentSession(Sfi, session1, $"At iteration {i}, unexpected session for thread 1.");
+					}
+				});
+
+				var thread2 = new Thread(() =>
+				{
+					for (var i = 1; i <= 34; i++)
+					{
+						CurrentSessionContext.Bind(session2);
+						// Have a different longer sleep for ensuring the other thread have changed its own.
+						Thread.Sleep(3);
+						AssertCurrentSession(Sfi, session2, $"At iteration {i}, unexpected session for thread 2.");
+					}
+				});
+
+				thread1.Start();
+				thread2.Start();
+				thread1.Join();
+				thread2.Join();
+			}
+		}
+
+		[Test]
+		public void ThreadStaticMultiFactory()
+		{
+			using (var factory1 = cfg.BuildSessionFactory())
+			using (var session1 = factory1.OpenSession())
+			using (var factory2 = cfg.BuildSessionFactory())
+			using (var session2 = factory2.OpenSession())
+			{
+				CurrentSessionContext.Bind(session1);
+				AssertCurrentSession(factory1, session1, "Unexpected session for factory1 after bind of session1.");
+				CurrentSessionContext.Bind(session2);
+				AssertCurrentSession(factory2, session2, "Unexpected session for factory2 after bind of session2.");
+				AssertCurrentSession(factory1, session1, "Unexpected session for factory1 after bind of session2.");
+			}
+		}
+
+		private void AssertCurrentSession(ISessionFactory factory, ISession session, string message)
+		{
+			Assert.That(
+				factory.GetCurrentSession(),
+				Is.EqualTo(session),
+				"{0} {1} instead of {2}.", message,
+				factory.GetCurrentSession().GetSessionImplementation().SessionId,
+				session.GetSessionImplementation().SessionId);
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -209,6 +209,7 @@
     <Compile Include="ConnectionTest\AggressiveReleaseTest.cs" />
     <Compile Include="ConnectionTest\ConnectionManagementTestCase.cs" />
     <Compile Include="ConnectionTest\AsyncLocalSessionContextFixture.cs" />
+    <Compile Include="ConnectionTest\ThreadStaticSessionContextFixture.cs" />
     <Compile Include="ConnectionTest\YetAnother.cs" />
     <Compile Include="ConnectionTest\Other.cs" />
     <Compile Include="ConnectionTest\Silly.cs" />

--- a/src/NHibernate/Context/ThreadStaticSessionContext.cs
+++ b/src/NHibernate/Context/ThreadStaticSessionContext.cs
@@ -1,27 +1,29 @@
 using System;
+using System.Collections;
+using NHibernate.Engine;
 
 namespace NHibernate.Context
 {
 	/// <summary>
 	/// Provides a <see cref="ISessionFactory.GetCurrentSession()">current session</see>
 	/// for each thread using the [<see cref="ThreadStaticAttribute"/>].
-	/// To avoid if there are two session factories in the same thread.
 	/// </summary>
 	[Serializable]
-	public class ThreadStaticSessionContext : CurrentSessionContext
+	public class ThreadStaticSessionContext : MapBasedSessionContext
 	{
 		[ThreadStatic]
-		private static ISession _session;
+		private static IDictionary _map;
 
-		public ThreadStaticSessionContext(Engine.ISessionFactoryImplementor factory)
+		public ThreadStaticSessionContext(ISessionFactoryImplementor factory) : base (factory) { }
+
+		protected override IDictionary GetMap()
 		{
+			return _map;
 		}
 
-		/// <summary> Gets or sets the currently bound session. </summary>
-		protected override ISession Session
+		protected override void SetMap(IDictionary value)
 		{
-			get { return _session; }
-			set { _session = value; }
+			_map = value;
 		}
 	}
 }


### PR DESCRIPTION
[NH-4032](https://nhibernate.jira.com/browse/NH-4032) - Supports multiple factories with ThreadStaticSessionContext

`ThreadStaticSessionContext` does not currently supports multiple factories usage in a same context (thread in its case).
Supporting it should just be a mater of deriving from `MapBasedSessionContext`.
This is the only context having that limitation.
`ThreadLocalSessionContext` supports multiple factories but have a contrived implementation with debatable semantics, such as "auto-opening" a session at first request instead of mandating explicit bind/unbind operations. Its test case is not even activated due to the lack of the "auto-close on transaction end" feature implementation it requires for having its pattern making sens.