### PR TITLE
NH-2241 - IStatelessSession is accidentally 2LC enabled in some cases

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH2241/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2241/Fixture.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.NH2241
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var country = new Country {CountryCode = "SE", CountryName = "Sweden"};
+				session.Save(country);
+				tran.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Delete("from Country");
+				session.Delete("from User");
+				tran.Commit();
+			}
+		}
+
+		[Test]
+		public void CanInsertUsingStatelessEvenWhenAssociatedEntityHasCacheStategy()
+		{
+			using (var ss = Sfi.OpenStatelessSession())
+			using (var tx = ss.BeginTransaction())
+			{
+				var user = new User();
+				user.Country = new Country {CountryCode = "SE", CountryName = "Sweden"};
+
+				ss.Insert(user);
+				tx.Commit();
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/NH2241/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2241/Mappings.hbm.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+	assembly="NHibernate.Test"
+	namespace="NHibernate.Test.NHSpecificTest.NH2241">
+
+  <class name="User" table="Users">
+    <id name="Id">
+      <generator class="native"/>
+    </id>
+
+    <many-to-one name="Country" column="CountryCode" cascade="none" />
+  </class>
+
+  <class name="Country">
+    <cache region="ShortTerm" usage="read-write" />
+
+    <id name="CountryCode">
+      <generator class="assigned"/>
+    </id>
+
+    <property name="CountryName" />
+
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/NH2241/Model.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2241/Model.cs
@@ -1,0 +1,16 @@
+namespace NHibernate.Test.NHSpecificTest.NH2241
+{
+	public class User
+	{
+		public virtual int Id { get; set; }
+
+		public virtual Country Country { get; set; }
+	}
+
+	public class Country
+	{
+		public virtual string CountryCode { get; set; }
+
+		public virtual string CountryName { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -760,6 +760,8 @@
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\Fixture.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\FooExample.cs" />
     <Compile Include="NHSpecificTest\EntityWithUserTypeCanHaveLinqGenerators\IExample.cs" />
+    <Compile Include="NHSpecificTest\NH2241\Fixture.cs" />
+    <Compile Include="NHSpecificTest\NH2241\Model.cs" />
     <Compile Include="Insertordering\NH3931Entities.cs" />
     <Compile Include="NHSpecificTest\NH4004\Entity.cs" />
     <Compile Include="NHSpecificTest\NH4004\Fixture.cs" />
@@ -3284,6 +3286,7 @@
     <EmbeddedResource Include="NHSpecificTest\NH1291AnonExample\Mappings.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="NHSpecificTest\NH2241\Mappings.hbm.xml" />
     <EmbeddedResource Include="Futures\Mappings.hbm.xml" />
     <EmbeddedResource Include="SessionBuilder\Mappings.hbm.xml" />
     <EmbeddedResource Include="IdTest\IdentityClass.hbm.xml" />

--- a/src/NHibernate/Engine/BatchFetchQueue.cs
+++ b/src/NHibernate/Engine/BatchFetchQueue.cs
@@ -236,7 +236,7 @@ namespace NHibernate.Engine
 
 		private bool IsCached(EntityKey entityKey, IEntityPersister persister)
 		{
-			if (persister.HasCache)
+			if (persister.HasCache && context.Session.CacheMode.HasFlag(CacheMode.Get))
 			{
 				CacheKey key = context.Session.GenerateCacheKey(entityKey.Identifier, persister.IdentifierType, entityKey.EntityName);
 				return persister.Cache.Cache.Get(key) != null;
@@ -246,7 +246,7 @@ namespace NHibernate.Engine
 
 		private bool IsCached(object collectionKey, ICollectionPersister persister)
 		{
-			if (persister.HasCache)
+			if (persister.HasCache && context.Session.CacheMode.HasFlag(CacheMode.Get))
 			{
 				CacheKey cacheKey = context.Session.GenerateCacheKey(collectionKey, persister.KeyType, persister.Role);
 				return persister.Cache.Cache.Get(cacheKey) != null;

--- a/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
+++ b/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
@@ -260,7 +260,7 @@ namespace NHibernate.Engine.Loading
 			}
 
 			bool addToCache = hasNoQueuedAdds && persister.HasCache && 
-				((session.CacheMode & CacheMode.Put) == CacheMode.Put) && !ce.IsDoremove; // and this is not a forced initialization during flush
+				session.CacheMode.HasFlag(CacheMode.Put) && !ce.IsDoremove; // and this is not a forced initialization during flush
 
 			if (addToCache)
 			{

--- a/src/NHibernate/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Engine/TwoPhaseLoad.cs
@@ -98,7 +98,7 @@ namespace NHibernate.Engine
 			
 			ISessionFactoryImplementor factory = session.Factory;
 
-			if (persister.HasCache && ((session.CacheMode & CacheMode.Put) == CacheMode.Put))
+			if (persister.HasCache && session.CacheMode.HasFlag(CacheMode.Put))
 			{
 				if (log.IsDebugEnabled)
 					log.Debug("adding entity to second-level cache: " + MessageHelper.InfoString(persister, id, session.Factory));

--- a/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Event.Default
 				return false;
 			}
 
-			bool useCache = persister.HasCache && ((source.CacheMode & CacheMode.Get) == CacheMode.Get);
+			bool useCache = persister.HasCache && source.CacheMode.HasFlag(CacheMode.Get);
 
 			if (!useCache)
 			{

--- a/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
@@ -413,7 +413,7 @@ namespace NHibernate.Event.Default
 		protected virtual object LoadFromSecondLevelCache(LoadEvent @event, IEntityPersister persister, LoadType options)
 		{
 			ISessionImplementor source = @event.Session;
-			bool useCache = persister.HasCache && ((source.CacheMode & CacheMode.Get) == CacheMode.Get)
+			bool useCache = persister.HasCache && source.CacheMode .HasFlag(CacheMode.Get)
 				&& @event.LockMode.LessThan(LockMode.Read);
 
 			if (useCache)

--- a/src/NHibernate/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Impl/MultiCriteriaImpl.cs
@@ -137,7 +137,7 @@ namespace NHibernate.Impl
 				log.Debug("Cache miss for multi criteria query");
 				IList list = DoList();
 				result = list;
-				if ((session.CacheMode & CacheMode.Put) == CacheMode.Put)
+				if (session.CacheMode.HasFlag(CacheMode.Put))
 				{
 					bool put = queryCache.Put(key, new ICacheAssembler[] { assembler }, new object[] { list }, combinedParameters.NaturalKeyLookup, session);
 					if (put && factory.Statistics.IsStatisticsEnabled)

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1582,7 +1582,7 @@ namespace NHibernate.Loader
 		{
 			IList result = null;
 
-			if ((!queryParameters.ForceCacheRefresh) && (session.CacheMode & CacheMode.Get) == CacheMode.Get)
+			if (!queryParameters.ForceCacheRefresh && session.CacheMode.HasFlag(CacheMode.Get))
 			{
 				IPersistenceContext persistenceContext = session.PersistenceContext;
 
@@ -1620,7 +1620,7 @@ namespace NHibernate.Loader
 		private void PutResultInQueryCache(ISessionImplementor session, QueryParameters queryParameters, IType[] resultTypes,
 										   IQueryCache queryCache, QueryKey key, IList result)
 		{
-			if ((session.CacheMode & CacheMode.Put) == CacheMode.Put)
+			if (session.CacheMode.HasFlag(CacheMode.Put))
 			{
 				bool put = queryCache.Put(key, key.ResultTransformer.GetCachedResultTypes(resultTypes), result, queryParameters.NaturalKeyLookup, session);
 				if (put && _factory.Statistics.IsStatisticsEnabled)

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1245,7 +1245,7 @@ namespace NHibernate.Persister.Entity
 												MessageHelper.InfoString(this, id, Factory), fieldName));
 			}
 
-			if (HasCache)
+			if (HasCache && session.CacheMode.HasFlag(CacheMode.Get))
 			{
 				CacheKey cacheKey = session.GenerateCacheKey(id, IdentifierType, EntityName);
 				object ce = Cache.Get(cacheKey, session.Timestamp);
@@ -3818,7 +3818,7 @@ namespace NHibernate.Persister.Entity
             }
 
 			// check to see if it is in the second-level cache
-			if (HasCache)
+			if (HasCache && session.CacheMode.HasFlag(CacheMode.Get))
 			{
 				CacheKey ck = session.GenerateCacheKey(id, IdentifierType, RootEntityName);
 				if (Cache.Get(ck, session.Timestamp) != null)


### PR DESCRIPTION
[NH-2241](https://nhibernate.jira.com/browse/NH-2241) - When inserting an entity that references an entity with assigned id causes exception if that entity as a cache property.

Example:
```xml
<class name="Document" >
    <cache region="ShortTerm" usage="read-write" />
    <id name="Name" >
        <generator class="assigned"/>
    </id>
    <property name="Text"/>
</class>
<class name="Paper">
    <id name="Id">
        <generator class="native"/>
    </id>
    <property name="Color"/>
    <many-to-one name="Document" column="DocId" cascade="none" />
</class>
```
When inserting a `Paper` entity using `BatchInsert` in the stateless session throws `NotSupported` exception from the `Timestamp` property on the session (`ISessionImplementor`).

This happens in the end of the `IsTransient` method (of the `AbstractEntityPersister`):

```c#
// check to see if it is in the second-level cache
if (HasCache)
{
    CacheKey ck = new CacheKey(id, IdentifierType, RootEntityName, session.EntityMode, session.Factory);
    if (Cache.Get(ck, session.Timestamp) != null)
        return false;
}
```

Also logged at https://nhibernate.jira.com/browse/NH-2241

This PR adds a unit test, but unfortunately I couldn't find a solution for this bug.