### PR TITLE
NH-4046 - Set default length for variable length types with SAP Anywhere / ASE

### DIFF
--- a/src/NHibernate/Dialect/SybaseASE15Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASE15Dialect.cs
@@ -39,9 +39,9 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Decimal, "numeric(18,0)");
 			RegisterColumnType(DbType.Single, "real");
 			RegisterColumnType(DbType.Double, "float");
-			RegisterColumnType(DbType.AnsiStringFixedLength, "char(1)");
+			RegisterColumnType(DbType.AnsiStringFixedLength, "char(255)");
 			RegisterColumnType(DbType.AnsiStringFixedLength, 255, "char($l)");
-			RegisterColumnType(DbType.StringFixedLength, "nchar(1)");
+			RegisterColumnType(DbType.StringFixedLength, "nchar(255)");
 			RegisterColumnType(DbType.StringFixedLength, 255, "nchar($l)");
 			RegisterColumnType(DbType.AnsiString, "varchar(255)");
 			RegisterColumnType(DbType.AnsiString, 16384, "varchar($l)");

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -63,17 +63,17 @@ namespace NHibernate.Dialect
 
 		protected virtual void RegisterCharacterTypeMappings()
 		{
-			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR(1)");
+			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR(255)");
 			RegisterColumnType(DbType.AnsiStringFixedLength, 32767, "CHAR($l)");
-			RegisterColumnType(DbType.AnsiString, "VARCHAR(1)");
+			RegisterColumnType(DbType.AnsiString, "VARCHAR(255)");
 			RegisterColumnType(DbType.AnsiString, 32767, "VARCHAR($l)");
 			RegisterColumnType(DbType.AnsiString, 2147483647, "LONG VARCHAR");
-			RegisterColumnType(DbType.StringFixedLength, "NCHAR(1)");
+			RegisterColumnType(DbType.StringFixedLength, "NCHAR(255)");
 			RegisterColumnType(DbType.StringFixedLength, 32767, "NCHAR($l)");
-			RegisterColumnType(DbType.String, "NVARCHAR(1)");
+			RegisterColumnType(DbType.String, "NVARCHAR(255)");
 			RegisterColumnType(DbType.String, 32767, "NVARCHAR($l)");
 			RegisterColumnType(DbType.String, 2147483647, "LONG NVARCHAR");
-			RegisterColumnType(DbType.Binary, "BINARY(1)");
+			RegisterColumnType(DbType.Binary, "BINARY(8000)");
 			RegisterColumnType(DbType.Binary, 32767, "VARBINARY($l)");
 			RegisterColumnType(DbType.Binary, 2147483647, "LONG BINARY");
 			RegisterColumnType(DbType.Guid, "UNIQUEIDENTIFIER");


### PR DESCRIPTION
This is [NH-4046](https://nhibernate.jira.com/browse/NH-4046).

This splits off the default length for types from NH-4043 pull request #654.

Before fixing this, huge numbers of tests would fail with a truncation error when running against SAP/Sybase SQL Anywhere.  After this, fewer tests fail.