### PR TITLE
Prevent SQLite from messing with timezone offset of DateTime.

### DIFF
--- a/src/NHibernate/Driver/SQLite20Driver.cs
+++ b/src/NHibernate/Driver/SQLite20Driver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Data.Common;
 
@@ -56,6 +57,23 @@ namespace NHibernate.Driver
                 }
             }
         }
+
+		public override void AdjustCommand(DbCommand command)
+		{
+			ChangeDateTimeKindToUnspecified(command.Parameters);
+		}
+
+		private static void ChangeDateTimeKindToUnspecified(DbParameterCollection commandParameters)
+		{
+			for (var i = 0; i < commandParameters.Count; i++)
+			{
+				var commandParameter = commandParameters[i];
+				if (commandParameter.Value is DateTime dateTimeParameter)
+				{
+					commandParameter.Value = DateTime.SpecifyKind(dateTimeParameter, DateTimeKind.Unspecified);
+				}
+			}
+		}
 
 		public override bool UseNamedPrefixInSql
 		{

--- a/src/NHibernate/Type/AbstractDateTimeType.cs
+++ b/src/NHibernate/Type/AbstractDateTimeType.cs
@@ -52,7 +52,7 @@ namespace NHibernate.Type
 		/// <param name="dateValue">The <see cref="System.DateTime" /> to adjust.</param>
 		/// <returns>A <see cref="System.DateTime" />.</returns>
 		protected virtual DateTime AdjustDateTime(DateTime dateValue) =>
-			Kind == DateTimeKind.Unspecified ? dateValue : DateTime.SpecifyKind(dateValue, Kind);
+			DateTime.SpecifyKind(dateValue, Kind);
 
 		/// <inheritdoc />
 		public override object Get(DbDataReader rs, int index, ISessionImplementor session) =>


### PR DESCRIPTION
This addresses #1362 by writing all `DateTime` parameter values to SQLite as `DateTimeKind.Unspecified`.

This should work even when the connection string has `;DateTimeKind=Utc`, as the ADO.Net driver uses that to mung all `DateTime` values to Utc on reading back, irregardless of how they were saved.