### PR TITLE
NH-3990 - Upgrade VB test project to VS2017 project structure

### DIFF
--- a/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
+++ b/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
@@ -1,160 +1,51 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>
-    </ProductVersion>
-    <SchemaVersion>
-    </SchemaVersion>
-    <ProjectGuid>{7C2EF610-BCA0-4D1F-898A-DE9908E4970C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>NHibernate.Test.VisualBasic</RootNamespace>
-    <AssemblyName>NHibernate.Test.VisualBasic</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
-    <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildProjectDirectory)\..\..\Tools\nunit\nunit-x86.exe</StartProgram>
-    <StartArguments>NHibernate.Test.VisualBasic.dll</StartArguments>
+    <TargetFramework>net461</TargetFramework>
+    <GenerateAssemblyTitleAttribute>False</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyProductAttribute>False</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCompanyAttribute>False</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyDescriptionAttribute>False</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyVersionAttribute>False</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>False</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>False</GenerateAssemblyInformationalVersionAttribute>
+    <NoWarn>$(NoWarn);3001;3002;3003;3005</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>NHibernate.Test.VisualBasic.xml</DocumentationFile>
-    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>NHibernate.Test.VisualBasic.xml</DocumentationFile>
-    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionExplicit>On</OptionExplicit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionCompare>Binary</OptionCompare>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionStrict>Off</OptionStrict>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionInfer>On</OptionInfer>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
+    <Compile Remove="Issues\NH3302\**" /> <!--"Like" not supported in new dotnet compiler, not implemented anyways in .net framework-->
   </ItemGroup>
+
   <ItemGroup>
-    <Import Include="Microsoft.VisualBasic" />
-    <Import Include="System" />
-    <Import Include="System.Collections" />
-    <Import Include="System.Collections.Generic" />
-    <Import Include="System.Data" />
-    <Import Include="System.Diagnostics" />
-    <Import Include="System.Linq" />
-    <Import Include="System.Xml.Linq" />
+    <None Remove="**\*.hbm.xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="..\SharedAssemblyInfo.vb">
-      <Link>SharedAssemblyInfo.vb</Link>
-    </Compile>
-    <Compile Include="AssemblyInfo.vb" />
-    <Compile Include="Issues\NH2966\Client.vb" />
-    <Compile Include="Issues\NH2966\Fixture.vb" />
-    <Compile Include="Issues\NH3302\Entity.vb" />
-    <Compile Include="Issues\NH3302\Fixture.vb" />
-    <Compile Include="Issues\NH2963\Entity.vb" />
-    <Compile Include="Issues\NH2963\Fixture.vb" />
-    <Compile Include="Issues\NH0000\Entity.vb" />
-    <Compile Include="Issues\NH0000\Fixture.vb" />
-    <Compile Include="Issues\IssueTestCase.vb" />
-    <Compile Include="Issues\NH2545\Fixture.vb" />
-    <Compile Include="Issues\NH2545\Entity.vb" />
-    <Compile Include="Issues\NH2966\Order.vb" />
-    <Compile Include="My Project\AssemblyInfo.vb" />
-    <Compile Include="My Project\Application.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Application.myapp</DependentUpon>
-    </Compile>
-    <Compile Include="My Project\Resources.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="My Project\Settings.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
+    <EmbeddedResource Include="**\*.hbm.xml" Exclude="bin\**\*.*" />
   </ItemGroup>
+
   <ItemGroup>
-    <EmbeddedResource Include="My Project\Resources.resx">
-      <Generator>VbMyResourcesResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.vb</LastGenOutput>
-      <CustomToolNamespace>My.Resources</CustomToolNamespace>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
+    <Compile Include="..\SharedAssemblyInfo.vb" Link="SharedAssemblyInfo.vb" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="..\NHibernate.Test\App.config">
-      <Link>App.config</Link>
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="My Project\Application.myapp">
-      <Generator>MyApplicationCodeGenerator</Generator>
-      <LastGenOutput>Application.Designer.vb</LastGenOutput>
-    </None>
-    <None Include="My Project\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <CustomToolNamespace>My</CustomToolNamespace>
-      <LastGenOutput>Settings.Designer.vb</LastGenOutput>
-    </None>
-    <None Include="packages.config" />
+    <None Include="..\NHibernate.Test\App.config" Link="App.config" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\NHibernate.Test\NHibernate.Test.csproj">
-      <Project>{7AEE5B37-C552-4E59-9B6F-88755BCB5070}</Project>
-      <Name>NHibernate.Test</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\NHibernate\NHibernate.csproj">
-      <Project>{5909BFE7-93CF-4E5F-BE22-6293368AF01D}</Project>
-      <Name>NHibernate</Name>
-    </ProjectReference>
+    <PackageReference Include="Antlr3.Runtime" Version="3.5.1" />
+    <PackageReference Include="Iesi.Collections" Version="4.0.2" />
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="nunit" Version="3.6.0" />
+    <PackageReference Include="Remotion.Linq" Version="2.1.2" />
+    <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.1.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.7.6" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
+
   <ItemGroup>
-    <EmbeddedResource Include="Issues\NH2545\Issues.NH2545.Mappings.hbm.xml" />
+    <ProjectReference Include="..\NHibernate\NHibernate.csproj" />
+    <ProjectReference Include="..\NHibernate.Test\NHibernate.Test.csproj" ExcludeAssets="ContentFiles" />
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Issues\NH0000\Issues.NH0000.Mappings.hbm.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Issues\NH2966\Issues.NH2966.Mappings.hbm.xml" />
-    <EmbeddedResource Include="Issues\NH3302\Issues.NH3302.Mappings.hbm.xml" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
+++ b/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
@@ -36,16 +36,22 @@
     <PackageReference Include="Antlr3.Runtime" Version="3.5.1" />
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="nunit" Version="3.6.0" />
+    <PackageReference Include="nunit" Version="3.7.1" />
     <PackageReference Include="Remotion.Linq" Version="2.1.2" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.1.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.7.6" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NHibernate\NHibernate.csproj" />
     <ProjectReference Include="..\NHibernate.Test\NHibernate.Test.csproj" ExcludeAssets="ContentFiles" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/NHibernate.Test.VisualBasic/packages.config
+++ b/src/NHibernate.Test.VisualBasic/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.6.0" targetFramework="net461" />
-</packages>

--- a/src/NHibernate.Test/NHSpecificTest/DtcFailures/DtcFailuresFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/DtcFailures/DtcFailuresFixture.cs
@@ -331,7 +331,11 @@ and with a rollback in the second dtc and a ForceRollback outside nh-session-sco
 
 			public void Prepare(PreparingEnlistment preparingEnlistment)
 			{
-				Assert.AreNotEqual(thread, Thread.CurrentThread.ManagedThreadId);
+				if (thread == Thread.CurrentThread.ManagedThreadId)
+				{
+					log.Warn("Thread.CurrentThread.ManagedThreadId ({0}) is same as creation thread");
+				}
+
 				if (shouldRollBack)
 				{
 					log.Debug(">>>>Force Rollback<<<<<");

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -42,11 +42,13 @@
     <PackageReference Include="Antlr3.Runtime" Version="3.5.1" />
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="nunit" Version="3.6.0" />
+    <PackageReference Include="nunit" Version="3.7.1" />
     <PackageReference Include="Remotion.Linq" Version="2.1.2" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.1.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.7.6" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,6 +60,10 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Transactions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/NHibernate.TestDatabaseSetup/NHibernate.TestDatabaseSetup.csproj
+++ b/src/NHibernate.TestDatabaseSetup/NHibernate.TestDatabaseSetup.csproj
@@ -13,7 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.6.0" />
+    <PackageReference Include="nunit" Version="3.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +32,10 @@
     <Reference Include="System.Data.SqlServerCe">
       <HintPath>..\..\lib\teamcity\sqlServerCe\System.Data.SqlServerCe.dll</HintPath>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/NHibernate/Linq/Functions/CompareGenerator.cs
+++ b/src/NHibernate/Linq/Functions/CompareGenerator.cs
@@ -44,9 +44,17 @@ namespace NHibernate.Linq.Functions
 				return true;
 
 			// This is .Net 4 only, and in the System.Data.Services assembly, which we don't depend directly on.
-			return methodInfo != null && methodInfo.Name == "Compare" &&
+			if (methodInfo != null && methodInfo.Name == "Compare" &&
 				   methodInfo.DeclaringType != null &&
-				   methodInfo.DeclaringType.FullName == "System.Data.Services.Providers.DataServiceProviderMethods";
+				   methodInfo.DeclaringType.FullName == "System.Data.Services.Providers.DataServiceProviderMethods")
+				return true;
+
+			if (methodInfo != null && methodInfo.Name == "CompareString" &&
+				   methodInfo.DeclaringType != null &&
+				   (methodInfo.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.EmbeddedOperators"))
+				return true;
+
+			return false;
 		}
 
 


### PR DESCRIPTION
This is a continuation of #605.

* Adds the ability on all test projects to be ran from `dotnet test`.
* Accounts for some changes in the VB compiler around `CompareString` methods being generated from LINQ queries.
* Also, some test behavior is different on my machine in release mode when build with `dotnet build`, so that is addressed.  Specifically, `IEnlistmentNotification.Prepare` doesn't seem to be guaranteed to be called from a different thread like it asserts.