### PR TITLE
Fixes with prepare_sql

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
@@ -9,7 +9,8 @@
 
 
 using NHibernate.Cfg;
-using NHibernate.Dialect;
+using NHibernate.Driver;
+using NHibernate.Engine;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
@@ -25,11 +26,13 @@ namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 			configuration.DataBaseIntegration(x => x.ExceptionConverter<SqlConverter>());
 		}
 
-		protected override bool AppliesTo(Dialect.Dialect dialect)
+		protected override bool AppliesTo(ISessionFactoryImplementor factory)
 		{
-			// MsSqlCe throws InvalidOperationException instead of a DbException for these tests, preventing
-			// the test SqlConverter to do its job.
-			return !(Dialect is MsSqlCeDialect);
+			// Test current implementation allows to test mmostly SQL Server. Other databases
+			// tend to (validly) send InvalidOperationException during prepare phase due to the closed
+			// connection, which get not converted. For testing other case, maybe a failure caused by a
+			// schema mismatch (like done in transaction tests) would be better.
+			return factory.ConnectionProvider.Driver is SqlClientDriver;
 		}
 
 		[Test]

--- a/src/NHibernate.Test/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
@@ -1,5 +1,6 @@
 using NHibernate.Cfg;
-using NHibernate.Dialect;
+using NHibernate.Driver;
+using NHibernate.Engine;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
@@ -14,11 +15,13 @@ namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 			configuration.DataBaseIntegration(x => x.ExceptionConverter<SqlConverter>());
 		}
 
-		protected override bool AppliesTo(Dialect.Dialect dialect)
+		protected override bool AppliesTo(ISessionFactoryImplementor factory)
 		{
-			// MsSqlCe throws InvalidOperationException instead of a DbException for these tests, preventing
-			// the test SqlConverter to do its job.
-			return !(Dialect is MsSqlCeDialect);
+			// Test current implementation allows to test mmostly SQL Server. Other databases
+			// tend to (validly) send InvalidOperationException during prepare phase due to the closed
+			// connection, which get not converted. For testing other case, maybe a failure caused by a
+			// schema mismatch (like done in transaction tests) would be better.
+			return factory.ConnectionProvider.Driver is SqlClientDriver;
 		}
 
 		[Test]

--- a/src/NHibernate/Driver/Sql2008ClientDriver.cs
+++ b/src/NHibernate/Driver/Sql2008ClientDriver.cs
@@ -2,12 +2,13 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
-using System.Linq;
 
 namespace NHibernate.Driver
 {
 	public class Sql2008ClientDriver : SqlClientDriver
 	{
+		const byte MaxTime = 5;
+
 		protected override void InitializeParameter(DbParameter dbParam, string name, SqlTypes.SqlType sqlType)
 		{
 			base.InitializeParameter(dbParam, name, sqlType);
@@ -15,6 +16,7 @@ namespace NHibernate.Driver
 			{
 				case DbType.Time:
 					((SqlParameter) dbParam).SqlDbType = SqlDbType.Time;
+					dbParam.Size = MaxTime;
 					break;
 				case DbType.Date:
 					((SqlParameter) dbParam).SqlDbType = SqlDbType.Date;

--- a/src/NHibernate/Driver/SqlClientDriver.cs
+++ b/src/NHibernate/Driver/SqlClientDriver.cs
@@ -100,7 +100,6 @@ namespace NHibernate.Driver
 			SetVariableLengthParameterSize(dbParam, sqlType);
 		}
 
-		// Used from SqlServerCeDriver as well
 		public static void SetVariableLengthParameterSize(DbParameter dbParam, SqlType sqlType)
 		{
 			SetDefaultParameterSize(dbParam, sqlType);

--- a/src/NHibernate/Driver/SqlServerCeDriver.cs
+++ b/src/NHibernate/Driver/SqlServerCeDriver.cs
@@ -4,8 +4,6 @@ using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using NHibernate.SqlTypes;
-using NHibernate.Util;
-using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Driver
 {
@@ -25,13 +23,11 @@ namespace NHibernate.Driver
 		{
 		}
 
-		private bool prepareSql;
 		private PropertyInfo dbParamSqlDbTypeProperty;
 
 		public override void Configure(IDictionary<string, string> settings)
 		{
 			base.Configure(settings);
-			prepareSql = PropertiesHelper.GetBoolean(Environment.PrepareSql, settings, false);
 
 			using (var cmd = CreateCommand())
 			{
@@ -102,10 +98,6 @@ namespace NHibernate.Driver
 			base.InitializeParameter(dbParam, name, AdjustSqlType(sqlType));
 
 			AdjustDbParamTypeForLargeObjects(dbParam, sqlType);
-			if (prepareSql)
-			{
-				SqlClientDriver.SetVariableLengthParameterSize(dbParam, sqlType);
-		}
 		}
 
 		private static SqlType AdjustSqlType(SqlType sqlType)


### PR DESCRIPTION
prepare_sql requires all sizes/scales to be specified upfront.

~This PR to be dropped if all tests are successful.~