### PR TITLE
Manually serialize system types in preparation for .NET Core.

### DIFF
--- a/src/NHibernate.Test/ExceptionsTest/SerializationFixture.cs
+++ b/src/NHibernate.Test/ExceptionsTest/SerializationFixture.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using NUnit.Framework;
+
+namespace NHibernate.Test.ExceptionsTest
+{
+	[TestFixture]
+	public class SerializationFixture
+	{
+		[Test]
+		public void InstantiationExceptionSerialization()
+		{
+			var formatter = new BinaryFormatter();
+			using (var memoryStream = new MemoryStream())
+			{
+				formatter.Serialize(memoryStream, new InstantiationException("test", GetType()));
+				memoryStream.Position = 0;
+				var ex = formatter.Deserialize(memoryStream) as InstantiationException;
+				Assert.That(ex, Is.Not.Null);
+				Assert.That(ex.PersistentType, Is.EqualTo(GetType()));
+			}
+		}
+	}
+}

--- a/src/NHibernate/Async/Impl/CriteriaImpl.cs
+++ b/src/NHibernate/Async/Impl/CriteriaImpl.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using NHibernate.Criterion;

--- a/src/NHibernate/Async/Type/ArrayType.cs
+++ b/src/NHibernate/Async/Type/ArrayType.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Runtime.Serialization;
 using NHibernate.Collection;
 using NHibernate.Engine;
 using NHibernate.Persister.Collection;

--- a/src/NHibernate/Async/Type/EntityType.cs
+++ b/src/NHibernate/Async/Type/EntityType.cs
@@ -18,6 +18,7 @@ using NHibernate.Persister.Entity;
 using NHibernate.Proxy;
 using NHibernate.Util;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace NHibernate.Type
 {
@@ -98,9 +99,9 @@ namespace NHibernate.Type
 				{
 					return target;
 				}
-				if (session.GetContextEntityIdentifier(original) == null && (await (ForeignKeys.IsTransientFastAsync(associatedEntityName, original, session, cancellationToken)).ConfigureAwait(false)).GetValueOrDefault())
+				if (session.GetContextEntityIdentifier(original) == null && (await (ForeignKeys.IsTransientFastAsync(_associatedEntityName, original, session, cancellationToken)).ConfigureAwait(false)).GetValueOrDefault())
 				{
-					object copy = session.Factory.GetEntityPersister(associatedEntityName).Instantiate(null);
+					object copy = session.Factory.GetEntityPersister(_associatedEntityName).Instantiate(null);
 					//TODO: should this be Session.instantiate(Persister, ...)?
 					copyCache.Add(original, copy);
 					return copy;
@@ -129,7 +130,7 @@ namespace NHibernate.Type
 		/// <returns>
 		/// An instance of the object or <see langword="null" /> if the identifer was null.
 		/// </returns>
-		public override sealed async Task<object> NullSafeGetAsync(DbDataReader rs, string[] names, ISessionImplementor session, object owner, CancellationToken cancellationToken)
+		public sealed override async Task<object> NullSafeGetAsync(DbDataReader rs, string[] names, ISessionImplementor session, object owner, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			return await (ResolveIdentifierAsync(await (HydrateAsync(rs, names, session, owner, cancellationToken)).ConfigureAwait(false), session, owner, cancellationToken)).ConfigureAwait(false);
@@ -144,10 +145,10 @@ namespace NHibernate.Type
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			string entityName = GetAssociatedEntityName();
-			bool isProxyUnwrapEnabled = unwrapProxy && session.Factory
+			bool isProxyUnwrapEnabled = _unwrapProxy && session.Factory
 			                                                  .GetEntityPersister(entityName).IsInstrumented;
 
-			object proxyOrEntity = await (session.InternalLoadAsync(entityName, id, eager, IsNullable && !isProxyUnwrapEnabled, cancellationToken)).ConfigureAwait(false);
+			object proxyOrEntity = await (session.InternalLoadAsync(entityName, id, _eager, IsNullable && !isProxyUnwrapEnabled, cancellationToken)).ConfigureAwait(false);
 
 			if (proxyOrEntity.IsProxy())
 			{
@@ -178,21 +179,19 @@ namespace NHibernate.Type
 				{
 					return Task.FromResult<object>(null);
 				}
+
+				if (IsNull(owner, session))
+				{
+					return Task.FromResult<object>(null); //EARLY EXIT!
+				}
+
+				if (IsReferenceToPrimaryKey)
+				{
+					return ResolveIdentifierAsync(value, session, cancellationToken);
+				}
 				else
 				{
-					if (IsNull(owner, session))
-					{
-						return Task.FromResult<object>(null); //EARLY EXIT!
-					}
-
-					if (IsReferenceToPrimaryKey)
-					{
-						return ResolveIdentifierAsync(value, session, cancellationToken);
-					}
-					else
-					{
-						return LoadByUniqueKeyAsync(GetAssociatedEntityName(), _uniqueKeyPropertyName, value, session, cancellationToken);
-					}
+					return LoadByUniqueKeyAsync(GetAssociatedEntityName(), _uniqueKeyPropertyName, value, session, cancellationToken);
 				}
 			}
 			catch (Exception ex)

--- a/src/NHibernate/Async/Type/EntityType.cs
+++ b/src/NHibernate/Async/Type/EntityType.cs
@@ -65,12 +65,12 @@ namespace NHibernate.Type
 			else
 			{
 				IEntityPersister entityPersister = session.Factory.GetEntityPersister(GetAssociatedEntityName());
-				object propertyValue = entityPersister.GetPropertyValue(value, uniqueKeyPropertyName);
+				object propertyValue = entityPersister.GetPropertyValue(value, _uniqueKeyPropertyName);
 
 				// We now have the value of the property-ref we reference.  However,
 				// we need to dig a little deeper, as that property might also be
 				// an entity type, in which case we need to resolve its identitifier
-				IType type = entityPersister.GetPropertyType(uniqueKeyPropertyName);
+				IType type = entityPersister.GetPropertyType(_uniqueKeyPropertyName);
 				if (type.IsEntityType)
 				{
 					propertyValue = await (((EntityType) type).GetReferenceValueAsync(propertyValue, session, cancellationToken)).ConfigureAwait(false);
@@ -191,7 +191,7 @@ namespace NHibernate.Type
 					}
 					else
 					{
-						return LoadByUniqueKeyAsync(GetAssociatedEntityName(), uniqueKeyPropertyName, value, session, cancellationToken);
+						return LoadByUniqueKeyAsync(GetAssociatedEntityName(), _uniqueKeyPropertyName, value, session, cancellationToken);
 					}
 				}
 			}

--- a/src/NHibernate/Async/Type/SerializableType.cs
+++ b/src/NHibernate/Async/Type/SerializableType.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using NHibernate.Engine;
 using NHibernate.SqlTypes;
+using NHibernate.Util;
 
 namespace NHibernate.Type
 {

--- a/src/NHibernate/Mapping/Array.cs
+++ b/src/NHibernate/Mapping/Array.cs
@@ -10,7 +10,9 @@ namespace NHibernate.Mapping
 	[Serializable]
 	public class Array : List
 	{
+		[NonSerialized]
 		private System.Type elementClass;
+
 		private string elementClassName;
 
 		public Array(PersistentClass owner) : base(owner)
@@ -21,23 +23,22 @@ namespace NHibernate.Mapping
 		{
 			get
 			{
-				if (elementClass == null)
+				if (elementClass != null) return elementClass;
+
+				if (elementClassName == null)
 				{
-					if (elementClassName == null)
+					IType elementType = Element.Type;
+					elementClass = IsPrimitiveArray ? ((PrimitiveType) elementType).PrimitiveClass : elementType.ReturnedClass;
+				}
+				else
+				{
+					try
 					{
-						IType elementType = Element.Type;
-						elementClass = IsPrimitiveArray ? ((PrimitiveType) elementType).PrimitiveClass : elementType.ReturnedClass;
+						elementClass = ReflectHelper.ClassForName(elementClassName);
 					}
-					else
+					catch (Exception cnfe)
 					{
-						try
-						{
-							elementClass = ReflectHelper.ClassForName(elementClassName);
-						}
-						catch (Exception cnfe)
-						{
-							throw new MappingException(cnfe);
-						}
+						throw new MappingException(cnfe);
 					}
 				}
 				return elementClass;

--- a/src/NHibernate/Mapping/Collection.cs
+++ b/src/NHibernate/Mapping/Collection.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
@@ -42,7 +44,9 @@ namespace NHibernate.Mapping
 		private bool orphanDelete;
 		private int batchSize = -1;
 		private FetchMode fetchMode;
+		[NonSerialized]
 		private System.Type collectionPersisterClass;
+		private SerializableSystemType _serializableCollectionPersisterClass;
 		private string referencedPropertyName;
 		private string typeName;
 
@@ -65,7 +69,9 @@ namespace NHibernate.Mapping
 		private ExecuteUpdateResultCheckStyle deleteAllCheckStyle;
 
 		private bool isGeneric;
+		[NonSerialized]
 		private System.Type[] genericArguments;
+		private SerializableSystemType[] _serializableGenericArguments;
 		private readonly Dictionary<string, string> filters = new Dictionary<string, string>();
 		private readonly Dictionary<string, string> manyToManyFilters = new Dictionary<string, string>();
 		private bool subselectLoadable;
@@ -79,6 +85,20 @@ namespace NHibernate.Mapping
 		protected Collection(PersistentClass owner)
 		{
 			this.owner = owner;
+		}
+
+		[OnSerializing]
+		private void OnSerializing(StreamingContext context)
+		{
+			_serializableCollectionPersisterClass = SerializableSystemType.Wrap(collectionPersisterClass);
+			_serializableGenericArguments = genericArguments?.Select(SerializableSystemType.Wrap).ToArray();
+		}
+
+		[OnDeserialized]
+		private void OnDeserialized(StreamingContext context)
+		{
+			collectionPersisterClass = _serializableCollectionPersisterClass?.GetSystemType();
+			genericArguments = _serializableGenericArguments?.Select(sst => sst?.GetSystemType()).ToArray();
 		}
 
 		public int ColumnSpan

--- a/src/NHibernate/Mapping/Component.cs
+++ b/src/NHibernate/Mapping/Component.cs
@@ -14,7 +14,10 @@ namespace NHibernate.Mapping
 	public class Component : SimpleValue, IMetaAttributable
 	{
 		private readonly List<Property> properties = new List<Property>();
+
+		[NonSerialized]
 		private System.Type componentClass;
+
 		private bool embedded;
 		private Property parentProperty;
 		private PersistentClass owner;

--- a/src/NHibernate/Mapping/Component.cs
+++ b/src/NHibernate/Mapping/Component.cs
@@ -133,26 +133,26 @@ namespace NHibernate.Mapping
 			get
 			{
 				// NH Different implementation (we use reflection only when needed)
-				if (componentClass == null)
+				if (componentClass != null) return componentClass;
+				if (componentClassName == null) return null;
+
+				try
 				{
-					try
-					{
-						componentClass = ReflectHelper.ClassForName(componentClassName);
-					}
-					catch (Exception cnfe)
-					{
-						if (!IsDynamic) // TODO remove this if leave the Exception
-							throw new MappingException("component class not found: " + componentClassName, cnfe);
-						return null;
-					}
+					componentClass = ReflectHelper.ClassForName(componentClassName);
+				}
+				catch (Exception cnfe)
+				{
+					if (!IsDynamic) // TODO remove this if leave the Exception
+						throw new MappingException("component class not found: " + componentClassName, cnfe);
+					return null;
 				}
 				return componentClass;
 			}
 			set // TODO NH: Remove the setter
 			{
 				componentClass = value;
-				if (componentClass != null)
-					componentClassName = componentClass.AssemblyQualifiedName;
+				if (value != null)
+					componentClassName = value.AssemblyQualifiedName;
 			} 
 		}
 

--- a/src/NHibernate/Mapping/PersistentClass.cs
+++ b/src/NHibernate/Mapping/PersistentClass.cs
@@ -63,7 +63,10 @@ namespace NHibernate.Mapping
 
 		private Versioning.OptimisticLock optimisticLockMode;
 
+		[NonSerialized]
 		private System.Type mappedClass;
+
+		[NonSerialized]
 		private System.Type proxyInterface;
 
 		public string ClassName
@@ -98,18 +101,17 @@ namespace NHibernate.Mapping
 		{
 			get
 			{
-				if (mappedClass == null)
+				if (mappedClass != null) return mappedClass;
+
+				if (className == null)
+					return null;
+				try
 				{
-					if (className == null)
-						return null;
-					try
-					{
-						mappedClass = ReflectHelper.ClassForName(className);
-					}
-					catch (Exception cnfe)
-					{
-						throw new MappingException("entity class not found: " + className, cnfe);
-					}
+					mappedClass = ReflectHelper.ClassForName(className);
+				}
+				catch (Exception cnfe)
+				{
+					throw new MappingException("entity class not found: " + className, cnfe);
 				}
 				return mappedClass;
 			}
@@ -126,18 +128,17 @@ namespace NHibernate.Mapping
 		{
 			get
 			{
-				if (proxyInterface == null)
+				if (proxyInterface != null) return proxyInterface;
+
+				if (proxyInterfaceName == null)
+					return null;
+				try
 				{
-					if (proxyInterfaceName == null)
-						return null;
-					try
-					{
-						proxyInterface = ReflectHelper.ClassForName(proxyInterfaceName);
-					}
-					catch (Exception cnfe)
-					{
-						throw new MappingException("proxy class not found: " + proxyInterfaceName, cnfe);
-					}
+					proxyInterface = ReflectHelper.ClassForName(proxyInterfaceName);
+				}
+				catch (Exception cnfe)
+				{
+					throw new MappingException("proxy class not found: " + proxyInterfaceName, cnfe);
 				}
 				return proxyInterface;
 			}

--- a/src/NHibernate/Mapping/RootClass.cs
+++ b/src/NHibernate/Mapping/RootClass.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-
+using System.Runtime.Serialization;
 using NHibernate.Engine;
 using NHibernate.Util;
 
@@ -40,12 +40,26 @@ namespace NHibernate.Mapping
 		private bool mutable;
 		private bool embeddedIdentifier = false;
 		private bool explicitPolymorphism;
+		[NonSerialized]
 		private System.Type entityPersisterClass;
+		private SerializableSystemType _serializableEntityPersisterClass;
 		private bool forceDiscriminator;
 		private string where;
 		private Table table;
 		private bool discriminatorInsertable = true;
 		private int nextSubclassId = 0;
+
+		[OnSerializing]
+		private void OnSerializing(StreamingContext context)
+		{
+			_serializableEntityPersisterClass = SerializableSystemType.Wrap(entityPersisterClass);
+		}
+
+		[OnDeserialized]
+		private void OnDeserialized(StreamingContext context)
+		{
+			entityPersisterClass = _serializableEntityPersisterClass?.GetSystemType();
+		}
 
 		public override int SubclassId
 		{

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyObjectReference.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyObjectReference.cs
@@ -16,7 +16,10 @@ namespace NHibernate.Proxy.DynamicProxy
 	[Serializable]
 	public class ProxyObjectReference : IObjectReference, ISerializable
 	{
+		[NonSerialized]
 		private readonly System.Type _baseType;
+
+		[NonSerialized]
 		private readonly IProxy _proxy;
 
 		protected ProxyObjectReference(SerializationInfo info, StreamingContext context)

--- a/src/NHibernate/Proxy/LiteLazyInitializer.cs
+++ b/src/NHibernate/Proxy/LiteLazyInitializer.cs
@@ -1,17 +1,35 @@
 using System;
+using System.Runtime.Serialization;
 using NHibernate.Engine;
+using NHibernate.Util;
 
 namespace NHibernate.Proxy
 {
 	[Serializable]
 	internal sealed class LiteLazyInitializer : AbstractLazyInitializer
 	{
+		[NonSerialized]
+		private System.Type _persistentClass;
+		private SerializableSystemType _serializablePersistentClass;
+
 		internal LiteLazyInitializer(string entityName, object id, ISessionImplementor session, System.Type persistentClass) 
 			: base(entityName, id, session)
 		{
-			PersistentClass = persistentClass;
+			_persistentClass = persistentClass;
 		}
 
-		public override System.Type PersistentClass { get; }
+		public override System.Type PersistentClass => _persistentClass;
+
+		[OnSerializing]
+		private void OnSerializing(StreamingContext context)
+		{
+			_serializablePersistentClass = SerializableSystemType.Wrap(_persistentClass);
+		}
+
+		[OnDeserialized]
+		private void OnDeserialized(StreamingContext context)
+		{
+			_persistentClass = _serializablePersistentClass?.GetSystemType();
+		}
 	}
 }

--- a/src/NHibernate/Tuple/Component/PocoComponentTuplizer.cs
+++ b/src/NHibernate/Tuple/Component/PocoComponentTuplizer.cs
@@ -2,6 +2,7 @@ using System;
 using NHibernate.Bytecode;
 using NHibernate.Intercept;
 using NHibernate.Properties;
+using NHibernate.Util;
 
 namespace NHibernate.Tuple.Component
 {
@@ -11,25 +12,33 @@ namespace NHibernate.Tuple.Component
 	/// A <see cref="IComponentTuplizer"/> specific to the POCO entity mode. 
 	/// </summary>
 	[Serializable]
-	public class PocoComponentTuplizer : AbstractComponentTuplizer
+	public class PocoComponentTuplizer : AbstractComponentTuplizer, IDeserializationCallback
 	{
-		private readonly System.Type componentClass;
-		private readonly ISetter parentSetter;
-		private readonly IGetter parentGetter;
 		[NonSerialized]
-		private IReflectionOptimizer optimizer;
+		private System.Type _componentClass;
+		private SerializableSystemType _serializableComponentClass;
+		private readonly ISetter _parentSetter;
+		private readonly IGetter _parentGetter;
 
+		[NonSerialized]
+		private IReflectionOptimizer _optimizer;
 
-		[OnDeserialized]
-		internal void OnDeserialized(StreamingContext context)
+		[OnSerializing]
+		private void OnSerializing(StreamingContext context)
 		{
+			_serializableComponentClass = SerializableSystemType.Wrap(_componentClass);
+		}
+
+		void IDeserializationCallback.OnDeserialization(object sender)
+		{
+			_componentClass = _serializableComponentClass?.GetSystemType();
 			SetReflectionOptimizer();
 
-			if (optimizer != null)
+			if (_optimizer != null)
 			{
 				// Fix for NH-3119:
 				// Also set the InstantiationOptimizer on the deserialized PocoInstantiator.
-				((PocoInstantiator)instantiator).SetOptimizer(optimizer.InstantiationOptimizer);
+				((PocoInstantiator)instantiator).SetOptimizer(_optimizer.InstantiationOptimizer);
 			}
 
 			ClearOptimizerWhenUsingCustomAccessors();
@@ -38,18 +47,18 @@ namespace NHibernate.Tuple.Component
 		public PocoComponentTuplizer(Mapping.Component component)
 			: base(component)
 		{
-			componentClass = component.ComponentClass;
+			_componentClass = component.ComponentClass;
 
 			var parentProperty = component.ParentProperty;
 			if (parentProperty == null)
 			{
-				parentSetter = null;
-				parentGetter = null;
+				_parentSetter = null;
+				_parentGetter = null;
 			}
 			else
 			{
-				parentSetter = parentProperty.GetSetter(componentClass);
-				parentGetter = parentProperty.GetGetter(componentClass);
+				_parentSetter = parentProperty.GetSetter(_componentClass);
+				_parentGetter = parentProperty.GetGetter(_componentClass);
 			}
 
 			SetReflectionOptimizer();
@@ -60,10 +69,7 @@ namespace NHibernate.Tuple.Component
 			ClearOptimizerWhenUsingCustomAccessors();
 		}
 
-		public override System.Type MappedClass
-		{
-			get { return componentClass; }
-		}
+		public override System.Type MappedClass => _componentClass;
 
 		public override object[] GetPropertyValues(object component)
 		{
@@ -73,9 +79,9 @@ namespace NHibernate.Tuple.Component
 				return new object[propertySpan];
 			}
 
-			if (optimizer != null && optimizer.AccessOptimizer != null)
+			if (_optimizer != null && _optimizer.AccessOptimizer != null)
 			{
-				return optimizer.AccessOptimizer.GetPropertyValues(component);
+				return _optimizer.AccessOptimizer.GetPropertyValues(component);
 			}
 			else
 			{
@@ -85,9 +91,9 @@ namespace NHibernate.Tuple.Component
 
 		public override void SetPropertyValues(object component, object[] values)
 		{
-			if (optimizer != null && optimizer.AccessOptimizer != null)
+			if (_optimizer != null && _optimizer.AccessOptimizer != null)
 			{
-				optimizer.AccessOptimizer.SetPropertyValues(component, values);
+				_optimizer.AccessOptimizer.SetPropertyValues(component, values);
 			}
 			else
 			{
@@ -97,17 +103,17 @@ namespace NHibernate.Tuple.Component
 
 		public override object GetParent(object component)
 		{
-			return parentGetter.Get(component);
+			return _parentGetter.Get(component);
 		}
 
 		public override void SetParent(object component, object parent, Engine.ISessionFactoryImplementor factory)
 		{
-			parentSetter.Set(component, parent);
+			_parentSetter.Set(component, parent);
 		}
 
 		public override bool HasParentProperty
 		{
-			get { return parentGetter != null; }
+			get { return _parentGetter != null; }
 		}
 
 		protected internal override IInstantiator BuildInstantiator(Mapping.Component component)
@@ -118,13 +124,13 @@ namespace NHibernate.Tuple.Component
 			//  return new ProxiedInstantiator(component);
 			//}
 
-			if (optimizer == null)
+			if (_optimizer == null)
 			{
 				return new PocoInstantiator(component, null);
 			}
 			else
 			{
-				return new PocoInstantiator(component, optimizer.InstantiationOptimizer);
+				return new PocoInstantiator(component, _optimizer.InstantiationOptimizer);
 			}
 		}
 
@@ -142,7 +148,7 @@ namespace NHibernate.Tuple.Component
 		{
 			if (Cfg.Environment.UseReflectionOptimizer)
 			{
-				optimizer = Cfg.Environment.BytecodeProvider.GetReflectionOptimizer(componentClass, getters, setters);
+				_optimizer = Cfg.Environment.BytecodeProvider.GetReflectionOptimizer(_componentClass, getters, setters);
 			}
 		}
 
@@ -150,7 +156,7 @@ namespace NHibernate.Tuple.Component
 		{
 			if (hasCustomAccessors)
 			{
-				optimizer = null;
+				_optimizer = null;
 			}
 		}
 	}

--- a/src/NHibernate/Type/AbstractEnumType.cs
+++ b/src/NHibernate/Type/AbstractEnumType.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using NHibernate.SqlTypes;
+using NHibernate.Util;
 
 namespace NHibernate.Type
 {
@@ -17,29 +19,40 @@ namespace NHibernate.Type
 		{
 			if (enumType.IsEnum)
 			{
-				this.enumType = enumType;
+				_enumType = enumType;
 			}
 			else
 			{
 				throw new MappingException(enumType.Name + " did not inherit from System.Enum");
 			}
-			defaultValue = Enum.ToObject(enumType, 0);
+			_defaultValue = Enum.ToObject(enumType, 0);
 		}
 
-		private readonly object defaultValue;
-		private readonly System.Type enumType;
-
-		public override System.Type ReturnedClass
+		[OnSerializing]
+		private void OnSerializing(StreamingContext context)
 		{
-			get { return enumType; }
+			_serializableEnumType = SerializableSystemType.Wrap(_enumType);
 		}
+
+		[OnDeserialized]
+		private void OnDeserialized(StreamingContext context)
+		{
+			_enumType = _serializableEnumType?.GetSystemType();
+		}
+
+		private readonly object _defaultValue;
+		[NonSerialized]
+		private System.Type _enumType;
+		private SerializableSystemType _serializableEnumType;
+
+		public override System.Type ReturnedClass => _enumType;
 
 
 		#region IIdentifierType Members
 
 		public object StringToObject(string xml)
 		{
-			return Enum.Parse(enumType, xml);
+			return Enum.Parse(_enumType, xml);
 		}
 
 		#endregion
@@ -50,14 +63,8 @@ namespace NHibernate.Type
 			return StringToObject(xml);
 		}
 
-		public override System.Type PrimitiveClass
-		{
-			get { return this.enumType; }
-		}
+		public override System.Type PrimitiveClass => _enumType;
 
-		public override object DefaultValue
-		{
-			get { return defaultValue; }
-		}
+		public override object DefaultValue => _defaultValue;
 	}
 }

--- a/src/NHibernate/Type/ArrayType.cs
+++ b/src/NHibernate/Type/ArrayType.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Runtime.Serialization;
 using NHibernate.Collection;
 using NHibernate.Engine;
 using NHibernate.Persister.Collection;
@@ -16,8 +17,12 @@ namespace NHibernate.Type
 	[Serializable]
 	public partial class ArrayType : CollectionType
 	{
-		private readonly System.Type elementClass;
-		private readonly System.Type arrayClass;
+		[NonSerialized]
+		private System.Type _elementClass;
+		private SerializableSystemType _serializableElementClass;
+		[NonSerialized]
+		private System.Type _arrayClass;
+		private SerializableSystemType _serializableArrayClass;
 
 		/// <summary>
 		/// Initializes a new instance of a <see cref="ArrayType"/> class for
@@ -34,17 +39,28 @@ namespace NHibernate.Type
 		public ArrayType(string role, string propertyRef, System.Type elementClass)
 			: base(role, propertyRef)
 		{
-			this.elementClass = elementClass;
-			arrayClass = Array.CreateInstance(elementClass, 0).GetType();
+			_elementClass = elementClass;
+			_arrayClass = Array.CreateInstance(elementClass, 0).GetType();
+		}
+
+		[OnSerializing]
+		private void OnSerializing(StreamingContext context)
+		{
+			_serializableElementClass = SerializableSystemType.Wrap(_elementClass);
+			_serializableArrayClass = SerializableSystemType.Wrap(_arrayClass);
+		}
+
+		[OnDeserialized]
+		private void OnDeserialized(StreamingContext context)
+		{
+			_elementClass = _serializableElementClass?.GetSystemType();
+			_arrayClass = _serializableArrayClass?.GetSystemType();
 		}
 
 		/// <summary>
 		/// The <see cref="System.Array"/> for the element.
 		/// </summary>
-		public override System.Type ReturnedClass
-		{
-			get { return arrayClass; }
-		}
+		public override System.Type ReturnedClass => _arrayClass;
 
 		public override IPersistentCollection Instantiate(ISessionImplementor session, ICollectionPersister persister, object key)
 		{
@@ -82,17 +98,14 @@ namespace NHibernate.Type
 		}
 
 		/// <summary></summary>
-		public override bool IsArrayType
-		{
-			get { return true; }
-		}
+		public override bool IsArrayType => true;
 
 		// Not ported - ToString( object value, ISessionFactoryImplementor factory )
 		// - PesistentCollectionType implementation is able to handle arrays too in .NET
 
 		public override object InstantiateResult(object original)
 		{
-			return Array.CreateInstance(elementClass, ((Array) original).Length);
+			return Array.CreateInstance(_elementClass, ((Array) original).Length);
 		}
 
 		public override object Instantiate(int anticipatedSize)

--- a/src/NHibernate/Type/EntityType.cs
+++ b/src/NHibernate/Type/EntityType.cs
@@ -17,7 +17,11 @@ namespace NHibernate.Type
 	[Serializable]
 	public abstract partial class EntityType : AbstractType, IAssociationType
 	{
+		// Since v5.1
+		[Obsolete("This field has no more usages in NHibernate and will be removed.  Use RHSUniqueKeyPropertyName instead.")]
 		protected readonly string uniqueKeyPropertyName;
+
+		private readonly string _uniqueKeyPropertyName;
 		private readonly bool eager;
 		private readonly string associatedEntityName;
 		private readonly bool unwrapProxy;
@@ -37,8 +41,12 @@ namespace NHibernate.Type
 		/// </param>
 		protected internal EntityType(string entityName, string uniqueKeyPropertyName, bool eager, bool unwrapProxy)
 		{
-			associatedEntityName = entityName;
+#pragma warning disable 618
 			this.uniqueKeyPropertyName = uniqueKeyPropertyName;
+#pragma warning restore 618
+
+			associatedEntityName = entityName;
+			_uniqueKeyPropertyName = uniqueKeyPropertyName;
 			this.eager = eager;
 			this.unwrapProxy = unwrapProxy;
 		}
@@ -165,12 +173,12 @@ namespace NHibernate.Type
 			else
 			{
 				IEntityPersister entityPersister = session.Factory.GetEntityPersister(GetAssociatedEntityName());
-				object propertyValue = entityPersister.GetPropertyValue(value, uniqueKeyPropertyName);
+				object propertyValue = entityPersister.GetPropertyValue(value, _uniqueKeyPropertyName);
 
 				// We now have the value of the property-ref we reference.  However,
 				// we need to dig a little deeper, as that property might also be
 				// an entity type, in which case we need to resolve its identitifier
-				IType type = entityPersister.GetPropertyType(uniqueKeyPropertyName);
+				IType type = entityPersister.GetPropertyType(_uniqueKeyPropertyName);
 				if (type.IsEntityType)
 				{
 					propertyValue = ((EntityType) type).GetReferenceValue(propertyValue, session);
@@ -283,7 +291,7 @@ namespace NHibernate.Type
 
 		public bool IsUniqueKeyReference
 		{
-			get { return uniqueKeyPropertyName != null; }
+			get { return _uniqueKeyPropertyName != null; }
 		}
 
 		public abstract bool IsNullable { get; }
@@ -311,7 +319,7 @@ namespace NHibernate.Type
 			}
 			else
 			{
-				IType type = factory.GetReferencedPropertyType(GetAssociatedEntityName(), uniqueKeyPropertyName);
+				IType type = factory.GetReferencedPropertyType(GetAssociatedEntityName(), _uniqueKeyPropertyName);
 				if (type.IsEntityType)
 				{
 					type = ((EntityType) type).GetIdentifierOrUniqueKeyType(factory);
@@ -333,7 +341,7 @@ namespace NHibernate.Type
 			}
 			else
 			{
-				return uniqueKeyPropertyName;
+				return _uniqueKeyPropertyName;
 			}
 		}
 
@@ -399,7 +407,7 @@ namespace NHibernate.Type
 				}
 				else
 				{
-					return LoadByUniqueKey(GetAssociatedEntityName(), uniqueKeyPropertyName, value, session);
+					return LoadByUniqueKey(GetAssociatedEntityName(), _uniqueKeyPropertyName, value, session);
 				}
 			}
 		}
@@ -438,7 +446,7 @@ namespace NHibernate.Type
 
 		public string RHSUniqueKeyPropertyName
 		{
-			get { return uniqueKeyPropertyName; }
+			get { return _uniqueKeyPropertyName; }
 		}
 
 		public virtual string PropertyName
@@ -472,7 +480,7 @@ namespace NHibernate.Type
 
 		public bool IsReferenceToPrimaryKey
 		{
-			get { return string.IsNullOrEmpty(uniqueKeyPropertyName); }
+			get { return string.IsNullOrEmpty(_uniqueKeyPropertyName); }
 		}
 
 		public string GetOnCondition(string alias, ISessionFactoryImplementor factory, IDictionary<string, IFilter> enabledFilters)

--- a/src/NHibernate/Type/ManyToOneType.cs
+++ b/src/NHibernate/Type/ManyToOneType.cs
@@ -97,7 +97,7 @@ namespace NHibernate.Type
 		private void ScheduleBatchLoadIfNeeded(object id, ISessionImplementor session)
 		{
 			//cannot batch fetch by unique key (property-ref associations)
-			if (uniqueKeyPropertyName == null && id != null)
+			if (RHSUniqueKeyPropertyName == null && id != null)
 			{
 				IEntityPersister persister = session.Factory.GetEntityPersister(GetAssociatedEntityName());
 				EntityKey entityKey = session.GenerateEntityKey(id, persister);

--- a/src/NHibernate/Util/AssemblyQualifiedTypeName.cs
+++ b/src/NHibernate/Util/AssemblyQualifiedTypeName.cs
@@ -2,35 +2,26 @@ using System;
 
 namespace NHibernate.Util
 {
+	[Serializable]
 	public class AssemblyQualifiedTypeName
 	{
-		private readonly string type;
-		private readonly string assembly;
-		private readonly int hashCode;
+		private readonly string _type;
+		private readonly string _assembly;
+		private readonly int _hashCode;
 
 		public AssemblyQualifiedTypeName(string type, string assembly)
 		{
-			if (type == null)
-			{
-				throw new ArgumentNullException("type");
-			}
-			this.type = type;
-			this.assembly = assembly;
+			_type = type ?? throw new ArgumentNullException(nameof(type));
+			_assembly = assembly;
 			unchecked
 			{
-				hashCode = (type.GetHashCode() * 397) ^ (assembly != null ? assembly.GetHashCode() : 0);
+				_hashCode = (type.GetHashCode() * 397) ^ (assembly?.GetHashCode() ?? 0);
 			}
 		}
 
-		public string Type
-		{
-			get { return type; }
-		}
+		public string Type => _type;
 
-		public string Assembly
-		{
-			get { return assembly; }
-		}
+		public string Assembly => _assembly;
 
 		public override bool Equals(object obj)
 		{
@@ -40,12 +31,12 @@ namespace NHibernate.Util
 
 		public override string ToString()
 		{
-			if (assembly == null)
+			if (_assembly == null)
 			{
-				return type;
+				return _type;
 			}
 
-			return string.Concat(type, ", ", assembly);
+			return string.Concat(_type, ", ", _assembly);
 		}
 
 		public bool Equals(AssemblyQualifiedTypeName obj)
@@ -58,12 +49,12 @@ namespace NHibernate.Util
 			{
 				return true;
 			}
-			return Equals(obj.type, type) && Equals(obj.assembly, assembly);
+			return Equals(obj._type, _type) && Equals(obj._assembly, _assembly);
 		}
 
 		public override int GetHashCode()
 		{
-			return hashCode;
+			return _hashCode;
 		}
 	}
 }

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -392,7 +392,7 @@ namespace NHibernate.Util
 		/// type cannot be found then the assembly is loaded using
 		/// <see cref="Assembly.Load(string)" />.
 		/// </remarks>
-		public static System.Type TypeFromAssembly(AssemblyQualifiedTypeName name, bool throwOnError)
+		public static System.Type TypeFromAssembly(this AssemblyQualifiedTypeName name, bool throwOnError)
 		{
 			try
 			{

--- a/src/NHibernate/Util/SerializableConstructorInfo.cs
+++ b/src/NHibernate/Util/SerializableConstructorInfo.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace NHibernate.Util
+{
+	[Serializable]
+	internal sealed class SerializableConstructorInfo : ISerializable, IEquatable<SerializableConstructorInfo>
+	{
+		[NonSerialized]
+		private readonly ConstructorInfo _constructorInfo;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="SerializableConstructorInfo"/> if 
+		/// <paramref name="constructorInfo"/> is not null, otherwise returns <c>null</c>.
+		/// </summary>
+		/// <param name="constructorInfo">The <see cref="ConstructorInfo"/> being wrapped for serialization.</param>
+		/// <returns>New instance of <see cref="SerializableConstructorInfo"/> or <c>null</c>.</returns>
+		public static SerializableConstructorInfo Wrap(ConstructorInfo constructorInfo)
+		{
+			return constructorInfo == null ? null : new SerializableConstructorInfo(constructorInfo);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="SerializableConstructorInfo"/>
+		/// </summary>
+		/// <param name="constructorInfo">The <see cref="ConstructorInfo"/> being wrapped for serialization.</param>
+		private SerializableConstructorInfo(ConstructorInfo constructorInfo)
+		{
+			_constructorInfo = constructorInfo ?? throw new ArgumentNullException(nameof(constructorInfo));
+			if (constructorInfo.DeclaringType == null)
+			{
+				throw new ArgumentException("ConstructorInfo must have non-null DeclaringType", nameof(constructorInfo));
+			}
+		}
+
+		private SerializableConstructorInfo(SerializationInfo info, StreamingContext context)
+		{
+			System.Type declaringType = info.GetValue<SerializableSystemType>("declaringType").GetSystemType();
+			SerializableSystemType[] parameterSystemTypes = info.GetValue<SerializableSystemType[]>("parameterTypesHelper");
+
+			System.Type[] parameterTypes = parameterSystemTypes?.Select(x => x.GetSystemType()).ToArray() ?? new System.Type[0];
+			_constructorInfo = declaringType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, parameterTypes, null);
+
+			if (_constructorInfo == null) throw new MissingMethodException(declaringType.FullName, ".ctor");
+		}
+
+		[SecurityCritical]
+		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			SerializableSystemType[] parameterSystemTypes =
+				_constructorInfo.GetParameters()
+				                .Select(x => SerializableSystemType.Wrap(x.ParameterType))
+				                .ToArray();
+
+			info.AddValue("declaringType", SerializableSystemType.Wrap(_constructorInfo.DeclaringType));
+			info.AddValue("parameterTypesHelper", parameterSystemTypes);
+		}
+
+		public ConstructorInfo Value => _constructorInfo;
+
+		public bool Equals(SerializableConstructorInfo other)
+		{
+			return other != null && Equals(_constructorInfo, other._constructorInfo);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			return obj is SerializableConstructorInfo && Equals((SerializableConstructorInfo) obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return (_constructorInfo != null ? _constructorInfo.GetHashCode() : 0);
+		}
+	}
+}

--- a/src/NHibernate/Util/SerializableFieldInfo.cs
+++ b/src/NHibernate/Util/SerializableFieldInfo.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace NHibernate.Util
+{
+	[Serializable]
+	internal sealed class SerializableFieldInfo : ISerializable, IEquatable<SerializableFieldInfo>
+	{
+		[NonSerialized]
+		private readonly FieldInfo _fieldInfo;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="SerializableFieldInfo"/> if 
+		/// <paramref name="fieldInfo"/> is not null, otherwise returns <c>null</c>.
+		/// </summary>
+		/// <param name="fieldInfo">The <see cref="FieldInfo"/> being wrapped for serialization.</param>
+		/// <returns>New instance of <see cref="SerializableFieldInfo"/> or <c>null</c>.</returns>
+		public static SerializableFieldInfo Wrap(FieldInfo fieldInfo)
+		{
+			return fieldInfo == null ? null : new SerializableFieldInfo(fieldInfo);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="SerializableFieldInfo"/>
+		/// </summary>
+		/// <param name="fieldInfo">The <see cref="FieldInfo"/> being wrapped for serialization.</param>
+		private SerializableFieldInfo(FieldInfo fieldInfo)
+		{
+			_fieldInfo = fieldInfo ?? throw new ArgumentNullException(nameof(fieldInfo));
+			if (fieldInfo.IsStatic) throw new ArgumentException("Only for instance fields", nameof(fieldInfo));
+			if (fieldInfo.DeclaringType == null) throw new ArgumentException("FieldInfo must have non-null DeclaringType", nameof(fieldInfo));
+		}
+
+		private SerializableFieldInfo(SerializationInfo info, StreamingContext context)
+		{
+			System.Type declaringType = info.GetValue<SerializableSystemType>("declaringType").GetSystemType();
+			string fieldName = info.GetString("fieldName");
+
+			_fieldInfo = declaringType.GetField(
+				fieldName,
+				BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+			if (_fieldInfo == null) throw new MissingFieldException(declaringType.FullName, fieldName);
+		}
+
+		[SecurityCritical]
+		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue("declaringType", SerializableSystemType.Wrap(_fieldInfo.DeclaringType));
+			info.AddValue("fieldName", _fieldInfo.Name);
+		}
+
+		public FieldInfo Value => _fieldInfo;
+
+		public bool Equals(SerializableFieldInfo other)
+		{
+			return other != null && Equals(_fieldInfo, other._fieldInfo);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			return obj is SerializableFieldInfo && Equals((SerializableFieldInfo) obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return (_fieldInfo != null ? _fieldInfo.GetHashCode() : 0);
+		}
+	}
+}

--- a/src/NHibernate/Util/SerializableMethodInfo.cs
+++ b/src/NHibernate/Util/SerializableMethodInfo.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace NHibernate.Util
+{
+	[Serializable]
+	internal sealed class SerializableMethodInfo : ISerializable, IEquatable<SerializableMethodInfo>
+	{
+		[NonSerialized]
+		private readonly MethodInfo _methodInfo;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="SerializableMethodInfo"/> if 
+		/// <paramref name="methodInfo"/> is not null, otherwise returns <c>null</c>.
+		/// </summary>
+		/// <param name="methodInfo">The <see cref="MethodInfo"/> being wrapped for serialization.</param>
+		/// <returns>New instance of <see cref="SerializableMethodInfo"/> or <c>null</c>.</returns>
+		public static SerializableMethodInfo Wrap(MethodInfo methodInfo)
+		{
+			return methodInfo == null ? null : new SerializableMethodInfo(methodInfo);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="SerializableMethodInfo"/>
+		/// </summary>
+		/// <param name="methodInfo">The <see cref="MethodInfo"/> being wrapped for serialization.</param>
+		private SerializableMethodInfo(MethodInfo methodInfo)
+		{
+			_methodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+			if (methodInfo.IsStatic) throw new ArgumentException("Only for instance fields", nameof(methodInfo));
+			if (methodInfo.DeclaringType == null) throw new ArgumentException("MethodInfo must have non-null DeclaringType", nameof(methodInfo));
+		}
+
+		private SerializableMethodInfo(SerializationInfo info, StreamingContext context)
+		{
+			System.Type declaringType = info.GetValue<SerializableSystemType>("declaringType").GetSystemType();
+			string methodName = info.GetString("methodName");
+			SerializableSystemType[] parameterSystemTypes = info.GetValue<SerializableSystemType[]>("parameterTypesHelper");
+
+			System.Type[] parameterTypes = parameterSystemTypes?.Select(x => x.GetSystemType()).ToArray() ?? new System.Type[0];
+			_methodInfo = declaringType.GetMethod(
+				methodName,
+				BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, parameterTypes, null);
+
+			if (_methodInfo == null) throw new MissingMethodException(declaringType.FullName, methodName);
+		}
+
+		[SecurityCritical]
+		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			SerializableSystemType[] parameterSystemTypes =
+				_methodInfo.GetParameters()
+				           .Select(x => SerializableSystemType.Wrap(x.ParameterType))
+				           .ToArray();
+
+			info.AddValue("declaringType", SerializableSystemType.Wrap(_methodInfo.DeclaringType));
+			info.AddValue("methodName", _methodInfo.Name);
+			info.AddValue("parameterTypesHelper", parameterSystemTypes);
+		}
+
+		public MethodInfo Value => _methodInfo;
+
+		public bool Equals(SerializableMethodInfo other)
+		{
+			return other != null && Equals(_methodInfo, other._methodInfo);
+		}
+	}
+}

--- a/src/NHibernate/Util/SerializablePropertyInfo.cs
+++ b/src/NHibernate/Util/SerializablePropertyInfo.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace NHibernate.Util
+{
+	[Serializable]
+	internal sealed class SerializablePropertyInfo : ISerializable, IEquatable<SerializablePropertyInfo>
+	{
+		[NonSerialized]
+		private readonly PropertyInfo _propertyInfo;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="SerializablePropertyInfo"/> if 
+		/// <paramref name="propertyInfo"/> is not null, otherwise returns <c>null</c>.
+		/// </summary>
+		/// <param name="propertyInfo">The <see cref="PropertyInfo"/> being wrapped for serialization.</param>
+		/// <returns>New instance of <see cref="SerializablePropertyInfo"/> or <c>null</c>.</returns>
+		public static SerializablePropertyInfo Wrap(PropertyInfo propertyInfo)
+		{
+			return propertyInfo == null ? null : new SerializablePropertyInfo(propertyInfo);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="SerializablePropertyInfo"/>
+		/// </summary>
+		/// <param name="propertyInfo">The <see cref="PropertyInfo"/> being wrapped for serialization.</param>
+		private SerializablePropertyInfo(PropertyInfo propertyInfo)
+		{
+			_propertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
+			if (propertyInfo.DeclaringType == null) throw new ArgumentException("PropertyInfo must have non-null DeclaringType", nameof(propertyInfo));
+			if (propertyInfo.GetIndexParameters().Length > 0) throw new ArgumentException("PropertyInfo not supported with IndexParameters", nameof(propertyInfo));
+		}
+
+		private SerializablePropertyInfo(SerializationInfo info, StreamingContext context)
+		{
+			System.Type declaringType = info.GetValue<SerializableSystemType>("declaringType").GetSystemType();
+			string propertyName = info.GetString("propertyName");
+
+			_propertyInfo = declaringType.GetProperty(
+				propertyName,
+				BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+			if (_propertyInfo == null) throw new MissingMethodException(declaringType.FullName, propertyName);
+		}
+
+		[SecurityCritical]
+		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue("declaringType", SerializableSystemType.Wrap(_propertyInfo.DeclaringType));
+			info.AddValue("propertyName", _propertyInfo.Name);
+		}
+
+		public PropertyInfo Value => _propertyInfo;
+
+		public bool Equals(SerializablePropertyInfo other)
+		{
+			return other != null && Equals(_propertyInfo, other._propertyInfo);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			return obj is SerializablePropertyInfo && Equals((SerializablePropertyInfo) obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return (_propertyInfo != null ? _propertyInfo.GetHashCode() : 0);
+		}
+	}
+}

--- a/src/NHibernate/Util/SerializableSystemType.cs
+++ b/src/NHibernate/Util/SerializableSystemType.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace NHibernate.Util
+{
+	[Serializable]
+	internal class SerializableSystemType : ISerializable, IEquatable<SerializableSystemType>
+	{
+		[NonSerialized]
+		private readonly System.Type _type;
+
+		private AssemblyQualifiedTypeName _typeName;
+
+		protected AssemblyQualifiedTypeName TypeName => _typeName;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="SerializableSystemType"/> if
+		/// <paramref name="type"/> is not null, otherwise returns <c>null</c>.
+		/// </summary>
+		/// <param name="type">The <see cref="System.Type"/> being wrapped for serialization.</param>
+		/// <returns>New instance of <see cref="SerializableSystemType"/> or <c>null</c>.</returns>
+		public static SerializableSystemType Wrap(System.Type type)
+		{
+			return type == null ? null : new SerializableSystemType(type);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="SerializableSystemType"/>
+		/// </summary>
+		/// <param name="type">The <see cref="System.Type"/> being wrapped for serialization.</param>
+		protected SerializableSystemType(System.Type type)
+		{
+			_type = type ?? throw new ArgumentNullException(nameof(type));
+		}
+
+		protected SerializableSystemType(SerializationInfo info, StreamingContext context)
+		{
+			_typeName = info.GetValue<AssemblyQualifiedTypeName>("_typeName");
+			if (_typeName == null)
+				throw new InvalidOperationException("_typeName was null after deserialization");
+			_type = _typeName.TypeFromAssembly(false);
+		}
+
+		/// <summary>
+		/// Returns the wrapped type. Will throw if it was unable to load it after deserialization.
+		/// </summary>
+		/// <returns>The type that this class was initialized with or initialized after deserialization.</returns>
+		public System.Type GetSystemType() => _type ?? throw new TypeLoadException("Could not load type " + _typeName + ".");
+
+		/// <summary>
+		/// Returns the wrapped type. Will return null if it was unable to load it after deserialization.
+		/// </summary>
+		/// <returns>The type that this class was initialized with, the type initialized after deserialization, or null if unable to load.</returns>
+		public System.Type TryGetSystemType() => _type;
+
+		public string FullName => _type?.FullName ?? _typeName.Type;
+
+		public string AssemblyQualifiedName => _type?.AssemblyQualifiedName ?? _typeName.ToString();
+
+		[SecurityCritical]
+		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			if (_typeName == null)
+			{
+				_typeName = new AssemblyQualifiedTypeName(_type.FullName, _type.Assembly.FullName);
+			}
+
+			info.AddValue("_typeName", _typeName);
+		}
+
+		public bool Equals(SerializableSystemType other)
+		{
+			return other != null &&
+				(_type == null || other._type == null
+					? Equals(_typeName, other._typeName)
+					: Equals(_type, other._type));
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			return obj is SerializableSystemType type && Equals(type);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return (FullName.GetHashCode() * 397) ^ (AssemblyQualifiedName?.GetHashCode() ?? 0);
+			}
+		}
+	}
+
+	[Serializable]
+	internal sealed class ObjectReferenceSystemType : SerializableSystemType, IObjectReference
+	{
+		private readonly bool _throwOnDeserializationError;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="SerializableSystemType"/> if
+		/// <paramref name="type"/> is not null, otherwise returns <c>null</c>.
+		/// </summary>
+		/// <param name="type">The <see cref="System.Type"/> being wrapped for serialization.</param>
+		/// <param name="throwOnDeserializationError"><see langword="true" /> for failing if unable to load the type
+		/// in <see cref="IObjectReference.GetRealObject" />, <see langword="false" /> to yield
+		/// <see langword="null" /> instead.</param>
+		/// <returns>New instance of <see cref="SerializableSystemType"/> or <c>null</c>.</returns>
+		public static ObjectReferenceSystemType Wrap(System.Type type, bool throwOnDeserializationError)
+		{
+			return type == null ? null : new ObjectReferenceSystemType(type, throwOnDeserializationError);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="SerializableSystemType"/>
+		/// </summary>
+		/// <param name="type">The <see cref="System.Type"/> being wrapped for serialization.</param>
+		/// <param name="throwOnDeserializationError"><see langword="true" /> for failing if unable to load the type
+		/// in <see cref="IObjectReference.GetRealObject" />, <see langword="false" /> to yield 
+		/// <see langword="null" /> instead.</param>
+		private ObjectReferenceSystemType(System.Type type, bool throwOnDeserializationError) : base(type)
+		{
+			_throwOnDeserializationError = throwOnDeserializationError;
+		}
+
+		private ObjectReferenceSystemType(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+			_throwOnDeserializationError = info.GetBoolean("_throwOnDeserializationError");
+		}
+
+		[SecurityCritical]
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue("_throwOnDeserializationError", _throwOnDeserializationError);
+		}
+
+		[SecurityCritical]
+		object IObjectReference.GetRealObject(StreamingContext context)
+		{
+			return TypeName.TypeFromAssembly(_throwOnDeserializationError);
+		}
+	}
+}

--- a/src/NHibernate/Util/SerializationInfoExtensions.cs
+++ b/src/NHibernate/Util/SerializationInfoExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace NHibernate.Util
+{
+	internal static class SerializationInfoExtensions
+	{
+		public static T GetValue<T>(this SerializationInfo info, string name)
+		{
+			if (info == null) throw new ArgumentNullException(nameof(info));
+			return (T) info.GetValue(name, typeof(T));
+		}
+	}
+}


### PR DESCRIPTION
Serialize `System.Type`, `ConstructorInfo`, `FieldInfo`, `MethodInfo`, and `PropertyInfo` using only basic types.

I used reflection generated list of `[Serializable]` types in .NET Core 2.0 to find and replace fields in serialized types.

This partially addresses #889 - NH3853.  While not switching away from binary serialization, it should be compatible with .NET Core (to be verified).

If an application is serializing NHibernate internals (like `ISession` or some of the exceptions that are now completely serialized like `PropertyNotFoundException`) into permanent storage and expects them to be rehydrated with any future version of NHibernate, then this will break that.  Applications should only expect binary serialization compatibility within a very limited version range.