### PR TITLE
NH-4051 - Use newer System.Linq.Dynamic.Core.

### DIFF
--- a/src/NHibernate.Test/Linq/DynamicQueryTests.cs
+++ b/src/NHibernate.Test/Linq/DynamicQueryTests.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using System.Linq.Dynamic;
+using System.Linq.Dynamic.Core;
 using NHibernate.Linq;
 using NUnit.Framework;
 

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -97,9 +97,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Linq.Dynamic, Version=1.0.6132.35681, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Linq.Dynamic.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=0f07ec44de6ac832, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.Dynamic.Core.1.0.7.6\lib\net46\System.Linq.Dynamic.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/src/NHibernate.Test/packages.config
+++ b/src/NHibernate.Test/packages.config
@@ -6,7 +6,7 @@
   <package id="NUnit" version="3.6.0" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
-  <package id="System.Linq.Dynamic" version="1.0.7" targetFramework="net461" />
+  <package id="System.Linq.Dynamic.Core" version="1.0.7.6" targetFramework="net461" />
   <!-- System.Threading.Tasks.Extensions is required for dynamically loaded Npgsql.dll (Postgresql driver) -->
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This is [NH-4051](https://nhibernate.jira.com/browse/NH-4051)

For two tests, the System.Linq.Dynamic has been pulled from the community maintained [NuGet here](https://www.nuget.org/packages/System.Linq.Dynamic/), but has not been updated for compatibility with .NET Standard or .NET Core.

A newer, also community maintained, version has been released on [NuGet as System.Linq.Dynamic.Core](https://www.nuget.org/packages/System.Linq.Dynamic.Core/).

This replaces like for like, and is needed for #633 