### PR TITLE
NH-4088 - Dialect.GetCastTypeName is buggy

### DIFF
--- a/src/NHibernate.Test/Async/Criteria/ProjectionsTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/ProjectionsTest.cs
@@ -11,8 +11,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NHibernate.Criterion;
 using NHibernate.Dialect;
+using NHibernate.SqlTypes;
 using NHibernate.Type;
 using NUnit.Framework;
 
@@ -105,6 +107,11 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public async Task CastWithLengthAsync()
 		{
+			if (Regex.IsMatch(Dialect.GetCastTypeName(SqlTypeFactory.GetString(3)), @"^[^(]*$"))
+			{
+				Assert.Ignore($"Dialect {Dialect} does not seem to handle string length in cast");
+			}
+
 			using (var s = OpenSession())
 			{
 				try
@@ -120,8 +127,7 @@ namespace NHibernate.Test.Criteria
 				}
 				catch (Exception e)
 				{
-					if (!e.Message.Contains("truncation") && 
-						(e.InnerException == null || !e.InnerException.Message.Contains("truncation")))
+					if (e.InnerException == null || !e.InnerException.Message.Contains("truncation"))
 						throw;
 				}
 			}

--- a/src/NHibernate.Test/Async/Criteria/ProjectionsTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/ProjectionsTest.cs
@@ -8,10 +8,12 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Criterion;
 using NHibernate.Dialect;
+using NHibernate.Type;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Criteria
@@ -97,6 +99,59 @@ namespace NHibernate.Test.Criteria
 					))
 					.UniqueResultAsync<string>());
 				Assert.AreEqual("27 ayende", result);
+			}
+		}
+
+		[Test]
+		public async Task CastWithLengthAsync()
+		{
+			using (var s = OpenSession())
+			{
+				try
+				{
+					var shortName = await (s
+						.CreateCriteria<Student>()
+						.SetProjection(
+							Projections.Cast(
+								TypeFactory.GetStringType(3),
+								Projections.Property("Name")))
+						.UniqueResultAsync<string>());
+					Assert.That(shortName, Is.EqualTo("aye"));
+				}
+				catch (Exception e)
+				{
+					if (!e.Message.Contains("truncation") && 
+						(e.InnerException == null || !e.InnerException.Message.Contains("truncation")))
+						throw;
+				}
+			}
+		}
+
+		[Test]
+		public async Task CastWithPrecisionScaleAsync()
+		{
+			if (TestDialect.HasBrokenDecimalType)
+				Assert.Ignore("Dialect does not correctly handle decimal.");
+
+			using (var s = OpenSession())
+			{
+				var value = await (s
+					.CreateCriteria<Student>()
+					.SetProjection(
+						Projections.Cast(
+							TypeFactory.Basic("decimal(18,9)"),
+							Projections.Constant(123456789.123456789m, TypeFactory.Basic("decimal(18,9)"))))
+					.UniqueResultAsync<decimal>());
+				Assert.That(value, Is.EqualTo(123456789.123456789m), "Same type cast");
+
+				value = await (s
+					.CreateCriteria<Student>()
+					.SetProjection(
+						Projections.Cast(
+							TypeFactory.Basic("decimal(18,7)"),
+							Projections.Constant(123456789.987654321m, TypeFactory.Basic("decimal(18,9)"))))
+					.UniqueResultAsync<decimal>());
+				Assert.That(value, Is.EqualTo(123456789.9876543m), "Reduced scale cast");
 			}
 		}
 

--- a/src/NHibernate.Test/Async/DialectTest/DialectFixture.cs
+++ b/src/NHibernate.Test/Async/DialectTest/DialectFixture.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 using NHibernate.Dialect;
 using NHibernate.Driver;
 using NHibernate.Engine;

--- a/src/NHibernate.Test/Criteria/ProjectionsTest.cs
+++ b/src/NHibernate.Test/Criteria/ProjectionsTest.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NHibernate.Criterion;
 using NHibernate.Dialect;
+using NHibernate.SqlTypes;
 using NHibernate.Type;
 using NUnit.Framework;
 
@@ -94,6 +96,11 @@ namespace NHibernate.Test.Criteria
 		[Test]
 		public void CastWithLength()
 		{
+			if (Regex.IsMatch(Dialect.GetCastTypeName(SqlTypeFactory.GetString(3)), @"^[^(]*$"))
+			{
+				Assert.Ignore($"Dialect {Dialect} does not seem to handle string length in cast");
+			}
+
 			using (var s = OpenSession())
 			{
 				try
@@ -109,8 +116,7 @@ namespace NHibernate.Test.Criteria
 				}
 				catch (Exception e)
 				{
-					if (!e.Message.Contains("truncation") && 
-						(e.InnerException == null || !e.InnerException.Message.Contains("truncation")))
+					if (e.InnerException == null || !e.InnerException.Message.Contains("truncation"))
 						throw;
 				}
 			}

--- a/src/NHibernate.Test/DialectTest/DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/DialectFixture.cs
@@ -178,6 +178,7 @@ namespace NHibernate.Test.DialectTest
 			var dialect = Dialect.Dialect.GetDialect(cfg.Properties);
 
 			Assert.That(dialect.GetTypeName(SqlTypeFactory.GetSqlType(DbType.Decimal, 40, 40)), Does.Not.Contain("40"), "oversized decimal");
+			// This regex tests wether the type is qualified with expected length/precision/scale or not qualified at all.
 			Assert.That(dialect.GetTypeName(SqlTypeFactory.GetSqlType(DbType.Decimal, 3, 2)), Does.Match(@"^[^(]*(\(\s*3\s*,\s*2\s*\))?\s*$"), "small decimal");
 		}
 
@@ -190,8 +191,11 @@ namespace NHibernate.Test.DialectTest
 			cfg.SetProperty(Environment.QueryDefaultCastScale, "3");
 			var dialect = Dialect.Dialect.GetDialect(cfg.Properties);
 
+			// Those regex test wether the type is qualified with expected length/precision/scale or not qualified at all.
 			Assert.That(dialect.GetCastTypeName(SqlTypeFactory.Decimal), Does.Match(@"^[^(]*(\(\s*10\s*,\s*3\s*\))?\s*$"), "decimal");
+			Assert.That(dialect.GetCastTypeName(SqlTypeFactory.GetSqlType(DbType.Decimal, 12, 4)), Does.Match(@"^[^(]*(\(\s*12\s*,\s*4\s*\))?\s*$"), "decimal(12,4)");
 			Assert.That(dialect.GetCastTypeName(new SqlType(DbType.String)), Does.Match(@"^[^(]*(\(\s*20\s*\))?\s*$"), "string");
+			Assert.That(dialect.GetCastTypeName(SqlTypeFactory.GetString(25)), Does.Match(@"^[^(]*(\(\s*25\s*\))?\s*$"), "string(25)");
 		}
 	}
 }

--- a/src/NHibernate.Test/DialectTest/DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/DialectFixture.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 using NHibernate.Dialect;
 using NHibernate.Driver;
 using NHibernate.Engine;
@@ -170,6 +169,29 @@ namespace NHibernate.Test.DialectTest
 					Assert.That(reader[0], Is.InstanceOf<DateTime>());
 				}
 			}
+		}
+
+		[Test]
+		public void GetDecimalTypeName()
+		{
+			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+			var dialect = Dialect.Dialect.GetDialect(cfg.Properties);
+
+			Assert.That(dialect.GetTypeName(SqlTypeFactory.GetSqlType(DbType.Decimal, 40, 40)), Does.Not.Contain("40"), "oversized decimal");
+			Assert.That(dialect.GetTypeName(SqlTypeFactory.GetSqlType(DbType.Decimal, 3, 2)), Does.Match(@"^[^(]*(\(\s*3\s*,\s*2\s*\))?\s*$"), "small decimal");
+		}
+
+		[Test]
+		public void GetTypeCastName()
+		{
+			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+			cfg.SetProperty(Environment.QueryDefaultCastLength, "20");
+			cfg.SetProperty(Environment.QueryDefaultCastPrecision, "10");
+			cfg.SetProperty(Environment.QueryDefaultCastScale, "3");
+			var dialect = Dialect.Dialect.GetDialect(cfg.Properties);
+
+			Assert.That(dialect.GetCastTypeName(SqlTypeFactory.Decimal), Does.Match(@"^[^(]*(\(\s*10\s*,\s*3\s*\))?\s*$"), "decimal");
+			Assert.That(dialect.GetCastTypeName(new SqlType(DbType.String)), Does.Match(@"^[^(]*(\(\s*20\s*\))?\s*$"), "string");
 		}
 	}
 }

--- a/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
@@ -14,157 +14,160 @@ namespace NHibernate.Test.DriverTest
 		private string _connectionString;
 		private FirebirdClientDriver _driver;
 
-		[Test]
-		public void ConnectionPooling_OpenThenCloseThenOpenAnotherOne_OnlyOneConnectionIsPooled()
-		{
-			MakeDriver();
-
-			_driver.ClearPool(_connectionString);
-
-			var allreadyEstablished = GetEstablishedConnections();
-
-			var connection1 = MakeConnection();
-			var connection2 = MakeConnection();
-
-			//open first connection
-			connection1.Open();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After first open");
-
-			//return it to the pool
-			connection1.Close();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After first close");
-
-			//open the second connection
-			connection2.Open();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After second open");
-
-			//return it to the pool
-			connection2.Close();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After second close");
-		}
-
-		[Test]
-		public void ConnectionPooling_OpenThenCloseTwoAtTheSameTime_TowConnectionsArePooled()
-		{
-			MakeDriver();
-
-			_driver.ClearPool(_connectionString);
-
-			var allreadyEstablished = GetEstablishedConnections();
-
-			var connection1 = MakeConnection();
-			var connection2 = MakeConnection();
-
-			//open first connection
-			connection1.Open();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After first open");
-
-			//open second one
-			connection2.Open();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 2, "After second open");
-
-			//return connection1 to the pool
-			connection1.Close();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 2, "After first close");
-
-			//return connection2 to the pool
-			connection2.Close();
-			VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 2, "After second close");
-		}
-
-		[Test]
-		public void AdjustCommand_StringParametersWithinConditionalSelect_ThenParameterIsWrappedByAVarcharCastStatement()
-		{
-			MakeDriver();
-			var cmd = BuildSelectCaseCommand(SqlTypeFactory.GetString(255));
-
-			_driver.AdjustCommand(cmd);
-
-			var expectedCommandTxt = "select (case when col = @p0 then cast(@p1 as VARCHAR(255)) else cast(@p2 as VARCHAR(255)) end) from table";
-			Assert.That(cmd.CommandText, Is.EqualTo(expectedCommandTxt));
-		}
-
-		[Test]
-		public void AdjustCommand_IntParametersWithinConditionalSelect_ThenParameterIsWrappedByAnIntCastStatement()
-		{
-			MakeDriver();
-			var cmd = BuildSelectCaseCommand(SqlTypeFactory.Int32);
-
-			_driver.AdjustCommand(cmd);
-
-			var expectedCommandTxt = "select (case when col = @p0 then cast(@p1 as INTEGER) else cast(@p2 as INTEGER) end) from table";
-			Assert.That(cmd.CommandText, Is.EqualTo(expectedCommandTxt));
-		}
-
-		[Test]
-		public void AdjustCommand_ParameterWithinSelectConcat_ParameterIsCasted()
-		{
-			MakeDriver();
-			var cmd = BuildSelectConcatCommand(SqlTypeFactory.GetString(255));
-
-			_driver.AdjustCommand(cmd);
-
-			var expected = "select col || cast(@p0 as VARCHAR(255)) || col from table";
-			Assert.That(cmd.CommandText, Is.EqualTo(expected));
-		}
-
-		[Test]
-		public void AdjustCommand_ParameterWithinSelectAddFunction_ParameterIsCasted()
-		{
-			MakeDriver();
-			var cmd = BuildSelectAddCommand(SqlTypeFactory.GetString(255));
-
-			_driver.AdjustCommand(cmd);
-
-			var expected = "select col + cast(@p0 as VARCHAR(255)) from table";
-			Assert.That(cmd.CommandText, Is.EqualTo(expected));
-		}
-
-		[Test]
-		public void AdjustCommand_InsertWithParamsInSelect_ParameterIsCasted()
-		{
-			MakeDriver();
-			var cmd = BuildInsertWithParamsInSelectCommand(SqlTypeFactory.Int32);
-
-			_driver.AdjustCommand(cmd);
-
-			var expected = "insert into table1 (col1, col2) select col1, cast(@p0 as INTEGER) from table2";
-			Assert.That(cmd.CommandText, Is.EqualTo(expected));
-		}
-
-		[Test]
-		public void AdjustCommand_InsertWithParamsInSelect_ParameterIsNotCasted_WhenColumnNameContainsSelect()
-		{
-			MakeDriver();
-			var cmd = BuildInsertWithParamsInSelectCommandWithSelectInColumnName(SqlTypeFactory.Int32);
-
-			_driver.AdjustCommand(cmd);
-
-			var expected = "insert into table1 (col1_select_aaa) values(@p0) from table2";
-			Assert.That(cmd.CommandText, Is.EqualTo(expected));
-		}
-
-		[Test]
-		public void AdjustCommand_InsertWithParamsInSelect_ParameterIsNotCasted_WhenColumnNameContainsWhere()
-		{
-			MakeDriver();
-			var cmd = BuildInsertWithParamsInSelectCommandWithWhereInColumnName(SqlTypeFactory.Int32);
-
-			_driver.AdjustCommand(cmd);
-
-			var expected = "insert into table1 (col1_where_aaa) values(@p0) from table2";
-			Assert.That(cmd.CommandText, Is.EqualTo(expected));
-		}
-
-		private void MakeDriver()
+		[OneTimeSetUp]
+		public void OneTimeSetup()
 		{
 			var cfg = TestConfigurationHelper.GetDefaultConfiguration();
+
 			var dlct = cfg.GetProperty("dialect");
 			if (!dlct.Contains("Firebird"))
 				Assert.Ignore("Applies only to Firebird");
 
 			_driver = new FirebirdClientDriver();
+			_driver.Configure(cfg.Properties);
 			_connectionString = cfg.GetProperty("connection.connection_string");
+		}
+
+		[Test]
+		public void ConnectionPooling_OpenThenCloseThenOpenAnotherOne_OnlyOneConnectionIsPooled()
+		{
+			_driver.ClearPool(_connectionString);
+
+			var allreadyEstablished = GetEstablishedConnections();
+
+			using (var connection1 = MakeConnection())
+			using (var connection2 = MakeConnection())
+			{
+				//open first connection
+				connection1.Open();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After first open");
+
+				//return it to the pool
+				connection1.Close();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After first close");
+
+				//open the second connection
+				connection2.Open();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After second open");
+
+				//return it to the pool
+				connection2.Close();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After second close");
+			}
+		}
+
+		[Test]
+		public void ConnectionPooling_OpenThenCloseTwoAtTheSameTime_TowConnectionsArePooled()
+		{
+			_driver.ClearPool(_connectionString);
+
+			var allreadyEstablished = GetEstablishedConnections();
+
+			using (var connection1 = MakeConnection())
+			using (var connection2 = MakeConnection())
+			{
+				//open first connection
+				connection1.Open();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 1, "After first open");
+
+				//open second one
+				connection2.Open();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 2, "After second open");
+
+				//return connection1 to the pool
+				connection1.Close();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 2, "After first close");
+
+				//return connection2 to the pool
+				connection2.Close();
+				VerifyCountOfEstablishedConnectionsIs(allreadyEstablished + 2, "After second close");
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_StringParametersWithinConditionalSelect_ThenParameterIsWrappedByAVarcharCastStatement()
+		{
+			using (var cmd = BuildSelectCaseCommand(SqlTypeFactory.GetString(255)))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expectedCommandTxt =
+					"select (case when col = @p0 then cast(@p1 as VARCHAR(4000)) else cast(@p2 as VARCHAR(4000)) end) from table";
+				Assert.That(cmd.CommandText, Is.EqualTo(expectedCommandTxt));
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_IntParametersWithinConditionalSelect_ThenParameterIsWrappedByAnIntCastStatement()
+		{
+			using (var cmd = BuildSelectCaseCommand(SqlTypeFactory.Int32))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expectedCommandTxt =
+					"select (case when col = @p0 then cast(@p1 as INTEGER) else cast(@p2 as INTEGER) end) from table";
+				Assert.That(cmd.CommandText, Is.EqualTo(expectedCommandTxt));
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_ParameterWithinSelectConcat_ParameterIsCasted()
+		{
+			using (var cmd = BuildSelectConcatCommand(SqlTypeFactory.GetString(255)))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expected = "select col || cast(@p0 as VARCHAR(4000)) || col from table";
+				Assert.That(cmd.CommandText, Is.EqualTo(expected));
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_ParameterWithinSelectAddFunction_ParameterIsCasted()
+		{
+			using (var cmd = BuildSelectAddCommand(SqlTypeFactory.GetString(255)))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expected = "select col + cast(@p0 as VARCHAR(4000)) from table";
+				Assert.That(cmd.CommandText, Is.EqualTo(expected));
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_InsertWithParamsInSelect_ParameterIsCasted()
+		{
+			using (var cmd = BuildInsertWithParamsInSelectCommand(SqlTypeFactory.Int32))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expected = "insert into table1 (col1, col2) select col1, cast(@p0 as INTEGER) from table2";
+				Assert.That(cmd.CommandText, Is.EqualTo(expected));
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_InsertWithParamsInSelect_ParameterIsNotCasted_WhenColumnNameContainsSelect()
+		{
+			using (var cmd = BuildInsertWithParamsInSelectCommandWithSelectInColumnName(SqlTypeFactory.Int32))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expected = "insert into table1 (col1_select_aaa) values(@p0) from table2";
+				Assert.That(cmd.CommandText, Is.EqualTo(expected));
+			}
+		}
+
+		[Test]
+		public void AdjustCommand_InsertWithParamsInSelect_ParameterIsNotCasted_WhenColumnNameContainsWhere()
+		{
+			using (var cmd = BuildInsertWithParamsInSelectCommandWithWhereInColumnName(SqlTypeFactory.Int32))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expected = "insert into table1 (col1_where_aaa) values(@p0) from table2";
+				Assert.That(cmd.CommandText, Is.EqualTo(expected));
+			}
 		}
 
 		private DbConnection MakeConnection()
@@ -197,14 +200,14 @@ namespace NHibernate.Test.DriverTest
 		private DbCommand BuildSelectCaseCommand(SqlType paramType)
 		{
 			var sqlString = new SqlStringBuilder()
-					.Add("select (case when col = ")
-					.AddParameter()
-					.Add(" then ")
-					.AddParameter()
-					.Add(" else ")
-					.AddParameter()
-					.Add(" end) from table")
-					.ToSqlString();
+				.Add("select (case when col = ")
+				.AddParameter()
+				.Add(" then ")
+				.AddParameter()
+				.Add(" else ")
+				.AddParameter()
+				.Add(" end) from table")
+				.ToSqlString();
 
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType, paramType, paramType });
 		}
@@ -212,12 +215,12 @@ namespace NHibernate.Test.DriverTest
 		private DbCommand BuildSelectConcatCommand(SqlType paramType)
 		{
 			var sqlString = new SqlStringBuilder()
-					.Add("select col || ")
-					.AddParameter()
-					.Add(" || ")
-					.Add("col ")
-					.Add("from table")
-					.ToSqlString();
+				.Add("select col || ")
+				.AddParameter()
+				.Add(" || ")
+				.Add("col ")
+				.Add("from table")
+				.ToSqlString();
 
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType });
 		}
@@ -225,10 +228,10 @@ namespace NHibernate.Test.DriverTest
 		private DbCommand BuildSelectAddCommand(SqlType paramType)
 		{
 			var sqlString = new SqlStringBuilder()
-					.Add("select col + ")
-					.AddParameter()
-					.Add(" from table")
-					.ToSqlString();
+				.Add("select col + ")
+				.AddParameter()
+				.Add(" from table")
+				.ToSqlString();
 
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType });
 		}
@@ -244,6 +247,7 @@ namespace NHibernate.Test.DriverTest
 
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType });
 		}
+
 		private DbCommand BuildInsertWithParamsInSelectCommandWithSelectInColumnName(SqlType paramType)
 		{
 			var sqlString = new SqlStringBuilder()
@@ -256,7 +260,7 @@ namespace NHibernate.Test.DriverTest
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType });
 		}
 
-        private DbCommand BuildInsertWithParamsInSelectCommandWithWhereInColumnName(SqlType paramType)
+		private DbCommand BuildInsertWithParamsInSelectCommandWithWhereInColumnName(SqlType paramType)
 		{
 			var sqlString = new SqlStringBuilder()
 				.Add("insert into table1 (col1_where_aaa) ")

--- a/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
@@ -76,7 +76,7 @@ namespace NHibernate.Test.DriverTest
 		public void AdjustCommand_StringParametersWithinConditionalSelect_ThenParameterIsWrappedByAVarcharCastStatement()
 		{
 			MakeDriver();
-			var cmd = BuildSelectCaseCommand(SqlTypeFactory.GetString(0));
+			var cmd = BuildSelectCaseCommand(SqlTypeFactory.GetString(255));
 
 			_driver.AdjustCommand(cmd);
 
@@ -100,7 +100,7 @@ namespace NHibernate.Test.DriverTest
 		public void AdjustCommand_ParameterWithinSelectConcat_ParameterIsCasted()
 		{
 			MakeDriver();
-			var cmd = BuildSelectConcatCommand(SqlTypeFactory.GetString(0));
+			var cmd = BuildSelectConcatCommand(SqlTypeFactory.GetString(255));
 
 			_driver.AdjustCommand(cmd);
 
@@ -112,7 +112,7 @@ namespace NHibernate.Test.DriverTest
 		public void AdjustCommand_ParameterWithinSelectAddFunction_ParameterIsCasted()
 		{
 			MakeDriver();
-			var cmd = BuildSelectAddCommand(SqlTypeFactory.GetString(0));
+			var cmd = BuildSelectAddCommand(SqlTypeFactory.GetString(255));
 
 			_driver.AdjustCommand(cmd);
 

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -204,6 +204,24 @@ namespace NHibernate.Cfg
 		public const string QueryModelRewriterFactory = "query.query_model_rewriter_factory";
 
 		/// <summary>
+		/// Set the default length used in casting when the target type is length bound and
+		/// does not specify it. <c>4000</c> by default, automatically trim down according to dialect type registration.
+		/// </summary>
+		public const string QueryDefaultCastLength = "query.default_cast_length";
+
+		/// <summary>
+		/// Set the default precision used in casting when the target type is decimal and
+		/// does not specify it. <c>28</c> by default, automatically trim down according to dialect type registration.
+		/// </summary>
+		public const string QueryDefaultCastPrecision = "query.default_cast_precision";
+
+		/// <summary>
+		/// Set the default scale used in casting when the target type is decimal and
+		/// does not specify it. <c>10</c> by default, automatically trim down according to dialect type registration.
+		/// </summary>
+		public const string QueryDefaultCastScale = "query.default_cast_scale";
+
+		/// <summary>
 		/// This may need to be set to 3 if you are using the OdbcDriver with MS SQL Server 2008+.
 		/// </summary>
 		public const string OdbcDateTimeScale = "odbc.explicit_datetime_scale";

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -39,7 +39,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "TIMESTAMP");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "DECIMAL(19, $l)");
+			// DB2 max precision is 31, but .Net is 28-29 anyway.
+			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INTEGER");

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -215,17 +215,10 @@ namespace NHibernate.Dialect
 		{
 			if (sqlType.LengthDefined || sqlType.PrecisionDefined || sqlType.ScaleDefined)
 			{
-				string resultWithLength = _typeNames.Get(sqlType.DbType, sqlType.Length, sqlType.Precision, sqlType.Scale);
-				if (resultWithLength != null) return resultWithLength;
+				return _typeNames.Get(sqlType.DbType, sqlType.Length, sqlType.Precision, sqlType.Scale);
 			}
 
-			string result = _typeNames.Get(sqlType.DbType);
-			if (result == null)
-			{
-				throw new HibernateException(string.Format("No default type mapping for SqlType {0}", sqlType));
-			}
-
-			return result;
+			return _typeNames.Get(sqlType.DbType);
 		}
 
 		/// <summary>
@@ -239,12 +232,7 @@ namespace NHibernate.Dialect
 		/// <returns>The database type name used by ddl.</returns>
 		public virtual string GetTypeName(SqlType sqlType, int length, int precision, int scale)
 		{
-			string result = _typeNames.Get(sqlType.DbType, length, precision, scale);
-			if (result == null)
-			{
-				throw new HibernateException(string.Format("No type mapping for SqlType {0} of length {1}", sqlType, length));
-			}
-			return result;
+			return _typeNames.Get(sqlType.DbType, length, precision, scale);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -275,9 +275,11 @@ namespace NHibernate.Dialect
 			switch (sqlType.DbType)
 			{
 				case DbType.Decimal:
+				// Oracle dialect defines precision and scale for double, because it uses number instead of binary_double.
+				case DbType.Double:
 					// We cannot know if the user needs its digit after or before the dot, so use a configurable
 					// default.
-					return castTypeNames.Get(DbType.Decimal, 0, DefaultCastPrecision, DefaultCastScale);
+					return castTypeNames.Get(sqlType.DbType, 0, DefaultCastPrecision, DefaultCastScale);
 				case DbType.DateTime:
 				case DbType.DateTime2:
 				case DbType.DateTimeOffset:

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -6,7 +6,6 @@ using NHibernate.Dialect.Function;
 using NHibernate.Dialect.Schema;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
-using NHibernate.SqlTypes;
 using NHibernate.Type;
 using Environment = NHibernate.Cfg.Environment;
 
@@ -30,12 +29,6 @@ namespace NHibernate.Dialect
 	/// </remarks>
 	public class FirebirdDialect : Dialect
 	{
-		#region Fields
-
-		private const int MAX_DECIMAL_PRECISION = 18;
-
-		#endregion
-
 		public FirebirdDialect()
 		{
 			RegisterKeywords();
@@ -47,23 +40,6 @@ namespace NHibernate.Dialect
 		public override string AddColumnString
 		{
 			get { return "add"; }
-		}
-
-		public override string GetTypeName(SqlType sqlType)
-		{
-			if (IsUnallowedDecimal(sqlType.DbType, sqlType.Precision))
-				return base.GetTypeName(new SqlType(sqlType.DbType, MAX_DECIMAL_PRECISION, sqlType.Scale));
-
-			return base.GetTypeName(sqlType);
-		}
-
-		public override string GetTypeName(SqlType sqlType, int length, int precision, int scale)
-		{
-			var fbDecimalPrecision = precision;
-			if (IsUnallowedDecimal(sqlType.DbType, precision))
-				fbDecimalPrecision = MAX_DECIMAL_PRECISION;
-
-			return base.GetTypeName(sqlType, length, fbDecimalPrecision, scale);
 		}
 
 		public override string GetSelectSequenceNextValString(string sequenceName)
@@ -542,11 +518,6 @@ namespace NHibernate.Dialect
 			RegisterFunction("sinh", new StandardSQLFunction("sinh", NHibernateUtil.Double));
 			RegisterFunction("tan", new StandardSQLFunction("tan", NHibernateUtil.Double));
 			RegisterFunction("tanh", new StandardSQLFunction("tanh", NHibernateUtil.Double));
-		}
-
-		private static bool IsUnallowedDecimal(DbType dbType, int precision)
-		{
-			return dbType == DbType.Decimal && precision > MAX_DECIMAL_PRECISION;
 		}
 
 		#region Informational metadata

--- a/src/NHibernate/Dialect/GenericDialect.cs
+++ b/src/NHibernate/Dialect/GenericDialect.cs
@@ -9,25 +9,31 @@ namespace NHibernate.Dialect
 	public class GenericDialect : Dialect
 	{
 		/// <summary></summary>
-		public GenericDialect() : base()
+		public GenericDialect()
 		{
-			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR($l)");
-			RegisterColumnType(DbType.AnsiString, "VARCHAR($l)");
-			RegisterColumnType(DbType.Binary, "VARBINARY($l)");
+			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR(255)");
+			RegisterColumnType(DbType.AnsiStringFixedLength, 8000, "CHAR($l)");
+			RegisterColumnType(DbType.AnsiString, "VARCHAR(255)");
+			RegisterColumnType(DbType.AnsiString, 8000, "VARCHAR($l)");
+			RegisterColumnType(DbType.Binary, "VARBINARY(255)");
+			RegisterColumnType(DbType.Binary, 8000, "VARBINARY($l)");
 			RegisterColumnType(DbType.Boolean, "BIT");
 			RegisterColumnType(DbType.Byte, "TINYINT");
 			RegisterColumnType(DbType.Currency, "MONEY");
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "DATETIME");
-			RegisterColumnType(DbType.Decimal, "DECIMAL(19, $l)");
+			RegisterColumnType(DbType.Decimal, "DECIMAL(19, 5)");
+			RegisterColumnType(DbType.Decimal, 19, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "DOUBLE PRECISION");
 			RegisterColumnType(DbType.Guid, "UNIQUEIDENTIFIER");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INT");
 			RegisterColumnType(DbType.Int64, "BIGINT");
 			RegisterColumnType(DbType.Single, "REAL");
-			RegisterColumnType(DbType.StringFixedLength, "NCHAR($l)");
-			RegisterColumnType(DbType.String, "NVARCHAR($l)");
+			RegisterColumnType(DbType.StringFixedLength, "NCHAR(255)");
+			RegisterColumnType(DbType.StringFixedLength, 4000, "NCHAR($l)");
+			RegisterColumnType(DbType.String, "NVARCHAR(255)");
+			RegisterColumnType(DbType.String, 4000, "NVARCHAR($l)");
 			RegisterColumnType(DbType.Time, "TIME");
 		}
 

--- a/src/NHibernate/Dialect/InformixDialect.cs
+++ b/src/NHibernate/Dialect/InformixDialect.cs
@@ -36,7 +36,8 @@ namespace NHibernate.Dialect
 		/// <summary></summary>
 		public InformixDialect()
 		{
-			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR($l)");
+			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR(255)");
+			RegisterColumnType(DbType.AnsiStringFixedLength, 255, "CHAR($l)");
 			RegisterColumnType(DbType.AnsiString, 255, "VARCHAR($l)");
 			RegisterColumnType(DbType.AnsiString, 32739, "LVARCHAR($l)");
 			RegisterColumnType(DbType.AnsiString, 2147483647, "TEXT");
@@ -49,14 +50,16 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "datetime year to fraction(5)");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19, 5)");
-			RegisterColumnType(DbType.Decimal, 19, "DECIMAL($p, $s)");
+			// Informix max precision is 32, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INTEGER");
 			RegisterColumnType(DbType.Int64, "BIGINT");
 			RegisterColumnType(DbType.Single, "SmallFloat");
 			RegisterColumnType(DbType.Time, "datetime hour to second");
-			RegisterColumnType(DbType.StringFixedLength, "CHAR($l)");
+			RegisterColumnType(DbType.StringFixedLength, "CHAR(255)");
+			RegisterColumnType(DbType.StringFixedLength, 255, "CHAR($l)");
 			RegisterColumnType(DbType.String, 255, "VARCHAR($l)");
 			RegisterColumnType(DbType.String, 32739, "LVARCHAR($l)");
 			RegisterColumnType(DbType.String, 2147483647, "TEXT");

--- a/src/NHibernate/Dialect/IngresDialect.cs
+++ b/src/NHibernate/Dialect/IngresDialect.cs
@@ -36,7 +36,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Date, "date");
 			RegisterColumnType(DbType.DateTime, "timestamp");
 			RegisterColumnType(DbType.Decimal, "decimal(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "decimal(18, $l)");
+			// Ingres max precision is 31, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "decimal($p, $s)");
 			RegisterColumnType(DbType.Double, "float8");
 			RegisterColumnType(DbType.Int16, "int2");
 			RegisterColumnType(DbType.Int32, "int4");

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -373,7 +373,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Byte, "TINYINT");
 			RegisterColumnType(DbType.Currency, "MONEY");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "DECIMAL($p, $s)");
+			// SQL Server max precision is 38, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "FLOAT(53)");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INT");

--- a/src/NHibernate/Dialect/MsSqlCeDialect.cs
+++ b/src/NHibernate/Dialect/MsSqlCeDialect.cs
@@ -150,7 +150,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Date, "DATETIME");
 			RegisterColumnType(DbType.DateTime, "DATETIME");
 			RegisterColumnType(DbType.Decimal, "NUMERIC(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "NUMERIC($p, $s)");
+			// SQL Server CE max precision is 38, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "NUMERIC($p, $s)");
 			RegisterColumnType(DbType.Double, "FLOAT");
 			RegisterColumnType(DbType.Guid, "UNIQUEIDENTIFIER");
 			RegisterColumnType(DbType.Int16, "SMALLINT");

--- a/src/NHibernate/Dialect/MySQL5Dialect.cs
+++ b/src/NHibernate/Dialect/MySQL5Dialect.cs
@@ -8,7 +8,8 @@ namespace NHibernate.Dialect
 		public MySQL5Dialect()
 		{
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "DECIMAL($p, $s)");
+			// My SQL supports precision up to 65, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Guid, "BINARY(16)");
 		}
 
@@ -17,7 +18,7 @@ namespace NHibernate.Dialect
 			// MySql 5 also supports DECIMAL as a cast type target
 			// http://dev.mysql.com/doc/refman/5.0/en/cast-functions.html
 			RegisterCastType(DbType.Decimal, "DECIMAL(19,5)");
-			RegisterCastType(DbType.Decimal, 19, "DECIMAL($p, $s)");
+			RegisterCastType(DbType.Decimal, 28, "DECIMAL($p, $s)");
 			RegisterCastType(DbType.Double, "DECIMAL(19,5)");
 			RegisterCastType(DbType.Single, "DECIMAL(19,5)");
 			RegisterCastType(DbType.Guid, "BINARY(16)");

--- a/src/NHibernate/Dialect/MySQLDialect.cs
+++ b/src/NHibernate/Dialect/MySQLDialect.cs
@@ -4,7 +4,6 @@ using System.Data.Common;
 using System.Text;
 using NHibernate.Dialect.Function;
 using NHibernate.Dialect.Schema;
-using NHibernate.Mapping;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
 using NHibernate.Util;
@@ -64,7 +63,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.String, 16777215, "MEDIUMTEXT");
 			//todo: future: add compatibility with decimal???
 			//An unpacked fixed-point number. Behaves like a CHAR column; 
-			//ìunpackedî means the number is stored as a string, using one character for each digit of the value.
+			//‚Äúunpacked‚Äù means the number is stored as a string, using one character for each digit of the value.
 			//M is the total number of digits and D is the number of digits after the decimal point
 			//DECIMAL[(M[,D])] [UNSIGNED] [ZEROFILL]
 
@@ -494,15 +493,8 @@ namespace NHibernate.Dialect
 		/// </summary>
 		/// <param name="sqlType">The <see cref="SqlType"/> typecode </param>
 		/// <returns> The database type name </returns>
-		public override string GetCastTypeName(SqlType sqlType)
-		{
-			string result = castTypeNames.Get(sqlType.DbType, Column.DefaultLength, Column.DefaultPrecision, Column.DefaultScale);
-			if (result == null)
-			{
-				throw new HibernateException(string.Format("No CAST() type mapping for SqlType {0}", sqlType));
-			}
-			return result;
-		}
+		public override string GetCastTypeName(SqlType sqlType) =>
+			GetCastTypeName(sqlType, castTypeNames);
 
 		public override long TimestampResolutionInTicks
 		{

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -185,9 +185,10 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Currency, "NUMBER(20,2)");
 			RegisterColumnType(DbType.Single, "FLOAT(24)");
 			RegisterColumnType(DbType.Double, "DOUBLE PRECISION");
-			RegisterColumnType(DbType.Double, 19, "NUMBER($p,$s)");
+			// Oracle max precision is 39-40, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Double, 28, "NUMBER($p,$s)");
 			RegisterColumnType(DbType.Decimal, "NUMBER(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "NUMBER($p,$s)");
+			RegisterColumnType(DbType.Decimal, 28, "NUMBER($p,$s)");
 		}
 
 		protected virtual void RegisterDateTimeTypeMappings()

--- a/src/NHibernate/Dialect/OracleLiteDialect.cs
+++ b/src/NHibernate/Dialect/OracleLiteDialect.cs
@@ -43,7 +43,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "TIMESTAMP(4)");
 			RegisterColumnType(DbType.Decimal, "NUMBER(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "NUMBER(19, $l)");
+			// Oracle max precision is 39-40, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "NUMBER($p, $s)");
 			// having problems with both ODP and OracleClient from MS not being able
 			// to read values out of a field that is DOUBLE PRECISION
 			RegisterColumnType(DbType.Double, "DOUBLE PRECISION"); //"FLOAT(53)" );

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -42,7 +42,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Byte, "int2");
 			RegisterColumnType(DbType.Currency, "decimal(16,4)");
 			RegisterColumnType(DbType.Decimal, "decimal(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "decimal($p, $s)");
+			// PostgreSQL max precision is unlimited, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "decimal($p, $s)");
 			RegisterColumnType(DbType.Double, "float8");
 			RegisterColumnType(DbType.Int16, "int2");
 			RegisterColumnType(DbType.Int32, "int4");

--- a/src/NHibernate/Dialect/SybaseASA9Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASA9Dialect.cs
@@ -51,7 +51,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "TIMESTAMP");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(18,5)"); // NUMERIC(18,5) is equivalent to DECIMAL(18,5)
-			RegisterColumnType(DbType.Decimal, 18, "DECIMAL(18,$l)");
+			// Sybase max precision is 38, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p,$s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Guid, "CHAR(16)");
 			RegisterColumnType(DbType.Int16, "SMALLINT");

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -92,7 +92,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Decimal, "NUMERIC(19,5)"); // Precision ranges from 0-127
 			// Anywhere max precision is 127, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 38, "NUMERIC($p, $s)"); // Precision ranges from 0-127
+			RegisterColumnType(DbType.Decimal, 28, "NUMERIC($p, $s)"); // Precision ranges from 0-127
 		}
 
 		protected virtual void RegisterDateTimeTypeMappings()

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -91,7 +91,8 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Single, "REAL");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Decimal, "NUMERIC(19,5)"); // Precision ranges from 0-127
-			RegisterColumnType(DbType.Decimal, 19, "NUMERIC($p, $s)"); // Precision ranges from 0-127
+			// Anywhere max precision is 127, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 38, "NUMERIC($p, $s)"); // Precision ranges from 0-127
 		}
 
 		protected virtual void RegisterDateTimeTypeMappings()

--- a/src/NHibernate/Dialect/TypeNames.cs
+++ b/src/NHibernate/Dialect/TypeNames.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using NHibernate.Util;
 
 namespace NHibernate.Dialect
@@ -56,10 +57,9 @@ namespace NHibernate.Dialect
 		/// <returns>the default type name associated with the specified key</returns>
 		public string Get(DbType typecode)
 		{
-			string result;
-			if (!defaults.TryGetValue(typecode, out result))
+			if (!defaults.TryGetValue(typecode, out var result))
 			{
-				throw new ArgumentException("Dialect does not support DbType." + typecode, "typecode");
+				throw new ArgumentException("Dialect does not support DbType." + typecode, nameof(typecode));
 			}
 			return result;
 		}
@@ -72,15 +72,18 @@ namespace NHibernate.Dialect
 		/// <param name="scale">the SQL scale </param>
 		/// <param name="precision">the SQL precision </param>
 		/// <returns>
-		/// The associated name with smallest capacity >= size (or scale for date time types) if available,
-		/// otherwise the default type name.
+		/// The associated name with smallest capacity >= size (or precision for decimal, or scale for date time types)
+		/// if available, otherwise the default type name.
 		/// </returns>
 		public string Get(DbType typecode, int size, int precision, int scale)
 		{
 			weighted.TryGetValue(typecode, out var map);
 			if (map != null && map.Count > 0)
 			{
-				var requiredCapacity = IsScaleType(typecode) ? scale : size;
+				var isPrecisionType = IsPrecisionType(typecode);
+				var requiredCapacity = isPrecisionType
+					? precision
+					: IsScaleType(typecode) ? scale : size;
 				foreach (var entry in map)
 				{
 					if (requiredCapacity <= entry.Key)
@@ -88,14 +91,27 @@ namespace NHibernate.Dialect
 						return Replace(entry.Value, size, precision, scale);
 					}
 				}
+				if (isPrecisionType && precision != 0)
+				{
+					// The default is usually not the max for precision type, fallback to last entry instead.
+					var maxEntry = map.Last();
+					var adjustedPrecision = maxEntry.Key;
+					// Reduce the scale (most databases restrict scale to be less or equal to precision)
+					// For a proportionnal reduction, we could use
+					// Math.Min((int) Math.Round(scale * adjustedPrecision / (double) precision), adjustedPrecision);
+					// But if the type is used for storing amounts, this may cause losing the ability to store cents...
+					// So better just reduce as few as possible.
+					var adjustedScale = Math.Min(scale, adjustedPrecision);
+					return Replace(maxEntry.Value, size, adjustedPrecision, adjustedScale);
+				}
 			}
 			//Could not find a specific type for the capacity, using the default
-			return Replace(Get(typecode), size, precision, scale);
+			return Get(typecode);
 		}
 
 		/// <summary>
-		/// For types with a simple length (or scale for date time types), this method returns the definition
-		/// for the longest registered type.
+		/// For types with a simple length (or precision for decimal, or scale for date time types), this method
+		/// returns the definition for the longest registered type.
 		/// </summary>
 		/// <param name="typecode"></param>
 		/// <returns></returns>
@@ -104,16 +120,30 @@ namespace NHibernate.Dialect
 			weighted.TryGetValue(typecode, out var map);
 			if (map != null && map.Count > 0)
 			{
+				var isPrecisionType = IsPrecisionType(typecode);
 				var isScaleType = IsScaleType(typecode);
+				var isSizeType = !isPrecisionType && !isScaleType;
 				var capacity = map.Keys[map.Count - 1];
 				return Replace(
 					map.Values[map.Count - 1],
-					isScaleType ? 0 : capacity,
-					0,
+					isSizeType ? capacity : 0,
+					isPrecisionType ? capacity : 0,
 					isScaleType ? capacity : 0);
 			}
 
 			return Get(typecode);
+		}
+
+		private static bool IsPrecisionType(DbType typecode)
+		{
+			switch (typecode)
+			{
+				case DbType.Decimal:
+				// Oracle dialect defines precision and scale for double, because it uses number instead of binary_double.
+				case DbType.Double:
+					return true;
+			}
+			return false;
 		}
 
 		private static bool IsScaleType(DbType typecode)
@@ -140,10 +170,12 @@ namespace NHibernate.Dialect
 		/// Set a type name for specified type key and capacity
 		/// </summary>
 		/// <param name="typecode">the type key</param>
-		/// <param name="capacity">the (maximum) type size/length or scale</param>
+		/// <param name="capacity">the (maximum) type size/length, precision or scale</param>
 		/// <param name="value">The associated name</param>
 		public void Put(DbType typecode, int capacity, string value)
 		{
+			if (value == null)
+				throw new ArgumentNullException(nameof(value));
 			SortedList<int, string> map;
 			if (!weighted.TryGetValue(typecode, out map))
 			{
@@ -160,7 +192,7 @@ namespace NHibernate.Dialect
 		/// <param name="value"></param>
 		public void Put(DbType typecode, string value)
 		{
-			defaults[typecode] = value;
+			defaults[typecode] = value ?? throw new ArgumentNullException(nameof(value));
 		}
 	}
 }

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -169,6 +169,30 @@
 										</xs:documentation>
 									</xs:annotation>
 								</xs:enumeration>
+								<xs:enumeration value="query.default_cast_length">
+									<xs:annotation>
+										<xs:documentation>
+											Set the default length used in casting when the target type is length bound and
+											does not specify it. 4000 by default, automatically trim down according to dialect type registration.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
+								<xs:enumeration value="query.default_cast_precision">
+									<xs:annotation>
+										<xs:documentation>
+											Set the default precision used in casting when the target type is decimal and
+											does not specify it. 28 by default, automatically trim down according to dialect type registration.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
+								<xs:enumeration value="query.default_cast_scale">
+									<xs:annotation>
+										<xs:documentation>
+											Set the default scale used in casting when the target type is decimal and
+											does not specify it. 10 by default, automatically trim down according to dialect type registration.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>


### PR DESCRIPTION
[NH-4088](https://nhibernate.jira.com/browse/NH-4088) - Dialect.GetCastTypeName is buggy

Fix TypeNames.Get for decimal capacity
 * Compare capacity against precision for precision based types
 * Fix dialects declarations for max precision
 * Fix dialects declarations for precision based types which were using length as precision or scale

Fix GetCastTypeName
 * Use type length/precision/scale when defined
 * Use maximal capacity types otherwise when it makes sens
 * Use configurable default length/precision/scale otherwise