### PR TITLE
Allow naming an entity property FieldInterceptor when it has lazy properties

### DIFF
--- a/src/NHibernate.Test/Async/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/Async/LazyProperty/LazyPropertyFixture.cs
@@ -9,6 +9,7 @@
 
 
 using System.Collections;
+using NHibernate.Intercept;
 using NHibernate.Tuple.Entity;
 using NUnit.Framework;
 
@@ -42,6 +43,11 @@ namespace NHibernate.Test.LazyProperty
 
 		protected override void OnSetUp()
 		{
+			Assert.That(
+				nameof(Book.FieldInterceptor),
+				Is.EqualTo(nameof(IFieldInterceptorAccessor.FieldInterceptor)),
+				$"Test pre-condition not met: entity property {nameof(Book.FieldInterceptor)} should have the same " +
+				$"name than {nameof(IFieldInterceptorAccessor)}.{nameof(IFieldInterceptorAccessor.FieldInterceptor)}");
 			using (var s = OpenSession())
 			using (var tx = s.BeginTransaction())
 			{
@@ -49,7 +55,8 @@ namespace NHibernate.Test.LazyProperty
 				{
 					Name = "some name",
 					Id = 1,
-					ALotOfText = "a lot of text ..."
+					ALotOfText = "a lot of text ...",
+					FieldInterceptor = "Why not that name?"
 				});
 				tx.Commit();
 			}
@@ -76,12 +83,14 @@ namespace NHibernate.Test.LazyProperty
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Id"), Is.False);
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Name"), Is.False);
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False);
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, nameof(Book.FieldInterceptor)), Is.False);
 
 				await (NHibernateUtil.InitializeAsync(book));
 
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Id"), Is.True);
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Name"), Is.True);
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False);
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, nameof(Book.FieldInterceptor)), Is.True);
 			}
 		}
 
@@ -95,6 +104,7 @@ namespace NHibernate.Test.LazyProperty
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Id"), Is.True);
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Name"), Is.True);
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False);
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, nameof(Book.FieldInterceptor)), Is.True);
 			}
 		}
 
@@ -118,6 +128,7 @@ namespace NHibernate.Test.LazyProperty
 				var book = await (s.GetAsync<Book>(1));
 
 				Assert.That(book.Name, Is.EqualTo("some name"));
+				Assert.That(book.FieldInterceptor, Is.EqualTo("Why not that name?"));
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False);
 			}
 		}
@@ -137,7 +148,6 @@ namespace NHibernate.Test.LazyProperty
 			}
 		}
 
-
 		[Test]
 		public async Task CanUpdateNonLazyWithoutLoadingLazyPropertyAsync()
 		{
@@ -147,16 +157,18 @@ namespace NHibernate.Test.LazyProperty
 			{
 				book = await (s.GetAsync<Book>(1));
 				book.Name += "updated";
+				book.FieldInterceptor += "updated";
 
-				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False);
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False, "Before flush and commit");
 				await (trans.CommitAsync());
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.False, "After flush and commit");
 			}
-
 
 			using (ISession s = OpenSession())
 			{
 				book = await (s.GetAsync<Book>(1));
 				Assert.That(book.Name, Is.EqualTo("some nameupdated"));
+				Assert.That(book.FieldInterceptor, Is.EqualTo("Why not that name?updated"));
 			}
 		}
 	}

--- a/src/NHibernate.Test/LazyProperty/Book.cs
+++ b/src/NHibernate.Test/LazyProperty/Book.cs
@@ -12,5 +12,7 @@
 			get { return _aLotOfText; }
 			set { _aLotOfText = value; }
 		}
+
+		public virtual string FieldInterceptor { get; set; }
 	}
 }

--- a/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
+++ b/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
@@ -9,6 +9,7 @@
 		</id>
 		<property name="Name" />
 		<property name="ALotOfText" lazy="true" />
+		<property name="FieldInterceptor" />
 	</class>
 
 </hibernate-mapping>

--- a/src/NHibernate/Intercept/DefaultDynamicLazyFieldInterceptor.cs
+++ b/src/NHibernate/Intercept/DefaultDynamicLazyFieldInterceptor.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Intercept
 			{
 				if (ReflectHelper.IsPropertyGet(info.TargetMethod))
 				{
-					if("get_FieldInterceptor".Equals(methodName))
+					if (IsGetFieldInterceptorCall(methodName, info.TargetMethod))
 					{
 						return FieldInterceptor;
 					}
@@ -33,7 +33,7 @@ namespace NHibernate.Intercept
 				}
 				else if (ReflectHelper.IsPropertySet(info.TargetMethod))
 				{
-					if ("set_FieldInterceptor".Equals(methodName))
+					if (IsSetFieldInterceptorCall(methodName, info.TargetMethod))
 					{
 						FieldInterceptor = (IFieldInterceptor)info.Arguments[0];
 						return null;
@@ -44,7 +44,7 @@ namespace NHibernate.Intercept
 			}
 			else
 			{
-				if ("set_FieldInterceptor".Equals(methodName))
+				if (IsSetFieldInterceptorCall(methodName, info.TargetMethod))
 				{
 					FieldInterceptor = (IFieldInterceptor)info.Arguments[0];
 					return null;
@@ -61,6 +61,16 @@ namespace NHibernate.Intercept
 				throw ReflectHelper.UnwrapTargetInvocationException(ex);
 			}
 			return returnValue;
+		}
+
+		private static bool IsGetFieldInterceptorCall(string methodName, MethodInfo targetMethod)
+		{
+			return "get_FieldInterceptor".Equals(methodName) && targetMethod.DeclaringType == typeof(IFieldInterceptorAccessor);
+		}
+
+		private static bool IsSetFieldInterceptorCall(string methodName, MethodInfo targetMethod)
+		{
+			return "set_FieldInterceptor".Equals(methodName) && targetMethod.DeclaringType == typeof(IFieldInterceptorAccessor);
 		}
 	}
 }


### PR DESCRIPTION
 * Fixes #1442

Since there is already some refactoring on that code in #1437, those two PR are going to conflict.