### PR TITLE
NH-3990 - Fixes for upgrade to VS2017 project structure

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="**\*.hbm.xml" />
+    <EmbeddedResource Include="**\*.hbm.xml" Exclude="bin\**\*.*" />
     <EmbeddedResource Include="**\*.jpg" />
     <EmbeddedResource Include="TestEmbeddedConfig.cfg.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/NHibernate.Tool.HbmXsd/HbmCodeGenerator.cs
+++ b/src/NHibernate.Tool.HbmXsd/HbmCodeGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom;
 using System.IO;
 using System.Xml.Schema;
@@ -18,6 +19,8 @@ namespace NHibernate.Tool.HbmXsd
 		{
 			using (Stream stream = GetType().Assembly.GetManifestResourceStream(MappingSchemaResourceName))
 			{
+				if (stream == null)
+					throw new InvalidOperationException($"Unable to load resource {MappingSchemaResourceName}");
 				XmlSchema schema = XmlSchema.Read(stream, null);
 				Execute(outputFileName, GeneratedCodeNamespace, schema);
 			}

--- a/src/NHibernate.Tool.HbmXsd/How to generate Hbm.generated.cs.txt
+++ b/src/NHibernate.Tool.HbmXsd/How to generate Hbm.generated.cs.txt
@@ -1,4 +1,4 @@
 1) Clean the "EveryThing" solution
 2) Build all
-3) open console and change dir to "src\NHibernate.Tool.HbmXsd\bin\Debug"
-4) run: hbmxsd ..\..\..\NHibernate\Cfg\MappingSchema\Hbm.generated.cs
+3) open console and change dir to "src\NHibernate.Tool.HbmXsd\bin\Debug\net461"
+4) run: HbmXsd ..\..\..\..\NHibernate\Cfg\MappingSchema\Hbm.generated.cs

--- a/src/NHibernate.Tool.HbmXsd/NHibernate.Tool.HbmXsd.csproj
+++ b/src/NHibernate.Tool.HbmXsd/NHibernate.Tool.HbmXsd.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <StartupObject>NHibernate.Tool.HbmXsd.Program</StartupObject>
     <GenerateAssemblyTitleAttribute>False</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyProductAttribute>False</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>False</GenerateAssemblyCompanyAttribute>

--- a/src/NHibernate.Tool.HbmXsd/NHibernate.Tool.HbmXsd.csproj
+++ b/src/NHibernate.Tool.HbmXsd/NHibernate.Tool.HbmXsd.csproj
@@ -11,10 +11,15 @@
     <GenerateAssemblyVersionAttribute>False</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>False</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>False</GenerateAssemblyInformationalVersionAttribute>
+    <AssemblyName>HbmXsd</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\NHibernate\nhibernate-mapping.xsd" />
   </ItemGroup>
 
 </Project>

--- a/src/NHibernate.Tool.HbmXsd/Program.cs
+++ b/src/NHibernate.Tool.HbmXsd/Program.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 
 namespace NHibernate.Tool.HbmXsd
@@ -7,11 +9,21 @@ namespace NHibernate.Tool.HbmXsd
 	{
 		private static void Main(string[] args)
 		{
-			string outFile = args.Length == 0 ? @"..\..\..\NHibernate\Cfg\MappingSchema\Hbm.generated.cs" : args[0];
+			string outFile = Path.GetFullPath(args.Length == 0
+				? @"..\..\..\..\NHibernate\Cfg\MappingSchema\Hbm.generated.cs"
+				: args[0]);
+			if (!Directory.Exists(Path.GetDirectoryName(outFile)))
+			{
+				Console.Error.WriteLine("Invalid target path: directory does not exist.");
+				Console.Error.WriteLine(outFile);
+				Environment.ExitCode = -1;
+				return;
+			}
 			var currentUiCulture = new CultureInfo("en-us");
 			Thread.CurrentThread.CurrentCulture = currentUiCulture;
 			Thread.CurrentThread.CurrentUICulture = currentUiCulture;
 			new HbmCodeGenerator().Execute(outFile);
+			Console.WriteLine("Done");
 		}
 	}
 }

--- a/src/NHibernate/Cfg/MappingSchema/Hbm.generated.cs
+++ b/src/NHibernate/Cfg/MappingSchema/Hbm.generated.cs
@@ -1627,6 +1627,7 @@ namespace NHibernate.Cfg.MappingSchema {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute("timestamp", typeof(HbmTimestamp))]
+        [System.Xml.Serialization.XmlElementAttribute("timestamputc", typeof(HbmTimestamputc))]
         [System.Xml.Serialization.XmlElementAttribute("version", typeof(HbmVersion))]
         public object Item1;
         
@@ -3601,6 +3602,89 @@ namespace NHibernate.Cfg.MappingSchema {
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:nhibernate-mapping-2.2")]
+    [System.Xml.Serialization.XmlRootAttribute("timestamputc", Namespace="urn:nhibernate-mapping-2.2", IsNullable=false)]
+    public partial class HbmTimestamputc {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute("meta")]
+        public HbmMeta[] meta;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string name;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string node;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string column;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string access;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute("unsaved-value")]
+        public HbmTimestamputcUnsavedvalue unsavedvalue;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool unsavedvalueSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(HbmTimestamputcSource.Vm)]
+        public HbmTimestamputcSource source;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(HbmVersionGeneration.Never)]
+        public HbmVersionGeneration generated;
+        
+        public HbmTimestamputc() {
+            this.source = HbmTimestamputcSource.Vm;
+            this.generated = HbmVersionGeneration.Never;
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("HbmXsd", "5.0.0.Alpha1")]
+    [System.SerializableAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:nhibernate-mapping-2.2")]
+    public enum HbmTimestamputcUnsavedvalue {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlEnumAttribute("null")]
+        Null,
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlEnumAttribute("undefined")]
+        Undefined,
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("HbmXsd", "5.0.0.Alpha1")]
+    [System.SerializableAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:nhibernate-mapping-2.2")]
+    public enum HbmTimestamputcSource {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlEnumAttribute("vm")]
+        Vm,
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlEnumAttribute("db")]
+        Db,
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("HbmXsd", "5.0.0.Alpha1")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:nhibernate-mapping-2.2")]
     [System.Xml.Serialization.XmlRootAttribute("version", Namespace="urn:nhibernate-mapping-2.2", IsNullable=false)]
     public partial class HbmVersion {
         
@@ -4294,15 +4378,15 @@ namespace NHibernate.Cfg.MappingSchema {
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("auto")]
         Auto,
-
+        
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("manual")]
         Manual,
-
+        
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("always")]
         Always,
-
+        
         /// <remarks/>
         [System.Xml.Serialization.XmlEnumAttribute("never")]
         Never,

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -47,9 +47,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
This corrects a few issues with #605 

* NHibernate.Tool.HbmXsd.csproj wasn't generating an .EXE.
* Because `ABC.hbm.xml` was copied to the `bin` output folders, it was being re-included as an EmbeddedResource.  This will cause problems when the VB project is migrated to VS 2017 and depends on `NHibernate.Test.csproj`.  Solution is to exclude the `bin` folders from being considered when finding files for embedding.
* Certain references are auto-included, so they can be removed.