### PR TITLE
NH-4003 - avoiding session override on interceptor 

### DIFF
--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1330,15 +1330,17 @@ namespace NHibernate.Impl
 			{
 				_log.Debug("Opening Hibernate Session.");
 				var session = new SessionImpl(_sessionFactory, this);
-				if (_interceptor != null)
-				{
-					// NH specific feature
-					// _interceptor may be the shared accros threads EmptyInterceptor.Instance, but that is
-					// not an issue, SetSession is no-op on it.
-					_interceptor.SetSession(session);
-				}
+				SetSessionOnInterceptor(session);
 
 				return session;
+			}
+
+			protected virtual void SetSessionOnInterceptor(SessionImpl session)
+			{
+				// NH specific feature
+				// _interceptor may be the shared accros threads EmptyInterceptor.Instance, but that is
+				// not an issue, SetSession is no-op on it.
+				_interceptor?.SetSession(session);
 			}
 
 			public virtual T Interceptor(IInterceptor interceptor)


### PR DESCRIPTION
NH-4003 lack: avoiding session override on interceptor when a spawned session re-use its "parent" interceptor.

Consequences of a NH specific feature I have not sufficiently analyzed for the session builder from session case.