### PR TITLE
NH-3905 - upgrade async generator and regen

### DIFF
--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -7,6 +7,6 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net461" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="CSharpAsyncGenerator.CommandLine" version="0.4.4" targetFramework="net461" />
+  <package id="CSharpAsyncGenerator.CommandLine" version="0.5.0" targetFramework="net461" />
   <package id="vswhere" version="2.1.4" targetFramework="net461" />
 </packages>

--- a/doc/reference/modules/quickstart.xml
+++ b/doc/reference/modules/quickstart.xml
@@ -420,6 +420,12 @@ finally
             cases.
         </para>
 
+        <para>
+            Since NHibernate 5.0, the session and its queries IO bound methods have async counterparts.
+            Each call to an async method must be awaited before further interacting with the session or
+            its queries.
+        </para>
+
     </sect1>
 
     <sect1 id="quickstart-summary">

--- a/doc/reference/modules/transactions.xml
+++ b/doc/reference/modules/transactions.xml
@@ -93,6 +93,11 @@
                     Never access the same <literal>ISession</literal> in two concurrent threads.
                     An <literal>ISession</literal> is usually only a single unit-of-work!
                 </para>
+                <para>
+                    Since NHibernate 5.0, the session and its queries IO bound methods have async counterparts.
+                    Each call to an async method must be awaited before further interacting with the session or
+                    its queries.
+                </para>
             </listitem>
         </itemizedlist>
     </sect1>

--- a/src/AsyncGenerator.yml
+++ b/src/AsyncGenerator.yml
@@ -185,8 +185,6 @@
     - hasAttributeName: TheoryAttribute
     typeConversion:
     - conversion: Ignore
-      name: NorthwindDbCreator
-    - conversion: Ignore
       name: ObjectAssert
     - conversion: Ignore
       name: LinqReadonlyTestsContext
@@ -200,9 +198,13 @@
       rule: IsTestCase
     - conversion: Ignore
       anyBaseTypeRule: IsTestCase
+    ignoreSearchForMethodReferences:
+    - hasAttributeName: TheoryAttribute
+    - hasAttributeName: TestAttribute
     ignoreDocuments:
     - filePathEndsWith: Linq\MathTests.cs
     - filePathEndsWith: Linq\ExpressionSessionLeakTest.cs
+    - filePathEndsWith: Linq\NorthwindDbCreator.cs
     cancellationTokens:
       withoutCancellationToken:
       - hasAttributeName: TestAttribute

--- a/src/NHibernate.DomainModel/Async/CustomPersister.cs
+++ b/src/NHibernate.DomainModel/Async/CustomPersister.cs
@@ -26,9 +26,6 @@ namespace NHibernate.DomainModel
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CustomPersister : IEntityPersister
 	{
 

--- a/src/NHibernate.Test/Async/ConnectionStringTest/NamedConnectionStringFixture.cs
+++ b/src/NHibernate.Test/Async/ConnectionStringTest/NamedConnectionStringFixture.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Test.ConnectionStringTest
 	using System.Threading.Tasks;
 	using System.Threading;
 	
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MockConnectionProvider : ConnectionProvider
 	{
 		

--- a/src/NHibernate.Test/Async/DebugConnectionProvider.cs
+++ b/src/NHibernate.Test/Async/DebugConnectionProvider.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Test
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DebugConnectionProvider : DriverConnectionProvider
 	{
 

--- a/src/NHibernate.Test/Async/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/Async/DebugSessionFactory.cs
@@ -37,9 +37,6 @@ namespace NHibernate.Test
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DebugSessionFactory : ISessionFactoryImplementor
 	{
 

--- a/src/NHibernate.Test/Async/DynamicProxyTests/PeVerifier.cs
+++ b/src/NHibernate.Test/Async/DynamicProxyTests/PeVerifier.cs
@@ -16,11 +16,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.DynamicProxyTests
 {
 	using System.Threading.Tasks;
-	
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
-
 	public partial class PeVerifier
 	{
 

--- a/src/NHibernate.Test/Async/Events/Collections/CollectionListeners.cs
+++ b/src/NHibernate.Test/Async/Events/Collections/CollectionListeners.cs
@@ -17,9 +17,6 @@ using NHibernate.Event.Default;
 
 namespace NHibernate.Test.Events.Collections
 {
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionListeners
 	{
 
@@ -32,9 +29,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: InitializeCollectionListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class InitializeCollectionListener : DefaultInitializeCollectionEventListener, IListener
 		{
 
@@ -53,9 +47,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: PostCollectionRecreateListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PostCollectionRecreateListener : AbstractListener, IPostCollectionRecreateEventListener
 		{
 
@@ -81,9 +72,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: PostCollectionRemoveListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PostCollectionRemoveListener : AbstractListener, IPostCollectionRemoveEventListener
 		{
 
@@ -109,9 +97,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: PostCollectionUpdateListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PostCollectionUpdateListener : AbstractListener, IPostCollectionUpdateEventListener
 		{
 
@@ -137,9 +122,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: PreCollectionRecreateListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PreCollectionRecreateListener : AbstractListener, IPreCollectionRecreateEventListener
 		{
 
@@ -165,9 +147,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: PreCollectionRemoveListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PreCollectionRemoveListener : AbstractListener, IPreCollectionRemoveEventListener
 		{
 
@@ -193,9 +172,6 @@ namespace NHibernate.Test.Events.Collections
 
 		#region Nested type: PreCollectionUpdateListener
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PreCollectionUpdateListener : AbstractListener, IPreCollectionUpdateEventListener
 		{
 

--- a/src/NHibernate.Test/Async/Events/DisposableListenersTest.cs
+++ b/src/NHibernate.Test/Async/Events/DisposableListenersTest.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Test.Events
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MyDisposableListener : IPostUpdateEventListener, IDisposable
 	{
 		public Task OnPostUpdateAsync(PostUpdateEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate.Test/Async/Events/PostEvents/AssertOldStatePostListener.cs
+++ b/src/NHibernate.Test/Async/Events/PostEvents/AssertOldStatePostListener.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Test.Events.PostEvents
 	using System.Threading.Tasks;
 	using System.Threading;
  
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AssertOldStatePostListener : IPostUpdateEventListener
 	{
 

--- a/src/NHibernate.Test/Async/IdGen/Enhanced/SourceMock.cs
+++ b/src/NHibernate.Test/Async/IdGen/Enhanced/SourceMock.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Test.IdGen.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SourceMock : IAccessCallback
 	{
 

--- a/src/NHibernate.Test/Async/Insertordering/InsertOrderingFixture.cs
+++ b/src/NHibernate.Test/Async/Insertordering/InsertOrderingFixture.cs
@@ -677,9 +677,6 @@ namespace NHibernate.Test.Insertordering
 
 		#endregion
 	}
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class InsertOrderingFixture : TestCase
 	{
 
@@ -695,9 +692,6 @@ namespace NHibernate.Test.Insertordering
 
 		
 		
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class StatsBatcher : SqlClientBatchingBatcher
 		{
 

--- a/src/NHibernate.Test/Async/Linq/ObjectDumper.cs
+++ b/src/NHibernate.Test/Async/Linq/ObjectDumper.cs
@@ -17,9 +17,6 @@ using System.Text;
 namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ObjectDumper
 	{
 

--- a/src/NHibernate.Test/Async/Linq/QueryTimeoutTests.cs
+++ b/src/NHibernate.Test/Async/Linq/QueryTimeoutTests.cs
@@ -141,16 +141,10 @@ namespace NHibernate.Test.Linq
 			}
 		}
 	}
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class QueryTimeoutTests : LinqTestCase
 	{
 
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class TimeoutCatchingNonBatchingBatcher : NonBatchingBatcher
 		{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1054/DummyTransactionFactory.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1054/DummyTransactionFactory.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1054
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DummyTransactionFactory : ITransactionFactory
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1230/PreSaveDoVeto.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1230/PreSaveDoVeto.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1230
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PreSaveDoVeto : IPreInsertEventListener
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1270/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1270/Fixture.cs
@@ -18,7 +18,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1270
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync
 	{

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1274ExportExclude/NH1274ExportExcludeFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1274ExportExclude/NH1274ExportExcludeFixture.cs
@@ -22,7 +22,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1274ExportExclude
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class NH1274ExportExcludeFixtureAsync
 	{

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1332/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1332/Fixture.cs
@@ -80,15 +80,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1332
 			}
 		}
 	}
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Fixture : BugTestCase
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PostCommitDelete : IPostDeleteEventListener
 		{
 			public Task OnPostDeleteAsync(PostDeleteEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1487/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1487/Fixture.cs
@@ -18,7 +18,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1487
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 
 	/// <summary>
 	/// Summary description for TestTestCase.

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1714/UseCaseDemonstrationFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1714/UseCaseDemonstrationFixture.cs
@@ -64,9 +64,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1714
 		}
 	}
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MyCustomEventListener : IPreInsertEventListener
 	{
 		public async Task<bool> OnPreInsertAsync(PreInsertEvent e, CancellationToken cancellationToken)

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1789/DomainObject.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1789/DomainObject.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1789
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class DomainObject : IDomainObject
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
@@ -155,15 +155,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1882
 			Assert.That(listener.FoundAny, Is.True);
 		}
 	}
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TestCollectionInitializingDuringFlush : TestCaseMappingByCode
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class InitializingPreUpdateEventListener : IPreUpdateEventListener
 		{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2322/PostUpdateEventListener.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2322/PostUpdateEventListener.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2322
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PostUpdateEventListener : IPostUpdateEventListener
 	{
 		Task IPostUpdateEventListener.OnPostUpdateAsync(PostUpdateEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2583/Domain.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2583/Domain.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2583
 {
     using System.Threading.Tasks;
     using System.Threading;
-    /// <content>
-    /// Contains generated async methods
-    /// </content>
     public partial class MyRef1
     {
 
@@ -41,9 +38,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2583
         }
     }
 
-    /// <content>
-    /// Contains generated async methods
-    /// </content>
     public partial class MyBO
     {
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2898/BinaryFormatterCache.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2898/BinaryFormatterCache.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2898
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BinaryFormatterCache : ICache
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3023/DeadlockHelper.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3023/DeadlockHelper.cs
@@ -17,9 +17,6 @@ using log4net;
 namespace NHibernate.Test.NHSpecificTest.NH3023
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DeadlockHelper
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3564/FixtureByCode.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3564/FixtureByCode.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3564
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MyDummyCache : ICache
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH4077/PostInsertFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH4077/PostInsertFixture.cs
@@ -145,15 +145,9 @@ namespace NHibernate.Test.NHSpecificTest.NH4077
 			}
 		}
 	}
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PostInsertFixture : TestCaseMappingByCode
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private sealed partial class CausesAutoflushListener : IPostInsertEventListener
 		{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH4077/PostUpdateFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH4077/PostUpdateFixture.cs
@@ -149,15 +149,9 @@ namespace NHibernate.Test.NHSpecificTest.NH4077
 			}
 		}
 	}
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PostUpdateFixture : TestCaseMappingByCode
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private sealed partial class CausesAutoflushListener : IPostUpdateEventListener
 		{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH720/Domain.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH720/Domain.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Test.NHSpecificTest.NH720
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class FooCache : ICache
 	{
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/SetFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/SetFixture.cs
@@ -28,9 +28,6 @@ namespace NHibernate.Test.NHSpecificTest
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	internal partial class CollectionPersisterStub : ICollectionPersister
 	{
 

--- a/src/NHibernate/Async/Action/BulkOperationCleanupAction.cs
+++ b/src/NHibernate/Async/Action/BulkOperationCleanupAction.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BulkOperationCleanupAction: IExecutable
 	{
 

--- a/src/NHibernate/Async/Action/CollectionAction.cs
+++ b/src/NHibernate/Async/Action/CollectionAction.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class CollectionAction : IExecutable, IComparable<CollectionAction>, IDeserializationCallback
 	{
 

--- a/src/NHibernate/Async/Action/CollectionRecreateAction.cs
+++ b/src/NHibernate/Async/Action/CollectionRecreateAction.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class CollectionRecreateAction : CollectionAction
 	{
 

--- a/src/NHibernate/Async/Action/CollectionRemoveAction.cs
+++ b/src/NHibernate/Async/Action/CollectionRemoveAction.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class CollectionRemoveAction : CollectionAction
 	{
 

--- a/src/NHibernate/Async/Action/CollectionUpdateAction.cs
+++ b/src/NHibernate/Async/Action/CollectionUpdateAction.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class CollectionUpdateAction : CollectionAction
 	{
 

--- a/src/NHibernate/Async/Action/EntityAction.cs
+++ b/src/NHibernate/Async/Action/EntityAction.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class EntityAction : IExecutable, IComparable<EntityAction>, IDeserializationCallback
 	{
 

--- a/src/NHibernate/Async/Action/EntityDeleteAction.cs
+++ b/src/NHibernate/Async/Action/EntityDeleteAction.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class EntityDeleteAction : EntityAction
 	{
 

--- a/src/NHibernate/Async/Action/EntityIdentityInsertAction.cs
+++ b/src/NHibernate/Async/Action/EntityIdentityInsertAction.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class EntityIdentityInsertAction : EntityAction
 	{
 

--- a/src/NHibernate/Async/Action/EntityInsertAction.cs
+++ b/src/NHibernate/Async/Action/EntityInsertAction.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class EntityInsertAction : EntityAction
 	{
 

--- a/src/NHibernate/Async/Action/EntityUpdateAction.cs
+++ b/src/NHibernate/Async/Action/EntityUpdateAction.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class EntityUpdateAction : EntityAction
 	{
 

--- a/src/NHibernate/Async/Action/IExecutable.cs
+++ b/src/NHibernate/Async/Action/IExecutable.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Action
 	using System.Threading.Tasks;
 	using System.Threading;
 	
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IExecutable
 	{
 

--- a/src/NHibernate/Async/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/AbstractBatcher.cs
@@ -26,9 +26,6 @@ using NHibernate.AdoNet.Util;
 namespace NHibernate.AdoNet
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractBatcher : IBatcher
 	{
 

--- a/src/NHibernate/Async/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/Async/AdoNet/ConnectionManager.cs
@@ -21,9 +21,6 @@ namespace NHibernate.AdoNet
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ConnectionManager : ISerializable, IDeserializationCallback
 	{
 

--- a/src/NHibernate/Async/AdoNet/MySqlClientBatchingBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/MySqlClientBatchingBatcher.cs
@@ -18,9 +18,6 @@ namespace NHibernate.AdoNet
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MySqlClientBatchingBatcher : AbstractBatcher
 	{
 

--- a/src/NHibernate/Async/AdoNet/NonBatchingBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/NonBatchingBatcher.cs
@@ -17,9 +17,6 @@ namespace NHibernate.AdoNet
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NonBatchingBatcher : AbstractBatcher
 	{
 

--- a/src/NHibernate/Async/AdoNet/OracleDataClientBatchingBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/OracleDataClientBatchingBatcher.cs
@@ -19,9 +19,6 @@ namespace NHibernate.AdoNet
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OracleDataClientBatchingBatcher : AbstractBatcher
 	{
 

--- a/src/NHibernate/Async/AdoNet/SqlClientBatchingBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/SqlClientBatchingBatcher.cs
@@ -19,9 +19,6 @@ namespace NHibernate.AdoNet
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SqlClientBatchingBatcher : AbstractBatcher
 	{
 

--- a/src/NHibernate/Async/Cache/Entry/CacheEntry.cs
+++ b/src/NHibernate/Async/Cache/Entry/CacheEntry.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Cache.Entry
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class CacheEntry
 	{
 

--- a/src/NHibernate/Async/Cache/Entry/CollectionCacheEntry.cs
+++ b/src/NHibernate/Async/Cache/Entry/CollectionCacheEntry.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Cache.Entry
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionCacheEntry
 	{
 

--- a/src/NHibernate/Async/Cache/FakeCache.cs
+++ b/src/NHibernate/Async/Cache/FakeCache.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class FakeCache : ICache
 	{
 

--- a/src/NHibernate/Async/Cache/HashtableCache.cs
+++ b/src/NHibernate/Async/Cache/HashtableCache.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class HashtableCache : ICache
 	{
 

--- a/src/NHibernate/Async/Cache/ICache.cs
+++ b/src/NHibernate/Async/Cache/ICache.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ICache
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Cache/ICacheConcurrencyStrategy.cs
+++ b/src/NHibernate/Async/Cache/ICacheConcurrencyStrategy.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ICacheConcurrencyStrategy
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Cache/IQueryCache.cs
+++ b/src/NHibernate/Async/Cache/IQueryCache.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IQueryCache
 	{
 

--- a/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NonstrictReadWriteCache : ICacheConcurrencyStrategy
 	{
 

--- a/src/NHibernate/Async/Cache/ReadOnlyCache.cs
+++ b/src/NHibernate/Async/Cache/ReadOnlyCache.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ReadOnlyCache : ICacheConcurrencyStrategy
 	{
 

--- a/src/NHibernate/Async/Cache/ReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/ReadWriteCache.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ReadWriteCache : ICacheConcurrencyStrategy
 	{
 		private readonly NHibernate.Util.AsyncLock _lockObjectAsync = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Async/Cache/StandardQueryCache.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class StandardQueryCache : IQueryCache
 	{
 

--- a/src/NHibernate/Async/Cache/UpdateTimestampsCache.cs
+++ b/src/NHibernate/Async/Cache/UpdateTimestampsCache.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Cache
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UpdateTimestampsCache
 	{
 		private readonly NHibernate.Util.AsyncLock _preInvalidate = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Collection/AbstractPersistentCollection.cs
+++ b/src/NHibernate/Async/Collection/AbstractPersistentCollection.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractPersistentCollection : IPersistentCollection
 	{
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentGenericBag<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
 	{
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericIdentifierBag.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericIdentifierBag.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentIdentifierBag<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
 	{
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericList.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentGenericList<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
 	{
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericMap.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentGenericMap<TKey, TValue> : AbstractPersistentCollection, IDictionary<TKey, TValue>, ICollection
 	{
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericSet.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericSet.cs
@@ -28,9 +28,6 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentGenericSet<T> : AbstractPersistentCollection, ISet<T>, IQueryable<T>
 	{
 

--- a/src/NHibernate/Async/Collection/IPersistentCollection.cs
+++ b/src/NHibernate/Async/Collection/IPersistentCollection.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPersistentCollection
 	{
 

--- a/src/NHibernate/Async/Collection/PersistentArrayHolder.cs
+++ b/src/NHibernate/Async/Collection/PersistentArrayHolder.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentArrayHolder : AbstractPersistentCollection, ICollection
 	{
 

--- a/src/NHibernate/Async/Connection/ConnectionProvider.cs
+++ b/src/NHibernate/Async/Connection/ConnectionProvider.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Connection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class ConnectionProvider : IConnectionProvider
 	{
 

--- a/src/NHibernate/Async/Connection/DriverConnectionProvider.cs
+++ b/src/NHibernate/Async/Connection/DriverConnectionProvider.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Connection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DriverConnectionProvider : ConnectionProvider
 	{
 

--- a/src/NHibernate/Async/Connection/IConnectionProvider.cs
+++ b/src/NHibernate/Async/Connection/IConnectionProvider.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Connection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IConnectionProvider : IDisposable
 	{
 

--- a/src/NHibernate/Async/Connection/UserSuppliedConnectionProvider.cs
+++ b/src/NHibernate/Async/Connection/UserSuppliedConnectionProvider.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Connection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UserSuppliedConnectionProvider : ConnectionProvider
 	{
 

--- a/src/NHibernate/Async/Context/ThreadLocalSessionContext.cs
+++ b/src/NHibernate/Async/Context/ThreadLocalSessionContext.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Context
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ThreadLocalSessionContext : ICurrentSessionContext
 	{
 

--- a/src/NHibernate/Async/Criterion/QueryOver.cs
+++ b/src/NHibernate/Async/Criterion/QueryOver.cs
@@ -22,9 +22,6 @@ using NHibernate.Transform;
 namespace NHibernate.Criterion
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class QueryOver<TRoot> : QueryOver, IQueryOver<TRoot>
 	{
 

--- a/src/NHibernate/Async/Dialect/Dialect.cs
+++ b/src/NHibernate/Async/Dialect/Dialect.cs
@@ -32,9 +32,6 @@ namespace NHibernate.Dialect
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class Dialect
 	{
 		#region Callable statement support

--- a/src/NHibernate/Async/Dialect/InformixDialect.cs
+++ b/src/NHibernate/Async/Dialect/InformixDialect.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Dialect
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class InformixDialect : Dialect
 	{
 

--- a/src/NHibernate/Async/Dialect/Lock/ILockingStrategy.cs
+++ b/src/NHibernate/Async/Dialect/Lock/ILockingStrategy.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Dialect.Lock
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ILockingStrategy
 	{
 		/// <summary> 

--- a/src/NHibernate/Async/Dialect/Lock/SelectLockingStrategy.cs
+++ b/src/NHibernate/Async/Dialect/Lock/SelectLockingStrategy.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Dialect.Lock
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SelectLockingStrategy : ILockingStrategy
 	{
 

--- a/src/NHibernate/Async/Dialect/Lock/UpdateLockingStrategy.cs
+++ b/src/NHibernate/Async/Dialect/Lock/UpdateLockingStrategy.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Dialect.Lock
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UpdateLockingStrategy : ILockingStrategy
 	{
 

--- a/src/NHibernate/Async/Dialect/SybaseASE15Dialect.cs
+++ b/src/NHibernate/Async/Dialect/SybaseASE15Dialect.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Dialect
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SybaseASE15Dialect : Dialect
 	{
 		

--- a/src/NHibernate/Async/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Async/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Dialect
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SybaseSQLAnywhere10Dialect : Dialect
 	{
 		#region Callable statement support

--- a/src/NHibernate/Async/Driver/BasicResultSetsCommand.cs
+++ b/src/NHibernate/Async/Driver/BasicResultSetsCommand.cs
@@ -22,9 +22,6 @@ using NHibernate.SqlTypes;
 
 namespace NHibernate.Driver
 {
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BasicResultSetsCommand: IResultSetsCommand
 	{
 
@@ -45,9 +42,6 @@ namespace NHibernate.Driver
 		}
 	}
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BatcherDataReaderWrapper: DbDataReader
 	{
 

--- a/src/NHibernate/Async/Driver/IResultSetsCommand.cs
+++ b/src/NHibernate/Async/Driver/IResultSetsCommand.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Driver
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IResultSetsCommand
 	{
 		Task<DbDataReader> GetReaderAsync(int? commandTimeout, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Driver/NDataReader.cs
+++ b/src/NHibernate/Async/Driver/NDataReader.cs
@@ -19,9 +19,6 @@ using NHibernate.Util;
 
 namespace NHibernate.Driver
 {
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NDataReader : DbDataReader
 	{
 
@@ -74,9 +71,6 @@ namespace NHibernate.Driver
 			return dataReader;
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class NResult
 		{
 

--- a/src/NHibernate/Async/Driver/NHybridDataReader.cs
+++ b/src/NHibernate/Async/Driver/NHybridDataReader.cs
@@ -17,9 +17,6 @@ using System.Threading.Tasks;
 
 namespace NHibernate.Driver
 {
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NHybridDataReader : DbDataReader
 	{
 

--- a/src/NHibernate/Async/Driver/SQLite20Driver.cs
+++ b/src/NHibernate/Async/Driver/SQLite20Driver.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Driver
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SQLite20Driver : ReflectionBasedDriver
 	{
 

--- a/src/NHibernate/Async/Engine/ActionQueue.cs
+++ b/src/NHibernate/Async/Engine/ActionQueue.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ActionQueue
 	{
 
@@ -137,9 +134,6 @@ namespace NHibernate.Engine
 			}
 			return afterTransactionProcesses.AfterTransactionCompletionAsync(success, cancellationToken);
 		}
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class AfterTransactionCompletionProcessQueue 
 		{
 	

--- a/src/NHibernate/Async/Engine/BatchFetchQueue.cs
+++ b/src/NHibernate/Async/Engine/BatchFetchQueue.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BatchFetchQueue
 	{
 

--- a/src/NHibernate/Async/Engine/Cascade.cs
+++ b/src/NHibernate/Async/Engine/Cascade.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Engine
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class Cascade
 	{
 

--- a/src/NHibernate/Async/Engine/CascadingAction.cs
+++ b/src/NHibernate/Async/Engine/CascadingAction.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class CascadingAction
 	{
 
@@ -67,9 +64,6 @@ namespace NHibernate.Engine
 
 		#endregion
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class DeleteCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -93,9 +87,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class LockCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -119,9 +110,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class RefreshCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -145,9 +133,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class EvictCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -171,9 +156,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class SaveUpdateCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -197,9 +179,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class MergeCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -223,9 +202,6 @@ namespace NHibernate.Engine
 			}
 		}
         
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class PersistCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -249,9 +225,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class PersistOnFlushCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)
@@ -299,9 +272,6 @@ namespace NHibernate.Engine
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class ReplicateCascadingAction : CascadingAction
 		{
 			public override Task CascadeAsync(IEventSource session, object child, string entityName, object anything, bool isCascadeDeleteEnabled, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Engine/CollectionEntry.cs
+++ b/src/NHibernate/Async/Engine/CollectionEntry.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionEntry
 	{
 

--- a/src/NHibernate/Async/Engine/Collections.cs
+++ b/src/NHibernate/Async/Engine/Collections.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class Collections
 	{
 

--- a/src/NHibernate/Async/Engine/ForeignKeys.cs
+++ b/src/NHibernate/Async/Engine/ForeignKeys.cs
@@ -18,15 +18,9 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class ForeignKeys
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class Nullifier
 		{
 

--- a/src/NHibernate/Async/Engine/IBatcher.cs
+++ b/src/NHibernate/Async/Engine/IBatcher.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IBatcher : IDisposable
 	{
 

--- a/src/NHibernate/Async/Engine/IPersistenceContext.cs
+++ b/src/NHibernate/Async/Engine/IPersistenceContext.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPersistenceContext
 	{
 

--- a/src/NHibernate/Async/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Async/Engine/ISessionImplementor.cs
@@ -28,9 +28,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ISessionImplementor
 	{
 

--- a/src/NHibernate/Async/Engine/Loading/CollectionLoadContext.cs
+++ b/src/NHibernate/Async/Engine/Loading/CollectionLoadContext.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Engine.Loading
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionLoadContext
 	{
 

--- a/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Engine.Query
 {
     using System.Threading.Tasks;
     using System.Threading;
-    /// <content>
-    /// Contains generated async methods
-    /// </content>
     public partial interface IQueryPlan
     {
         Task PerformListAsync(QueryParameters queryParameters, ISessionImplementor statelessSessionImpl, IList results, CancellationToken cancellationToken);
@@ -32,9 +29,6 @@ namespace NHibernate.Engine.Query
         Task<IEnumerable<T>> PerformIterateAsync<T>(QueryParameters queryParameters, IEventSource session, CancellationToken cancellationToken);
         Task<IEnumerable> PerformIterateAsync(QueryParameters queryParameters, IEventSource session, CancellationToken cancellationToken);
     }
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class HQLQueryPlan : IQueryPlan
 	{
 

--- a/src/NHibernate/Async/Engine/Query/NativeSQLQueryPlan.cs
+++ b/src/NHibernate/Async/Engine/Query/NativeSQLQueryPlan.cs
@@ -31,9 +31,6 @@ namespace NHibernate.Engine.Query
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NativeSQLQueryPlan
 	{
 

--- a/src/NHibernate/Async/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Async/Engine/StatefulPersistenceContext.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class StatefulPersistenceContext : IPersistenceContext, ISerializable, IDeserializationCallback
 	{
 

--- a/src/NHibernate/Async/Engine/Transaction/IIsolatedWork.cs
+++ b/src/NHibernate/Async/Engine/Transaction/IIsolatedWork.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Engine.Transaction
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IIsolatedWork
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Engine/Transaction/Isolater.cs
+++ b/src/NHibernate/Async/Engine/Transaction/Isolater.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Engine.Transaction
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Isolater
 	{
 

--- a/src/NHibernate/Async/Engine/TransactionHelper.cs
+++ b/src/NHibernate/Async/Engine/TransactionHelper.cs
@@ -16,14 +16,8 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class TransactionHelper
 	{
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class Work : IIsolatedWork
 		{
 

--- a/src/NHibernate/Async/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Async/Engine/TwoPhaseLoad.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class TwoPhaseLoad
 	{
 		

--- a/src/NHibernate/Async/Engine/Versioning.cs
+++ b/src/NHibernate/Async/Engine/Versioning.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Versioning
 	{
 

--- a/src/NHibernate/Async/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractFlushingEventListener.cs
@@ -25,9 +25,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractFlushingEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/AbstractLockUpgradeEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractLockUpgradeEventListener.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AbstractLockUpgradeEventListener : AbstractReassociateEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/AbstractReassociateEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractReassociateEventListener.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AbstractReassociateEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/AbstractSaveEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractSaveEventListener.cs
@@ -25,9 +25,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractSaveEventListener : AbstractReassociateEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/AbstractVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractVisitor.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultAutoFlushEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultAutoFlushEventListener.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultAutoFlushEventListener : AbstractFlushingEventListener, IAutoFlushEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultDeleteEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultDeleteEventListener.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultDeleteEventListener : IDeleteEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultDirtyCheckEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultDirtyCheckEventListener.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultDirtyCheckEventListener : AbstractFlushingEventListener, IDirtyCheckEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultEvictEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultEvictEventListener.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultEvictEventListener : IEvictEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultFlushEntityEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultFlushEntityEventListener.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultFlushEntityEventListener : IFlushEntityEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultFlushEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultFlushEventListener.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultFlushEventListener : AbstractFlushingEventListener, IFlushEventListener
 	{
 		public virtual async Task OnFlushAsync(FlushEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultInitializeCollectionEventListener : IInitializeCollectionEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultLoadEventListener.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultLoadEventListener : AbstractLockUpgradeEventListener, ILoadEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultLockEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultLockEventListener.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultLockEventListener : AbstractLockUpgradeEventListener, ILockEventListener
 	{
 		/// <summary>Handle the given lock event. </summary>

--- a/src/NHibernate/Async/Event/Default/DefaultMergeEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultMergeEventListener.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultMergeEventListener : AbstractSaveEventListener, IMergeEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultPersistEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultPersistEventListener.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultPersistEventListener : AbstractSaveEventListener, IPersistEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultPreLoadEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultPreLoadEventListener.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultPreLoadEventListener : IPreLoadEventListener
 	{
 		public virtual Task OnPreLoadAsync(PreLoadEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Event/Default/DefaultRefreshEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultRefreshEventListener.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultRefreshEventListener : IRefreshEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultReplicateEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultReplicateEventListener.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultReplicateEventListener : AbstractSaveEventListener, IReplicateEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultSaveEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultSaveEventListener.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultSaveEventListener : DefaultSaveOrUpdateEventListener
 	{
 		protected override Task<object> PerformSaveOrUpdateAsync(SaveOrUpdateEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Event/Default/DefaultSaveOrUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultSaveOrUpdateEventListener.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultSaveOrUpdateEventListener : AbstractSaveEventListener, ISaveOrUpdateEventListener
 	{
 

--- a/src/NHibernate/Async/Event/Default/DefaultUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultUpdateEventListener.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultUpdateEventListener : DefaultSaveOrUpdateEventListener
 	{
 		protected override async Task<object> PerformSaveOrUpdateAsync(SaveOrUpdateEvent @event, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Event/Default/DirtyCollectionSearchVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/DirtyCollectionSearchVisitor.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DirtyCollectionSearchVisitor : AbstractVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/EvictVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/EvictVisitor.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class EvictVisitor : AbstractVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/FlushVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/FlushVisitor.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class FlushVisitor : AbstractVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/OnLockVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/OnLockVisitor.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OnLockVisitor : ReattachVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/OnReplicateVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/OnReplicateVisitor.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OnReplicateVisitor : ReattachVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/OnUpdateVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/OnUpdateVisitor.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OnUpdateVisitor : ReattachVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/ReattachVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/ReattachVisitor.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class ReattachVisitor : ProxyVisitor
 	{
 

--- a/src/NHibernate/Async/Event/Default/WrapVisitor.cs
+++ b/src/NHibernate/Async/Event/Default/WrapVisitor.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Event.Default
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class WrapVisitor : ProxyVisitor
 	{
 

--- a/src/NHibernate/Async/Event/IAutoFlushEventListener.cs
+++ b/src/NHibernate/Async/Event/IAutoFlushEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IAutoFlushEventListener
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Event/IDeleteEventListener.cs
+++ b/src/NHibernate/Async/Event/IDeleteEventListener.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IDeleteEventListener
 	{
 		/// <summary>Handle the given delete event. </summary>

--- a/src/NHibernate/Async/Event/IDirtyCheckEventListener.cs
+++ b/src/NHibernate/Async/Event/IDirtyCheckEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IDirtyCheckEventListener
 	{
 		/// <summary>Handle the given dirty-check event. </summary>

--- a/src/NHibernate/Async/Event/IEventSource.cs
+++ b/src/NHibernate/Async/Event/IEventSource.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IEventSource : ISessionImplementor, ISession
 	{
 

--- a/src/NHibernate/Async/Event/IEvictEventListener.cs
+++ b/src/NHibernate/Async/Event/IEvictEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IEvictEventListener
 	{
 		/// <summary> Handle the given evict event. </summary>

--- a/src/NHibernate/Async/Event/IFlushEntityEventListener.cs
+++ b/src/NHibernate/Async/Event/IFlushEntityEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IFlushEntityEventListener
 	{
 		Task OnFlushEntityAsync(FlushEntityEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IFlushEventListener.cs
+++ b/src/NHibernate/Async/Event/IFlushEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IFlushEventListener
 	{
 		/// <summary>Handle the given flush event. </summary>

--- a/src/NHibernate/Async/Event/IInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Async/Event/IInitializeCollectionEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IInitializeCollectionEventListener
 	{
 		Task OnInitializeCollectionAsync(InitializeCollectionEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/ILoadEventListener.cs
+++ b/src/NHibernate/Async/Event/ILoadEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ILoadEventListener
 	{
 		/// <summary> 

--- a/src/NHibernate/Async/Event/ILockEventListener.cs
+++ b/src/NHibernate/Async/Event/ILockEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ILockEventListener
 	{
 		/// <summary>Handle the given lock event. </summary>

--- a/src/NHibernate/Async/Event/IMergeEventListener.cs
+++ b/src/NHibernate/Async/Event/IMergeEventListener.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IMergeEventListener
 	{
 		/// <summary> Handle the given merge event. </summary>

--- a/src/NHibernate/Async/Event/IPersistEventListener.cs
+++ b/src/NHibernate/Async/Event/IPersistEventListener.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPersistEventListener
 	{
 		/// <summary> Handle the given create event.</summary>

--- a/src/NHibernate/Async/Event/IPostCollectionRecreateEventListener.cs
+++ b/src/NHibernate/Async/Event/IPostCollectionRecreateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPostCollectionRecreateEventListener
 	{
 		Task OnPostRecreateCollectionAsync(PostCollectionRecreateEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IPostCollectionRemoveEventListener.cs
+++ b/src/NHibernate/Async/Event/IPostCollectionRemoveEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPostCollectionRemoveEventListener
 	{
 		Task OnPostRemoveCollectionAsync(PostCollectionRemoveEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IPostCollectionUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/IPostCollectionUpdateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPostCollectionUpdateEventListener
 	{
 		Task OnPostUpdateCollectionAsync(PostCollectionUpdateEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IPostDeleteEventListener.cs
+++ b/src/NHibernate/Async/Event/IPostDeleteEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPostDeleteEventListener
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Event/IPostInsertEventListener.cs
+++ b/src/NHibernate/Async/Event/IPostInsertEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPostInsertEventListener
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Event/IPostUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/IPostUpdateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPostUpdateEventListener
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Event/IPreCollectionRecreateEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreCollectionRecreateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreCollectionRecreateEventListener
 	{
 		Task OnPreRecreateCollectionAsync(PreCollectionRecreateEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IPreCollectionRemoveEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreCollectionRemoveEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreCollectionRemoveEventListener
 	{
 		Task OnPreRemoveCollectionAsync(PreCollectionRemoveEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IPreCollectionUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreCollectionUpdateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreCollectionUpdateEventListener
 	{
 		Task OnPreUpdateCollectionAsync(PreCollectionUpdateEvent @event, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Event/IPreDeleteEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreDeleteEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreDeleteEventListener
 	{
 		/// <summary> Return true if the operation should be vetoed</summary>

--- a/src/NHibernate/Async/Event/IPreInsertEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreInsertEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreInsertEventListener
 	{
 		/// <summary> Return true if the operation should be vetoed</summary>

--- a/src/NHibernate/Async/Event/IPreLoadEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreLoadEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreLoadEventListener
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Event/IPreUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/IPreUpdateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IPreUpdateEventListener
 	{
 		/// <summary> Return true if the operation should be vetoed</summary>

--- a/src/NHibernate/Async/Event/IRefreshEventListener.cs
+++ b/src/NHibernate/Async/Event/IRefreshEventListener.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IRefreshEventListener
 	{
 		/// <summary> Handle the given refresh event. </summary>

--- a/src/NHibernate/Async/Event/IReplicateEventListener.cs
+++ b/src/NHibernate/Async/Event/IReplicateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IReplicateEventListener
 	{
 		/// <summary>Handle the given replicate event. </summary>

--- a/src/NHibernate/Async/Event/ISaveOrUpdateEventListener.cs
+++ b/src/NHibernate/Async/Event/ISaveOrUpdateEventListener.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Event
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ISaveOrUpdateEventListener
 	{
 		/// <summary> Handle the given update event. </summary>

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
@@ -29,9 +29,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractStatementExecutor : IStatementExecutor
 	{
 
@@ -138,9 +135,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class TmpIdTableCreationIsolatedWork : IIsolatedWork
 		{
 
@@ -177,9 +171,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class TmpIdTableDropIsolatedWork : IIsolatedWork
 		{
 

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/BasicExecutor.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/BasicExecutor.cs
@@ -28,9 +28,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BasicExecutor : AbstractStatementExecutor
 	{
 

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/IStatementExecutor.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/IStatementExecutor.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IStatementExecutor
 	{
 

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/MultiTableDeleteExecutor.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/MultiTableDeleteExecutor.cs
@@ -25,9 +25,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MultiTableDeleteExecutor : AbstractStatementExecutor
 	{
 

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/MultiTableUpdateExecutor.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/MultiTableUpdateExecutor.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MultiTableUpdateExecutor : AbstractStatementExecutor
 	{
 

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
@@ -32,9 +32,6 @@ namespace NHibernate.Hql.Ast.ANTLR
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class QueryTranslatorImpl : IFilterTranslator
 	{
 

--- a/src/NHibernate/Async/Hql/IQueryTranslator.cs
+++ b/src/NHibernate/Async/Hql/IQueryTranslator.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Hql
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IQueryTranslator
 	{
 

--- a/src/NHibernate/Async/ICriteria.cs
+++ b/src/NHibernate/Async/ICriteria.cs
@@ -19,9 +19,6 @@ using NHibernate.Transform;
 namespace NHibernate
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ICriteria : ICloneable
 	{
 

--- a/src/NHibernate/Async/IMultiCriteria.cs
+++ b/src/NHibernate/Async/IMultiCriteria.cs
@@ -16,9 +16,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IMultiCriteria
 	{
 		/// <summary>

--- a/src/NHibernate/Async/IMultiQuery.cs
+++ b/src/NHibernate/Async/IMultiQuery.cs
@@ -17,9 +17,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IMultiQuery
 	{
 		/// <summary>

--- a/src/NHibernate/Async/IQuery.cs
+++ b/src/NHibernate/Async/IQuery.cs
@@ -18,9 +18,6 @@ using System.Threading;
 namespace NHibernate
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IQuery
 	{
 

--- a/src/NHibernate/Async/IQueryOver.cs
+++ b/src/NHibernate/Async/IQueryOver.cs
@@ -22,9 +22,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IQueryOver<TRoot> : IQueryOver
 	{
 		/// <summary>

--- a/src/NHibernate/Async/ISession.cs
+++ b/src/NHibernate/Async/ISession.cs
@@ -21,9 +21,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ISession : IDisposable
 	{
 

--- a/src/NHibernate/Async/ISessionFactory.cs
+++ b/src/NHibernate/Async/ISessionFactory.cs
@@ -21,9 +21,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ISessionFactory : IDisposable
 	{
 

--- a/src/NHibernate/Async/IStatelessSession.cs
+++ b/src/NHibernate/Async/IStatelessSession.cs
@@ -19,9 +19,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IStatelessSession : IDisposable
 	{
 

--- a/src/NHibernate/Async/ITransaction.cs
+++ b/src/NHibernate/Async/ITransaction.cs
@@ -17,9 +17,6 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ITransaction : IDisposable
 	{
 

--- a/src/NHibernate/Async/Id/AbstractPostInsertGenerator.cs
+++ b/src/NHibernate/Async/Id/AbstractPostInsertGenerator.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractPostInsertGenerator : IPostInsertIdentifierGenerator
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Id/Assigned.cs
+++ b/src/NHibernate/Async/Id/Assigned.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Assigned : IIdentifierGenerator, IConfigurable
 	{
 

--- a/src/NHibernate/Async/Id/CounterGenerator.cs
+++ b/src/NHibernate/Async/Id/CounterGenerator.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CounterGenerator : IIdentifierGenerator
 	{
 

--- a/src/NHibernate/Async/Id/Enhanced/IAccessCallback.cs
+++ b/src/NHibernate/Async/Id/Enhanced/IAccessCallback.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IAccessCallback
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Id/Enhanced/IOptimizer.cs
+++ b/src/NHibernate/Async/Id/Enhanced/IOptimizer.cs
@@ -12,9 +12,6 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IOptimizer
 	{
 

--- a/src/NHibernate/Async/Id/Enhanced/OptimizerFactory.cs
+++ b/src/NHibernate/Async/Id/Enhanced/OptimizerFactory.cs
@@ -17,17 +17,11 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OptimizerFactory
 	{
 
 		#region Nested type: HiLoOptimizer
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class HiLoOptimizer : OptimizerSupport
 		{
 			private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();
@@ -66,9 +60,6 @@ namespace NHibernate.Id.Enhanced
 
 		#region Nested type: NoopOptimizer
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class NoopOptimizer : OptimizerSupport
 		{
 
@@ -94,9 +85,6 @@ namespace NHibernate.Id.Enhanced
 
 		#region Nested type: OptimizerSupport
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public abstract partial class OptimizerSupport : IOptimizer
 		{
 
@@ -111,9 +99,6 @@ namespace NHibernate.Id.Enhanced
 
 		#region Nested type: PooledOptimizer
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PooledOptimizer : OptimizerSupport, IInitialValueAwareOptimizer
 		{
 			private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();
@@ -158,9 +143,6 @@ namespace NHibernate.Id.Enhanced
 
 		#region Nested type: PooledLoOptimizer
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class PooledLoOptimizer : OptimizerSupport
 		{
 			private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Id/Enhanced/SequenceStructure.cs
+++ b/src/NHibernate/Async/Id/Enhanced/SequenceStructure.cs
@@ -21,17 +21,11 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SequenceStructure : IDatabaseStructure
 	{
 
 		#region Nested type: SequenceAccessCallback
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class SequenceAccessCallback : IAccessCallback
 		{
 

--- a/src/NHibernate/Async/Id/Enhanced/SequenceStyleGenerator.cs
+++ b/src/NHibernate/Async/Id/Enhanced/SequenceStyleGenerator.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SequenceStyleGenerator : IPersistentIdentifierGenerator, IConfigurable
 	{
 

--- a/src/NHibernate/Async/Id/Enhanced/TableGenerator.cs
+++ b/src/NHibernate/Async/Id/Enhanced/TableGenerator.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TableGenerator : TransactionHelper, IPersistentIdentifierGenerator, IConfigurable
 	{
 		private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();
@@ -43,9 +40,6 @@ namespace NHibernate.Id.Enhanced
 		}
 
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class TableAccessCallback : IAccessCallback
 		{
 

--- a/src/NHibernate/Async/Id/Enhanced/TableStructure.cs
+++ b/src/NHibernate/Async/Id/Enhanced/TableStructure.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Id.Enhanced
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TableStructure : TransactionHelper, IDatabaseStructure
 	{
 
@@ -97,9 +94,6 @@ namespace NHibernate.Id.Enhanced
 
 		#region Nested type: TableAccessCallback
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class TableAccessCallback : IAccessCallback
 		{
 

--- a/src/NHibernate/Async/Id/ForeignGenerator.cs
+++ b/src/NHibernate/Async/Id/ForeignGenerator.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ForeignGenerator : IIdentifierGenerator, IConfigurable
 	{
 

--- a/src/NHibernate/Async/Id/GuidCombGenerator.cs
+++ b/src/NHibernate/Async/Id/GuidCombGenerator.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class GuidCombGenerator : IIdentifierGenerator
 	{
 

--- a/src/NHibernate/Async/Id/GuidGenerator.cs
+++ b/src/NHibernate/Async/Id/GuidGenerator.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class GuidGenerator : IIdentifierGenerator
 	{
 		#region IIdentifierGenerator Members

--- a/src/NHibernate/Async/Id/IIdentifierGenerator.cs
+++ b/src/NHibernate/Async/Id/IIdentifierGenerator.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Id
 	using System.Threading;
 
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IIdentifierGenerator
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Id/IdentifierGeneratorFactory.cs
+++ b/src/NHibernate/Async/Id/IdentifierGeneratorFactory.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class IdentifierGeneratorFactory
 	{
 

--- a/src/NHibernate/Async/Id/IdentityGenerator.cs
+++ b/src/NHibernate/Async/Id/IdentityGenerator.cs
@@ -19,15 +19,9 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class IdentityGenerator : AbstractPostInsertGenerator
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class InsertSelectDelegate : AbstractReturningDelegate, IInsertGeneratedIdentifierDelegate
 		{
 
@@ -55,9 +49,6 @@ namespace NHibernate.Id
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class BasicDelegate : AbstractSelectingDelegate, IInsertGeneratedIdentifierDelegate
 		{
 

--- a/src/NHibernate/Async/Id/IncrementGenerator.cs
+++ b/src/NHibernate/Async/Id/IncrementGenerator.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class IncrementGenerator : IIdentifierGenerator, IConfigurable
 	{
 		private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Id/Insert/AbstractReturningDelegate.cs
+++ b/src/NHibernate/Async/Id/Insert/AbstractReturningDelegate.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Id.Insert
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractReturningDelegate : IInsertGeneratedIdentifierDelegate
 	{
 

--- a/src/NHibernate/Async/Id/Insert/AbstractSelectingDelegate.cs
+++ b/src/NHibernate/Async/Id/Insert/AbstractSelectingDelegate.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Id.Insert
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractSelectingDelegate : IInsertGeneratedIdentifierDelegate
 	{
 

--- a/src/NHibernate/Async/Id/Insert/IBinder.cs
+++ b/src/NHibernate/Async/Id/Insert/IBinder.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Id.Insert
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IBinder
 	{
 		Task BindValuesAsync(DbCommand cm, CancellationToken cancellationToken);

--- a/src/NHibernate/Async/Id/Insert/IInsertGeneratedIdentifierDelegate.cs
+++ b/src/NHibernate/Async/Id/Insert/IInsertGeneratedIdentifierDelegate.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Id.Insert
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IInsertGeneratedIdentifierDelegate
 	{
 

--- a/src/NHibernate/Async/Id/Insert/OutputParamReturningDelegate.cs
+++ b/src/NHibernate/Async/Id/Insert/OutputParamReturningDelegate.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Id.Insert
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OutputParamReturningDelegate : AbstractReturningDelegate
 	{
 

--- a/src/NHibernate/Async/Id/NativeGuidGenerator.cs
+++ b/src/NHibernate/Async/Id/NativeGuidGenerator.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NativeGuidGenerator : IIdentifierGenerator
 	{
 

--- a/src/NHibernate/Async/Id/SelectGenerator.cs
+++ b/src/NHibernate/Async/Id/SelectGenerator.cs
@@ -21,17 +21,11 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SelectGenerator : AbstractPostInsertGenerator, IConfigurable
 	{
 
 		#region Nested type: SelectGeneratorDelegate
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class SelectGeneratorDelegate : AbstractSelectingDelegate
 		{
 

--- a/src/NHibernate/Async/Id/SequenceGenerator.cs
+++ b/src/NHibernate/Async/Id/SequenceGenerator.cs
@@ -25,9 +25,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SequenceGenerator : IPersistentIdentifierGenerator, IConfigurable
 	{
 

--- a/src/NHibernate/Async/Id/SequenceHiLoGenerator.cs
+++ b/src/NHibernate/Async/Id/SequenceHiLoGenerator.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SequenceHiLoGenerator : SequenceGenerator
 	{
 		private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Id/SequenceIdentityGenerator.cs
+++ b/src/NHibernate/Async/Id/SequenceIdentityGenerator.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SequenceIdentityGenerator : SequenceGenerator, IPostInsertIdentifierGenerator
 	{
 		#region IPostInsertIdentifierGenerator Members

--- a/src/NHibernate/Async/Id/TableGenerator.cs
+++ b/src/NHibernate/Async/Id/TableGenerator.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TableGenerator : TransactionHelper, IPersistentIdentifierGenerator, IConfigurable
 	{
 		private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Id/TableHiLoGenerator.cs
+++ b/src/NHibernate/Async/Id/TableHiLoGenerator.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TableHiLoGenerator : TableGenerator
 	{
 		private readonly NHibernate.Util.AsyncLock _generate = new NHibernate.Util.AsyncLock();

--- a/src/NHibernate/Async/Id/UUIDHexGenerator.cs
+++ b/src/NHibernate/Async/Id/UUIDHexGenerator.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UUIDHexGenerator : IIdentifierGenerator, IConfigurable
 	{
 

--- a/src/NHibernate/Async/Id/UUIDStringGenerator.cs
+++ b/src/NHibernate/Async/Id/UUIDStringGenerator.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Id
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UUIDStringGenerator : IIdentifierGenerator
 	{
 		#region IIdentifierGenerator Members

--- a/src/NHibernate/Async/Impl/AbstractQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/AbstractQueryImpl.cs
@@ -25,9 +25,6 @@ using System.Threading;
 namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractQueryImpl : IQuery
 	{
 

--- a/src/NHibernate/Async/Impl/AbstractQueryImpl2.cs
+++ b/src/NHibernate/Async/Impl/AbstractQueryImpl2.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractQueryImpl2 : AbstractQueryImpl
 	{
 

--- a/src/NHibernate/Async/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Async/Impl/AbstractSessionImpl.cs
@@ -33,9 +33,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractSessionImpl : ISessionImplementor
 	{
 

--- a/src/NHibernate/Async/Impl/CollectionFilterImpl.cs
+++ b/src/NHibernate/Async/Impl/CollectionFilterImpl.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionFilterImpl : QueryImpl
 	{
 

--- a/src/NHibernate/Async/Impl/CriteriaImpl.cs
+++ b/src/NHibernate/Async/Impl/CriteriaImpl.cs
@@ -22,9 +22,6 @@ using NHibernate.Util;
 namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CriteriaImpl : ICriteria
 	{
 
@@ -77,9 +74,6 @@ namespace NHibernate.Impl
 			cancellationToken.ThrowIfCancellationRequested();
 			return AbstractQueryImpl.UniqueElement(await (ListAsync(cancellationToken)).ConfigureAwait(false));
 		}
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public sealed partial class Subcriteria : ICriteria
 		{
 

--- a/src/NHibernate/Async/Impl/ExpressionQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/ExpressionQueryImpl.cs
@@ -26,9 +26,6 @@ namespace NHibernate.Impl
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	partial class ExpressionFilterImpl : ExpressionQueryImpl
 	{
 

--- a/src/NHibernate/Async/Impl/FutureBatch.cs
+++ b/src/NHibernate/Async/Impl/FutureBatch.cs
@@ -16,9 +16,6 @@ using System.Threading.Tasks;
 
 namespace NHibernate.Impl
 {
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class FutureBatch<TQueryApproach, TMultiApproach>
 	{
 

--- a/src/NHibernate/Async/Impl/FutureCriteriaBatch.cs
+++ b/src/NHibernate/Async/Impl/FutureCriteriaBatch.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class FutureCriteriaBatch : FutureBatch<ICriteria, IMultiCriteria>
 	{
 

--- a/src/NHibernate/Async/Impl/FutureQueryBatch.cs
+++ b/src/NHibernate/Async/Impl/FutureQueryBatch.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Impl
 {
     using System.Threading.Tasks;
     using System.Threading;
-    /// <content>
-    /// Contains generated async methods
-    /// </content>
     public partial class FutureQueryBatch : FutureBatch<IQuery, IMultiQuery>
     {
 

--- a/src/NHibernate/Async/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Async/Impl/MultiCriteriaImpl.cs
@@ -27,9 +27,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MultiCriteriaImpl : IMultiCriteria
 	{
 

--- a/src/NHibernate/Async/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/MultiQueryImpl.cs
@@ -29,9 +29,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MultiQueryImpl : IMultiQuery
 	{
 

--- a/src/NHibernate/Async/Impl/MultipleQueriesCacheAssembler.cs
+++ b/src/NHibernate/Async/Impl/MultipleQueriesCacheAssembler.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	internal partial class MultipleQueriesCacheAssembler : ICacheAssembler
 	{
 

--- a/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
@@ -47,9 +47,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class SessionFactoryImpl : ISessionFactoryImplementor, IObjectReference
 	{
 		#region ISessionFactoryImplementor Members

--- a/src/NHibernate/Async/Impl/SessionImpl.cs
+++ b/src/NHibernate/Async/Impl/SessionImpl.cs
@@ -38,9 +38,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public sealed partial class SessionImpl : AbstractSessionImpl, IEventSource, ISerializable, IDeserializationCallback
 	{
 

--- a/src/NHibernate/Async/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/SqlQueryImpl.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SqlQueryImpl : AbstractQueryImpl, ISQLQuery
 	{
 

--- a/src/NHibernate/Async/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Async/Impl/StatelessSessionImpl.cs
@@ -35,9 +35,6 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class StatelessSessionImpl : AbstractSessionImpl, IStatelessSession
 	{
 

--- a/src/NHibernate/Async/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Async/Linq/DefaultQueryProvider.cs
@@ -23,17 +23,11 @@ using System.Threading.Tasks;
 
 namespace NHibernate.Linq
 {
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface INhQueryProvider : IQueryProvider
 	{
 		Task<int> ExecuteDmlAsync<T>(QueryMode queryMode, Expression expression, CancellationToken cancellationToken);
 	}
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DefaultQueryProvider : INhQueryProvider
 	{
 

--- a/src/NHibernate/Async/Linq/DmlExtensionMethods.cs
+++ b/src/NHibernate/Async/Linq/DmlExtensionMethods.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class DmlExtensionMethods
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Linq/InsertBuilder.cs
+++ b/src/NHibernate/Async/Linq/InsertBuilder.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Linq
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class InsertBuilder<TSource, TTarget>
 	{
 

--- a/src/NHibernate/Async/Linq/UpdateBuilder.cs
+++ b/src/NHibernate/Async/Linq/UpdateBuilder.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UpdateBuilder<TSource>
 	{
 

--- a/src/NHibernate/Async/Loader/Collection/BatchingCollectionInitializer.cs
+++ b/src/NHibernate/Async/Loader/Collection/BatchingCollectionInitializer.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Loader.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BatchingCollectionInitializer : ICollectionInitializer
 	{
 

--- a/src/NHibernate/Async/Loader/Collection/CollectionLoader.cs
+++ b/src/NHibernate/Async/Loader/Collection/CollectionLoader.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Loader.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionLoader : OuterJoinLoader, ICollectionInitializer
 	{
 

--- a/src/NHibernate/Async/Loader/Collection/ICollectionInitializer.cs
+++ b/src/NHibernate/Async/Loader/Collection/ICollectionInitializer.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Loader.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ICollectionInitializer
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Loader/Collection/SubselectCollectionLoader.cs
+++ b/src/NHibernate/Async/Loader/Collection/SubselectCollectionLoader.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Loader.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SubselectCollectionLoader : BasicCollectionLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Collection/SubselectOneToManyLoader.cs
+++ b/src/NHibernate/Async/Loader/Collection/SubselectOneToManyLoader.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Loader.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SubselectOneToManyLoader : OneToManyLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Criteria/CriteriaLoader.cs
+++ b/src/NHibernate/Async/Loader/Criteria/CriteriaLoader.cs
@@ -25,9 +25,6 @@ namespace NHibernate.Loader.Criteria
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CriteriaLoader : OuterJoinLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Custom/CustomLoader.cs
+++ b/src/NHibernate/Async/Loader/Custom/CustomLoader.cs
@@ -28,9 +28,6 @@ namespace NHibernate.Loader.Custom
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CustomLoader : Loader
 	{
 
@@ -55,9 +52,6 @@ namespace NHibernate.Loader.Custom
 			return rowProcessor.BuildResultRowAsync(row, rs, resultTransformer != null, session, cancellationToken);
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class ResultRowProcessor
 		{
 
@@ -99,17 +93,11 @@ namespace NHibernate.Loader.Custom
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial interface IResultColumnProcessor
 		{
 			Task<object> ExtractAsync(object[] data, DbDataReader resultSet, ISessionImplementor session, CancellationToken cancellationToken);
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class NonScalarResultColumnProcessor : IResultColumnProcessor
 		{
 
@@ -130,9 +118,6 @@ namespace NHibernate.Loader.Custom
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		public partial class ScalarResultColumnProcessor : IResultColumnProcessor
 		{
 

--- a/src/NHibernate/Async/Loader/Entity/AbstractEntityLoader.cs
+++ b/src/NHibernate/Async/Loader/Entity/AbstractEntityLoader.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Loader.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractEntityLoader : OuterJoinLoader, IUniqueEntityLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Entity/BatchingEntityLoader.cs
+++ b/src/NHibernate/Async/Loader/Entity/BatchingEntityLoader.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Loader.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BatchingEntityLoader : IUniqueEntityLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Entity/CollectionElementLoader.cs
+++ b/src/NHibernate/Async/Loader/Entity/CollectionElementLoader.cs
@@ -25,9 +25,6 @@ namespace NHibernate.Loader.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionElementLoader : OuterJoinLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Entity/EntityLoader.cs
+++ b/src/NHibernate/Async/Loader/Entity/EntityLoader.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Loader.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class EntityLoader : AbstractEntityLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Entity/IUniqueEntityLoader.cs
+++ b/src/NHibernate/Async/Loader/Entity/IUniqueEntityLoader.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Loader.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IUniqueEntityLoader
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Async/Loader/Hql/QueryLoader.cs
@@ -32,9 +32,6 @@ namespace NHibernate.Loader.Hql
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class QueryLoader : BasicLoader
 	{
 

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -39,9 +39,6 @@ namespace NHibernate.Loader
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class Loader
 	{
 

--- a/src/NHibernate/Async/NHibernateUtil.cs
+++ b/src/NHibernate/Async/NHibernateUtil.cs
@@ -25,9 +25,6 @@ namespace NHibernate
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class NHibernateUtil
 	{
 

--- a/src/NHibernate/Async/Param/AbstractExplicitParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/AbstractExplicitParameterSpecification.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractExplicitParameterSpecification : IPageableParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/AggregatedIndexCollectionSelectorParameterSpecifications.cs
+++ b/src/NHibernate/Async/Param/AggregatedIndexCollectionSelectorParameterSpecifications.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AggregatedIndexCollectionSelectorParameterSpecifications : IParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/CollectionFilterKeyParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/CollectionFilterKeyParameterSpecification.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CollectionFilterKeyParameterSpecification : IParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/CriteriaNamedParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/CriteriaNamedParameterSpecification.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CriteriaNamedParameterSpecification : IParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/DynamicFilterParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/DynamicFilterParameterSpecification.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DynamicFilterParameterSpecification : IParameterSpecification
 	{
 
@@ -53,9 +50,6 @@ namespace NHibernate.Param
 		}
 
 		#endregion
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class CollectionOfValuesType : IType
 		{
 

--- a/src/NHibernate/Async/Param/IParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/IParameterSpecification.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IParameterSpecification
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Param/NamedParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/NamedParameterSpecification.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NamedParameterSpecification : AbstractExplicitParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/PositionalParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/PositionalParameterSpecification.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PositionalParameterSpecification : AbstractExplicitParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/QuerySkipParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/QuerySkipParameterSpecification.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class QuerySkipParameterSpecification : IParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/QueryTakeParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/QueryTakeParameterSpecification.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class QueryTakeParameterSpecification : IParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Param/VersionTypeSeedParameterSpecification.cs
+++ b/src/NHibernate/Async/Param/VersionTypeSeedParameterSpecification.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Param
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class VersionTypeSeedParameterSpecification : IParameterSpecification
 	{
 

--- a/src/NHibernate/Async/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Async/Persister/Collection/AbstractCollectionPersister.cs
@@ -38,9 +38,6 @@ namespace NHibernate.Persister.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractCollectionPersister : ICollectionMetadata, ISqlLoadableCollection,
 														IPostInsertIdentityPersister
 	{
@@ -566,9 +563,6 @@ namespace NHibernate.Persister.Collection
 			}
 		}
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		protected partial class GeneratedIdentifierBinder : IBinder
 		{
 

--- a/src/NHibernate/Async/Persister/Collection/BasicCollectionPersister.cs
+++ b/src/NHibernate/Async/Persister/Collection/BasicCollectionPersister.cs
@@ -29,9 +29,6 @@ namespace NHibernate.Persister.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class BasicCollectionPersister : AbstractCollectionPersister
 	{
 

--- a/src/NHibernate/Async/Persister/Collection/ICollectionPersister.cs
+++ b/src/NHibernate/Async/Persister/Collection/ICollectionPersister.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Persister.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ICollectionPersister
 	{
 

--- a/src/NHibernate/Async/Persister/Collection/NamedQueryCollectionInitializer.cs
+++ b/src/NHibernate/Async/Persister/Collection/NamedQueryCollectionInitializer.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Persister.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NamedQueryCollectionInitializer : ICollectionInitializer
 	{
 

--- a/src/NHibernate/Async/Persister/Collection/OneToManyPersister.cs
+++ b/src/NHibernate/Async/Persister/Collection/OneToManyPersister.cs
@@ -29,9 +29,6 @@ namespace NHibernate.Persister.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OneToManyPersister : AbstractCollectionPersister
 	{
 

--- a/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
@@ -43,15 +43,9 @@ namespace NHibernate.Persister.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractEntityPersister : IOuterJoinLoadable, IQueryable, IClassMetadata, IUniqueKeyLoadable, ISqlLoadable, ILazyPropertyInitializer, IPostInsertIdentityPersister, ILockable
 	{
 
-		/// <content>
-		/// Contains generated async methods
-		/// </content>
 		private partial class GeneratedIdentifierBinder : IBinder
 		{
 

--- a/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Persister.Entity
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IEntityPersister : IOptimisticCacheSource
 	{
 

--- a/src/NHibernate/Async/Persister/Entity/ILoadable.cs
+++ b/src/NHibernate/Async/Persister/Entity/ILoadable.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Persister.Entity
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ILoadable : IEntityPersister
 	{
 

--- a/src/NHibernate/Async/Persister/Entity/IUniqueKeyLoadable.cs
+++ b/src/NHibernate/Async/Persister/Entity/IUniqueKeyLoadable.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Persister.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IUniqueKeyLoadable
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Persister/Entity/NamedQueryLoader.cs
+++ b/src/NHibernate/Async/Persister/Entity/NamedQueryLoader.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Persister.Entity
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class NamedQueryLoader : IUniqueEntityLoader
 	{
 

--- a/src/NHibernate/Async/Proxy/AbstractLazyInitializer.cs
+++ b/src/NHibernate/Async/Proxy/AbstractLazyInitializer.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Proxy
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractLazyInitializer : ILazyInitializer
 	{
 		

--- a/src/NHibernate/Async/Proxy/ILazyInitializer.cs
+++ b/src/NHibernate/Async/Proxy/ILazyInitializer.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Proxy
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ILazyInitializer
 	{
 		/// <summary>

--- a/src/NHibernate/Async/SqlCommand/SqlCommandImpl.cs
+++ b/src/NHibernate/Async/SqlCommand/SqlCommandImpl.cs
@@ -20,9 +20,6 @@ namespace NHibernate.SqlCommand
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ISqlCommand
 	{
 
@@ -54,9 +51,6 @@ namespace NHibernate.SqlCommand
 		Task BindAsync(DbCommand command, ISessionImplementor session, CancellationToken cancellationToken);
 	}
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SqlCommandImpl : ISqlCommand
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/DatabaseMetadata.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/DatabaseMetadata.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DatabaseMetadata : IDatabaseMetadata
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/IConnectionHelper.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/IConnectionHelper.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IConnectionHelper
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Tool/hbm2ddl/ManagedProviderConnectionHelper.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/ManagedProviderConnectionHelper.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ManagedProviderConnectionHelper : IConnectionHelper
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaExport.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaExport.cs
@@ -24,9 +24,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SchemaExport
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaMetadataUpdater.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaMetadataUpdater.cs
@@ -18,10 +18,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
-
 	public static partial class SchemaMetadataUpdater
 	{
 		public static Task UpdateAsync(ISessionFactoryImplementor sessionFactory, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaUpdate.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaUpdate.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SchemaUpdate
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaValidator.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaValidator.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SchemaValidator
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/SuppliedConnectionHelper.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SuppliedConnectionHelper.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Tool.hbm2ddl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SuppliedConnectionHelper : IConnectionHelper
 	{
 

--- a/src/NHibernate/Async/Tool/hbm2ddl/SuppliedConnectionProviderConnectionHelper.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SuppliedConnectionProviderConnectionHelper.cs
@@ -16,9 +16,6 @@ namespace NHibernate.Tool.hbm2ddl
 	using System.Threading.Tasks;
 	using System.Threading;
 
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SuppliedConnectionProviderConnectionHelper : IConnectionHelper
 	{
 

--- a/src/NHibernate/Async/Transaction/AdoNetTransactionFactory.cs
+++ b/src/NHibernate/Async/Transaction/AdoNetTransactionFactory.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Transaction
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AdoNetTransactionFactory : ITransactionFactory
 	{
 

--- a/src/NHibernate/Async/Transaction/AdoNetWithSystemTransactionFactory.cs
+++ b/src/NHibernate/Async/Transaction/AdoNetWithSystemTransactionFactory.cs
@@ -22,9 +22,6 @@ using NHibernate.Util;
 namespace NHibernate.Transaction
 {
 	using System.Threading.Tasks;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AdoNetWithSystemTransactionFactory : AdoNetTransactionFactory
 	{
 

--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Transaction
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AdoTransaction : ITransaction
 	{
 

--- a/src/NHibernate/Async/Transaction/ITransactionFactory.cs
+++ b/src/NHibernate/Async/Transaction/ITransactionFactory.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Transaction
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ITransactionFactory
 	{
 

--- a/src/NHibernate/Async/Type/AbstractBinaryType.cs
+++ b/src/NHibernate/Async/Type/AbstractBinaryType.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractBinaryType : MutableType, IVersionType, IComparer
 	{
 

--- a/src/NHibernate/Async/Type/AbstractType.cs
+++ b/src/NHibernate/Async/Type/AbstractType.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class AbstractType : IType
 	{
 

--- a/src/NHibernate/Async/Type/AnyType.cs
+++ b/src/NHibernate/Async/Type/AnyType.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class AnyType : AbstractType, IAbstractComponentType, IAssociationType
 	{
 

--- a/src/NHibernate/Async/Type/ArrayType.cs
+++ b/src/NHibernate/Async/Type/ArrayType.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ArrayType : CollectionType
 	{
 

--- a/src/NHibernate/Async/Type/ByteType.cs
+++ b/src/NHibernate/Async/Type/ByteType.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ByteType : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/ClassMetaType.cs
+++ b/src/NHibernate/Async/Type/ClassMetaType.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ClassMetaType : AbstractType
 	{
 

--- a/src/NHibernate/Async/Type/CollectionType.cs
+++ b/src/NHibernate/Async/Type/CollectionType.cs
@@ -26,9 +26,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class CollectionType : AbstractType, IAssociationType
 	{
 

--- a/src/NHibernate/Async/Type/ComponentType.cs
+++ b/src/NHibernate/Async/Type/ComponentType.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ComponentType : AbstractType, IAbstractComponentType
 	{
 

--- a/src/NHibernate/Async/Type/CompositeCustomType.cs
+++ b/src/NHibernate/Async/Type/CompositeCustomType.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CompositeCustomType : AbstractType, IAbstractComponentType
 	{
 

--- a/src/NHibernate/Async/Type/CustomCollectionType.cs
+++ b/src/NHibernate/Async/Type/CustomCollectionType.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CustomCollectionType : CollectionType
 	{
 

--- a/src/NHibernate/Async/Type/CustomType.cs
+++ b/src/NHibernate/Async/Type/CustomType.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class CustomType : AbstractType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/DateTime2Type.cs
+++ b/src/NHibernate/Async/Type/DateTime2Type.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DateTime2Type : DateTimeType
 	{
 

--- a/src/NHibernate/Async/Type/DateTimeOffSetType.cs
+++ b/src/NHibernate/Async/Type/DateTimeOffSetType.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DateTimeOffsetType : PrimitiveType, IIdentifierType, ILiteralType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/DateTimeType.cs
+++ b/src/NHibernate/Async/Type/DateTimeType.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DateTimeType : PrimitiveType, IIdentifierType, ILiteralType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/DbTimestampType.cs
+++ b/src/NHibernate/Async/Type/DbTimestampType.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class DbTimestampType : TimestampType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/EntityType.cs
+++ b/src/NHibernate/Async/Type/EntityType.cs
@@ -23,9 +23,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class EntityType : AbstractType, IAssociationType
 	{
 

--- a/src/NHibernate/Async/Type/EnumCharType.cs
+++ b/src/NHibernate/Async/Type/EnumCharType.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class EnumCharType<T> : AbstractEnumType
 	{
 

--- a/src/NHibernate/Async/Type/EnumStringType.cs
+++ b/src/NHibernate/Async/Type/EnumStringType.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class EnumStringType : AbstractEnumType
 	{
 

--- a/src/NHibernate/Async/Type/GenericIdentifierBagType.cs
+++ b/src/NHibernate/Async/Type/GenericIdentifierBagType.cs
@@ -22,9 +22,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class GenericIdentifierBagType<T> : CollectionType
 	{
 

--- a/src/NHibernate/Async/Type/GenericMapType.cs
+++ b/src/NHibernate/Async/Type/GenericMapType.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class GenericMapType<TKey, TValue> : CollectionType
 	{
 

--- a/src/NHibernate/Async/Type/IAbstractComponentType.cs
+++ b/src/NHibernate/Async/Type/IAbstractComponentType.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IAbstractComponentType : IType
 	{
 

--- a/src/NHibernate/Async/Type/ICacheAssembler.cs
+++ b/src/NHibernate/Async/Type/ICacheAssembler.cs
@@ -14,9 +14,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface ICacheAssembler
 	{
 		/// <summary> Return a cacheable "disassembled" representation of the object.</summary>

--- a/src/NHibernate/Async/Type/IType.cs
+++ b/src/NHibernate/Async/Type/IType.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IType : ICacheAssembler
 	{
 

--- a/src/NHibernate/Async/Type/IVersionType.cs
+++ b/src/NHibernate/Async/Type/IVersionType.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial interface IVersionType : IType
 	{
 		/// <summary>

--- a/src/NHibernate/Async/Type/ImmutableType.cs
+++ b/src/NHibernate/Async/Type/ImmutableType.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class ImmutableType : NullableType
 	{
 

--- a/src/NHibernate/Async/Type/Int16Type.cs
+++ b/src/NHibernate/Async/Type/Int16Type.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Int16Type : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/Int32Type.cs
+++ b/src/NHibernate/Async/Type/Int32Type.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Int32Type : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/Int64Type.cs
+++ b/src/NHibernate/Async/Type/Int64Type.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class Int64Type : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/ManyToOneType.cs
+++ b/src/NHibernate/Async/Type/ManyToOneType.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class ManyToOneType : EntityType
 	{
 

--- a/src/NHibernate/Async/Type/MetaType.cs
+++ b/src/NHibernate/Async/Type/MetaType.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class MetaType : AbstractType
 	{
 

--- a/src/NHibernate/Async/Type/MutableType.cs
+++ b/src/NHibernate/Async/Type/MutableType.cs
@@ -17,9 +17,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class MutableType : NullableType
 	{
 

--- a/src/NHibernate/Async/Type/NullableType.cs
+++ b/src/NHibernate/Async/Type/NullableType.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public abstract partial class NullableType : AbstractType
 	{
 

--- a/src/NHibernate/Async/Type/OneToOneType.cs
+++ b/src/NHibernate/Async/Type/OneToOneType.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class OneToOneType : EntityType, IAssociationType
 	{
 

--- a/src/NHibernate/Async/Type/PersistentEnumType.cs
+++ b/src/NHibernate/Async/Type/PersistentEnumType.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class PersistentEnumType : AbstractEnumType
 	{
 

--- a/src/NHibernate/Async/Type/SerializableType.cs
+++ b/src/NHibernate/Async/Type/SerializableType.cs
@@ -21,9 +21,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SerializableType : MutableType
 	{
 

--- a/src/NHibernate/Async/Type/SpecialOneToOneType.cs
+++ b/src/NHibernate/Async/Type/SpecialOneToOneType.cs
@@ -15,9 +15,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class SpecialOneToOneType : OneToOneType
 	{
 

--- a/src/NHibernate/Async/Type/TicksType.cs
+++ b/src/NHibernate/Async/Type/TicksType.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TicksType : PrimitiveType, IVersionType, ILiteralType
 	{
 

--- a/src/NHibernate/Async/Type/TimeAsTimeSpanType.cs
+++ b/src/NHibernate/Async/Type/TimeAsTimeSpanType.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TimeAsTimeSpanType : PrimitiveType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/TimeSpanType.cs
+++ b/src/NHibernate/Async/Type/TimeSpanType.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TimeSpanType : PrimitiveType, IVersionType, ILiteralType
 	{
 

--- a/src/NHibernate/Async/Type/TimestampType.cs
+++ b/src/NHibernate/Async/Type/TimestampType.cs
@@ -18,9 +18,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class TimestampType : PrimitiveType, IVersionType, ILiteralType
 	{
 

--- a/src/NHibernate/Async/Type/TypeHelper.cs
+++ b/src/NHibernate/Async/Type/TypeHelper.cs
@@ -19,9 +19,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public static partial class TypeHelper
 	{
 		

--- a/src/NHibernate/Async/Type/UInt16Type.cs
+++ b/src/NHibernate/Async/Type/UInt16Type.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UInt16Type : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/UInt32Type.cs
+++ b/src/NHibernate/Async/Type/UInt32Type.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UInt32Type : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 

--- a/src/NHibernate/Async/Type/UInt64Type.cs
+++ b/src/NHibernate/Async/Type/UInt64Type.cs
@@ -20,9 +20,6 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	/// <content>
-	/// Contains generated async methods
-	/// </content>
 	public partial class UInt64Type : PrimitiveType, IDiscriminatorType, IVersionType
 	{
 


### PR DESCRIPTION
Speeds up generation by 30%, removes <content> generated comments which sometimes interfere with some tooling (Rider), and clean some undue generated imports.

The <content> comment removal (maca88/AsyncGenerator#55) is responsible of most changes, while some async test files also have some undue `import System.Threading` removed (maca88/AsyncGenerator#51).