### PR TITLE
NH-4073 - Fix problem in NHibernate.Example.Web

### DIFF
--- a/src/NHibernate.Example.Web/Pages/Error.cshtml.cs
+++ b/src/NHibernate.Example.Web/Pages/Error.cshtml.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace AspNetCoreFxWebApplication.Pages
+namespace NHibernate.Example.Web.Pages
 {
 	public class ErrorModel : PageModel
 	{


### PR DESCRIPTION
There was an issue with one of the code-behinds that prevented the Razor Pages from pre-compiling.

`dotnet publish` now works.