### PR TITLE
NH-4003 - Refactor session constructor, some missing cleanup.

### DIFF
--- a/src/NHibernate.Test/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/DebugSessionFactory.cs
@@ -140,7 +140,9 @@ namespace NHibernate.Test
 			bool autoCloseSessionEnabled,
 			ConnectionReleaseMode connectionReleaseMode)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var s = ActualFactory.OpenSession(connection, flushBeforeCompletionEnabled, autoCloseSessionEnabled, connectionReleaseMode);
+#pragma warning restore CS0618 // Type or member is obsolete
 			_openedSessions.Add(s.GetSessionImplementation());
 			return s;
 		}

--- a/src/NHibernate/Context/ThreadLocalSessionContext.cs
+++ b/src/NHibernate/Context/ThreadLocalSessionContext.cs
@@ -8,6 +8,7 @@ namespace NHibernate.Context
 {
 	//TODO: refactoring on this class. Maybe using MapBasedSessionContext.
 	/// <summary>
+	/// <para>
 	/// A <see cref="ICurrentSessionContext"/> impl which scopes the notion of current
 	/// session by the current thread of execution. Threads do not give us a 
 	/// nice hook to perform any type of cleanup making
@@ -19,13 +20,15 @@ namespace NHibernate.Context
 	/// generated here are unusable until after {@link Session#beginTransaction()}
 	/// has been called. If <tt>Close()</tt> is called on a session managed by
 	/// this class, it will be automatically unbound.
-	/// <p/>
+	/// </para>
+	/// <para>
 	/// Additionally, the static <see cref="Bind"/> and <see cref="Unbind"/> methods are
 	/// provided to allow application code to explicitly control opening and
 	/// closing of these sessions.  This, with some from of interception,
 	/// is the preferred approach.  It also allows easy framework integration
 	/// and one possible approach for implementing long-sessions.
-	/// <p/>
+	/// </para>
+	/// <para>The cleanup on transaction end is indeed not implemented.</para>
 	/// </summary>
 	[Serializable]
 	public class ThreadLocalSessionContext : ICurrentSessionContext
@@ -148,11 +151,10 @@ namespace NHibernate.Context
 
 		protected ISession BuildOrObtainSession()
 		{
-			return factory.OpenSession(
-				null,
-				IsAutoFlushEnabled(),
-				IsAutoCloseEnabled(),
-				GetConnectionReleaseMode());
+			return factory.WithOptions()
+				.AutoClose(IsAutoCloseEnabled())
+				.ConnectionReleaseMode(GetConnectionReleaseMode())
+				.OpenSession();
 		}
 
 		private ConnectionReleaseMode GetConnectionReleaseMode()
@@ -160,11 +162,17 @@ namespace NHibernate.Context
 			return factory.Settings.ConnectionReleaseMode;
 		}
 
+		/// <summary>
+		/// Not currently implemented.
+		/// </summary>
+		/// <returns><see langword="true"/></returns>
 		protected virtual bool IsAutoCloseEnabled()
 		{
 			return true;
 		}
 
+		// Obsolete since v5
+		[Obsolete("Had never any implementation, has always had no effect.")]
 		protected virtual bool IsAutoFlushEnabled()
 		{
 			return true;

--- a/src/NHibernate/Engine/ISessionFactoryImplementor.cs
+++ b/src/NHibernate/Engine/ISessionFactoryImplementor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using NHibernate.Cache;
@@ -132,21 +133,17 @@ namespace NHibernate.Engine
 		/// <summary> Get a named second-level cache region</summary>
 		ICache GetSecondLevelCacheRegion(string regionName);
 
+		// Obsolete since v5
 		/// <summary>
 		/// Open a session conforming to the given parameters. Used mainly
 		/// for current session processing.
 		/// </summary>
 		/// <param name="connection">The external ado.net connection to use, if one (i.e., optional).</param>
-		/// <param name="flushBeforeCompletionEnabled">
-		/// Should the session be auto-flushed 
-		/// prior to transaction completion?
-		/// </param>
-		/// <param name="autoCloseSessionEnabled">
-		/// Should the session be auto-closed after
-		/// transaction completion?
-		/// </param>
+		/// <param name="flushBeforeCompletionEnabled">No usage.</param>
+		/// <param name="autoCloseSessionEnabled">Not yet implemented.</param>
 		/// <param name="connectionReleaseMode">The release mode for managed jdbc connections.</param>
 		/// <returns>An appropriate session.</returns>
+		[Obsolete("Please use WithOptions() instead.")]
 		ISession OpenSession(DbConnection connection, bool flushBeforeCompletionEnabled, bool autoCloseSessionEnabled,
 		                     ConnectionReleaseMode connectionReleaseMode);
 

--- a/src/NHibernate/ISessionBuilder.cs
+++ b/src/NHibernate/ISessionBuilder.cs
@@ -59,7 +59,7 @@ namespace NHibernate
 		T ConnectionReleaseMode(ConnectionReleaseMode connectionReleaseMode);
 
 		/// <summary>
-		/// Should the session be automatically closed after transaction completion?
+		/// Should the session be automatically closed after transaction completion? Not yet implemented, will have no effect.
 		/// </summary>
 		/// <param name="autoClose">Should the session be automatically closed.</param>
 		/// <returns><see langword="this" />, for method chaining.</returns>

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -505,7 +505,6 @@ namespace NHibernate.Impl
 		{
 			return WithOptions()
 				.Connection(connection)
-				.Interceptor(interceptor)
 				.AutoClose(autoCloseSessionEnabled)
 				.ConnectionReleaseMode(connectionReleaseMode)
 				.OpenSession();


### PR DESCRIPTION
[https://nhibernate.jira.com/browse/NH-4003](NH-4003) - Refactor session constructor

Some cleanup was missing, due to that `ThreadLocalSessionContext` thing. This appears to be a partial port from Hibernate, left semi-functional. It is documented as closing automatically session at end of transaction, but this `autoClose` feature is not implemented. For hiding that from "innocent user", the `OpenSession` overload allowing to specify this useless `autoClose` is on `ISessionFactoryImplementor` instead of `ISessionFactory`, and I have missed marking it obsolete in the interface, while obsoleting the implementation.

I have also added some xml comments about things actually implemented.

Maybe should we instead drop them completely. At least drop the `AutoClose`, which is now visible by any user on the `ISessionBuilder`. Having publicly available non internal members with a "Not yet implemented" comment is not very nice.

The `ThreadLocalSessionContext` could not be that easy to drop: it has some special semantics implemented which some users may rely on: 

- Auto-open a session if none was there, instead of yielding null.
- Auto-close previous session if any when binding a new one.
- Unless #644 is merged, supports multiple factories, contrary to `ThreadStaticSessionContext`.
