### PR TITLE
Switch doc generation to UTF-8.

### DIFF
--- a/doc/reference/reference.build
+++ b/doc/reference/reference.build
@@ -66,14 +66,12 @@
 			<arg file="styles/html_chunk.xsl"/>
 		</exec>
 
-		<exec program="java">
+		<exec program="java" workingdir="${build.single.dir}">
 			<arg value="-classpath" />
 			<arg>
 				<path refid="saxon.classpath"/>
 			</arg>
 			<arg value="com.icl.saxon.StyleSheet" />
-			<arg value="-o"/>
-			<arg file="${build.single.dir}/index.html"/>
 			<arg file="master.xml"/>
 			<arg file="styles/html.xsl"/>
 		</exec>

--- a/doc/reference/styles/html.xsl
+++ b/doc/reference/styles/html.xsl
@@ -23,12 +23,13 @@
                 xmlns="http://www.w3.org/TR/xhtml1/transitional"
                 exclude-result-prefixes="#default">
                 
-<xsl:import href="&db_xsl_path;/html/docbook.xsl"/>
+<xsl:import href="&db_xsl_path;/html/onechunk.xsl"/>
 
 <!--###################################################
                      HTML Settings
     ################################################### -->   
 
+    <xsl:param name="chunker.output.encoding">UTF-8</xsl:param>
     <xsl:param name="html.stylesheet">../shared/css/html.css</xsl:param>
 
     <!-- These extensions are required for table printing and other stuff -->

--- a/doc/reference/styles/html_chunk.xsl
+++ b/doc/reference/styles/html_chunk.xsl
@@ -29,6 +29,7 @@
                      HTML Settings
     ################################################### -->   
 
+    <xsl:param name="chunker.output.encoding">UTF-8</xsl:param>
     <xsl:param name="chunk.section.depth">'5'</xsl:param>
     <xsl:param name="use.id.as.filename">'1'</xsl:param>
     <xsl:param name="html.stylesheet">../shared/css/html.css</xsl:param>


### PR DESCRIPTION
Not found how to add the html 5 dtd, it seems to supports only XHTML dtd. And I have not searched for meta.