### PR TITLE
NH-4050 - Use Task.Run instead of BeginInvoke in Tests.

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3050/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3050/Fixture.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 
 using NHibernate.Engine.Query;
 using NHibernate.Linq;
@@ -144,11 +145,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3050
 						}
 					};
 
-				var queryExecutorAsyncResult = queryExecutor.BeginInvoke(null, null);
-				var cacheCleanerAsyncResult = cacheCleaner.BeginInvoke(null, null);
+				var queryExecutorTask = Task.Run(queryExecutor);
+				var cacheCleanerTask = Task.Run(cacheCleaner);
 
-				queryExecutor.EndInvoke(queryExecutorAsyncResult);
-				cacheCleaner.EndInvoke(cacheCleanerAsyncResult);
+				queryExecutorTask.Wait();
+				cacheCleanerTask.Wait();
 
 				Assert.IsTrue(allLinqQueriesSucceeded);
 			}


### PR DESCRIPTION
This is [NH-4050](https://nhibernate.jira.com/browse/NH-4050).

Calling BeginInvoke() on delegates is obsolete and throws an exception in .NET Core:

```
System.PlatformNotSupportedException : Operation is not supported on this platform.
```

The same thing can be done with Task.Run(), running in a thread pool like `BeginInvoke`.

A prerequisite for #633