### PR TITLE
ISession.IsDirty() should not throw exception on new ManyToOne object in session

### DIFF
--- a/src/NHibernate/Async/Type/ManyToOneType.cs
+++ b/src/NHibernate/Async/Type/ManyToOneType.cs
@@ -135,7 +135,25 @@ namespace NHibernate.Type
 			}
 		}
 
-		public override async Task<bool> IsDirtyAsync(object old, object current, ISessionImplementor session, CancellationToken cancellationToken)
+		public override Task<bool> IsDirtyAsync(object old, object current, ISessionImplementor session, CancellationToken cancellationToken)
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromCanceled<bool>(cancellationToken);
+			}
+			return IsDirtyManyToOneAsync(old, current, null, session, cancellationToken);
+		}
+
+		public override Task<bool> IsDirtyAsync(object old, object current, bool[] checkable, ISessionImplementor session, CancellationToken cancellationToken)
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromCanceled<bool>(cancellationToken);
+			}
+			return IsDirtyManyToOneAsync(old, current, IsAlwaysDirtyChecked ? null : checkable, session, cancellationToken);
+		}
+
+		private async Task<bool> IsDirtyManyToOneAsync(object old, object current, bool[] checkable, ISessionImplementor session, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			if (IsSame(old, current))
@@ -143,29 +161,23 @@ namespace NHibernate.Type
 				return false;
 			}
 
+			if (old == null || current == null)
+			{
+				return true;
+			}
+			
+			if (await (ForeignKeys.IsTransientFastAsync(GetAssociatedEntityName(), current, session, cancellationToken)).ConfigureAwait(false) == true)
+			{
+				return true;
+			}
+
 			object oldid = await (GetIdentifierAsync(old, session, cancellationToken)).ConfigureAwait(false);
 			object newid = await (GetIdentifierAsync(current, session, cancellationToken)).ConfigureAwait(false);
-			return await (GetIdentifierType(session).IsDirtyAsync(oldid, newid, session, cancellationToken)).ConfigureAwait(false);
-		}
+			IType identifierType = GetIdentifierType(session);
 
-		public override async Task<bool> IsDirtyAsync(object old, object current, bool[] checkable, ISessionImplementor session, CancellationToken cancellationToken)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			if (IsAlwaysDirtyChecked)
-			{
-				return await (IsDirtyAsync(old, current, session, cancellationToken)).ConfigureAwait(false);
-			}
-			else
-			{
-				if (IsSame(old, current))
-				{
-					return false;
-				}
-
-				object oldid = await (GetIdentifierAsync(old, session, cancellationToken)).ConfigureAwait(false);
-				object newid = await (GetIdentifierAsync(current, session, cancellationToken)).ConfigureAwait(false);
-				return await (GetIdentifierType(session).IsDirtyAsync(oldid, newid, checkable, session, cancellationToken)).ConfigureAwait(false);
-			}
+			return checkable == null
+				? await (identifierType.IsDirtyAsync(oldid, newid, session, cancellationToken)).ConfigureAwait(false)
+				: await (identifierType.IsDirtyAsync(old, current, checkable, session, cancellationToken)).ConfigureAwait(false);
 		}
 	}
 }


### PR DESCRIPTION
Fix one of the cases in  #1413.
Fixed case - exception is thrown by ISession.IsDirty() call when new ManyToOne object present in session. Fixed test case - SessionIsDirtyShouldNotFailForNewManyToOneObject in #1414:
https://github.com/nhibernate/nhibernate-core/pull/1414/files#diff-1c250a6682b3027be99e132c9257cb4dR72

