### PR TITLE
NH-4035 - cleanup even if tear down fails.

### DIFF
--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -151,20 +151,27 @@ namespace NHibernate.Test
 			string badCleanupMessage = null;
 			try
 			{
-				OnTearDown();
-				var wereClosed = _sessionFactory.CheckSessionsWereClosed();
-				var wasCleaned = CheckDatabaseWasCleaned();
-				var wereConnectionsClosed = CheckConnectionsWereClosed();
-				fail = !wereClosed || !wasCleaned || !wereConnectionsClosed;
-
-				if (fail)
+				try
 				{
-					badCleanupMessage = "Test didn't clean up after itself. session closed: " + wereClosed + "; database cleaned: " + wasCleaned
-						+ "; connection closed: " + wereConnectionsClosed;
-					if (testResult != null && testResult.Outcome.Status == TestStatus.Failed)
+					OnTearDown();
+				}
+				finally
+				{
+					var wereClosed = _sessionFactory.CheckSessionsWereClosed();
+					var wasCleaned = CheckDatabaseWasCleaned();
+					var wereConnectionsClosed = CheckConnectionsWereClosed();
+					fail = !wereClosed || !wasCleaned || !wereConnectionsClosed;
+
+					if (fail)
 					{
-						// Avoid hiding a test failure (asserts are usually not hidden, but other exception would be).
-						badCleanupMessage = GetCombinedFailureMessage(testResult, badCleanupMessage, null);
+						badCleanupMessage = "Test didn't clean up after itself. session closed: " + wereClosed + "; database cleaned: " +
+											wasCleaned
+											+ "; connection closed: " + wereConnectionsClosed;
+						if (testResult != null && testResult.Outcome.Status == TestStatus.Failed)
+						{
+							// Avoid hiding a test failure (asserts are usually not hidden, but other exception would be).
+							badCleanupMessage = GetCombinedFailureMessage(testResult, badCleanupMessage, null);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
[NH-4035](https://nhibernate.jira.com/browse/NH-4035) - Teardown failure should not prevent cleanup

When a test teardown fails, the database cleanup, session closing, connection closing is no more done.
Ensure they are done whatever happens.
Otherwise this could cause chained failures of unrelated tests.