### PR TITLE
NH-4028 - support another kind of inconclusive result.

### DIFF
--- a/teamcity.build
+++ b/teamcity.build
@@ -289,9 +289,10 @@
 		public enum ResultStatus
 		{
 			None,
+			Failure,
 			Ignored,
-			Success,
-			Failure
+			Inconclusive,
+			Success
 		}
 
 		public class Result
@@ -305,7 +306,7 @@
 			{
 				get
 				{
-					return Executed && !Success && Status == ResultStatus.Success;
+					return Executed && !Success && (Status == ResultStatus.Success || Status == ResultStatus.Inconclusive);
 				}
 			}
 
@@ -376,7 +377,7 @@
 							// Else ignored
 							.ThenBy(r => r.Executed)
 							// Else inconclusive
-							.ThenBy(r => r.Status == ResultStatus.Success ? 0 : 1)
+							.ThenBy(r => r.Inconclusive ? 0 : 1)
 							.First());
 				var after = Result.ParseFile(currentResult);
 


### PR DESCRIPTION
[NH-4028](https://nhibernate.jira.com/browse/NH-4028) - Supports inconclusive tests in result comparison.

Follow up on #641. As demonstrated in Nathan's #654 and in my #627, another kind of inconclusive results are not supported by the result comparison tool, and classified as failure.