### PR TITLE
Upgrade AsyncGenerator to 0.6.2 and regenerate.

### DIFF
--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -7,6 +7,6 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net461" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="CSharpAsyncGenerator.CommandLine" version="0.6.0" targetFramework="net461" />
+  <package id="CSharpAsyncGenerator.CommandLine" version="0.6.2" targetFramework="net461" />
   <package id="vswhere" version="2.1.4" targetFramework="net461" />
 </packages>

--- a/src/NHibernate.Test/Async/ExpressionTest/QueryByExampleTest.cs
+++ b/src/NHibernate.Test/Async/ExpressionTest/QueryByExampleTest.cs
@@ -17,7 +17,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.ExpressionTest
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class QueryByExampleTestAsync : TestCase
 	{
@@ -150,30 +149,6 @@ namespace NHibernate.Test.ExpressionTest
 			}
 		}
 
-		private async Task InitDataAsync(CancellationToken cancellationToken = default(CancellationToken))
-		{
-			using (ISession s = OpenSession())
-			{
-				Componentizable master = GetMaster("hibernate", "ORM tool", "ORM tool1");
-				await (s.SaveAsync(master, cancellationToken));
-				await (s.FlushAsync(cancellationToken));
-			}
-
-			using (ISession s = OpenSession())
-			{
-				Componentizable master = GetMaster("hibernate", "open source", "open source1");
-				await (s.SaveAsync(master, cancellationToken));
-				await (s.FlushAsync(cancellationToken));
-			}
-
-			using (ISession s = OpenSession())
-			{
-				Componentizable master = GetMaster("hibernate", null, null);
-				await (s.SaveAsync(master, cancellationToken));
-				await (s.FlushAsync(cancellationToken));
-			}
-		}
-
 		private void InitData()
 		{
 			using (ISession s = OpenSession())
@@ -195,16 +170,6 @@ namespace NHibernate.Test.ExpressionTest
 				Componentizable master = GetMaster("hibernate", null, null);
 				s.Save(master);
 				s.Flush();
-			}
-		}
-
-		private async Task DeleteDataAsync(CancellationToken cancellationToken = default(CancellationToken))
-		{
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
-			{
-				await (s.DeleteAsync("from Componentizable", cancellationToken));
-				await (t.CommitAsync(cancellationToken));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1507/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1507/Fixture.cs
@@ -16,7 +16,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1507
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -33,54 +32,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1507
 		protected override void OnTearDown()
 		{
 			CleanupData();
-		}
-
-		private async Task CreateDataAsync(CancellationToken cancellationToken = default(CancellationToken))
-		{
-			//Employee
-			var emp = new Employee
-						{
-							Address = "Zombie street",
-							City = "Bitonto",
-							PostalCode = "66666",
-							FirstName = "tomb",
-							LastName = "mutilated"
-						};
-
-			//and his related orders
-			var order = new Order
-							{OrderDate = DateTime.Now, Employee = emp, ShipAddress = "dead zone 1", ShipCountry = "Deadville"};
-
-			var order2 = new Order
-							{OrderDate = DateTime.Now, Employee = emp, ShipAddress = "dead zone 2", ShipCountry = "Deadville"};
-
-			//Employee with no related orders but with same PostalCode
-			var emp2 = new Employee
-						{
-							Address = "Gut street",
-							City = "Mariotto",
-							Country = "Arised",
-							PostalCode = "66666",
-							FirstName = "carcass",
-							LastName = "purulent"
-						};
-
-			//Order with no related employee but with same ShipCountry
-			var order3 = new Order {OrderDate = DateTime.Now, ShipAddress = "dead zone 2", ShipCountry = "Deadville"};
-
-			using (ISession session = OpenSession())
-			{
-				using (ITransaction tx = session.BeginTransaction())
-				{
-					await (session.SaveAsync(emp, cancellationToken));
-					await (session.SaveAsync(emp2, cancellationToken));
-					await (session.SaveAsync(order, cancellationToken));
-					await (session.SaveAsync(order2, cancellationToken));
-					await (session.SaveAsync(order3, cancellationToken));
-
-					await (tx.CommitAsync(cancellationToken));
-				}
-			}
 		}
 
 		private void CreateData()
@@ -127,23 +78,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1507
 					session.Save(order3);
 
 					tx.Commit();
-				}
-			}
-		}
-
-		private async Task CleanupDataAsync(CancellationToken cancellationToken = default(CancellationToken))
-		{
-			using (ISession session = OpenSession())
-			{
-				using (ITransaction tx = session.BeginTransaction())
-				{
-					//delete empolyee and related orders
-					await (session.DeleteAsync("from Employee ee where ee.PostalCode = '66666'", cancellationToken));
-
-					//delete order not related to employee
-					await (session.DeleteAsync("from Order oo where oo.ShipCountry = 'Deadville'", cancellationToken));
-
-					await (tx.CommitAsync(cancellationToken));
 				}
 			}
 		}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1553/MsSQL/SnapshotIsolationUpdateConflictTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1553/MsSQL/SnapshotIsolationUpdateConflictTest.cs
@@ -159,17 +159,6 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 			return factory.ConnectionProvider.Driver is SqlClientDriver;
 		}
 
-		private async Task SetAllowSnapshotIsolationAsync(bool on, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			using (ISession session = OpenSession())
-			{
-				var command = session.Connection.CreateCommand();
-				command.CommandText = "ALTER DATABASE " + session.Connection.Database + " set allow_snapshot_isolation "
-				                      + (on ? "on" : "off");
-				await (command.ExecuteNonQueryAsync(cancellationToken));
-			}
-		}
-
 		private void SetAllowSnapshotIsolation(bool on)
 		{
 			using (ISession session = OpenSession())

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1792/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1792/Fixture.cs
@@ -16,29 +16,12 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1792
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
 		protected override void OnTearDown()
 		{
 			DeleteAll();
-		}
-
-		/// <summary>
-		/// Deletes all the product entities from the persistence medium
-		/// </summary>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
-		private async Task DeleteAllAsync(CancellationToken cancellationToken = default(CancellationToken))
-		{
-			using (ISession session = OpenSession())
-			{
-				using (ITransaction trans = session.BeginTransaction())
-				{
-					await (session.DeleteAsync("from Product", cancellationToken));
-					await (trans.CommitAsync(cancellationToken));
-				}
-			}
 		}
 
 		/// <summary>

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2302/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2302/Fixture.cs
@@ -17,7 +17,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH2302
 {
     using System.Threading.Tasks;
-    using System.Threading;
     [TestFixture]
     public class FixtureAsync : BugTestCase
     {
@@ -196,16 +195,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2302
 						await (tx.CommitAsync());
 					}
 				}
-
-        private async Task CleanUpAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            using (ISession session = OpenSession())
-            using (ITransaction tx = session.BeginTransaction())
-            {
-                await (session.DeleteAsync("from StringLengthEntity", cancellationToken));
-                await (tx.CommitAsync(cancellationToken));
-            }
-        }
 
         private void CleanUp()
         {

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2583/ManualTestFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2583/ManualTestFixture.cs
@@ -305,18 +305,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2583
             }
         }
 
-        private static Task DeleteAllAsync<T>(ISession session, CancellationToken cancellationToken = default(CancellationToken))
-        {
-               try
-               {
-					       return session.CreateQuery("delete from " + typeof(T).Name).ExecuteUpdateAsync(cancellationToken);
-               }
-               catch (Exception ex)
-               {
-                      return Task.FromException<object>(ex);
-               }
-        }
-
         private static void DeleteAll<T>(ISession session)
         {
 					session.CreateQuery("delete from " + typeof(T).Name).ExecuteUpdate();

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3023/DeadlockConnectionPoolIssueTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3023/DeadlockConnectionPoolIssueTest.cs
@@ -273,34 +273,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3023
 			return scope;
 		}
 
-		private async Task RunScriptAsync(string script, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			var cxnString = cfg.Properties["connection.connection_string"] + "; Pooling=No";
-			// Disable connection pooling so this won't be hindered by
-			// problems encountered during the actual test
-
-			string sql;
-			using (var reader = new StreamReader(GetType().Assembly.GetManifestResourceStream(GetType().Namespace + "." + script)))
-			{
-				sql = await (reader.ReadToEndAsync());
-			}
-
-			using (var cxn = new SqlConnection(cxnString))
-			{
-				await (cxn.OpenAsync(cancellationToken));
-
-				foreach (var batch in Regex.Split(sql, @"^go\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)
-					.Where(b => !string.IsNullOrEmpty(b)))
-				{
-
-					using (var cmd = new System.Data.SqlClient.SqlCommand(batch, cxn))
-					{
-						await (cmd.ExecuteNonQueryAsync(cancellationToken));
-					}
-				}
-			}
-		}
-
 		private void RunScript(string script)
 		{
 			var cxnString = cfg.Properties["connection.connection_string"] + "; Pooling=No";

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3332/TestJoinsWithSameTable.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3332/TestJoinsWithSameTable.cs
@@ -16,7 +16,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH3332
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class TestJoinsWithSameTableAsync : BugTestCase
 	{
@@ -81,71 +80,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3332
 
 				Assert.That(list, Has.Count.EqualTo(1));
 			}
-		}
-
-
-		private async Task CreateObjectsAsync(ISession session, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			// Create the English culture
-			Culture englishCulture = new Culture();
-
-
-			englishCulture.CountryCode = "CA";
-			englishCulture.LanguageCode = "en";
-
-			await (session.SaveOrUpdateAsync(englishCulture, cancellationToken));
-			await (session.FlushAsync(cancellationToken));
-
-			// Create the Spanish culture
-			Culture spanishCulture = new Culture();
-			spanishCulture.CountryCode = "ES";
-			spanishCulture.LanguageCode = "es";
-
-			await (session.SaveOrUpdateAsync(spanishCulture, cancellationToken));
-			await (session.FlushAsync(cancellationToken));
-
-			// Create a DataType and attach it an English description
-
-			DataType dataType1 = new DataType();
-			dataType1.Name = "int";
-
-			DataTypeDescription dataTypeDescription1 = new DataTypeDescription();
-
-			dataTypeDescription1.Culture = englishCulture;
-			dataTypeDescription1.DataType = dataType1;
-
-			dataType1.DataTypeDescriptions.Add(dataTypeDescription1);
-
-
-
-			// Create a State and attach it an English description and a Spanish description
-
-			State state1 = new State();
-			state1.Name = "Development";
-
-			StateDescription englishStateDescription = new StateDescription();
-			englishStateDescription.Culture = englishCulture;
-			englishStateDescription.State = state1;
-			//      englishStateDescription.Description = "Development - English";
-
-			state1.StateDescriptions.Add(englishStateDescription);
-
-			StateDescription spanishStateDescription = new StateDescription();
-			spanishStateDescription.Culture = spanishCulture;
-			spanishStateDescription.State = state1;
-			//      spanishStateDescription.Description = "Development - Spanish";
-
-			state1.StateDescriptions.Add(spanishStateDescription);
-
-
-			MasterEntity masterEntity = new MasterEntity();
-
-			masterEntity.Name = "MasterEntity 1";
-			masterEntity.State = state1;
-			masterEntity.DataType = dataType1;
-
-			await (session.SaveOrUpdateAsync(masterEntity, cancellationToken));
-			await (session.FlushAsync(cancellationToken));
 		}
 
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3620/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3620/Fixture.cs
@@ -14,7 +14,6 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3620 {
     using System.Threading.Tasks;
-    using System.Threading;
     [TestFixture]
     public class FixtureAsync : BugTestCase {
         protected override bool AppliesTo(Engine.ISessionFactoryImplementor factory) {
@@ -40,16 +39,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3620 {
                     };
                     await (s.SaveAsync(tb));
                     await (tx.CommitAsync());
-                }
-            }
-        }
-
-        private async Task CleanupDataAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            using (ISession session = OpenSession()) {
-                using (ITransaction tx = session.BeginTransaction()) {
-                    await (session.DeleteAsync("from TwoBlobs", cancellationToken));
-                    await (tx.CommitAsync(cancellationToken));
                 }
             }
         }

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3641/TestFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3641/TestFixture.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH3641
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class TestFixtureAsync : BugTestCase
 	{
@@ -42,12 +41,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3641
 				DeleteAll<Entity>(session);
 				tx.Commit();
 			}
-		}
-
-		private static async Task DeleteAllAsync<T>(ISession session, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			await (session.CreateQuery("delete from " + typeof(T).Name + " where ChildInterface is not null").ExecuteUpdateAsync(cancellationToken));
-			await (session.CreateQuery("delete from " + typeof(T).Name).ExecuteUpdateAsync(cancellationToken));
 		}
 
 		private static void DeleteAll<T>(ISession session)

--- a/src/NHibernate.Test/Async/SystemTransactions/DistributedSystemTransactionFixture.cs
+++ b/src/NHibernate.Test/Async/SystemTransactions/DistributedSystemTransactionFixture.cs
@@ -157,46 +157,6 @@ namespace NHibernate.Test.SystemTransactions
 		}
 
 		[Theory]
-		public void CanRollbackTransaction(bool explicitFlush)
-		{
-			IgnoreIfUnsupported(explicitFlush);
-			var tx = new TransactionScope();
-			var disposeCalled = false;
-			try
-			{
-				using (var s = OpenSession())
-				{
-					ForceEscalationToDistributedTx.Escalate(true); //will rollback tx
-					s.Save(new Person());
-
-					if (explicitFlush)
-						s.Flush();
-
-					tx.Complete();
-				}
-				disposeCalled = true;
-				Assert.Throws<TransactionAbortedException>(tx.Dispose, "Scope disposal has not rollback and throw.");
-			}
-			finally
-			{
-				if (!disposeCalled)
-				{
-					try
-					{
-						tx.Dispose();
-					}
-					catch
-					{
-						// Ignore, if disposed has not been called, another exception has occurred in the try and
-						// we should avoid overriding it by the disposal failure.
-					}
-				}
-			}
-
-			AssertNoPersons();
-		}
-
-		[Theory]
 		public async Task CanRollbackTransactionFromScopeAsync(bool explicitFlush)
 		{
 			IgnoreIfUnsupported(explicitFlush);
@@ -230,38 +190,6 @@ namespace NHibernate.Test.SystemTransactions
 
 						if (explicitFlush)
 							await (s.FlushAsync());
-					}
-					ForceEscalationToDistributedTx.Escalate(true); //will rollback tx
-
-					txscope.Complete();
-				}
-
-				Assert.Fail("Scope disposal has not rollback and throw.");
-			}
-			catch (TransactionAbortedException)
-			{
-				_log.Debug("Transaction aborted.");
-			}
-
-			AssertNoPersons();
-		}
-
-		[Theory]
-		[Description("Another action inside the transaction do the rollBack outside nh-session-scope.")]
-		public void RollbackOutsideNh(bool explicitFlush)
-		{
-			IgnoreIfUnsupported(explicitFlush);
-			try
-			{
-				using (var txscope = new TransactionScope())
-				{
-					using (var s = OpenSession())
-					{
-						var person = new Person();
-						s.Save(person);
-
-						if (explicitFlush)
-							s.Flush();
 					}
 					ForceEscalationToDistributedTx.Escalate(true); //will rollback tx
 
@@ -316,37 +244,6 @@ namespace NHibernate.Test.SystemTransactions
 
 						if (explicitFlush)
 							await (s.FlushAsync());
-					}
-					txscope.Complete();
-				}
-
-				Assert.Fail("Scope disposal has not rollback and throw.");
-			}
-			catch (TransactionAbortedException)
-			{
-				_log.Debug("Transaction aborted.");
-			}
-
-			AssertNoPersons();
-		}
-
-		[Theory]
-		[Description("rollback inside nh-session-scope should not commit save and the transaction should be aborted.")]
-		public void TransactionInsertWithRollBackTask(bool explicitFlush)
-		{
-			IgnoreIfUnsupported(explicitFlush);
-			try
-			{
-				using (var txscope = new TransactionScope())
-				{
-					using (var s = OpenSession())
-					{
-						var person = new Person();
-						s.Save(person);
-						ForceEscalationToDistributedTx.Escalate(true); //will rollback tx
-
-						if (explicitFlush)
-							s.Flush();
 					}
 					txscope.Complete();
 				}
@@ -456,60 +353,6 @@ namespace NHibernate.Test.SystemTransactions
 			using (s.BeginTransaction())
 			{
 				Assert.AreEqual(createdAt, (await (s.GetAsync<Person>(savedId))).CreatedAt, "Entity update was not rollback-ed.");
-			}
-		}
-
-		[Theory]
-		[Description(@"Two session in two txscope
- (without an explicit NH transaction)
- and with a rollback in the second dtc and a ForceRollback outside nh-session-scope.")]
-		public void TransactionInsertLoadWithRollBackTask(bool explicitFlush)
-		{
-			IgnoreIfUnsupported(explicitFlush);
-			object savedId;
-			var createdAt = DateTime.Today;
-			using (var txscope = new TransactionScope())
-			{
-				using (var s = OpenSession())
-				{
-					var person = new Person { CreatedAt = createdAt };
-					savedId = s.Save(person);
-
-					if (explicitFlush)
-						s.Flush();
-				}
-				txscope.Complete();
-			}
-
-			try
-			{
-				using (var txscope = new TransactionScope())
-				{
-					using (var s = OpenSession())
-					{
-						var person = s.Get<Person>(savedId);
-						person.CreatedAt = createdAt.AddMonths(-1);
-
-						if (explicitFlush)
-							s.Flush();
-					}
-					ForceEscalationToDistributedTx.Escalate(true);
-
-					_log.Debug("completing the tx scope");
-					txscope.Complete();
-				}
-				_log.Debug("Transaction fail.");
-				Assert.Fail("Expected tx abort");
-			}
-			catch (TransactionAbortedException)
-			{
-				_log.Debug("Transaction aborted.");
-			}
-
-			using (var s = OpenSession())
-			using (s.BeginTransaction())
-			{
-				Assert.AreEqual(createdAt, s.Get<Person>(savedId).CreatedAt, "Entity update was not rollback-ed.");
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/GH1391/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1391/Fixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using NHibernate.Cfg;
@@ -10,6 +9,7 @@ using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Test.NHSpecificTest.GH1391
 {
+	[TestFixture]
 	public class Fixture
 	{
 		private readonly Random _random = new Random();


### PR DESCRIPTION
Fixes the invalid generation of async methods for test GH1391, which is currently an annoyance to revert every time async is regenerated.