### PR TITLE
NH-3884 - Default DateTime type can not be overridden

### DIFF
--- a/doc/reference/modules/basic_mapping.xml
+++ b/doc/reference/modules/basic_mapping.xml
@@ -2633,7 +2633,7 @@
                 types, <literal>System.Object</literal> types, and <literal>System.Object</literal> types for large objects.  Just like
                 Columns for System.ValueType types can handle <literal>null</literal> values only if the entity property is properly
                 typed with a <literal>Nullable&lt;T&gt;</literal>. Otherwise <literal>null</literal> will be replaced by the default
-                value for the type when reading, and when be overwritten by it when persisting the entity, potentially leading to
+                value for the type when reading, and then will be overwritten by it when persisting the entity, potentially leading to
                 phantom updates.
             </para>
             <table>
@@ -3023,6 +3023,12 @@
                 NHibernate type, <literal>type="short"</literal> to an <literal>Int16</literal> NHibernateType.
                 To see all of the conversions you can view the source of static constructor of the class
                 <literal>NHibernate.Type.TypeFactory</literal>.
+            </para>
+
+            <para>
+                Default NHibernate types used when no <literal>type</literal> attribute is specified can be overridden by using
+                the <literal>NHibernate.Type.TypeFactory.RegisterType</literal> static method before configuring and building
+                session factories.
             </para>
 
         </sect2>

--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeClass.cs
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeClass.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NHibernate.Test.TypesTest
+{
+	public class ChangeDefaultTypeClass
+	{
+		public int Id { get; set; }
+
+		public DateTime NormalDateTimeValue { get; set; } = DateTime.Today;
+	}
+}

--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeClass.hbm.xml
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeClass.hbm.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" default-lazy="false">
+
+  <class
+    name="NHibernate.Test.TypesTest.ChangeDefaultTypeClass, NHibernate.Test"
+    table="bc_datetime"
+  >
+
+    <id name="Id" column="id">
+      <generator class="assigned"/>
+    </id>
+
+    <property name="NormalDateTimeValue"/>
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeFixture.cs
@@ -25,9 +25,9 @@ namespace NHibernate.Test.TypesTest
 			_originalDefaultDateTimeType = TypeFactory.GetDefaultTypeFor(typeof(DateTime));
 			Assert.That(_originalDefaultDateTimeType, Is.Not.Null);
 			_testDefaultDateTimeType = NHibernateUtil.DateTime.Equals(_originalDefaultDateTimeType)
-				? (IType) NHibernateUtil.Timestamp
+				? (IType) NHibernateUtil.DateTimeNoMs
 				: NHibernateUtil.DateTime;
-			TypeFactory.SetDefaultType<DateTime>(_testDefaultDateTimeType);
+			TypeFactory.RegisterType(typeof(DateTime), _testDefaultDateTimeType, TypeFactory.EmptyAliases);
 			base.Configure(configuration);
 		}
 
@@ -35,7 +35,7 @@ namespace NHibernate.Test.TypesTest
 		{
 			base.DropSchema();
 			if (_originalDefaultDateTimeType != null)
-				TypeFactory.SetDefaultType<DateTime>(_originalDefaultDateTimeType);
+				TypeFactory.RegisterType(typeof(DateTime), _originalDefaultDateTimeType, TypeFactory.EmptyAliases);
 		}
 
 		[Test]
@@ -72,13 +72,13 @@ namespace NHibernate.Test.TypesTest
 				var q = s.CreateQuery($"from {nameof(ChangeDefaultTypeClass)} where :date1 = :date2 or :date1 = :date3")
 				         .SetParameter("date1", DateTime.Now)
 				         .SetDateTime("date2", DateTime.Now)
-				         .SetTimestamp("date3", DateTime.Now);
+				         .SetDateTimeNoMs("date3", DateTime.Now);
 
 				var namedParameters = namedParametersField.GetValue(q) as Dictionary<string, TypedValue>;
 				Assert.That(namedParameters, Is.Not.Null, "Unable to retrieve parameters internal field");
 				Assert.That(namedParameters["date1"].Type, Is.EqualTo(_testDefaultDateTimeType));
 				Assert.That(namedParameters["date2"].Type, Is.EqualTo(NHibernateUtil.DateTime));
-				Assert.That(namedParameters["date3"].Type, Is.EqualTo(NHibernateUtil.Timestamp));
+				Assert.That(namedParameters["date3"].Type, Is.EqualTo(NHibernateUtil.DateTimeNoMs));
 			}
 		}
 	}

--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeFixture.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NHibernate.Cfg;
+using NHibernate.Engine;
+using NHibernate.Impl;
+using NHibernate.Type;
+using NUnit.Framework;
+
+namespace NHibernate.Test.TypesTest
+{
+	/// <summary>
+	/// TestFixtures for changing a default .Net type.
+	/// </summary>
+	[TestFixture]
+	public class ChangeDefaultTypeFixture : TypeFixtureBase
+	{
+		protected override string TypeName => "ChangeDefaultType";
+
+		private IType _originalDefaultDateTimeType;
+		private IType _testDefaultDateTimeType;
+
+		protected override void Configure(Configuration configuration)
+		{
+			_originalDefaultDateTimeType = TypeFactory.GetDefaultTypeFor(typeof(DateTime));
+			Assert.That(_originalDefaultDateTimeType, Is.Not.Null);
+			_testDefaultDateTimeType = NHibernateUtil.DateTime.Equals(_originalDefaultDateTimeType)
+				? (IType) NHibernateUtil.Timestamp
+				: NHibernateUtil.DateTime;
+			TypeFactory.SetDefaultType<DateTime>(_testDefaultDateTimeType);
+			base.Configure(configuration);
+		}
+
+		protected override void DropSchema()
+		{
+			base.DropSchema();
+			if (_originalDefaultDateTimeType != null)
+				TypeFactory.SetDefaultType<DateTime>(_originalDefaultDateTimeType);
+		}
+
+		[Test]
+		public void DefaultType()
+		{
+			Assert.That(TypeFactory.GetDefaultTypeFor(typeof(DateTime)), Is.EqualTo(_testDefaultDateTimeType));
+		}
+
+		[Test]
+		public void PropertyType()
+		{
+			Assert.That(
+				Sfi.GetClassMetadata(typeof(ChangeDefaultTypeClass))
+				   .GetPropertyType(nameof(ChangeDefaultTypeClass.NormalDateTimeValue)),
+				Is.EqualTo(_testDefaultDateTimeType));
+		}
+
+		[Test]
+		public void GuessType()
+		{
+			Assert.That(NHibernateUtil.GuessType(typeof(DateTime)), Is.EqualTo(_testDefaultDateTimeType));
+		}
+
+		[Test]
+		public void ParameterType()
+		{
+			var namedParametersField = typeof(AbstractQueryImpl)
+				.GetField("namedParameters", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.That(namedParametersField, Is.Not.Null, "Missing internal field");
+
+			using (var s = OpenSession())
+			{
+				// Query where the parameter type cannot be deducted from compared entity property
+				var q = s.CreateQuery($"from {nameof(ChangeDefaultTypeClass)} where :date1 = :date2 or :date1 = :date3")
+				         .SetParameter("date1", DateTime.Now)
+				         .SetDateTime("date2", DateTime.Now)
+				         .SetTimestamp("date3", DateTime.Now);
+
+				var namedParameters = namedParametersField.GetValue(q) as Dictionary<string, TypedValue>;
+				Assert.That(namedParameters, Is.Not.Null, "Unable to retrieve parameters internal field");
+				Assert.That(namedParameters["date1"].Type, Is.EqualTo(_testDefaultDateTimeType));
+				Assert.That(namedParameters["date2"].Type, Is.EqualTo(NHibernateUtil.DateTime));
+				Assert.That(namedParameters["date3"].Type, Is.EqualTo(NHibernateUtil.Timestamp));
+			}
+		}
+	}
+}

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
 using NHibernate.Bytecode;
+using NHibernate.Cfg;
 using NHibernate.Classic;
 using NHibernate.SqlTypes;
 using NHibernate.UserTypes;
@@ -311,6 +312,25 @@ namespace NHibernate.Type
 						 l =>
 						 GetType(NHibernateUtil.Serializable, l,
 								 len => new SerializableType(typeof (object), SqlTypeFactory.GetBinary(len))));
+		}
+
+		/// <summary>
+		/// <para>Defines which NHibernate type should be chosen by default for handling a given .Net type.</para>
+		/// <para>This must be done before any operation on NHibernate, including building its
+		/// <see cref="Configuration" /> and building session factory. Otherwise the behavior will be undefined.</para>
+		/// </summary>
+		/// <param name="targetType">The NHibernate type.</param>
+		/// <typeparam name="T">The .Net type.</typeparam>
+		public static void SetDefaultType<T>(IType targetType)
+		{
+			if (targetType == null)
+				throw new ArgumentNullException(nameof(targetType));
+
+			var type = typeof(T);
+			foreach (var alias in GetClrTypeAliases(type))
+			{
+				typeByTypeOfName[alias] = targetType;
+			}
 		}
 
 		private static ICollectionTypeFactory CollectionTypeFactory =>

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -34,8 +34,9 @@ namespace NHibernate.Type
 			PrecisionScale
 		}
 
+		public static readonly string[] EmptyAliases = System.Array.Empty<string>();
+
 		private static readonly INHibernateLogger _log = NHibernateLogger.For(typeof(TypeFactory));
-		private static readonly string[] EmptyAliases= System.Array.Empty<string>();
 		private static readonly char[] PrecisionScaleSplit = { '(', ')', ',' };
 		private static readonly char[] LengthSplit = { '(', ')' };
 
@@ -96,7 +97,15 @@ namespace NHibernate.Type
 
 		private delegate NullableType NullableTypeCreatorDelegate(SqlType sqlType);
 
-		private static void RegisterType(System.Type systemType, IType nhibernateType, IEnumerable<string> aliases)
+		/// <summary>
+		/// <para>Defines which NHibernate type should be chosen by default for handling a given .Net type.</para>
+		/// <para>This must be done before any operation on NHibernate, including building its
+		/// <see cref="Configuration" /> and building session factory. Otherwise the behavior will be undefined.</para>
+		/// </summary>
+		/// <param name="systemType">The .Net type.</param>
+		/// <param name="nhibernateType">The NHibernate type.</param>
+		/// <param name="aliases">The additional aliases to map to the type. Use <see cref="EmptyAliases"/> if none.</param>
+		public static void RegisterType(System.Type systemType, IType nhibernateType, IEnumerable<string> aliases)
 		{
 			var typeAliases = new List<string>(aliases);
 			typeAliases.AddRange(GetClrTypeAliases(systemType));
@@ -312,25 +321,6 @@ namespace NHibernate.Type
 						 l =>
 						 GetType(NHibernateUtil.Serializable, l,
 								 len => new SerializableType(typeof (object), SqlTypeFactory.GetBinary(len))));
-		}
-
-		/// <summary>
-		/// <para>Defines which NHibernate type should be chosen by default for handling a given .Net type.</para>
-		/// <para>This must be done before any operation on NHibernate, including building its
-		/// <see cref="Configuration" /> and building session factory. Otherwise the behavior will be undefined.</para>
-		/// </summary>
-		/// <param name="targetType">The NHibernate type.</param>
-		/// <typeparam name="T">The .Net type.</typeparam>
-		public static void SetDefaultType<T>(IType targetType)
-		{
-			if (targetType == null)
-				throw new ArgumentNullException(nameof(targetType));
-
-			var type = typeof(T);
-			foreach (var alias in GetClrTypeAliases(type))
-			{
-				typeByTypeOfName[alias] = targetType;
-			}
 		}
 
 		private static ICollectionTypeFactory CollectionTypeFactory =>


### PR DESCRIPTION
[NH-3884](https://nhibernate.jira.com/browse/NH-3884) (#844) - Default DateTime type can not be overridden

Here is a proposition for allowing overriding default clr type mapping to NHibernate type.

Such a method is quite low level, and for having a coherent session factory, it must be used before configuring and building the session factory. So I have put proper warnings in its comment.

Such a method could become handy if by doing [NH-3919](https://nhibernate.jira.com/browse/NH-3919) as proposed [here](https://github.com/nhibernate/nhibernate-core/pull/693#issuecomment-330808981), we cause issues to some users.