### PR TITLE
Release 5.0.1

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -1,0 +1,23 @@
+create:
+  include-footer: false
+issue-labels-include:
+ - "t: Bug"
+ - "t: New Feature"
+ - "t: Improvement"
+ - "t: Task"
+issue-labels-exclude:
+ - "r: Rejected"
+ - "r: Replaced"
+issue-labels-alias:
+ - name:   "t: Bug"
+   header: Bug
+   plural: Bug
+ - name:   "t: New Feature"
+   header: New Feature
+   plural: New Feature
+ - name:   "t: Improvement"
+   header: Improvement
+   plural: Improvement
+ - name:   "t: Task"
+   header: Task
+   plural: Task

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -30,8 +30,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.0.0" overwrite="false" />
-	<property name="project.version.numeric" value="5.0.0" overwrite="false" />
+	<property name="project.version" value="5.0.1" overwrite="false" />
+	<property name="project.version.numeric" value="5.0.1" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -41,6 +41,7 @@ Release notes - NHibernate - Version 5.0.1
     * #711 Switch doc generation to UTF-8.
 
 ** Task
+    * #1431 Release 5.0.1
     * #1405 Remove unused and broken NHibernate.Setup WiX project
 
 

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -4,21 +4,44 @@
 Release notes - NHibernate - Version 5.0.1
 
 ** Bug
+    * #1428 Insert underscore in combined parameter name
+    * #1424 Bad wording and example fixes in cache documentation.
+    * #1420 Fix #1419 - ISession.IsDirty() shouldn't throw exception for transient many-to-one object in a session
     * #1419 ISession.IsDirty() shouldn't throw exception for transient many-to-one object in a session
     * #1418 Column.GetAlias should account for other suffixes
+    * #1415 Correct MaxAliasLength for various dialects
+    * #1393 Fix Linq Future aggregates failures, fixes #1387
+    * #1389 Add support for out/ref Nullable parameters of proxied methods
     * #1387 Linq Sum() with ToFutureValue fails
+    * #1384 Fix a column spec causing missing col in pdf, fix a text overflow
+    * #1380 #750 - AliasToBean failure, test case and fix
+    * #1378 Fix #1362 - Running Unit tests against SQLite fails on datetime/UTC
     * #1362 NH-4093 - Running Unit tests against SQLite fails on numerous (22) datetime/UTC related tests.
     * #1357 NH-3983 - ToFuture throws ArgumentException at CreateCombinedQueryParameters
     * #1179 NH-3840 - Wrong documentation of "cascade" in 5.1.11 (many-to-one)
     * #1165 NH-3554 - Docs - bidirectional, indexed collections
+    * #983 Fix forgotten CDATA closure.
     * #879 NH-4006 - Provide a correct MaxAliasLength for various dialects
     * #750 Transformers.AliasToBean: Value cannot be null. Parameter name: key
+    * #712 NH-4092 - AsyncGenerator creates unused private static event handler in SQLite20Driver
 
 ** Improvement
+    * #1410 Remove unused code in build scripts
+    * #1404 Use MsBuild for packing .nupkg files
+    * #1401 Clean up db tests dependencies
+    * #1395 Documentation fixes
     * #1386 Lack of custom logging documentation
+    * #1382 Jira to GitHub: change issue naming in tests
+    * #1379 Documentation fixes
+    * #982 Back port doc fixes
     * #824 NH-3208 - Document all possible settings in hibernate.cfg
     * #823 NH-3179 - Documentation should note that OnDelete should set IsSaved to false in chapter 24.1
     * #788 NH-1947 - Undocumented attributes on sql-query element
+    * #713 Switch to GitHub issues
+    * #711 Switch doc generation to UTF-8.
+
+** Task
+    * #1405 Remove unused and broken NHibernate.Setup WiX project
 
 
 Build 5.0.0

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,4 +1,27 @@
-﻿Build 5.0.0
+﻿Build 5.0.1
+=============================
+
+Release notes - NHibernate - Version 5.0.1
+
+** Bug
+    * #1419 ISession.IsDirty() shouldn't throw exception for transient many-to-one object in a session
+    * #1418 Column.GetAlias should account for other suffixes
+    * #1387 Linq Sum() with ToFutureValue fails
+    * #1362 NH-4093 - Running Unit tests against SQLite fails on numerous (22) datetime/UTC related tests.
+    * #1357 NH-3983 - ToFuture throws ArgumentException at CreateCombinedQueryParameters
+    * #1179 NH-3840 - Wrong documentation of "cascade" in 5.1.11 (many-to-one)
+    * #1165 NH-3554 - Docs - bidirectional, indexed collections
+    * #879 NH-4006 - Provide a correct MaxAliasLength for various dialects
+    * #750 Transformers.AliasToBean: Value cannot be null. Parameter name: key
+
+** Improvement
+    * #1386 Lack of custom logging documentation
+    * #824 NH-3208 - Document all possible settings in hibernate.cfg
+    * #823 NH-3179 - Documentation should note that OnDelete should set IsSaved to false in chapter 24.1
+    * #788 NH-1947 - Undocumented attributes on sql-query element
+
+
+Build 5.0.0
 =============================
 
 ** Highlights


### PR DESCRIPTION
I have not really found a satisfactory solution for the release.

I have manually drafted the [release](https://github.com/nhibernate/nhibernate-core/releases/tag/untagged-c7dece9a78efdef0dae0), it is probably view-able by all owners from the [release list](https://github.com/nhibernate/nhibernate-core/releases).

I have temporarily created another draft with [GitReleaseManager](https://github.com/GitTools/GitReleaseManager) for extracting the issue list. It has not the option to just create the list as a file, nor does it allows an easy text export, and it includes PR within issues.

I have taken the generated markdown and trimmed its code to amend the txt release notes.

That is a lot of manual manipulations.

Furthermore, in case an issue or PR is in the milestone without one of the configured label, the tool fails with an exception. Its message is understandable, but that is not a great error handling.

I have also tried [GitReleaseNotes](https://github.com/GitTools/GitReleaseNotes), but it has too few options. At least GitReleaseManager allows to handle our labels for sorting things into categories.