### PR TITLE
Fix #1387 - Linq Sum() with ToFutureValue fails

### DIFF
--- a/src/NHibernate.Test/Async/Futures/LinqToFutureValueFixture.cs
+++ b/src/NHibernate.Test/Async/Futures/LinqToFutureValueFixture.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Linq;
 using NHibernate.Linq;
 using NUnit.Framework;
@@ -45,13 +46,72 @@ namespace NHibernate.Test.Futures
 			}
 		}
 
+		[Test(Description = "https://github.com/nhibernate/nhibernate-core/issues/1387")]
+		public async Task ToFutureValueWithSumReturnsResultAsync()
+		{
+			using (var s = OpenSession())
+			{
+				var personsSum = s.Query<Person>()
+					.Select(x => x.Id)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(personsSum);
+				Assert.NotZero(await (personsSum.GetValueAsync()));
+			}
+		}
+
+		[Test]
+		public void ToFutureValueWithSumOnEmptySetThrowsAsync()
+		{
+			using (var s = OpenSession())
+			{
+				var personsSum = s.Query<Person>()
+					.Where(x => false) // make this an empty set
+					.Select(x => x.Id)
+					.ToFutureValue(x => x.Sum());
+
+				int value;
+				Assert.ThrowsAsync<ArgumentNullException>(async () => value = await (personsSum.GetValueAsync()));
+			}
+		}
+
+		[Test]
+		public async Task ToFutureValueWithNullableSumReturnsResultAsync()
+		{
+			using (var s = OpenSession())
+			{
+				var ageSum = s.Query<Person>()
+					.Select(x => x.Age)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(ageSum);
+				Assert.IsNotNull(await (ageSum.GetValueAsync()));
+				Assert.NotZero((await (ageSum.GetValueAsync())).Value);
+			}
+		}
+
+		[Test]
+		public async Task ToFutureValueWithNullableSumOnEmptySetReturnsNullAsync()
+		{
+			using (var s = OpenSession())
+			{
+				var ageSum = s.Query<Person>()
+					.Where(x => false) // make this an empty set
+					.Select(x => x.Age)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(ageSum);
+				Assert.IsNull(await (ageSum.GetValueAsync()));
+			}
+		}
+
 		protected override void OnSetUp()
 		{
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
-				session.Save(new Person {Name = "Test1"});
-				session.Save(new Person {Name = "Test2"});
+				session.Save(new Person {Name = "Test1", Age = 20});
+				session.Save(new Person {Name = "Test2", Age = 30});
 				session.Save(new Person {Name = "Test3"});
 				session.Save(new Person {Name = "Test4"});
 				transaction.Commit();

--- a/src/NHibernate.Test/Futures/LinqFutureFixture.cs
+++ b/src/NHibernate.Test/Futures/LinqFutureFixture.cs
@@ -360,36 +360,5 @@ namespace NHibernate.Test.Futures
 				}
 			}
 		}
-
-		[Test(Description = "https://github.com/nhibernate/nhibernate-core/issues/1387")]
-		public void ToFutureValueWithSumReturnsResult()
-		{
-			// Prepare data
-			using (var s = OpenSession())
-			using (var tx = s.BeginTransaction())
-			{
-				s.Save(new Person());
-				s.Save(new Person());
-				tx.Commit();
-			}
-
-			using (var s = OpenSession())
-			{
-				var personsSum = s.Query<Person>()
-					.Select(x => x.Id)
-					.ToFutureValue(x => x.Sum());
-
-				Assert.IsNotNull(personsSum);
-				Assert.NotZero(personsSum.Value);
-			}
-
-			// Cleanup
-			using (var s = OpenSession())
-			using (var tx = s.BeginTransaction())
-			{
-				s.Delete("from Person");
-				tx.Commit();
-			}
-		}
 	}
 }

--- a/src/NHibernate.Test/Futures/LinqFutureFixture.cs
+++ b/src/NHibernate.Test/Futures/LinqFutureFixture.cs
@@ -360,5 +360,36 @@ namespace NHibernate.Test.Futures
 				}
 			}
 		}
+
+		[Test(Description = "https://github.com/nhibernate/nhibernate-core/issues/1387")]
+		public void ToFutureValueWithSumReturnsResult()
+		{
+			// Prepare data
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Save(new Person());
+				s.Save(new Person());
+				tx.Commit();
+			}
+
+			using (var s = OpenSession())
+			{
+				var personsSum = s.Query<Person>()
+					.Select(x => x.Id)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(personsSum);
+				Assert.NotZero(personsSum.Value);
+			}
+
+			// Cleanup
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Delete("from Person");
+				tx.Commit();
+			}
+		}
 	}
 }

--- a/src/NHibernate.Test/Futures/LinqToFutureValueFixture.cs
+++ b/src/NHibernate.Test/Futures/LinqToFutureValueFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using NHibernate.Linq;
 using NUnit.Framework;
@@ -48,13 +49,58 @@ namespace NHibernate.Test.Futures
 			}
 		}
 
+		[Test]
+		public void ToFutureValueWithSumOnEmptySetThrows()
+		{
+			using (var s = OpenSession())
+			{
+				var personsSum = s.Query<Person>()
+					.Where(x => false) // make this an empty set
+					.Select(x => x.Id)
+					.ToFutureValue(x => x.Sum());
+
+				int value;
+				Assert.Throws<ArgumentNullException>(() => value = personsSum.Value);
+			}
+		}
+
+		[Test]
+		public void ToFutureValueWithNullableSumReturnsResult()
+		{
+			using (var s = OpenSession())
+			{
+				var ageSum = s.Query<Person>()
+					.Select(x => x.Age)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(ageSum);
+				Assert.IsNotNull(ageSum.Value);
+				Assert.NotZero(ageSum.Value.Value);
+			}
+		}
+
+		[Test]
+		public void ToFutureValueWithNullableSumOnEmptySetReturnsNull()
+		{
+			using (var s = OpenSession())
+			{
+				var ageSum = s.Query<Person>()
+					.Where(x => false) // make this an empty set
+					.Select(x => x.Age)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(ageSum);
+				Assert.IsNull(ageSum.Value);
+			}
+		}
+
 		protected override void OnSetUp()
 		{
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
-				session.Save(new Person {Name = "Test1"});
-				session.Save(new Person {Name = "Test2"});
+				session.Save(new Person {Name = "Test1", Age = 20});
+				session.Save(new Person {Name = "Test2", Age = 30});
 				session.Save(new Person {Name = "Test3"});
 				session.Save(new Person {Name = "Test4"});
 				transaction.Commit();

--- a/src/NHibernate.Test/Futures/LinqToFutureValueFixture.cs
+++ b/src/NHibernate.Test/Futures/LinqToFutureValueFixture.cs
@@ -34,6 +34,20 @@ namespace NHibernate.Test.Futures
 			}
 		}
 
+		[Test(Description = "https://github.com/nhibernate/nhibernate-core/issues/1387")]
+		public void ToFutureValueWithSumReturnsResult()
+		{
+			using (var s = OpenSession())
+			{
+				var personsSum = s.Query<Person>()
+					.Select(x => x.Id)
+					.ToFutureValue(x => x.Sum());
+
+				Assert.IsNotNull(personsSum);
+				Assert.NotZero(personsSum.Value);
+			}
+		}
+
 		protected override void OnSetUp()
 		{
 			using (var session = OpenSession())

--- a/src/NHibernate.Test/Futures/Mappings.hbm.xml
+++ b/src/NHibernate.Test/Futures/Mappings.hbm.xml
@@ -8,6 +8,7 @@
 			<generator class="native"/>
 		</id>
     <property name="Name"/>
+    <property name="Age"/>
 		<many-to-one name="Parent" />
 		<list name="Children" cascade="all">
 			<key column="parent_id" />

--- a/src/NHibernate.Test/Futures/Person.cs
+++ b/src/NHibernate.Test/Futures/Person.cs
@@ -7,6 +7,7 @@ namespace NHibernate.Test.Futures
 		private IList<Person> children = new List<Person>();
 		private IList<Person> friends = new List<Person>();
 		private int id;
+		private int? age;
 		private Person parent;
 
         public virtual string Name { get; set; }
@@ -33,6 +34,12 @@ namespace NHibernate.Test.Futures
 		{
 			get { return id; }
 			set { id = value; }
+		}
+
+		public virtual int? Age
+		{
+			get { return age; }
+			set { age = value; }
 		}
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH3850/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3850/Fixture.cs
@@ -143,11 +143,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				// This case should work because the aggregate is insensitive to ordering.
-				var result = session.Query<DomainClassGExtendedByH>()
-					.OrderBy(dc => dc.Id)
-					.Select(dc => dc.Id)
-					.Aggregate((p, n) => p + n);
-				Assert.AreEqual(10, result);
+				var query = session.Query<DomainClassGExtendedByH>()
+				                   .OrderBy(dc => dc.Id)
+				                   .Select(dc => dc.Id);
+				var result = query.Aggregate((p, n) => p + n);
+				Assert.That(result, Is.EqualTo(10));
+				var futureQuery = query.ToFutureValue(qdc => qdc.Aggregate((p, n) => p + n));
+				Assert.That(futureQuery.Value, Is.EqualTo(10), "Future");
 			}
 		}
 
@@ -159,12 +161,14 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				// This case cannot work because the aggregate is sensitive to ordering, and NHibernate currently always order polymorphic queries by class names,
 				// then only honors query ordering as secondary order criteria.
-				var result = session.Query<DomainClassGExtendedByH>()
-					.OrderByDescending(dc => dc.Id)
-					.Select(dc => dc.Id.ToString())
-					.Aggregate((p, n) => p + "," + n);
+				var query = session.Query<DomainClassGExtendedByH>()
+				                   .OrderByDescending(dc => dc.Id)
+				                   .Select(dc => dc.Id.ToString());
+				var result = query.Aggregate((p, n) => p + "," + n);
 				// Currently yields "2,1,4,3" instead.
-				Assert.AreEqual("4,3,2,1", result);
+				Assert.That(result, Is.EqualTo("4,3,2,1"));
+				var futureQuery = query.ToFutureValue(qdc => qdc.Aggregate((p, n) => p + "," + n));
+				Assert.That(futureQuery.Value, Is.EqualTo("4,3,2,1"), "Future");
 			}
 		}
 
@@ -176,10 +180,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				// This case works because the ordering accidentally matches with classes ordering.
 				// (And moreover, with current dataset, selected values are same whatever the classes.)
-				var result = session.Query<DomainClassGExtendedByH>()
-					.OrderBy(dc => dc.Id)
-					.Aggregate(new StringBuilder(), (s, dc) => s.Append(dc.Name).Append(","));
-				Assert.AreEqual(_searchName1 + "," + _searchName2 + "," + _searchName1 + "," + _searchName2 + ",", result.ToString());
+				var query = session.Query<DomainClassGExtendedByH>()
+				                    .OrderBy(dc => dc.Id);
+				var result = query.Aggregate(new StringBuilder(), (s, dc) => s.Append(dc.Name).Append(","));
+				var expectedResult = _searchName1 + "," + _searchName2 + "," + _searchName1 + "," + _searchName2 + ",";
+				Assert.That(result.ToString(), Is.EqualTo(expectedResult));
+				var futureQuery = query.ToFutureValue(qdc => qdc.Aggregate(new StringBuilder(), (s, dc) => s.Append(dc.Name).Append(",")));
+				Assert.That(futureQuery.Value.ToString(), Is.EqualTo(expectedResult), "Future");
 			}
 		}
 
@@ -190,10 +197,12 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				// This case should work because the aggregate is insensitive to ordering.
-				var result = session.Query<DomainClassGExtendedByH>()
-					.OrderBy(dc => dc.Id)
-					.Aggregate(5, (s, dc) => s + dc.Id);
-				Assert.AreEqual(15, result);
+				var query = session.Query<DomainClassGExtendedByH>()
+				                   .OrderBy(dc => dc.Id);
+				var result = query.Aggregate(5, (s, dc) => s + dc.Id);
+				Assert.That(result, Is.EqualTo(15));
+				var futureQuery = query.ToFutureValue(qdc => qdc.Aggregate(5, (s, dc) => s + dc.Id));
+				Assert.That(futureQuery.Value, Is.EqualTo(15), "Future");
 			}
 		}
 
@@ -204,7 +213,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().All(dc => dc.Name == _searchName1);
-				Assert.IsFalse(result);
+				Assert.That(result, Is.False);
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.All(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.False, "Future");
 			}
 		}
 
@@ -215,7 +226,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().All(dc => dc.Name == _searchName1);
-				Assert.IsFalse(result);
+				Assert.That(result, Is.False);
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.All(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.False, "Future");
 			}
 		}
 
@@ -226,7 +239,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().All(dc => dc.Name == _searchName1);
-				Assert.IsFalse(result);
+				Assert.That(result, Is.False);
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.All(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.False, "Future");
 			}
 		}
 
@@ -237,7 +252,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().All(dc => dc.Name == _searchName1);
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.All(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -248,7 +265,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().All(dc => dc.Name == _searchName1);
-				Assert.IsFalse(result);
+				Assert.That(result, Is.False);
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.All(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.False, "Future");
 			}
 		}
 
@@ -258,10 +277,12 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 		{
 			using (var session = OpenSession())
 			{
-				var result = session.Query<DomainClassGExtendedByH>()
-					.Where(dc => dc.Name == _searchName1)
-					.All(dc => dc.Name == _searchName1);
-				Assert.IsTrue(result);
+				var query = session.Query<DomainClassGExtendedByH>()
+				                   .Where(dc => dc.Name == _searchName1);
+				var result = query.All(dc => dc.Name == _searchName1);
+				Assert.That(result, Is.True);
+				var futureQuery = query.ToFutureValue(qdc => qdc.All(dc => dc.Name == _searchName1));
+				Assert.That(futureQuery.Value, Is.True, "Future");
 			}
 		}
 
@@ -272,7 +293,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().Any();
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.Any()).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -283,7 +306,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().Any(dc => dc.Name == _searchName1);
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -294,7 +319,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().Any();
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.Any()).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -305,7 +332,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().Any(dc => dc.Name == _searchName1);
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -316,7 +345,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().Any();
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.Any()).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -327,7 +358,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().Any(dc => dc.Name == _searchName1);
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -338,7 +371,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().Any();
-				Assert.IsFalse(result);
+				Assert.That(result, Is.False);
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.Any()).Value;
+				Assert.That(result, Is.False, "Future");
 			}
 		}
 
@@ -349,7 +384,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().Any(dc => dc.Name == _searchName1);
-				Assert.IsFalse(result);
+				Assert.That(result, Is.False);
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.False, "Future");
 			}
 		}
 
@@ -360,7 +397,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().Any();
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.Any()).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -371,7 +410,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().Any(dc => dc.Name == _searchName1);
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
@@ -382,18 +423,18 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<object>().Any();
-				Assert.IsTrue(result);
+				Assert.That(result, Is.True);
+				result = session.Query<object>().ToFutureValue(qdc => qdc.Any()).Value;
+				Assert.That(result, Is.True, "Future");
 			}
 		}
 
-		// Failing case till NH-3850 is fixed
 		[Test, Ignore("Won't fix: requires reshaping the query")]
 		public void AverageBBase()
 		{
 			Average<DomainClassBExtendedByA>(1.5m);
 		}
 
-		// Failing case till NH-3850 is fixed
 		[Test, Ignore("Won't fix: requires reshaping the query")]
 		public void AverageCBase()
 		{
@@ -414,7 +455,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			Average<DomainClassF>(null);
 		}
 
-		// Failing case till NH-3850 is fixed
 		[Test, Ignore("Won't fix: requires reshaping the query")]
 		public void AverageGBase()
 		{
@@ -428,39 +468,62 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 				var dcQuery = session.Query<DC>();
 				var integ = dcQuery.Average(dc => dc.Integer);
 				Assert.AreEqual(expectedResult, integ, "Integer average has failed");
+				var futureInteg = dcQuery.ToFutureValue(qdc => qdc.Average(dc => dc.Integer));
+				Assert.That(futureInteg.Value, Is.EqualTo(expectedResult), "Future integer average has failed");
+
 				var longInt = dcQuery.Average(dc => dc.Long);
 				Assert.AreEqual(expectedResult, longInt, "Long integer average has failed");
+				var futureLongInt = dcQuery.ToFutureValue(qdc => qdc.Average(dc => dc.Long));
+				Assert.That(futureLongInt.Value, Is.EqualTo(expectedResult), "Future long integer average has failed");
+
 				var dec = dcQuery.Average(dc => dc.Decimal);
 				Assert.AreEqual(expectedResult, dec, "Decimal average has failed");
+				var futureDec = dcQuery.ToFutureValue(qdc => qdc.Average(dc => dc.Decimal));
+				Assert.That(futureDec.Value, Is.EqualTo(expectedResult), "Future decimal average has failed");
+
 				var dbl = dcQuery.Average(dc => dc.Double);
-				Assert.AreEqual(expectedResult, dbl, "Double average has failed");
+				Assert.That(dbl.HasValue, Is.EqualTo(expectedResult.HasValue),"Double average has failed");
+				if (expectedResult.HasValue)
+					Assert.That(dbl.Value, Is.EqualTo(expectedResult).Within(0.001d), "Double average has failed");
+				var futureDbl = dcQuery.ToFutureValue(qdc => qdc.Average(dc => dc.Double));
+				Assert.That(futureDbl.Value.HasValue, Is.EqualTo(expectedResult.HasValue),"Future double average has failed");
+				if (expectedResult.HasValue)
+					Assert.That(futureDbl.Value.Value, Is.EqualTo(expectedResult).Within(0.001d), "Future double average has failed");
 
 				if (expectedResult.HasValue)
 				{
 					var nonNullableDecimal = -1m;
-					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Average(dc => dc.NonNullableDecimal); }, "Non nullable decimal average has failed");
-					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal average has failed");
+					Assert.That(() => nonNullableDecimal = dcQuery.Average(dc => dc.NonNullableDecimal), Throws.Nothing, "Non nullable decimal average has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Non nullable decimal average has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Average(dc => dc.NonNullableDecimal));
+					Assert.That(() => nonNullableDecimal = futureNonNullableDec.Value, Throws.Nothing, "Future non nullable decimal average has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Future non nullable decimal average has failed");
 				}
 				else
 				{
-					Assert.That(() => { dcQuery.Average(dc => dc.NonNullableDecimal); },
-						// After fix
-						Throws.InstanceOf<InvalidOperationException>()
-						// Before fix
-						.Or.InnerException.InstanceOf<ArgumentNullException>(),
-						"Non nullable decimal average has failed");
+					Assert.That(() => dcQuery.Average(dc => dc.NonNullableDecimal),
+					            // After fix
+					            Throws.InstanceOf<InvalidOperationException>()
+					                  // Before fix
+					                  .Or.InnerException.InstanceOf<ArgumentNullException>(),
+					            "Non nullable decimal average has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Average(dc => dc.NonNullableDecimal));
+					Assert.That(() => futureNonNullableDec.Value,
+					            Throws.InstanceOf<ArgumentNullException>(),
+					            "Future non nullable decimal average has failed");
 				}
 			}
 		}
 
-		// Failing case till NH-3850 is fixed
 		[Test, Ignore("Won't fix: requires reshaping the query")]
 		public void AverageObject()
 		{
 			using (var session = OpenSession())
 			{
 				var result = session.Query<object>().Average(o => (int?)2);
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<object>().ToFutureValue(qdc => qdc.Average(o => (int?)2)).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -471,7 +534,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().Count();
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.Count()).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -482,7 +547,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().Count(dc => dc.Name == _searchName1);
-				Assert.AreEqual(1, result);
+				Assert.That(result, Is.EqualTo(1));
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.Count(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(1), "Future");
 			}
 		}
 
@@ -493,7 +560,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().Count();
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.Count()).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -504,7 +573,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().Count(dc => dc.Name == _searchName1);
-				Assert.AreEqual(1, result);
+				Assert.That(result, Is.EqualTo(1));
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.Count(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(1), "Future");
 			}
 		}
 
@@ -515,7 +586,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().Count();
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.Count()).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -526,7 +599,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().Count(dc => dc.Name == _searchName1);
-				Assert.AreEqual(1, result);
+				Assert.That(result, Is.EqualTo(1));
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.Count(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(1), "Future");
 			}
 		}
 
@@ -537,7 +612,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().Count();
-				Assert.AreEqual(0, result);
+				Assert.That(result, Is.EqualTo(0));
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.Count()).Value;
+				Assert.That(result, Is.EqualTo(0), "Future");
 			}
 		}
 
@@ -548,7 +625,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().Count(dc => dc.Name == _searchName1);
-				Assert.AreEqual(0, result);
+				Assert.That(result, Is.EqualTo(0));
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.Count(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(0), "Future");
 			}
 		}
 
@@ -559,7 +638,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().Count();
-				Assert.AreEqual(4, result);
+				Assert.That(result, Is.EqualTo(4));
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.Count()).Value;
+				Assert.That(result, Is.EqualTo(4), "Future");
 			}
 		}
 
@@ -570,7 +651,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().Count(dc => dc.Name == _searchName1);
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.Count(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -581,7 +664,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<object>().Count();
-				Assert.AreEqual(_totalEntityCount, result);
+				Assert.That(result, Is.EqualTo(_totalEntityCount));
+				result = session.Query<object>().ToFutureValue(qdc => qdc.Count()).Value;
+				Assert.That(result, Is.EqualTo(_totalEntityCount), "Future");
 			}
 		}
 
@@ -593,9 +678,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassBExtendedByA>();
 				DomainClassBExtendedByA result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
-				Assert.IsNotNull(result);
-				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+				Assert.That(() => result = query.FirstOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>(), "Future");
 			}
 		}
 
@@ -607,10 +696,15 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassBExtendedByA>();
 				DomainClassBExtendedByA result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
-				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+				Assert.That(() => result = query.FirstOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>(), "Future");
 			}
 		}
 
@@ -622,9 +716,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassCExtendedByD>();
 				DomainClassCExtendedByD result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
-				Assert.IsNotNull(result);
-				Assert.IsInstanceOf<DomainClassCExtendedByD>(result);
+				Assert.That(() => result = query.FirstOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result, Is.TypeOf<DomainClassCExtendedByD>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result, Is.TypeOf<DomainClassCExtendedByD>(), "Future");
 			}
 		}
 
@@ -636,10 +734,15 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassCExtendedByD>();
 				DomainClassCExtendedByD result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
-				Assert.IsInstanceOf<DomainClassCExtendedByD>(result);
+				Assert.That(() => result = query.FirstOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
+				Assert.That(result, Is.TypeOf<DomainClassCExtendedByD>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
+				Assert.That(result, Is.TypeOf<DomainClassCExtendedByD>(), "Future");
 			}
 		}
 
@@ -651,9 +754,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassE>();
 				DomainClassE result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
-				Assert.IsNotNull(result);
-				Assert.IsInstanceOf<DomainClassE>(result);
+				Assert.That(() => result = query.FirstOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
 			}
 		}
 
@@ -665,10 +770,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassE>();
 				DomainClassE result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
-				Assert.IsInstanceOf<DomainClassE>(result);
+				Assert.That(() => result = query.FirstOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
 			}
 		}
 
@@ -680,8 +788,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassF>();
 				DomainClassF result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
-				Assert.IsNull(result);
+				Assert.That(() => result = query.FirstOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Null);
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Null, "Future");
 			}
 		}
 
@@ -693,8 +804,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassF>();
 				DomainClassF result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNull(result);
+				Assert.That(() => result = query.FirstOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Null);
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Null, "Future");
 			}
 		}
 
@@ -706,10 +820,15 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassGExtendedByH>();
 				DomainClassGExtendedByH result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
-				Assert.IsNotNull(result);
+				Assert.That(() => result = query.FirstOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
 				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
-				Assert.IsInstanceOf<DomainClassGExtendedByH>(result);
+				Assert.That(result, Is.TypeOf<DomainClassGExtendedByH>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
+				Assert.That(result, Is.TypeOf<DomainClassGExtendedByH>(), "Future");
 			}
 		}
 
@@ -721,11 +840,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassGExtendedByH>();
 				DomainClassGExtendedByH result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
+				Assert.That(() => result = query.FirstOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
 				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
-				Assert.IsInstanceOf<DomainClassGExtendedByH>(result);
+				Assert.That(result, Is.TypeOf<DomainClassGExtendedByH>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
+				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
+				Assert.That(result, Is.TypeOf<DomainClassGExtendedByH>(), "Future");
 			}
 		}
 
@@ -737,10 +862,15 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<object>();
 				object result = null;
-				Assert.DoesNotThrow(() => { result = query.FirstOrDefault(); });
-				Assert.IsNotNull(result);
+				Assert.That(() => result = query.FirstOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
 				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
-				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.FirstOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				// If class type assert starts failing, maybe just ignore it: order of first on polymorphic queries looks unspecified to me.
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>(), "Future");
 			}
 		}
 
@@ -751,7 +881,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().LongCount();
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.LongCount()).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -762,7 +894,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassBExtendedByA>().LongCount(dc => dc.Name == _searchName1);
-				Assert.AreEqual(1, result);
+				Assert.That(result, Is.EqualTo(1));
+				result = session.Query<DomainClassBExtendedByA>().ToFutureValue(qdc => qdc.LongCount(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(1), "Future");
 			}
 		}
 
@@ -773,7 +907,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().LongCount();
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.LongCount()).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -784,7 +920,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassCExtendedByD>().LongCount(dc => dc.Name == _searchName1);
-				Assert.AreEqual(1, result);
+				Assert.That(result, Is.EqualTo(1));
+				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.LongCount(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(1), "Future");
 			}
 		}
 
@@ -795,7 +933,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().LongCount();
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.LongCount()).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -806,7 +946,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassE>().LongCount(dc => dc.Name == _searchName1);
-				Assert.AreEqual(1, result);
+				Assert.That(result, Is.EqualTo(1));
+				result = session.Query<DomainClassE>().ToFutureValue(qdc => qdc.LongCount(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(1), "Future");
 			}
 		}
 
@@ -817,7 +959,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().LongCount();
-				Assert.AreEqual(0, result);
+				Assert.That(result, Is.EqualTo(0));
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.LongCount()).Value;
+				Assert.That(result, Is.EqualTo(0), "Future");
 			}
 		}
 
@@ -828,7 +972,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassF>().LongCount(dc => dc.Name == _searchName1);
-				Assert.AreEqual(0, result);
+				Assert.That(result, Is.EqualTo(0));
+				result = session.Query<DomainClassF>().ToFutureValue(qdc => qdc.LongCount(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(0), "Future");
 			}
 		}
 
@@ -839,7 +985,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().LongCount();
-				Assert.AreEqual(4, result);
+				Assert.That(result, Is.EqualTo(4));
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.LongCount()).Value;
+				Assert.That(result, Is.EqualTo(4), "Future");
 			}
 		}
 
@@ -850,7 +998,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<DomainClassGExtendedByH>().LongCount(dc => dc.Name == _searchName1);
-				Assert.AreEqual(2, result);
+				Assert.That(result, Is.EqualTo(2));
+				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.LongCount(dc => dc.Name == _searchName1)).Value;
+				Assert.That(result, Is.EqualTo(2), "Future");
 			}
 		}
 
@@ -861,7 +1011,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<object>().LongCount();
-				Assert.AreEqual(_totalEntityCount, result);
+				Assert.That(result, Is.EqualTo(_totalEntityCount));
+				result = session.Query<object>().ToFutureValue(qdc => qdc.LongCount()).Value;
+				Assert.That(result, Is.EqualTo(_totalEntityCount), "Future");
 			}
 		}
 
@@ -906,45 +1058,74 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var dcQuery = session.Query<DC>();
 				var name = dcQuery.Max(dc => dc.Name);
-				Assert.AreEqual(expectedResult.HasValue ? _searchName2 : null, name, "String max has failed");
+				Assert.That(name, Is.EqualTo(expectedResult.HasValue ? _searchName2 : null), "String max has failed");
+				var futureName = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.Name));
+				Assert.That(futureName.Value, Is.EqualTo(expectedResult.HasValue ? _searchName2 : null), "Future string max has failed");
+
 				var integ = dcQuery.Max(dc => dc.Integer);
-				Assert.AreEqual(expectedResult, integ, "Integer max has failed");
+				Assert.That(integ, Is.EqualTo(expectedResult), "Integer max has failed");
+				var futureInteg = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.Integer));
+				Assert.That(futureInteg.Value, Is.EqualTo(expectedResult), "Future integer max has failed");
+
 				var longInt = dcQuery.Max(dc => dc.Long);
-				Assert.AreEqual(expectedResult, longInt, "Long integer max has failed");
+				Assert.That(longInt, Is.EqualTo(expectedResult), "Long integer max has failed");
+				var futureLongInt = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.Long));
+				Assert.That(futureLongInt.Value, Is.EqualTo(expectedResult), "Future long integer max has failed");
+
 				var dec = dcQuery.Max(dc => dc.Decimal);
-				Assert.AreEqual(expectedResult, dec, "Decimal max has failed");
+				Assert.That(dec, Is.EqualTo(expectedResult), "Decimal max has failed");
+				var futureDec = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.Decimal));
+				Assert.That(futureDec.Value, Is.EqualTo(expectedResult), "Future decimal max has failed");
+
 				var dbl = dcQuery.Max(dc => dc.Double);
-				Assert.AreEqual(expectedResult.HasValue, dbl.HasValue, "Double max has failed");
+				Assert.That(dbl.HasValue, Is.EqualTo(expectedResult.HasValue),"Double max has failed");
 				if (expectedResult.HasValue)
-					Assert.AreEqual(expectedResult.Value, dbl.Value, 0.001d, "Double max has failed");
+					Assert.That(dbl.Value, Is.EqualTo(expectedResult).Within(0.001d), "Double max has failed");
+				var futureDbl = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.Double));
+				Assert.That(futureDbl.Value.HasValue, Is.EqualTo(expectedResult.HasValue),"Future double max has failed");
+				if (expectedResult.HasValue)
+					Assert.That(futureDbl.Value.Value, Is.EqualTo(expectedResult).Within(0.001d), "Future double max has failed");
 
 				var date = dcQuery.Max(dc => dc.DateTime);
 				var dateWithOffset = dcQuery.Max(dc => dc.DateTimeOffset);
+				var futureDate = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.DateTime));
+				var futureDateWithOffset = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.DateTimeOffset));
 				if (expectedResult.HasValue)
 				{
-					Assert.Greater(date, _testDate, "DateTime max has failed");
-					Assert.Greater(dateWithOffset, _testDateWithOffset, "DateTimeOffset max has failed");
+					Assert.That(date, Is.GreaterThan(_testDate), "DateTime max has failed");
+					Assert.That(dateWithOffset, Is.GreaterThan(_testDateWithOffset), "DateTimeOffset max has failed");
+					Assert.That(futureDate.Value, Is.GreaterThan(_testDate), "Future DateTime max has failed");
+					Assert.That(futureDateWithOffset.Value, Is.GreaterThan(_testDateWithOffset), "Future DateTimeOffset max has failed");
 				}
 				else
 				{
-					Assert.Null(date, "DateTime max has failed");
-					Assert.Null(dateWithOffset, "DateTimeOffset max has failed");
+					Assert.That(date, Is.Null, "DateTime max has failed");
+					Assert.That(dateWithOffset, Is.Null, "DateTimeOffset max has failed");
+					Assert.That(futureDate.Value, Is.Null, "Future DateTime max has failed");
+					Assert.That(futureDateWithOffset.Value, Is.Null, "Future DateTimeOffset max has failed");
 				}
 
 				if (expectedResult.HasValue)
 				{
 					var nonNullableDecimal = -1m;
-					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Max(dc => dc.NonNullableDecimal); }, "Non nullable decimal max has failed");
-					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal max has failed");
+					Assert.That(() => nonNullableDecimal = dcQuery.Max(dc => dc.NonNullableDecimal), Throws.Nothing, "Non nullable decimal max has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Non nullable decimal max has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.NonNullableDecimal));
+					Assert.That(() => nonNullableDecimal = futureNonNullableDec.Value, Throws.Nothing, "Future non nullable decimal max has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Future non nullable decimal max has failed");
 				}
 				else
 				{
-					Assert.That(() => { dcQuery.Max(dc => dc.NonNullableDecimal); },
-						// After fix
-						Throws.InstanceOf<InvalidOperationException>()
-						// Before fix
-						.Or.InnerException.InstanceOf<ArgumentNullException>(),
-						"Non nullable decimal max has failed");
+					Assert.That(() => dcQuery.Max(dc => dc.NonNullableDecimal),
+					            // After fix
+					            Throws.InstanceOf<InvalidOperationException>()
+					                  // Before fix
+					                  .Or.InnerException.InstanceOf<ArgumentNullException>(),
+					            "Non nullable decimal max has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Max(dc => dc.NonNullableDecimal));
+					Assert.That(() => futureNonNullableDec.Value,
+					            Throws.InstanceOf<ArgumentNullException>(),
+					            "Future non nullable decimal max has failed");
 				}
 			}
 		}
@@ -990,45 +1171,74 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var dcQuery = session.Query<DC>();
 				var name = dcQuery.Min(dc => dc.Name);
-				Assert.AreEqual(expectedResult.HasValue ? _searchName1 : null, name, "String min has failed");
+				Assert.That(name, Is.EqualTo(expectedResult.HasValue ? _searchName1 : null), "String min has failed");
+				var futureName = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.Name));
+				Assert.That(futureName.Value, Is.EqualTo(expectedResult.HasValue ? _searchName1 : null), "Future string min has failed");
+
 				var integ = dcQuery.Min(dc => dc.Integer);
-				Assert.AreEqual(expectedResult, integ, "Integer min has failed");
+				Assert.That(integ, Is.EqualTo(expectedResult), "Integer min has failed");
+				var futureInteg = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.Integer));
+				Assert.That(futureInteg.Value, Is.EqualTo(expectedResult), "Future integer min has failed");
+
 				var longInt = dcQuery.Min(dc => dc.Long);
-				Assert.AreEqual(expectedResult, longInt, "Long integer min has failed");
+				Assert.That(longInt, Is.EqualTo(expectedResult), "Long integer min has failed");
+				var futureLongInt = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.Long));
+				Assert.That(futureLongInt.Value, Is.EqualTo(expectedResult), "Future long integer min has failed");
+
 				var dec = dcQuery.Min(dc => dc.Decimal);
-				Assert.AreEqual(expectedResult, dec, "Decimal min has failed");
+				Assert.That(dec, Is.EqualTo(expectedResult), "Decimal min has failed");
+				var futureDec = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.Decimal));
+				Assert.That(futureDec.Value, Is.EqualTo(expectedResult), "Future decimal min has failed");
+
 				var dbl = dcQuery.Min(dc => dc.Double);
-				Assert.AreEqual(expectedResult.HasValue, dbl.HasValue, "Double min has failed");
+				Assert.That(dbl.HasValue, Is.EqualTo(expectedResult.HasValue),"Double min has failed");
 				if (expectedResult.HasValue)
-					Assert.AreEqual(expectedResult.Value, dbl.Value, 0.001d, "Double min has failed");
+					Assert.That(dbl.Value, Is.EqualTo(expectedResult).Within(0.001d), "Double min has failed");
+				var futureDbl = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.Double));
+				Assert.That(futureDbl.Value.HasValue, Is.EqualTo(expectedResult.HasValue),"Future double min has failed");
+				if (expectedResult.HasValue)
+					Assert.That(futureDbl.Value.Value, Is.EqualTo(expectedResult).Within(0.001d), "Future double min has failed");
 
 				var date = dcQuery.Min(dc => dc.DateTime);
 				var dateWithOffset = dcQuery.Min(dc => dc.DateTimeOffset);
+				var futureDate = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.DateTime));
+				var futureDateWithOffset = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.DateTimeOffset));
 				if (expectedResult.HasValue)
 				{
-					Assert.Less(date, _testDate, "DateTime min has failed");
-					Assert.Less(dateWithOffset, _testDateWithOffset, "DateTimeOffset min has failed");
+					Assert.That(date, Is.LessThan(_testDate), "DateTime min has failed");
+					Assert.That(dateWithOffset, Is.LessThan(_testDateWithOffset), "DateTimeOffset min has failed");
+					Assert.That(futureDate.Value, Is.LessThan(_testDate), "Future DateTime min has failed");
+					Assert.That(futureDateWithOffset.Value, Is.LessThan(_testDateWithOffset), "Future DateTimeOffset min has failed");
 				}
 				else
 				{
-					Assert.Null(date, "DateTime min has failed");
-					Assert.Null(dateWithOffset, "DateTimeOffset min has failed");
+					Assert.That(date, Is.Null, "DateTime min has failed");
+					Assert.That(dateWithOffset, Is.Null, "DateTimeOffset min has failed");
+					Assert.That(futureDate.Value, Is.Null, "Future DateTime min has failed");
+					Assert.That(futureDateWithOffset.Value, Is.Null, "Future DateTimeOffset min has failed");
 				}
 
 				if (expectedResult.HasValue)
 				{
 					var nonNullableDecimal = -1m;
-					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Min(dc => dc.NonNullableDecimal); }, "Non nullable decimal min has failed");
-					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal min has failed");
+					Assert.That(() => nonNullableDecimal = dcQuery.Min(dc => dc.NonNullableDecimal), Throws.Nothing, "Non nullable decimal min has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Non nullable decimal min has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.NonNullableDecimal));
+					Assert.That(() => nonNullableDecimal = futureNonNullableDec.Value, Throws.Nothing, "Future non nullable decimal min has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Future non nullable decimal min has failed");
 				}
 				else
 				{
-					Assert.That(() => { dcQuery.Min(dc => dc.NonNullableDecimal); },
-						// After fix
-						Throws.InstanceOf<InvalidOperationException>()
-						// Before fix
-						.Or.InnerException.InstanceOf<ArgumentNullException>(),
-						"Non nullable decimal min has failed");
+					Assert.That(() => dcQuery.Min(dc => dc.NonNullableDecimal),
+					            // After fix
+					            Throws.InstanceOf<InvalidOperationException>()
+					                  // Before fix
+					                  .Or.InnerException.InstanceOf<ArgumentNullException>(),
+					            "Non nullable decimal min has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Min(dc => dc.NonNullableDecimal));
+					Assert.That(() => futureNonNullableDec.Value,
+					            Throws.InstanceOf<ArgumentNullException>(),
+					            "Future non nullable decimal min has failed");
 				}
 			}
 		}
@@ -1040,8 +1250,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var query = session.Query<DomainClassBExtendedByA>();
-				DomainClassBExtendedByA result = null;
-				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+				Assert.That(() => query.SingleOrDefault(), Throws.InvalidOperationException);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault());
+				Assert.That(() => futureQuery.Value, Throws.TargetInvocationException.And.InnerException.TypeOf<InvalidOperationException>(), "Future");
 			}
 		}
 
@@ -1053,10 +1264,15 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassBExtendedByA>();
 				DomainClassBExtendedByA result = null;
-				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
-				Assert.IsInstanceOf<DomainClassBExtendedByA>(result);
+				Assert.That(() => result = query.SingleOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
+				Assert.That(result, Is.TypeOf<DomainClassBExtendedByA>(), "Future");
 			}
 		}
 
@@ -1067,8 +1283,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var query = session.Query<DomainClassCExtendedByD>();
-				DomainClassCExtendedByD result = null;
-				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+				Assert.That(() => query.SingleOrDefault(), Throws.InvalidOperationException);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault());
+				Assert.That(() => futureQuery.Value, Throws.TargetInvocationException.And.InnerException.TypeOf<InvalidOperationException>(), "Future");
 			}
 		}
 
@@ -1080,10 +1297,15 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassCExtendedByD>();
 				DomainClassCExtendedByD result = null;
-				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
-				Assert.IsInstanceOf<DomainClassCExtendedByD>(result);
+				Assert.That(() => result = query.SingleOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
+				Assert.That(result, Is.TypeOf<DomainClassCExtendedByD>());
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
+				Assert.That(result, Is.TypeOf<DomainClassCExtendedByD>(), "Future");
 			}
 		}
 
@@ -1094,8 +1316,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var query = session.Query<DomainClassE>();
-				DomainClassE result = null;
-				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+				Assert.That(() => query.SingleOrDefault(), Throws.InvalidOperationException);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault());
+				Assert.That(() => futureQuery.Value, Throws.TargetInvocationException.And.InnerException.TypeOf<InvalidOperationException>(), "Future");
 			}
 		}
 
@@ -1107,10 +1330,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassE>();
 				DomainClassE result = null;
-				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNotNull(result);
-				Assert.AreEqual(_searchName1, result.Name);
-				Assert.IsInstanceOf<DomainClassE>(result);
+				Assert.That(() => result = query.SingleOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(result.Name, Is.EqualTo(_searchName1));
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Not.Null, "Future");
+				Assert.That(result.Name, Is.EqualTo(_searchName1), "Future");
 			}
 		}
 
@@ -1122,8 +1348,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassF>();
 				DomainClassF result = null;
-				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(); });
-				Assert.IsNull(result);
+				Assert.That(() => result = query.SingleOrDefault(), Throws.Nothing);
+				Assert.That(result, Is.Null);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault());
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Null, "Future");
 			}
 		}
 
@@ -1135,8 +1364,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var query = session.Query<DomainClassF>();
 				DomainClassF result = null;
-				Assert.DoesNotThrow(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
-				Assert.IsNull(result);
+				Assert.That(() => result = query.SingleOrDefault(dc => dc.Name == _searchName1), Throws.Nothing);
+				Assert.That(result, Is.Null);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => result = futureQuery.Value, Throws.Nothing, "Future");
+				Assert.That(result, Is.Null, "Future");
 			}
 		}
 
@@ -1147,8 +1379,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var query = session.Query<DomainClassGExtendedByH>();
-				DomainClassGExtendedByH result = null;
-				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+				Assert.That(() => query.SingleOrDefault(), Throws.InvalidOperationException);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault());
+				Assert.That(() => futureQuery.Value, Throws.TargetInvocationException.And.InnerException.TypeOf<InvalidOperationException>(), "Future");
 			}
 		}
 
@@ -1159,8 +1392,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var query = session.Query<DomainClassGExtendedByH>();
-				DomainClassGExtendedByH result = null;
-				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(dc => dc.Name == _searchName1); });
+				Assert.That(() => query.SingleOrDefault(dc => dc.Name == _searchName1), Throws.InvalidOperationException);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault(dc => dc.Name == _searchName1));
+				Assert.That(() => futureQuery.Value, Throws.TargetInvocationException.And.InnerException.TypeOf<InvalidOperationException>(), "Future");
 			}
 		}
 
@@ -1171,8 +1405,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var query = session.Query<object>();
-				object result = null;
-				Assert.Throws<InvalidOperationException>(() => { result = query.SingleOrDefault(); });
+				Assert.That(() => query.SingleOrDefault(), Throws.InvalidOperationException);
+				var futureQuery = query.ToFutureValue(qdc => qdc.SingleOrDefault());
+				Assert.That(() => futureQuery.Value, Throws.TargetInvocationException.And.InnerException.TypeOf<InvalidOperationException>(), "Future");
 			}
 		}
 
@@ -1218,7 +1453,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			using (var session = OpenSession())
 			{
 				var result = session.Query<object>().Sum(o => (int?)2);
-				Assert.AreEqual(_totalEntityCount * 2, result);
+				Assert.That(result, Is.EqualTo(_totalEntityCount * 2));
 			}
 		}
 
@@ -1228,30 +1463,50 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			{
 				var dcQuery = session.Query<DC>();
 				var integ = dcQuery.Sum(dc => dc.Integer);
-				Assert.AreEqual(expectedResult, integ, "Integer sum has failed");
+				Assert.That(integ, Is.EqualTo(expectedResult), "Integer sum has failed");
+				var futureInteg = dcQuery.ToFutureValue(qdc => qdc.Sum(dc => dc.Integer));
+				Assert.That(futureInteg.Value, Is.EqualTo(expectedResult), "Future integer sum has failed");
+
 				var longInt = dcQuery.Sum(dc => dc.Long);
-				Assert.AreEqual(expectedResult, longInt, "Long integer sum has failed");
+				Assert.That(longInt, Is.EqualTo(expectedResult), "Long integer sum has failed");
+				var futureLongInt = dcQuery.ToFutureValue(qdc => qdc.Sum(dc => dc.Long));
+				Assert.That(futureLongInt.Value, Is.EqualTo(expectedResult), "Future long integer sum has failed");
+
 				var dec = dcQuery.Sum(dc => dc.Decimal);
-				Assert.AreEqual(expectedResult, dec, "Decimal sum has failed");
+				Assert.That(dec, Is.EqualTo(expectedResult), "Decimal sum has failed");
+				var futureDec = dcQuery.ToFutureValue(qdc => qdc.Sum(dc => dc.Decimal));
+				Assert.That(futureDec.Value, Is.EqualTo(expectedResult), "Future decimal sum has failed");
+
 				var dbl = dcQuery.Sum(dc => dc.Double);
-				Assert.AreEqual(expectedResult.HasValue, dbl.HasValue, "Double sum has failed");
+				Assert.That(dbl.HasValue, Is.EqualTo(expectedResult.HasValue), "Double sum has failed");
 				if (expectedResult.HasValue)
-					Assert.AreEqual(expectedResult.Value, dbl.Value, 0.001d, "Double sum has failed");
+					Assert.That(dbl.Value, Is.EqualTo(expectedResult).Within(0.001d), "Double sum has failed");
+				var futureDbl = dcQuery.ToFutureValue(qdc => qdc.Sum(dc => dc.Double));
+				Assert.That(futureDbl.Value.HasValue, Is.EqualTo(expectedResult.HasValue), "Future double sum has failed");
+				if (expectedResult.HasValue)
+					Assert.That(futureDbl.Value.Value, Is.EqualTo(expectedResult).Within(0.001d), "Future double sum has failed");
 
 				if (expectedResult.HasValue)
 				{
 					var nonNullableDecimal = -1m;
-					Assert.DoesNotThrow(() => { nonNullableDecimal = dcQuery.Sum(dc => dc.NonNullableDecimal); }, "Non nullable decimal sum has failed");
-					Assert.AreEqual(expectedResult, nonNullableDecimal, "Non nullable decimal sum has failed");
+					Assert.That(() => nonNullableDecimal = dcQuery.Sum(dc => dc.NonNullableDecimal), Throws.Nothing, "Non nullable decimal sum has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Non nullable decimal sum has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Sum(dc => dc.NonNullableDecimal));
+					Assert.That(() => nonNullableDecimal = futureNonNullableDec.Value, Throws.Nothing, "Future non nullable decimal sum has failed");
+					Assert.That(nonNullableDecimal, Is.EqualTo(expectedResult), "Future non nullable decimal sum has failed");
 				}
 				else
 				{
-					Assert.That(() => { dcQuery.Sum(dc => dc.NonNullableDecimal); },
-						// After fix
-						Throws.InstanceOf<InvalidOperationException>()
-						// Before fix
-						.Or.InnerException.InstanceOf<ArgumentNullException>(),
-						"Non nullable decimal sum has failed");
+					Assert.That(() => dcQuery.Sum(dc => dc.NonNullableDecimal),
+					            // After fix
+					            Throws.InstanceOf<InvalidOperationException>()
+					                  // Before fix
+					                  .Or.InnerException.InstanceOf<ArgumentNullException>(),
+					            "Non nullable decimal sum has failed");
+					var futureNonNullableDec = dcQuery.ToFutureValue(qdc => qdc.Sum(dc => dc.NonNullableDecimal));
+					Assert.That(() => futureNonNullableDec.Value,
+					            Throws.InstanceOf<ArgumentNullException>(),
+					            "Future non nullable decimal sum has failed");
 				}
 			}
 		}

--- a/src/NHibernate/Async/Impl/FutureBatch.cs
+++ b/src/NHibernate/Async/Impl/FutureBatch.cs
@@ -38,8 +38,12 @@ namespace NHibernate.Impl
 
 		private async Task<IEnumerable<TResult>> GetCurrentResultAsync<TResult>(int currentIndex, CancellationToken cancellationToken)
 		{
+			return (await GetCurrentResultAsync(currentIndex, cancellationToken)).Cast<TResult>();
+		}
+		private async Task<IEnumerable> GetCurrentResultAsync(int currentIndex, CancellationToken cancellationToken)
+		{
 			cancellationToken.ThrowIfCancellationRequested();
-			return ((IList) (await (GetResultsAsync(cancellationToken)).ConfigureAwait(false))[currentIndex]).Cast<TResult>();
+			return ((IEnumerable) (await (GetResultsAsync(cancellationToken)).ConfigureAwait(false))[currentIndex]);
 		}
 		protected abstract Task<IList> GetResultsFromAsync(TMultiApproach multiApproach, CancellationToken cancellationToken);
 	}

--- a/src/NHibernate/Async/Impl/FutureBatch.cs
+++ b/src/NHibernate/Async/Impl/FutureBatch.cs
@@ -36,14 +36,16 @@ namespace NHibernate.Impl
 			return results;
 		}
 
-		private async Task<IEnumerable<TResult>> GetCurrentResultAsync<TResult>(int currentIndex, CancellationToken cancellationToken)
-		{
-			return (await GetCurrentResultAsync(currentIndex, cancellationToken)).Cast<TResult>();
-		}
-		private async Task<IEnumerable> GetCurrentResultAsync(int currentIndex, CancellationToken cancellationToken)
+		private async Task<IList> GetCurrentResultAsync(int currentIndex, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			return ((IEnumerable) (await (GetResultsAsync(cancellationToken)).ConfigureAwait(false))[currentIndex]);
+			return ((IList) (await (GetResultsAsync(cancellationToken)).ConfigureAwait(false))[currentIndex]);
+		}
+
+		private async Task<IEnumerable<TResult>> GetCurrentResultAsync<TResult>(int currentIndex, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return (await (GetCurrentResultAsync(currentIndex, cancellationToken)).ConfigureAwait(false)).Cast<TResult>();
 		}
 		protected abstract Task<IList> GetResultsFromAsync(TMultiApproach multiApproach, CancellationToken cancellationToken);
 	}

--- a/src/NHibernate/Impl/FutureBatch.cs
+++ b/src/NHibernate/Impl/FutureBatch.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Impl
 		public IFutureValue<TResult> GetFutureValue<TResult>()
 		{
 			int currentIndex = index;
-			return new FutureValue<TResult>(() => GetCurrentResult(currentIndex), cancellationToken => GetCurrentResultAsync(currentIndex, cancellationToken));
+			return new FutureValue<TResult>(() => GetCurrentResult(currentIndex), async cancellationToken => await GetCurrentResultAsync(currentIndex, cancellationToken));
 		}
 
 		public IFutureEnumerable<TResult> GetEnumerator<TResult>()

--- a/src/NHibernate/Impl/FutureBatch.cs
+++ b/src/NHibernate/Impl/FutureBatch.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Impl
 		public IFutureValue<TResult> GetFutureValue<TResult>()
 		{
 			int currentIndex = index;
-			return new FutureValue<TResult>(() => GetCurrentResult<TResult>(currentIndex), cancellationToken => GetCurrentResultAsync<TResult>(currentIndex, cancellationToken));
+			return new FutureValue<TResult>(() => GetCurrentResult(currentIndex), cancellationToken => GetCurrentResultAsync(currentIndex, cancellationToken));
 		}
 
 		public IFutureEnumerable<TResult> GetEnumerator<TResult>()
@@ -69,9 +69,14 @@ namespace NHibernate.Impl
 			return results;
 		}
 
+		private IList GetCurrentResult(int currentIndex)
+		{
+			return ((IList) GetResults()[currentIndex]);
+		}
+
 		private IEnumerable<TResult> GetCurrentResult<TResult>(int currentIndex)
 		{
-			return ((IList) GetResults()[currentIndex]).Cast<TResult>();
+			return GetCurrentResult(currentIndex).Cast<TResult>();
 		}
 
 		protected abstract TMultiApproach CreateMultiApproach(bool isCacheable, string cacheRegion);

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -2422,7 +2422,7 @@ namespace NHibernate.Linq
 		{
 			var provider = GetNhProvider(source);
 			var future = provider.ExecuteFuture<TSource>(source.Expression);
-			return new FutureValue<TSource>(() => future.GetEnumerable(), async cancellationToken => await future.GetEnumerableAsync(cancellationToken));
+			return new FutureValue<TSource>(future.GetEnumerable, async cancellationToken => await future.GetEnumerableAsync(cancellationToken));
 		}
 
 		/// <summary>

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -2422,7 +2422,7 @@ namespace NHibernate.Linq
 		{
 			var provider = GetNhProvider(source);
 			var future = provider.ExecuteFuture<TSource>(source.Expression);
-			return new FutureValue<TSource>(() => future.GetEnumerable(), async cancellationToken => await future.GetEnumerableAsync());
+			return new FutureValue<TSource>(() => future.GetEnumerable(), async cancellationToken => await future.GetEnumerableAsync(cancellationToken));
 		}
 
 		/// <summary>

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -2422,7 +2422,7 @@ namespace NHibernate.Linq
 		{
 			var provider = GetNhProvider(source);
 			var future = provider.ExecuteFuture<TSource>(source.Expression);
-			return new FutureValue<TSource>(future.GetEnumerable, future.GetEnumerableAsync);
+			return new FutureValue<TSource>(() => future.GetEnumerable(), async cancellationToken => await future.GetEnumerableAsync());
 		}
 
 		/// <summary>

--- a/src/NHibernate/Util/MakeQueryableHelper.cs
+++ b/src/NHibernate/Util/MakeQueryableHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace NHibernate.Util
+{
+	internal static class MakeQueryableHelper
+    {
+		private static readonly Lazy<MethodInfo> _implMethod = new Lazy<MethodInfo>(() =>
+			typeof(MakeQueryableHelper).GetMethod(nameof(MakeQueryableImpl), BindingFlags.Static | BindingFlags.NonPublic));
+
+		public static object MakeQueryable(IEnumerable enumerable, System.Type elementType)
+		{
+			return _implMethod.Value.MakeGenericMethod(elementType).Invoke(null, new object[] { enumerable });
+		}
+
+		private static object MakeQueryableImpl<TElement>(IEnumerable enumerable)
+		{
+			return enumerable.Cast<TElement>().AsQueryable();
+		}
+	}
+}

--- a/src/NHibernate/Util/MakeQueryableHelper.cs
+++ b/src/NHibernate/Util/MakeQueryableHelper.cs
@@ -6,13 +6,13 @@ using System.Reflection;
 namespace NHibernate.Util
 {
 	internal static class MakeQueryableHelper
-    {
-		private static readonly Lazy<MethodInfo> _implMethod = new Lazy<MethodInfo>(() =>
-			typeof(MakeQueryableHelper).GetMethod(nameof(MakeQueryableImpl), BindingFlags.Static | BindingFlags.NonPublic));
+	{
+		private static readonly MethodInfo _implMethodDefinition =
+			ReflectHelper.GetMethodDefinition(() => MakeQueryableImpl<object>(null));
 
 		public static object MakeQueryable(IEnumerable enumerable, System.Type elementType)
 		{
-			return _implMethod.Value.MakeGenericMethod(elementType).Invoke(null, new object[] { enumerable });
+			return _implMethodDefinition.MakeGenericMethod(elementType).Invoke(null, new object[] { enumerable });
 		}
 
 		private static object MakeQueryableImpl<TElement>(IEnumerable enumerable)


### PR DESCRIPTION
This fixes issue #1387.

To cope for the mismatch between LINQ to Objects and SQL regarding sum behavior for an empty set (SQL will return NULL, LINQ will return 0), the result type of a `Sum` query is changed to `Nullable<int>` (or another nullable value type). A `PostExecuteTransformer` is applied which converts the resulting `IList<Nullable<int>>` to `int`. This happens in `NHibernate.Linq.Visitors.QueryModelVisitor.AddPostExecuteTransformerForSum()`.

I found an issue with `NHibernate.Impl.FutureValue<T>` where it can only apply post execute transformers which accept the future's result type as the parameter. This is because `NHibernate.Impl.FutureBatch<T1, T2>` already applies a `Cast<TResult>` operation in `GetCurrentResult<TResult>` before the post execute transformer is invoked.

In the PR, I removed type information from `FutureBatch.GetCurrentResult` and subsequently `FutureValue.GetResult` and `FutureValue.GetResultAsync`. If `ExecuteOnEval` is used, the result list is cast to the correct parameter type of the delegate.