### PR TITLE
NH-4062 - Oracle Unicode support dual model.

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/GroupByTests.cs
@@ -782,15 +782,13 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));
 		}
 
-		[Test(Description = "NH-3801")]
+		[Test(Description = "NH-3801, NH-4062")]
 		public async Task GroupByComputedValueInObjectArrayWithJoinInRightSideOfCaseAsync()
 		{
 			if (!TestDialect.SupportsComplexExpressionInGroupBy)
 				Assert.Ignore(Dialect.GetType().Name + " does not support complex group by expressions");
 			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
-			if (Dialect is Oracle8iDialect)
-				Assert.Ignore("ORA-12704: character set mismatch. Due to NHibernate creating Unicode string types as NVarchar2 but querying them as Varchar2.");
 
 			var orderGroups = await (db.OrderLines.GroupBy(o => new[] { o.Order.Customer.CustomerId == null ? "unknown" : o.Order.Customer.CompanyName }).Select(g => new { Key = g.Key, Count = g.Count() }).ToListAsync());
 			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));

--- a/src/NHibernate.Test/DriverTest/OracleDataClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/OracleDataClientDriverFixture.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using NHibernate.Dialect;
 using NHibernate.Driver;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
+using NHibernate.Util;
 using NUnit.Framework;
+using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Test.DriverTest
 {
@@ -17,21 +21,134 @@ namespace NHibernate.Test.DriverTest
 		/// </summary>
 		[Test]
 		[Category("ODP.NET")]
-		[Explicit]
-		public void NoBooleanParameters()
+		[Theory]
+		public void NoBooleanParameters(bool managed)
 		{
-			OracleDataClientDriver driver = new OracleDataClientDriver();
+			var driver = GetDriver(managed, TestConfigurationHelper.GetDefaultConfiguration().Properties);
+			var param = GetParameterForType(driver, SqlTypeFactory.Boolean);
 
-			SqlStringBuilder builder = new SqlStringBuilder();
+			Assert.That(param.DbType, Is.Not.EqualTo(DbType.Boolean), "should not still be a DbType.Boolean");
+		}
+
+		[Test]
+		[Category("ODP.NET")]
+		[Theory]
+		public void UnicodeParameters(bool managed)
+		{
+			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+			var driver = GetDriver(managed, cfg.Properties);
+			var useNPrefixedTypesForUnicode = PropertiesHelper.GetBoolean(Environment.OracleUseNPrefixedTypesForUnicode, cfg.Properties, false);
+
+			Assert.That(driver.UseNPrefixedTypesForUnicode, Is.EqualTo(useNPrefixedTypesForUnicode),
+				$"Unexpected value for {nameof(OracleDataClientDriverBase)}.{nameof(OracleDataClientDriverBase.UseNPrefixedTypesForUnicode)}");
+
+			var param = GetParameterForType(driver, SqlTypeFactory.GetString(200));
+			var oracleParamType = GetOracleParameterType(param);
+			Assert.That(oracleParamType.ToString(), Is.EqualTo(useNPrefixedTypesForUnicode ? "NVarchar2" : "Varchar2").IgnoreCase,
+				"Unexpected Unicode string parameter type");
+
+			param = GetParameterForType(driver, new StringFixedLengthSqlType(10));
+			oracleParamType = GetOracleParameterType(param);
+			Assert.That(oracleParamType.ToString(), Is.EqualTo(useNPrefixedTypesForUnicode ? "NChar" : "Char").IgnoreCase,
+				"Unexpected Unicode string fixed length parameter type");
+		}
+
+		[Test]
+		[Category("ODP.NET")]
+		[Theory]
+		public void UnicodeParametersNoPrefix(bool managed)
+		{
+			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+			cfg.SetProperty(Environment.OracleUseNPrefixedTypesForUnicode, "false");
+			var driver = GetDriver(managed, cfg.Properties);
+
+			Assert.That(driver.UseNPrefixedTypesForUnicode, Is.False,
+				$"Unexpected value for {nameof(OracleDataClientDriverBase)}.{nameof(OracleDataClientDriverBase.UseNPrefixedTypesForUnicode)}");
+
+			var param = GetParameterForType(driver, SqlTypeFactory.GetString(200));
+			var oracleParamType = GetOracleParameterType(param);
+			Assert.That(oracleParamType.ToString(), Is.EqualTo("Varchar2").IgnoreCase, "Unexpected Unicode string parameter type");
+
+			param = GetParameterForType(driver, new StringFixedLengthSqlType(10));
+			oracleParamType = GetOracleParameterType(param);
+			Assert.That(oracleParamType.ToString(), Is.EqualTo("Char").IgnoreCase, "Unexpected Unicode string fixed length parameter type");
+		}
+
+		[Test]
+		[Category("ODP.NET")]
+		[Theory]
+		public void UnicodeParametersWithPrefix(bool managed)
+		{
+			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+			cfg.SetProperty(Environment.OracleUseNPrefixedTypesForUnicode, "true");
+			var driver = GetDriver(managed, cfg.Properties);
+
+			Assert.That(driver.UseNPrefixedTypesForUnicode, Is.True,
+				$"Unexpected value for {nameof(OracleDataClientDriverBase)}.{nameof(OracleDataClientDriverBase.UseNPrefixedTypesForUnicode)}");
+
+			var param = GetParameterForType(driver, SqlTypeFactory.GetString(200));
+			var oracleParamType = GetOracleParameterType(param);
+			Assert.That(oracleParamType.ToString(), Is.EqualTo("NVarchar2").IgnoreCase, "Unexpected Unicode string parameter type");
+
+			param = GetParameterForType(driver, new StringFixedLengthSqlType(10));
+			oracleParamType = GetOracleParameterType(param);
+			Assert.That(oracleParamType.ToString(), Is.EqualTo("NChar").IgnoreCase, "Unexpected Unicode string fixed length parameter type");
+		}
+
+		[Test]
+		[Category("ODP.NET")]
+		[Theory]
+		public void HasSameUnicodeDefaultThanDialect(bool managed)
+		{
+			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+			cfg.Properties.Remove(Environment.OracleUseNPrefixedTypesForUnicode);
+			var driver = GetDriver(managed, cfg.Properties);
+			var dialect = new Oracle8iDialect();
+			dialect.Configure(cfg.Properties);
+
+			Assert.That(driver.UseNPrefixedTypesForUnicode, Is.EqualTo(dialect.UseNPrefixedTypesForUnicode),
+				$"Default {nameof(Oracle8iDialect.UseNPrefixedTypesForUnicode)} values mismatch between driver and dialect");
+		}
+
+
+		private static OracleDataClientDriverBase GetDriver(bool managed, IDictionary<string, string> settings)
+		{
+			OracleDataClientDriverBase driver = null;
+			try
+			{
+				driver = managed
+					? (OracleDataClientDriverBase)new OracleManagedDataClientDriver()
+					: new OracleDataClientDriver();
+			}
+			catch (Exception ex)
+			{
+				Assert.Ignore("Unable to load the driver: {0}", ex);
+			}
+
+			driver.Configure(settings);
+
+			return driver;
+		}
+
+		private static DbParameter GetParameterForType(IDriver driver, SqlType paramType)
+		{
+			var builder = new SqlStringBuilder();
 			builder.Add("select * from table1 where col1=");
 			builder.Add(Parameter.Placeholder);
 
-			var cmd = driver.GenerateCommand(CommandType.Text, builder.ToSqlString(), new SqlType[] {SqlTypeFactory.Boolean});
+			var cmd = driver.GenerateCommand(CommandType.Text, builder.ToSqlString(), new[] { paramType });
 
+			Assert.That(cmd.Parameters, Has.Count.EqualTo(1), "Unexpected parameters count");
 			var param = cmd.Parameters[0];
+			return param;
+		}
 
-			Assert.AreEqual("col1", param.ParameterName, "kept same param name");
-			Assert.IsFalse(param.DbType == DbType.Boolean, "should not still be a DbType.Boolean");
+		private static object GetOracleParameterType(DbParameter dbParameter)
+		{
+			var parameterType = dbParameter.GetType();
+			var typeProperty = parameterType.GetProperty("OracleDbType") ??
+				throw new InvalidOperationException("Unable to find OracleDbType property");
+			return typeProperty.GetValue(dbParameter);
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
@@ -771,15 +771,13 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));
 		}
 
-		[Test(Description = "NH-3801")]
+		[Test(Description = "NH-3801, NH-4062")]
 		public void GroupByComputedValueInObjectArrayWithJoinInRightSideOfCase()
 		{
 			if (!TestDialect.SupportsComplexExpressionInGroupBy)
 				Assert.Ignore(Dialect.GetType().Name + " does not support complex group by expressions");
 			if (Sfi.ConnectionProvider.Driver is OdbcDriver)
 				Assert.Ignore("SQL Server seems unable to match complex group by and select list arguments when running over ODBC.");
-			if (Dialect is Oracle8iDialect)
-				Assert.Ignore("ORA-12704: character set mismatch. Due to NHibernate creating Unicode string types as NVarchar2 but querying them as Varchar2.");
 
 			var orderGroups = db.OrderLines.GroupBy(o => new[] { o.Order.Customer.CustomerId == null ? "unknown" : o.Order.Customer.CompanyName }).Select(g => new { Key = g.Key, Count = g.Count() }).ToList();
 			Assert.AreEqual(2155, orderGroups.Sum(g => g.Count));

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -208,6 +208,20 @@ namespace NHibernate.Cfg
 		/// </summary>
 		public const string OdbcDateTimeScale = "odbc.explicit_datetime_scale";
 
+		/// <summary>
+		/// <para>Oracle has a dual Unicode support model.</para>
+		/// <para>Either the whole database use an Unicode encoding, and then all string types
+		/// will be Unicode. In such case, Unicode strings should be mapped to non <c>N</c> prefixed
+		/// types, such as <c>Varchar2</c>. This is the default.</para>
+		/// <para>Or <c>N</c> prefixed types such as <c>NVarchar2</c> are to be used for Unicode strings.</para>
+		/// </summary>
+		/// <remarks>
+		/// See https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch6unicode.htm#CACHCAHF
+		/// https://docs.oracle.com/database/121/ODPNT/featOraCommand.htm#i1007557
+		/// This setting applies only to Oracle dialects and ODP.Net managed or unmanaged driver.
+		/// </remarks>
+		public const string OracleUseNPrefixedTypesForUnicode = "oracle.use_n_prefixed_types_for_unicode";
+
 		private static readonly Dictionary<string, string> GlobalProperties;
 
 		private static IBytecodeProvider BytecodeProviderInstance;

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -154,7 +154,7 @@ namespace NHibernate.Dialect
 			{
 				throw new HibernateException("The dialect was not set. Set the property 'dialect'.", e);
 			}
-			return InstantiateDialect(dialectName);
+			return InstantiateDialect(dialectName, Environment.Properties);
 		}
 
 		/// <summary>
@@ -167,7 +167,7 @@ namespace NHibernate.Dialect
 		public static Dialect GetDialect(IDictionary<string, string> props)
 		{
 			if (props == null)
-				throw new ArgumentNullException("props");
+				throw new ArgumentNullException(nameof(props));
 			string dialectName;
 			if (props.TryGetValue(Environment.Dialect, out dialectName) == false)
 				throw new InvalidOperationException("Could not find the dialect in the configuration");
@@ -176,19 +176,29 @@ namespace NHibernate.Dialect
 				return GetDialect();
 			}
 
-			return InstantiateDialect(dialectName);
+			return InstantiateDialect(dialectName, props);
 		}
 
-		private static Dialect InstantiateDialect(string dialectName)
+		private static Dialect InstantiateDialect(string dialectName, IDictionary<string, string> props)
 		{
 			try
 			{
-				return (Dialect)Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(dialectName));
+				var dialect = (Dialect)Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(dialectName));
+				dialect.Configure(props);
+				return dialect;
 			}
 			catch (Exception e)
 			{
 				throw new HibernateException("Could not instantiate dialect class " + dialectName, e);
 			}
+		}
+
+		/// <summary>
+		/// Configure the dialect.
+		/// </summary>
+		/// <param name="settings">The configuration settings.</param>
+		public virtual void Configure(IDictionary<string, string> settings)
+		{
 		}
 
 		#endregion

--- a/src/NHibernate/Driver/OracleDataClientDriver.cs
+++ b/src/NHibernate/Driver/OracleDataClientDriver.cs
@@ -1,33 +1,10 @@
-using System;
-using System.Data;
-using System.Data.Common;
-using System.Reflection;
-using NHibernate.AdoNet;
-using NHibernate.Engine.Query;
-using NHibernate.SqlTypes;
-using NHibernate.Util;
-
 namespace NHibernate.Driver
 {
 	/// <summary>
-	/// A NHibernate Driver for using the Oracle.DataAccess DataProvider
+	/// A NHibernate Driver for using the Oracle.DataAccess (unmanaged) DataProvider
 	/// </summary>
-	/// <remarks>
-	/// Code was contributed by <a href="http://sourceforge.net/users/jemcalgary/">James Mills</a>
-	/// on the NHibernate forums in this 
-	/// <a href="http://sourceforge.net/forum/message.php?msg_id=2952662">post</a>.
-	/// </remarks>
-	public class OracleDataClientDriver : ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
+	public class OracleDataClientDriver : OracleDataClientDriverBase
 	{
-		private const string driverAssemblyName = "Oracle.DataAccess";
-		private const string connectionTypeName = "Oracle.DataAccess.Client.OracleConnection";
-		private const string commandTypeName = "Oracle.DataAccess.Client.OracleCommand";
-		private static readonly SqlType GuidSqlType = new SqlType(DbType.Binary, 16);
-		private readonly PropertyInfo oracleCommandBindByName;
-		private readonly PropertyInfo oracleDbType;
-		private readonly object oracleDbTypeRefCursor;
-		private readonly object oracleDbTypeXmlType;
-
 		/// <summary>
 		/// Initializes a new instance of <see cref="OracleDataClientDriver"/>.
 		/// </summary>
@@ -35,100 +12,8 @@ namespace NHibernate.Driver
 		/// Thrown when the <c>Oracle.DataAccess</c> assembly can not be loaded.
 		/// </exception>
 		public OracleDataClientDriver()
-			: base(
-			"Oracle.DataAccess.Client",
-			driverAssemblyName,
-			connectionTypeName,
-			commandTypeName)
+			: base("Oracle.DataAccess")
 		{
-			System.Type oracleCommandType = ReflectHelper.TypeFromAssembly("Oracle.DataAccess.Client.OracleCommand", driverAssemblyName, false);
-			oracleCommandBindByName = oracleCommandType.GetProperty("BindByName");
-
-			System.Type parameterType = ReflectHelper.TypeFromAssembly("Oracle.DataAccess.Client.OracleParameter", driverAssemblyName, false);
-			oracleDbType = parameterType.GetProperty("OracleDbType");
-
-			System.Type oracleDbTypeEnum = ReflectHelper.TypeFromAssembly("Oracle.DataAccess.Client.OracleDbType", driverAssemblyName, false);
-			oracleDbTypeRefCursor = Enum.Parse(oracleDbTypeEnum, "RefCursor");
-			oracleDbTypeXmlType = Enum.Parse(oracleDbTypeEnum, "XmlType");
-		}
-
-		/// <summary></summary>
-		public override bool UseNamedPrefixInSql
-		{
-			get { return true; }
-		}
-
-		/// <summary></summary>
-		public override bool UseNamedPrefixInParameter
-		{
-			get { return true; }
-		}
-
-		/// <summary></summary>
-		public override string NamedPrefix
-		{
-			get { return ":"; }
-		}
-
-		/// <remarks>
-		/// This adds logic to ensure that a DbType.Boolean parameter is not created since
-		/// ODP.NET doesn't support it.
-		/// </remarks>
-		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
-		{
-			// if the parameter coming in contains a boolean then we need to convert it 
-			// to another type since ODP.NET doesn't support DbType.Boolean
-			switch (sqlType.DbType)
-			{
-				case DbType.Boolean:
-					base.InitializeParameter(dbParam, name, SqlTypeFactory.Int16);
-					break;
-				case DbType.Guid:
-					base.InitializeParameter(dbParam, name, GuidSqlType);
-					break;
-				case DbType.Xml:
-					this.InitializeParameter(dbParam, name, oracleDbTypeXmlType);
-					break;
-				default:
-					base.InitializeParameter(dbParam, name, sqlType);
-					break;
-			}
-		}
-
-		private void InitializeParameter(DbParameter dbParam, string name, object sqlType)
-		{
-			dbParam.ParameterName = FormatNameForParameter(name);
-			oracleDbType.SetValue(dbParam, sqlType, null);
-		}
-
-		protected override void OnBeforePrepare(DbCommand command)
-		{
-			base.OnBeforePrepare(command);
-
-			// need to explicitly turn on named parameter binding
-			// http://tgaw.wordpress.com/2006/03/03/ora-01722-with-odp-and-command-parameters/
-			oracleCommandBindByName.SetValue(command, true, null);
-
-			CallableParser.Detail detail = CallableParser.Parse(command.CommandText);
-
-			if (!detail.IsCallable)
-				return;
-
-			command.CommandType = CommandType.StoredProcedure;
-			command.CommandText = detail.FunctionName;
-			oracleCommandBindByName.SetValue(command, false, null);
-
-			var outCursor = command.CreateParameter();
-			oracleDbType.SetValue(outCursor, oracleDbTypeRefCursor, null);
-
-			outCursor.Direction = detail.HasReturn ? ParameterDirection.ReturnValue : ParameterDirection.Output;
-
-			command.Parameters.Insert(0, outCursor);
-		}
-
-		System.Type IEmbeddedBatcherFactoryProvider.BatcherFactoryClass
-		{
-			get { return typeof (OracleDataClientBatchingBatcherFactory); }
 		}
 	}
 }

--- a/src/NHibernate/Driver/OracleDataClientDriverBase.cs
+++ b/src/NHibernate/Driver/OracleDataClientDriverBase.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Reflection;
+using NHibernate.AdoNet;
+using NHibernate.Engine.Query;
+using NHibernate.SqlTypes;
+using NHibernate.Util;
+
+namespace NHibernate.Driver
+{
+	/// <summary>
+	/// A NHibernate driver base for using ODP.Net.
+	/// </summary>
+	/// <remarks>
+	/// Original code was contributed by <a href="http://sourceforge.net/users/jemcalgary/">James Mills</a>
+	/// on the NHibernate forums in this 
+	/// <a href="http://sourceforge.net/forum/message.php?msg_id=2952662">post</a>.
+	/// </remarks>
+	public abstract class OracleDataClientDriverBase : ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
+	{
+		private const string _commandClassName = "OracleCommand";
+
+		private static readonly SqlType _guidSqlType = new SqlType(DbType.Binary, 16);
+		private readonly PropertyInfo _oracleCommandBindByName;
+		private readonly PropertyInfo _oracleDbType;
+		private readonly object _oracleDbTypeRefCursor;
+		private readonly object _oracleDbTypeXmlType;
+
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
+		/// <param name="assemblyName">The assembly name of the managed or unmanage driver. Namespaces will be derived from it.</param>
+		/// <exception cref="HibernateException">
+		/// Thrown when the requested assembly can not be loaded.
+		/// </exception>
+		protected OracleDataClientDriverBase(string assemblyName)
+			: this(assemblyName, assemblyName + ".Client")
+		{
+		}
+
+		private OracleDataClientDriverBase(string driverAssemblyName, string clientNamespace)
+			: base(clientNamespace, driverAssemblyName, clientNamespace + ".OracleConnection", clientNamespace + "." + _commandClassName)
+		{
+			var oracleCommandType = ReflectHelper.TypeFromAssembly(clientNamespace + "." + _commandClassName, driverAssemblyName, true);
+			_oracleCommandBindByName = oracleCommandType.GetProperty("BindByName");
+
+			var parameterType = ReflectHelper.TypeFromAssembly(clientNamespace + ".OracleParameter", driverAssemblyName, true);
+			_oracleDbType = parameterType.GetProperty("OracleDbType");
+
+			var oracleDbTypeEnum = ReflectHelper.TypeFromAssembly(clientNamespace + ".OracleDbType", driverAssemblyName, true);
+			_oracleDbTypeRefCursor = Enum.Parse(oracleDbTypeEnum, "RefCursor");
+			_oracleDbTypeXmlType = Enum.Parse(oracleDbTypeEnum, "XmlType");
+		}
+
+		/// <inheritdoc/>
+		public override bool UseNamedPrefixInSql => true;
+
+		/// <inheritdoc/>
+		public override bool UseNamedPrefixInParameter => true;
+
+		/// <inheritdoc/>
+		public override string NamedPrefix => ":";
+
+		/// <remarks>
+		/// Add logic to ensure that a <see cref="DbType.Boolean"/> parameter is not created since
+		/// ODP.NET doesn't support it. Handle <see cref="DbType.Guid"/> and <see cref="DbType.Xml"/> cases too.
+		/// Adjust <see cref="DbType.String"/> resulting type if needed.
+		/// </remarks>
+		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
+		{
+			switch (sqlType.DbType)
+			{
+				case DbType.Boolean:
+					// if the parameter coming in contains a boolean then we need to convert it 
+					// to another type since ODP.NET doesn't support DbType.Boolean
+					base.InitializeParameter(dbParam, name, SqlTypeFactory.Int16);
+					break;
+				case DbType.Guid:
+					base.InitializeParameter(dbParam, name, _guidSqlType);
+					break;
+				case DbType.Xml:
+					InitializeParameter(dbParam, name, _oracleDbTypeXmlType);
+					break;
+				default:
+					base.InitializeParameter(dbParam, name, sqlType);
+					break;
+			}
+		}
+
+		private void InitializeParameter(DbParameter dbParam, string name, object sqlType)
+		{
+			dbParam.ParameterName = FormatNameForParameter(name);
+			_oracleDbType.SetValue(dbParam, sqlType, null);
+		}
+
+		protected override void OnBeforePrepare(DbCommand command)
+		{
+			base.OnBeforePrepare(command);
+
+			// need to explicitly turn on named parameter binding
+			// http://tgaw.wordpress.com/2006/03/03/ora-01722-with-odp-and-command-parameters/
+			_oracleCommandBindByName.SetValue(command, true, null);
+
+			var detail = CallableParser.Parse(command.CommandText);
+
+			if (!detail.IsCallable)
+				return;
+
+			command.CommandType = CommandType.StoredProcedure;
+			command.CommandText = detail.FunctionName;
+			_oracleCommandBindByName.SetValue(command, false, null);
+
+			var outCursor = command.CreateParameter();
+			_oracleDbType.SetValue(outCursor, _oracleDbTypeRefCursor, null);
+
+			outCursor.Direction = detail.HasReturn ? ParameterDirection.ReturnValue : ParameterDirection.Output;
+
+			command.Parameters.Insert(0, outCursor);
+		}
+
+		System.Type IEmbeddedBatcherFactoryProvider.BatcherFactoryClass => typeof(OracleDataClientBatchingBatcherFactory);
+	}
+}

--- a/src/NHibernate/Driver/OracleManagedDataClientDriver.cs
+++ b/src/NHibernate/Driver/OracleManagedDataClientDriver.cs
@@ -1,134 +1,19 @@
-using System;
-using System.Data;
-using System.Data.Common;
-using System.Reflection;
-using NHibernate.AdoNet;
-using NHibernate.Engine.Query;
-using NHibernate.SqlTypes;
-using NHibernate.Util;
-
 namespace NHibernate.Driver
 {
 	/// <summary>
 	/// A NHibernate Driver for using the Oracle.ManagedDataAccess DataProvider
 	/// </summary>
-	public class OracleManagedDataClientDriver : ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
+	public class OracleManagedDataClientDriver : OracleDataClientDriverBase
 	{
-		private const string driverAssemblyName = "Oracle.ManagedDataAccess";
-		private const string connectionTypeName = "Oracle.ManagedDataAccess.Client.OracleConnection";
-		private const string commandTypeName = "Oracle.ManagedDataAccess.Client.OracleCommand";
-		private static readonly SqlType GuidSqlType = new SqlType(DbType.Binary, 16);
-		private readonly PropertyInfo oracleCommandBindByName;
-		private readonly PropertyInfo oracleDbType;
-		private readonly object oracleDbTypeRefCursor;
-		private readonly object oracleDbTypeXmlType;
-        private readonly object oracleDbTypeBlob;
-
 		/// <summary>
-		/// Initializes a new instance of <see cref="OracleDataClientDriver"/>.
+		/// Initializes a new instance of <see cref="OracleManagedDataClientDriver"/>.
 		/// </summary>
 		/// <exception cref="HibernateException">
 		/// Thrown when the <c>Oracle.ManagedDataAccess</c> assembly can not be loaded.
 		/// </exception>
 		public OracleManagedDataClientDriver()
-			: base(
-				"Oracle.ManagedDataAccess.Client",
-				driverAssemblyName,
-				connectionTypeName,
-				commandTypeName)
+			: base("Oracle.ManagedDataAccess")
 		{
-			var oracleCommandType = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleCommand", driverAssemblyName, true);
-			oracleCommandBindByName = oracleCommandType.GetProperty("BindByName");
-
-			var parameterType = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleParameter", driverAssemblyName, true);
-			oracleDbType = parameterType.GetProperty("OracleDbType");
-
-			var oracleDbTypeEnum = ReflectHelper.TypeFromAssembly("Oracle.ManagedDataAccess.Client.OracleDbType", driverAssemblyName, true);
-			oracleDbTypeRefCursor = Enum.Parse(oracleDbTypeEnum, "RefCursor");
-			oracleDbTypeXmlType = Enum.Parse(oracleDbTypeEnum, "XmlType");
-			oracleDbTypeBlob = Enum.Parse(oracleDbTypeEnum, "Blob");
-		}
-
-		/// <summary></summary>
-		public override string NamedPrefix
-		{
-			get { return ":"; }
-		}
-
-		/// <summary></summary>
-		public override bool UseNamedPrefixInParameter
-		{
-			get { return true; }
-		}
-
-		/// <summary></summary>
-		public override bool UseNamedPrefixInSql
-		{
-			get { return true; }
-		}
-
-		/// <remarks>
-		/// This adds logic to ensure that a DbType.Boolean parameter is not created since
-		/// ODP.NET doesn't support it.
-		/// </remarks>
-		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
-		{
-			// if the parameter coming in contains a boolean then we need to convert it 
-			// to another type since ODP.NET doesn't support DbType.Boolean
-			switch (sqlType.DbType)
-			{
-				case DbType.Boolean:
-					base.InitializeParameter(dbParam, name, SqlTypeFactory.Int16);
-					break;
-				case DbType.Guid:
-					base.InitializeParameter(dbParam, name, GuidSqlType);
-					break;
-				case DbType.Xml:
-					this.InitializeParameter(dbParam, name, oracleDbTypeXmlType);
-					break;
-                case DbType.Binary:
-                    this.InitializeParameter(dbParam, name, oracleDbTypeBlob);
-                    break;
-				default:
-					base.InitializeParameter(dbParam, name, sqlType);
-					break;
-			}
-		}
-
-		private void InitializeParameter(DbParameter dbParam, string name, object sqlType)
-		{
-			dbParam.ParameterName = FormatNameForParameter(name);
-			oracleDbType.SetValue(dbParam, sqlType, null);
-		}
-
-		protected override void OnBeforePrepare(DbCommand command)
-		{
-			base.OnBeforePrepare(command);
-
-			// need to explicitly turn on named parameter binding
-			// http://tgaw.wordpress.com/2006/03/03/ora-01722-with-odp-and-command-parameters/
-			oracleCommandBindByName.SetValue(command, true, null);
-
-			var detail = CallableParser.Parse(command.CommandText);
-
-			if (!detail.IsCallable)
-				return;
-
-			command.CommandType = CommandType.StoredProcedure;
-			command.CommandText = detail.FunctionName;
-			oracleCommandBindByName.SetValue(command, false, null);
-
-			var outCursor = command.CreateParameter();
-			oracleDbType.SetValue(outCursor, oracleDbTypeRefCursor, null);
-
-			outCursor.Direction = detail.HasReturn ? ParameterDirection.ReturnValue : ParameterDirection.Output;
-
-			command.Parameters.Insert(0, outCursor);
-		}
-
-		System.Type IEmbeddedBatcherFactoryProvider.BatcherFactoryClass
-		{
-			get { return typeof (OracleDataClientBatchingBatcherFactory); }
 		}
 
 		public override bool HasDelayedDistributedTransactionCompletion => true;

--- a/src/NHibernate/Util/DelegateHelper.cs
+++ b/src/NHibernate/Util/DelegateHelper.cs
@@ -19,9 +19,15 @@ namespace NHibernate.Util
 			var parameter = Expression.Parameter(typeof(object), "x");
 			var instance = Expression.Convert(parameter, type);
 			var property = Expression.Property(instance, propertyName);
-			var value = Expression.Parameter(typeof (T), "value");
+			var valueParameter = Expression.Parameter(typeof (T), "value");
+			Expression value = valueParameter;
+			// Cast value if required
+			if (!property.Type.IsAssignableFrom(typeof(T)))
+			{
+				value = Expression.Convert(valueParameter, property.Type);
+			}
 			var assign = Expression.Assign(property, value);
-			return Expression.Lambda<Action<object, T>>(assign, parameter, value).Compile();
+			return Expression.Lambda<Action<object, T>>(assign, parameter, valueParameter).Compile();
 		}
 
 		public static Action<object> BuildAction(System.Type type, string methodName)

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -148,6 +148,20 @@
 										</xs:documentation>
 									</xs:annotation>
 								</xs:enumeration>
+								<xs:enumeration value="oracle.use_n_prefixed_types_for_unicode">
+									<xs:annotation>
+										<xs:documentation>
+											Oracle has a dual Unicode support model.
+											Either the whole database use an Unicode encoding, and then all string types
+											will be Unicode. In such case, Unicode strings should be mapped to non N prefixed
+											types, such as Varchar2. This is the default.
+											Or N prefixed types such as NVarchar2 are to be used for Unicode strings.
+											See https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch6unicode.htm#CACHCAHF
+											https://docs.oracle.com/database/121/ODPNT/featOraCommand.htm#i1007557
+											This setting applies only to Oracle dialects and ODP.Net managed or unmanaged driver.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>

--- a/teamcity.build
+++ b/teamcity.build
@@ -148,6 +148,8 @@
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
+		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 		<copy todir="${bin.dir}">
 			<fileset basedir="${root.dir}/lib/teamcity/oracle/x86">
 				<include name="*.dll"/>
@@ -162,6 +164,8 @@
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
+		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 		<copy todir="${bin.dir}">
 			<fileset basedir="${root.dir}/lib/teamcity/oracle/x64">
 				<include name="*.dll"/>
@@ -175,6 +179,8 @@
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleManagedDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
+		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 		<copy todir="${bin.dir}">
 			<fileset basedir="${root.dir}/lib/teamcity/oracle-managed/common">
 				<include name="*.dll"/>
@@ -192,6 +198,8 @@
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleManagedDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
+		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 		<copy todir="${bin.dir}">
 			<fileset basedir="${root.dir}/lib/teamcity/oracle-managed/common">
 				<include name="*.dll"/>


### PR DESCRIPTION
[NH-4062](https://nhibernate.jira.com/browse/NH-4062) - Properly handle Oracle Unicode support dual model

~~And reverting [NH-3620](https://nhibernate.jira.com/browse/NH-3620): this was a workaround for a now obsolete bug in ODP.Net managed driver. Its test still pass without it now. It should probably have been solved as "external issue" with instruction on how to extend the driver for working around the bug till Oracle fixes it.~~ Removing this workaround causes another test to fail: `BinaryBlobTypeFixture.ReadWriteZeroLen`. Without it, the blob come back as `null`.

Managed and un-managed drivers require the same code, but it was duplicated. Now it is refactored in a single base class.