### PR TITLE
NH-4034 - flushing sessions sharing transaction on commit.

### DIFF
--- a/src/NHibernate.Test/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/DebugSessionFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Threading;
 using log4net;
 using NHibernate.Cache;
@@ -53,27 +54,39 @@ namespace NHibernate.Test
 			var allClosed = true;
 			foreach (var session in _openedSessions)
 			{
-				if (session.IsOpen)
+				// Do not inverse, we want to close all of them.
+				allClosed = CheckSessionWasClosed(session) && allClosed;
+				// Catches only session opened from another one while sharing the connection. Those
+				// opened without sharing the connection stay un-monitored.
+				foreach (var dependentSession in session.ConnectionManager.DependentSessions.ToList())
 				{
-					if (session.TransactionContext?.ShouldCloseSessionOnDistributedTransactionCompleted ?? false)
-					{
-						// Delayed transactions not having completed and closed their sessions? Give them a chance to complete.
-						Thread.Sleep(100);
-						if (!session.IsOpen)
-						{
-							_log.Warn($"Test case had a delayed close of session {session.SessionId}.");
-							continue;
-						}
-					}
-
-					_log.Error($"Test case didn't close session {session.SessionId}, closing");
-					allClosed = false;
-					(session as ISession)?.Close();
-					(session as IStatelessSession)?.Close();
+					allClosed = CheckSessionWasClosed(dependentSession) && allClosed;
 				}
 			}
 
 			return allClosed;
+		}
+
+		private bool CheckSessionWasClosed(ISessionImplementor session)
+		{
+			if (!session.IsOpen)
+				return true;
+
+			if (session.TransactionContext?.ShouldCloseSessionOnDistributedTransactionCompleted ?? false)
+			{
+				// Delayed transactions not having completed and closed their sessions? Give them a chance to complete.
+				Thread.Sleep(100);
+				if (!session.IsOpen)
+				{
+					_log.Warn($"Test case had a delayed close of session {session.SessionId}.");
+					return true;
+				}
+			}
+
+			_log.Error($"Test case didn't close session {session.SessionId}, closing");
+			(session as ISession)?.Close();
+			(session as IStatelessSession)?.Close();
+			return false;
 		}
 
 		ISessionBuilder ISessionFactory.WithOptions()

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -1464,6 +1464,8 @@
     <Compile Include="TestDialects\PostgreSQL83TestDialect.cs" />
     <Compile Include="TestDialects\SQLiteTestDialect.cs" />
     <Compile Include="Tools\hbm2ddl\SchemaExportTests\ExportToFileFixture.cs" />
+    <Compile Include="TransactionTest\Person.cs" />
+    <Compile Include="TransactionTest\TransactionFixtureBase.cs" />
     <Compile Include="TransformTests\ImplementationOfEqualityTests.cs" />
     <Compile Include="TypesTest\CharClass.cs" />
     <Compile Include="TypesTest\CharClassFixture.cs" />
@@ -3286,6 +3288,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="TransactionTest\Person.hbm.xml" />
     <EmbeddedResource Include="NHSpecificTest\NH2241\Mappings.hbm.xml" />
     <EmbeddedResource Include="Futures\Mappings.hbm.xml" />
     <EmbeddedResource Include="SessionBuilder\Mappings.hbm.xml" />

--- a/src/NHibernate.Test/SystemTransactions/TransactionFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/TransactionFixture.cs
@@ -1,26 +1,23 @@
-using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Transactions;
-using NHibernate.DomainModel;
+using NHibernate.Linq;
+using NHibernate.Test.TransactionTest;
 using NUnit.Framework;
 
 namespace NHibernate.Test.SystemTransactions
 {
 	[TestFixture]
-	public class TransactionFixture : TestCase
+	public class TransactionFixture : TransactionFixtureBase
 	{
-		protected override IList Mappings
-		{
-			get { return new string[] { "WZ.hbm.xml" }; }
-		}
-
 		[Test]
 		public void CanUseSystemTransactionsToCommit()
 		{
-			object identifier;
+			int identifier;
 			using(ISession session = Sfi.OpenSession())
 			using(TransactionScope tx = new TransactionScope())
 			{
-				W s = new W();
+				var s = new Person();
 				session.Save(s);
 				identifier = s.Id;
 				tx.Complete();
@@ -29,10 +26,83 @@ namespace NHibernate.Test.SystemTransactions
 			using (ISession session = Sfi.OpenSession())
 			using (TransactionScope tx = new TransactionScope())
 			{
-				W w = session.Get<W>(identifier);
+				var w = session.Get<Person>(identifier);
 				Assert.IsNotNull(w);
 				session.Delete(w);
 				tx.Complete();
+			}
+		}
+
+		[Test]
+		public void FlushFromTransactionAppliesToDisposedSharingSession()
+		{
+			var flushOrder = new List<int>();
+			using (var s = OpenSession(new TestInterceptor(0, flushOrder)))
+			{
+				var builder = s.SessionWithOptions().Connection();
+
+				using (var t = new TransactionScope())
+				{
+					var p1 = new Person();
+					var p2 = new Person();
+					var p3 = new Person();
+					var p4 = new Person();
+
+					using (var s1 = builder.Interceptor(new TestInterceptor(1, flushOrder)).OpenSession())
+						s1.Save(p1);
+					using (var s2 = builder.Interceptor(new TestInterceptor(2, flushOrder)).OpenSession())
+					{
+						s2.Save(p2);
+						using (var s3 = s2.SessionWithOptions().Connection().Interceptor(new TestInterceptor(3, flushOrder)).OpenSession())
+							s3.Save(p3);
+					}
+					s.Save(p4);
+					t.Complete();
+				}
+			}
+
+			Assert.That(flushOrder, Is.EqualTo(new[] { 1, 2, 3, 0 }));
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				Assert.That(s.Query<Person>().Count(), Is.EqualTo(4));
+				t.Commit();
+			}
+		}
+
+		[Test]
+		public void FlushFromTransactionAppliesToSharingSession()
+		{
+			var flushOrder = new List<int>();
+			using (var s = OpenSession(new TestInterceptor(0, flushOrder)))
+			{
+				var builder = s.SessionWithOptions().Connection();
+
+				using (var s1 = builder.Interceptor(new TestInterceptor(1, flushOrder)).OpenSession())
+				using (var s2 = builder.Interceptor(new TestInterceptor(2, flushOrder)).OpenSession())
+				using (var s3 = s2.SessionWithOptions().Connection().Interceptor(new TestInterceptor(3, flushOrder)).OpenSession())
+				using (var t = new TransactionScope())
+				{
+					var p1 = new Person();
+					var p2 = new Person();
+					var p3 = new Person();
+					var p4 = new Person();
+					s1.Save(p1);
+					s2.Save(p2);
+					s3.Save(p3);
+					s.Save(p4);
+					t.Complete();
+				}
+			}
+
+			Assert.That(flushOrder, Is.EqualTo(new[] { 1, 2, 3, 0 }));
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				Assert.That(s.Query<Person>().Count(), Is.EqualTo(4));
+				t.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/SystemTransactions/TransactionFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/TransactionFixture.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Test.SystemTransactions
 				}
 			}
 
-			Assert.That(flushOrder, Is.EqualTo(new[] { 1, 2, 3, 0 }));
+			Assert.That(flushOrder, Is.EqualTo(new[] { 0, 1, 2, 3 }));
 
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
@@ -96,7 +96,7 @@ namespace NHibernate.Test.SystemTransactions
 				}
 			}
 
-			Assert.That(flushOrder, Is.EqualTo(new[] { 1, 2, 3, 0 }));
+			Assert.That(flushOrder, Is.EqualTo(new[] { 0, 1, 2, 3 }));
 
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())

--- a/src/NHibernate.Test/TransactionTest/Person.cs
+++ b/src/NHibernate.Test/TransactionTest/Person.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NHibernate.Test.TransactionTest
+{
+	public class Person
+	{
+		public virtual int Id { get; set; }
+
+		public virtual DateTime CreatedAt { get; set; } = DateTime.Now;
+	}
+}

--- a/src/NHibernate.Test/TransactionTest/Person.hbm.xml
+++ b/src/NHibernate.Test/TransactionTest/Person.hbm.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+    namespace="NHibernate.Test.TransactionTest"
+    assembly="NHibernate.Test">
+
+  <class name="Person">
+    <id name="Id">
+      <generator class="hilo"/>
+    </id>
+    <property name="CreatedAt"/>
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/TransactionTest/TransactionFixture.cs
+++ b/src/NHibernate.Test/TransactionTest/TransactionFixture.cs
@@ -163,7 +163,7 @@ namespace NHibernate.Test.TransactionTest
 				}
 			}
 
-			Assert.That(flushOrder, Is.EqualTo(new[] { 1, 2, 3, 0 }));
+			Assert.That(flushOrder, Is.EqualTo(new[] { 0, 1, 2, 3 }));
 
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())

--- a/src/NHibernate.Test/TransactionTest/TransactionFixtureBase.cs
+++ b/src/NHibernate.Test/TransactionTest/TransactionFixtureBase.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NHibernate.Test.TransactionTest
+{
+	public abstract class TransactionFixtureBase : TestCase
+	{
+		protected override IList Mappings => new[] { "TransactionTest.Person.hbm.xml" };
+
+		protected override string MappingsAssembly => "NHibernate.Test";
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from System.Object");
+				t.Commit();
+			}
+		}
+
+		public class TestInterceptor : EmptyInterceptor
+		{
+			private readonly int _numero;
+			private readonly List<int> _flushOrder;
+
+			public TestInterceptor(int numero, List<int> flushOrder)
+			{
+				_numero = numero;
+				_flushOrder = flushOrder;
+			}
+
+			public override void PreFlush(ICollection entitites)
+			{
+				_flushOrder.Add(_numero);
+			}
+		}
+	}
+}

--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -187,6 +187,11 @@ namespace NHibernate.Engine
 		void BeforeTransactionCompletion(ITransaction tx);
 
 		/// <summary>
+		/// 
+		/// </summary>
+		void FlushBeforeTransactionCompletion();
+
+		/// <summary>
 		/// Notify the session that the transaction completed, so we no longer own the old locks.
 		/// (Also we should release cache softlocks). May be called multiple times during the transaction
 		/// completion process.

--- a/src/NHibernate/ISharedSessionBuilder.cs
+++ b/src/NHibernate/ISharedSessionBuilder.cs
@@ -9,6 +9,8 @@ namespace NHibernate
 	{
 		/// <summary>
 		/// Signifies that the connection from the original session should be used to create the new session.
+		/// The original session remains responsible for it and its closing will cause sharing sessions to be no
+		/// more usable.
 		/// </summary>
 		/// <returns><see langword="this" />, for method chaining.</returns>
 		ISharedSessionBuilder Connection();

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -152,6 +152,7 @@ namespace NHibernate.Impl
 		public abstract IEntityPersister GetEntityPersister(string entityName, object obj);
 		public abstract void AfterTransactionBegin(ITransaction tx);
 		public abstract void BeforeTransactionCompletion(ITransaction tx);
+		public abstract void FlushBeforeTransactionCompletion();
 		public abstract void AfterTransactionCompletion(bool successful, ITransaction tx);
 		public abstract object GetContextEntityIdentifier(object obj);
 		public abstract object Instantiate(string clazz, object id);
@@ -430,6 +431,7 @@ namespace NHibernate.Impl
 				if (!ConnectionManager.IsInActiveTransaction)
 				{
 					ConnectionManager.AfterNonTransactionalQuery(success);
+					ConnectionManager.AfterTransaction();
 					AfterTransactionCompletion(success, null);
 				}
 			}

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -27,8 +27,10 @@ namespace NHibernate.Impl
 	public class StatelessSessionImpl : AbstractSessionImpl, IStatelessSession
 	{
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof(StatelessSessionImpl));
+
 		[NonSerialized]
 		private readonly ConnectionManager connectionManager;
+
 		[NonSerialized]
 		private readonly StatefulPersistenceContext temporaryPersistenceContext;
 
@@ -179,7 +181,7 @@ namespace NHibernate.Impl
 				temporaryPersistenceContext.Clear();
 			}
 		}
-		
+
 		public override IEnumerable Enumerable(IQueryExpression queryExpression, QueryParameters queryParameters)
 		{
 			throw new NotImplementedException();
@@ -216,14 +218,20 @@ namespace NHibernate.Impl
 
 		public override void BeforeTransactionCompletion(ITransaction tx)
 		{
+			FlushBeforeTransactionCompletion();
+		}
+
+		public override void FlushBeforeTransactionCompletion()
+		{
+			using (new SessionIdLoggingContext(SessionId))
+			{
+				if (FlushMode != FlushMode.Manual)
+					Flush();
+			}
 		}
 
 		public override void AfterTransactionCompletion(bool successful, ITransaction tx)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				connectionManager.AfterTransaction();
-			}
 		}
 
 		public override object GetContextEntityIdentifier(object obj)
@@ -838,6 +846,7 @@ namespace NHibernate.Impl
 		#endregion
 
 		#region IDisposable Members
+
 		private bool _isAlreadyDisposed;
 
 		/// <summary>

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -186,6 +186,13 @@ namespace NHibernate.Transaction
 
 				log.Debug("Start Commit");
 
+				foreach (var dependentSession in session.ConnectionManager.DependentSessions)
+				{
+					if (dependentSession.FlushMode != FlushMode.Manual)
+					{
+						dependentSession.Flush();
+					}
+				}
 				if (session.FlushMode != FlushMode.Manual)
 				{
 					session.Flush();


### PR DESCRIPTION
[NH-4034](https://nhibernate.jira.com/browse/NH-4034) - Flush all sessions participating in a transaction

With [NH-4003](https://nhibernate.jira.com/browse/NH-4003), a transaction sharing mechanism between sessions has been introduced. It works by opening new sessions from another one, while using the `Connection()` option on the session builder.

When committing the NHibernate transaction with `FlushMode.Commit`, only the originating session get flushed. The other sessions should be flushed too.