### PR TITLE
Insert underscore in combined parameter name

### DIFF
--- a/src/NHibernate.Test/Async/Futures/LinqFutureFixture.cs
+++ b/src/NHibernate.Test/Async/Futures/LinqFutureFixture.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System.Collections.Generic;
 using NHibernate.Driver;
 using NHibernate.Linq;
 using NUnit.Framework;
@@ -205,7 +206,7 @@ namespace NHibernate.Test.Futures
 		public async Task CanUseFutureFetchQueryAsync()
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
-			
+
 			using (var s = Sfi.OpenSession())
 			using (var tx = s.BeginTransaction())
 			{
@@ -279,7 +280,7 @@ namespace NHibernate.Test.Futures
 		public async Task CanCombineSingleFutureValueWithEnumerableFuturesAsync()
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
-			
+
 			using (var s = Sfi.OpenSession())
 			{
 				var persons = s.Query<Person>()
@@ -364,11 +365,51 @@ namespace NHibernate.Test.Futures
 					var events = logSpy.Appender.GetEvents();
 					Assert.AreEqual(1, events.Length);
 					var wholeLog = logSpy.GetWholeLog();
-					string paramPrefix = ((DriverBase)Sfi.ConnectionProvider.Driver).NamedPrefix;
+					string paramPrefix = ((DriverBase) Sfi.ConnectionProvider.Driver).NamedPrefix;
 					Assert.That(
 						wholeLog,
 						Does.Contain(paramPrefix + "p0 = 1 [Type: Int32 (0:0:0)], " + paramPrefix + "p1 = 2 [Type: Int32 (0:0:0)]"));
 				}
+			}
+		}
+
+		[Test]
+		public async Task UsingManyParametersAndQueries_DoesNotCauseParameterNameCollisionsAsync()
+		{
+			//GH-1357
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var p1 = new Person { Name = "Person name", Age = 15};
+				var p2 = new Person { Name = "Person name", Age = 5 };
+
+				await (s.SaveAsync(p1));
+				await (s.SaveAsync(p2));
+				await (tx.CommitAsync());
+			}
+			using (var s = Sfi.OpenSession())
+			{
+				var list = new List<IFutureEnumerable<Person>>();
+				for (var i = 0; i < 12; i++)
+				{
+					var query = s.Query<Person>();
+					for (var j = 0; j < 12; j++)
+					{
+						query = query.Where(x => x.Age > j);
+					}
+					list.Add(query.SetOptions(x => x.SetCacheable(true)).ToFuture());
+				}
+				foreach (var query in list)
+				{
+					var result = query.ToList();
+					Assert.That(result.Count,Is.EqualTo(1));
+				}
+			}
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				await (s.DeleteAsync("from Person"));
+				await (tx.CommitAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/QueryTest/MultiCriteriaFixture.cs
+++ b/src/NHibernate.Test/Async/QueryTest/MultiCriteriaFixture.cs
@@ -441,5 +441,38 @@ namespace NHibernate.Test.QueryTest
 				Assert.That(results[1], Is.InstanceOf<List<int>>());
 			}
 		}
+
+		[Test]
+		public async Task UsingManyParametersAndQueries_DoesNotCauseParameterNameCollisionsAsync()
+		{
+			//GH-1357
+			using (var s = OpenSession())
+			{
+				var item = new Item {Id = 15};
+				await (s.SaveAsync(item));
+				await (s.FlushAsync());
+			}
+
+			using (var s = OpenSession())
+			{
+				var multi = s.CreateMultiCriteria();
+
+				for (var i = 0; i < 12; i++)
+				{
+					var criteria = s.CreateCriteria(typeof(Item));
+					for (var j = 0; j < 12; j++)
+					{
+						criteria = criteria.Add(Restrictions.Gt("id", j));
+					}
+					multi.Add(criteria);
+				}
+				//Parameter combining is only used for cacheable queries
+				multi.SetCacheable(true);
+				foreach (IList result in await (multi.ListAsync()))
+				{
+					Assert.That(result.Count, Is.EqualTo(1));
+				}
+			}
+		}
 	}
 }

--- a/src/NHibernate.Test/Futures/LinqFutureFixture.cs
+++ b/src/NHibernate.Test/Futures/LinqFutureFixture.cs
@@ -1,4 +1,5 @@
-﻿using NHibernate.Driver;
+﻿using System.Collections.Generic;
+using NHibernate.Driver;
 using NHibernate.Linq;
 using NUnit.Framework;
 using System.Linq;
@@ -194,7 +195,7 @@ namespace NHibernate.Test.Futures
 		public void CanUseFutureFetchQuery()
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
-			
+
 			using (var s = Sfi.OpenSession())
 			using (var tx = s.BeginTransaction())
 			{
@@ -268,7 +269,7 @@ namespace NHibernate.Test.Futures
 		public void CanCombineSingleFutureValueWithEnumerableFutures()
 		{
 			IgnoreThisTestIfMultipleQueriesArentSupportedByDriver();
-			
+
 			using (var s = Sfi.OpenSession())
 			{
 				var persons = s.Query<Person>()
@@ -353,11 +354,51 @@ namespace NHibernate.Test.Futures
 					var events = logSpy.Appender.GetEvents();
 					Assert.AreEqual(1, events.Length);
 					var wholeLog = logSpy.GetWholeLog();
-					string paramPrefix = ((DriverBase)Sfi.ConnectionProvider.Driver).NamedPrefix;
+					string paramPrefix = ((DriverBase) Sfi.ConnectionProvider.Driver).NamedPrefix;
 					Assert.That(
 						wholeLog,
 						Does.Contain(paramPrefix + "p0 = 1 [Type: Int32 (0:0:0)], " + paramPrefix + "p1 = 2 [Type: Int32 (0:0:0)]"));
 				}
+			}
+		}
+
+		[Test]
+		public void UsingManyParametersAndQueries_DoesNotCauseParameterNameCollisions()
+		{
+			//GH-1357
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var p1 = new Person { Name = "Person name", Age = 15};
+				var p2 = new Person { Name = "Person name", Age = 5 };
+
+				s.Save(p1);
+				s.Save(p2);
+				tx.Commit();
+			}
+			using (var s = Sfi.OpenSession())
+			{
+				var list = new List<IFutureEnumerable<Person>>();
+				for (var i = 0; i < 12; i++)
+				{
+					var query = s.Query<Person>();
+					for (var j = 0; j < 12; j++)
+					{
+						query = query.Where(x => x.Age > j);
+					}
+					list.Add(query.SetOptions(x => x.SetCacheable(true)).ToFuture());
+				}
+				foreach (var query in list)
+				{
+					var result = query.ToList();
+					Assert.That(result.Count,Is.EqualTo(1));
+				}
+			}
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Delete("from Person");
+				tx.Commit();
 			}
 		}
 	}

--- a/src/NHibernate/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Impl/MultiCriteriaImpl.cs
@@ -459,7 +459,7 @@ namespace NHibernate.Impl
 			{
 				foreach (KeyValuePair<string, TypedValue> dictionaryEntry in queryParameters.NamedParameters)
 				{
-					combinedQueryParameters.NamedParameters.Add(dictionaryEntry.Key + index, dictionaryEntry.Value);
+					combinedQueryParameters.NamedParameters.Add(dictionaryEntry.Key + "_" + index, dictionaryEntry.Value);
 				}
 				index += 1;
 				positionalParameterTypes.AddRange(queryParameters.PositionalParameterTypes);

--- a/src/NHibernate/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Impl/MultiQueryImpl.cs
@@ -752,7 +752,7 @@ namespace NHibernate.Impl
 			{
 				foreach (KeyValuePair<string, TypedValue> dictionaryEntry in queryParameters.NamedParameters)
 				{
-					combinedQueryParameters.NamedParameters.Add(dictionaryEntry.Key + index, dictionaryEntry.Value);
+					combinedQueryParameters.NamedParameters.Add(dictionaryEntry.Key + "_" + index, dictionaryEntry.Value);
 				}
 				index += 1;
 				positionalParameterTypes.AddRange(queryParameters.PositionalParameterTypes);


### PR DESCRIPTION
Simplest possible fix for #1357, which bit us in production today. 

Ideally, this should be extracted to a testable class.