### PR TITLE
Fix ProxyFactory cache

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3954/EqualsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3954/EqualsFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.Serialization;
 using NHibernate.Proxy;
 using NHibernate.Proxy.DynamicProxy;
 using NHibernate.Type;
@@ -48,9 +49,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3954
 		[Test]
 		public void InterfaceEquality()
 		{
-			var entry1 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(INHibernateProxy), typeof(IProxy) });
+			var entry1 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(INHibernateProxy), typeof(ISerializable) });
 			// Interfaces order inverted on purpose: must be supported.
-			var entry2 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(IProxy), typeof(INHibernateProxy) });
+			var entry2 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(ISerializable), typeof(INHibernateProxy) });
 			Assert.IsTrue(entry1.Equals(entry2));
 			Assert.IsTrue(entry2.Equals(entry1));
 		}
@@ -59,9 +60,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3954
 		[Test]
 		public void InterfaceEqualityWithLotOfUnordererdAndDupInterfaces()
 		{
-			var entry1 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(INHibernateProxy), typeof(IProxy), typeof(IType), typeof(IDisposable), typeof(IFilter) });
+			var entry1 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(INHibernateProxy), typeof(ISerializable), typeof(IType), typeof(IDisposable), typeof(IFilter) });
 			// Interfaces order inverted and duplicated on purpose: must be supported.
-			var entry2 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(IType), typeof(IProxy), typeof(IFilter), typeof(IDisposable), typeof(IType), typeof(IFilter), typeof(INHibernateProxy) });
+			var entry2 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(IType), typeof(ISerializable), typeof(IFilter), typeof(IDisposable), typeof(IType), typeof(IFilter), typeof(INHibernateProxy) });
 			Assert.IsTrue(entry1.Equals(entry2));
 			Assert.IsTrue(entry2.Equals(entry1));
 		}
@@ -69,8 +70,8 @@ namespace NHibernate.Test.NHSpecificTest.NH3954
 		[Test]
 		public void InterfaceInequality()
 		{
-			var entry1 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(INHibernateProxy), typeof(IProxy) });
-			var entry2 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(IProxy) });
+			var entry1 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(INHibernateProxy), typeof(ISerializable) });
+			var entry2 = new ProxyCacheEntry(typeof(Entity1), new[] { typeof(ISerializable) });
 			TweakEntry(entry2, entry1.GetHashCode());
 			Assert.IsFalse(entry1.Equals(entry2));
 			Assert.IsFalse(entry2.Equals(entry1));

--- a/src/NHibernate/Async/Engine/Cascade.cs
+++ b/src/NHibernate/Async/Engine/Cascade.cs
@@ -9,7 +9,7 @@
 
 
 using System.Collections;
-
+using System.Collections.Generic;
 using NHibernate.Collection;
 using NHibernate.Event;
 using NHibernate.Persister.Collection;

--- a/src/NHibernate/Proxy/DynamicProxy/DefaultMethodEmitter.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/DefaultMethodEmitter.cs
@@ -10,15 +10,12 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
-using NHibernate.Linq;
 using NHibernate.Util;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	internal class DefaultMethodEmitter : IMethodBodyEmitter
 	{
-		private static readonly MethodInfo getInterceptor;
-
 		private static readonly MethodInfo handlerMethod = ReflectHelper.GetMethod<IInterceptor>(
 			i => i.Intercept(null));
 		private static readonly MethodInfo getArguments = typeof(InvocationInfo).GetMethod("get_Arguments");
@@ -33,16 +30,7 @@ namespace NHibernate.Proxy.DynamicProxy
 				typeof (object[])
 			});
 
-		private static readonly PropertyInfo interceptorProperty = typeof (IProxy).GetProperty("Interceptor");
-
-		private static readonly ConstructorInfo notImplementedConstructor = typeof(NotImplementedException).GetConstructor(new System.Type[0]);
-
 		private readonly IArgumentHandler _argumentHandler;
-
-		static DefaultMethodEmitter()
-		{
-			getInterceptor = interceptorProperty.GetGetMethod();
-		}
 
 		public DefaultMethodEmitter() : this(new DefaultArgumentHandler()) {}
 
@@ -60,12 +48,12 @@ namespace NHibernate.Proxy.DynamicProxy
 			ParameterInfo[] parameters = method.GetParameters();
 			IL.DeclareLocal(typeof (object[]));
 			IL.DeclareLocal(typeof (InvocationInfo));
-			IL.DeclareLocal(typeof(System.Type[]));
+			IL.DeclareLocal(typeof (System.Type[]));
 
 			IL.Emit(OpCodes.Ldarg_0);
-			IL.Emit(OpCodes.Callvirt, getInterceptor);
+			IL.Emit(OpCodes.Ldfld, field);
 
-			// if (interceptor == null)
+			// if (this.__interceptor == null)
 			// 		return base.method(...);
 
 			Label skipBaseCall = IL.DefineLabel();
@@ -90,9 +78,9 @@ namespace NHibernate.Proxy.DynamicProxy
 			IL.Emit(OpCodes.Newobj, infoConstructor);
 			IL.Emit(OpCodes.Stloc_1);
 
-			// this.Interceptor.Intercept(info);
+			// this.__interceptor.Intercept(info);
 			IL.Emit(OpCodes.Ldarg_0);
-			IL.Emit(OpCodes.Callvirt, getInterceptor);
+			IL.Emit(OpCodes.Ldfld, field);
 			IL.Emit(OpCodes.Ldloc_1);
 			IL.Emit(OpCodes.Callvirt, handlerMethod);
 

--- a/src/NHibernate/Proxy/DynamicProxy/HashSetExtensions.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/HashSetExtensions.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
+	[Obsolete("This class is not used anymore and will be removed in a next major version")]
 	public static class HashSetExtensions
 	{
+		[Obsolete("This method is not used anymore and will be removed in a next major version")]
 		public static HashSet<T> Merge<T>(this HashSet<T> source, IEnumerable<T> toMerge)
 		{
 			foreach (T item in toMerge)

--- a/src/NHibernate/Proxy/DynamicProxy/IProxyCache.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/IProxyCache.cs
@@ -11,9 +11,12 @@ using System.Reflection;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
+	//Since v5.1
+	[Obsolete("This class is not used anymore and will be removed in a next major version")]
 	public interface IProxyCache
 	{
 		bool Contains(System.Type baseType, params System.Type[] baseInterfaces);
+
 		TypeInfo GetProxyType(System.Type baseType, params System.Type[] baseInterfaces);
 
 		bool TryGetProxyType(System.Type baseType, System.Type[] baseInterfaces, out TypeInfo proxyType);

--- a/src/NHibernate/Proxy/DynamicProxy/IProxyCache.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/IProxyCache.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 namespace NHibernate.Proxy.DynamicProxy
 {
 	//Since v5.1
-	[Obsolete("This class is not used anymore and will be removed in a next major version")]
+	[Obsolete("This interface is not used anymore and will be removed in a next major version")]
 	public interface IProxyCache
 	{
 		bool Contains(System.Type baseType, params System.Type[] baseInterfaces);

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyCache.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyCache.cs
@@ -6,32 +6,28 @@
 
 #endregion
 
-using System.Collections.Concurrent;
+using System;
 using System.Reflection;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
+	//Since v5.1
+	[Obsolete("This class is not used anymore and will be removed in a next major version")]
 	public class ProxyCache : IProxyCache
 	{
-		private static readonly ConcurrentDictionary<ProxyCacheEntry, TypeInfo> cache = new ConcurrentDictionary<ProxyCacheEntry, TypeInfo>();
-
-		#region IProxyCache Members
-
 		public bool Contains(System.Type baseType, params System.Type[] baseInterfaces)
 		{
 			if (baseType == null)
-			{
 				return false;
-			}
 
 			var entry = new ProxyCacheEntry(baseType, baseInterfaces);
-			return cache.ContainsKey(entry);
+			return ProxyFactory._cache.ContainsKey(entry);
 		}
 
 		public TypeInfo GetProxyType(System.Type baseType, params System.Type[] baseInterfaces)
 		{
 			var entry = new ProxyCacheEntry(baseType, baseInterfaces);
-			return cache[entry];
+			return ProxyFactory._cache[entry];
 		}
 
 		public bool TryGetProxyType(System.Type baseType, System.Type[] baseInterfaces, out TypeInfo proxyType)
@@ -42,15 +38,13 @@ namespace NHibernate.Proxy.DynamicProxy
 				return false;
 
 			var entry = new ProxyCacheEntry(baseType, baseInterfaces);
-			return cache.TryGetValue(entry, out proxyType);
+			return ProxyFactory._cache.TryGetValue(entry, out proxyType);
 		}
 
 		public void StoreProxyType(TypeInfo result, System.Type baseType, params System.Type[] baseInterfaces)
 		{
 			var entry = new ProxyCacheEntry(baseType, baseInterfaces);
-			cache[entry] = result;
+			ProxyFactory._cache[entry] = result;
 		}
-
-		#endregion
 	}
 }

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyCacheEntry.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyCacheEntry.cs
@@ -8,29 +8,32 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	public class ProxyCacheEntry : IEquatable<ProxyCacheEntry>
 	{
 		private readonly int _hashCode;
+		private readonly HashSet<System.Type> _uniqueInterfaces;
 
 		public ProxyCacheEntry(System.Type baseType, System.Type[] interfaces)
 		{
-			if (baseType == null)
-				throw new ArgumentNullException(nameof(baseType));
-			BaseType = baseType;
-			_uniqueInterfaces = new HashSet<System.Type>(interfaces ?? new System.Type[0]);
+			BaseType = baseType ?? throw new ArgumentNullException(nameof(baseType));
+
+			var uniqueInterfaces = new HashSet<System.Type>();
+			if (interfaces != null && interfaces.Length > 0)
+			{
+				uniqueInterfaces.UnionWith(interfaces.Where(i => i != null));
+			}
+			_uniqueInterfaces = uniqueInterfaces;
+
+			_hashCode = 59 ^ baseType.GetHashCode();
 
 			if (_uniqueInterfaces.Count == 0)
-			{
-				_hashCode = baseType.GetHashCode();
 				return;
-			}
-			
-			var allTypes = new List<System.Type>(_uniqueInterfaces) { baseType };
-			_hashCode = 59;
-			foreach (System.Type type in allTypes)
+
+			foreach (var type in _uniqueInterfaces)
 			{
 				// This simple implementation is nonsensitive to list order. If changing it for a sensitive one,
 				// take care of ordering the list.
@@ -39,14 +42,12 @@ namespace NHibernate.Proxy.DynamicProxy
 		}
 
 		public System.Type BaseType { get; }
-		public IReadOnlyCollection<System.Type> Interfaces { get { return _uniqueInterfaces; } }
-		
-		private HashSet<System.Type> _uniqueInterfaces;
+
+		public IReadOnlyCollection<System.Type> Interfaces => _uniqueInterfaces;
 
 		public override bool Equals(object obj)
 		{
-			var that = obj as ProxyCacheEntry;
-			return Equals(that);
+			return Equals(obj as ProxyCacheEntry);
 		}
 
 		public bool Equals(ProxyCacheEntry other)

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyFactory.cs
@@ -7,18 +7,20 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.Serialization;
-using NHibernate.Linq;
 using NHibernate.Util;
 
 namespace NHibernate.Proxy.DynamicProxy
 {
 	public sealed class ProxyFactory
 	{
+		internal static readonly ConcurrentDictionary<ProxyCacheEntry, TypeInfo> _cache = new ConcurrentDictionary<ProxyCacheEntry, TypeInfo>();
+
 		private static readonly ConstructorInfo defaultBaseConstructor = typeof(object).GetConstructor(new System.Type[0]);
 
 		private static readonly MethodInfo getValue = ReflectHelper.GetMethod<SerializationInfo>(
@@ -35,24 +37,21 @@ namespace NHibernate.Proxy.DynamicProxy
 			: this(new DefaultyProxyMethodBuilder(), proxyAssemblyBuilder) {}
 
 		public ProxyFactory(IProxyMethodBuilder proxyMethodBuilder)
-			: this(new DefaultyProxyMethodBuilder(), new DefaultProxyAssemblyBuilder()) {}
+			: this(proxyMethodBuilder, new DefaultProxyAssemblyBuilder()) {}
 
 		public ProxyFactory(IProxyMethodBuilder proxyMethodBuilder, IProxyAssemblyBuilder proxyAssemblyBuilder)
 		{
-			if (proxyMethodBuilder == null)
-			{
-				throw new ArgumentNullException("proxyMethodBuilder");
-			}
-			ProxyMethodBuilder = proxyMethodBuilder;
+			ProxyMethodBuilder = proxyMethodBuilder ?? throw new ArgumentNullException(nameof(proxyMethodBuilder));
 			ProxyAssemblyBuilder = proxyAssemblyBuilder;
-			Cache = new ProxyCache();
 		}
 
-		public IProxyCache Cache { get; private set; }
+		//Since v5.1
+		[Obsolete("This property is not used anymore and will be removed in a next major version")]
+		public IProxyCache Cache { get; } = new ProxyCache();
 
-		public IProxyMethodBuilder ProxyMethodBuilder { get; private set; }
+		public IProxyMethodBuilder ProxyMethodBuilder { get; }
 
-		public IProxyAssemblyBuilder ProxyAssemblyBuilder { get; private set; }
+		public IProxyAssemblyBuilder ProxyAssemblyBuilder { get; }
 
 		public object CreateProxy(System.Type instanceType, IInterceptor interceptor, params System.Type[] baseInterfaces)
 		{
@@ -60,37 +59,21 @@ namespace NHibernate.Proxy.DynamicProxy
 			object result = Activator.CreateInstance(proxyType);
 			var proxy = (IProxy) result;
 			proxy.Interceptor = interceptor;
-
 			return result;
 		}
 
 		public System.Type CreateProxyType(System.Type baseType, params System.Type[] interfaces)
 		{
-			System.Type[] baseInterfaces = ReferenceEquals(null, interfaces) ? new System.Type[0] : interfaces.Where(t => t != null).ToArray();
-			
-			TypeInfo proxyTypeInfo;
+			if (baseType == null) throw new ArgumentNullException(nameof(baseType));
 
-			// Reuse the previous results, if possible, Fast path without locking.
-			if (Cache.TryGetProxyType(baseType, baseInterfaces, out proxyTypeInfo))
-				return proxyTypeInfo;
+			var typeFactory = _cache.GetOrAdd(
+				new ProxyCacheEntry(baseType, interfaces),
+				k => CreateUncachedProxyType(k.BaseType, k.Interfaces));
 
-			lock (Cache)
-			{
-				// Recheck in case we got interrupted.
-				if (!Cache.TryGetProxyType(baseType, baseInterfaces, out proxyTypeInfo))
-				{
-					proxyTypeInfo = CreateUncachedProxyType(baseType, baseInterfaces);
-
-					// Cache the proxy type
-					if (proxyTypeInfo != null && Cache != null)
-						Cache.StoreProxyType(proxyTypeInfo, baseType, baseInterfaces);
-				}
-
-				return proxyTypeInfo;
-			}
+			return typeFactory;
 		}
 
-		private TypeInfo CreateUncachedProxyType(System.Type baseType, System.Type[] baseInterfaces)
+		private TypeInfo CreateUncachedProxyType(System.Type baseType, IReadOnlyCollection<System.Type> baseInterfaces)
 		{
 			AppDomain currentDomain = AppDomain.CurrentDomain;
 			string typeName = string.Format("{0}Proxy", baseType.Name);
@@ -102,10 +85,11 @@ namespace NHibernate.Proxy.DynamicProxy
 			ModuleBuilder moduleBuilder = ProxyAssemblyBuilder.DefineDynamicModule(assemblyBuilder, moduleName);
 
 			TypeAttributes typeAttributes = TypeAttributes.AutoClass | TypeAttributes.Class |
-											TypeAttributes.Public | TypeAttributes.BeforeFieldInit;
+			                                TypeAttributes.Public | TypeAttributes.BeforeFieldInit;
 
 			var interfaces = new HashSet<System.Type>();
-			interfaces.Merge(baseInterfaces);
+			interfaces.UnionWith(baseInterfaces);
+			interfaces.UnionWith(baseInterfaces.SelectMany(i => i.GetInterfaces()));
 
 			// Use the proxy dummy as the base type 
 			// since we're not inheriting from any class type
@@ -115,13 +99,7 @@ namespace NHibernate.Proxy.DynamicProxy
 				parentType = typeof (ProxyDummy);
 				interfaces.Add(baseType);
 			}
-
-			// Add any inherited interfaces
-			System.Type[] computedInterfaces = interfaces.ToArray();
-			foreach (System.Type interfaceType in computedInterfaces)
-			{
-				interfaces.Merge(GetInterfaces(interfaceType));
-			}
+			interfaces.UnionWith(baseType.GetInterfaces());
 
 			// Add the ISerializable interface so that it can be implemented
 			interfaces.Add(typeof (ISerializable));
@@ -151,32 +129,14 @@ namespace NHibernate.Proxy.DynamicProxy
 			return proxyType;
 		}
 
-		private IEnumerable<System.Type> GetInterfaces(System.Type currentType)
-		{
-			return GetAllInterfaces(currentType);
-		}
-
-		private IEnumerable<System.Type> GetAllInterfaces(System.Type currentType)
-		{
-			System.Type[] interfaces = currentType.GetInterfaces();
-
-			foreach (System.Type current in interfaces)
-			{
-				yield return current;
-				foreach (System.Type @interface in GetAllInterfaces(current))
-				{
-					yield return @interface;
-				}
-			}
-		}
-
 		private IEnumerable<MethodInfo> GetProxiableMethods(System.Type type, IEnumerable<System.Type> interfaces)
 		{
 			const BindingFlags candidateMethodsBindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-			return 
+			return
 				type.GetMethods(candidateMethodsBindingFlags)
-					.Where(method=> method.IsProxiable())
-					.Concat(interfaces.SelectMany(interfaceType => interfaceType.GetMethods())).Distinct();
+					.Where(method => method.IsProxiable())
+					.Concat(interfaces.SelectMany(interfaceType => interfaceType.GetMethods()))
+					.Distinct();
 		}
 
 		private static ConstructorBuilder DefineConstructor(TypeBuilder typeBuilder, System.Type parentType)
@@ -206,7 +166,7 @@ namespace NHibernate.Proxy.DynamicProxy
 			return constructor;
 		}
 
-		private static void ImplementGetObjectData(System.Type baseType, System.Type[] baseInterfaces, TypeBuilder typeBuilder, FieldInfo interceptorField)
+		private static void ImplementGetObjectData(System.Type baseType, IReadOnlyCollection<System.Type> baseInterfaces, TypeBuilder typeBuilder, FieldInfo interceptorField)
 		{
 			const MethodAttributes attributes = MethodAttributes.Public | MethodAttributes.HideBySig |
 												MethodAttributes.Virtual;
@@ -236,7 +196,7 @@ namespace NHibernate.Proxy.DynamicProxy
 			IL.Emit(OpCodes.Ldstr, baseType.AssemblyQualifiedName);
 			IL.Emit(OpCodes.Callvirt, addValue);
 
-			int baseInterfaceCount = baseInterfaces.Length;
+			int baseInterfaceCount = baseInterfaces.Count;
 
 			// Save the number of base interfaces
 			IL.Emit(OpCodes.Ldarg_1);
@@ -294,7 +254,7 @@ namespace NHibernate.Proxy.DynamicProxy
 			IL.Emit(OpCodes.Ret);
 		}
 
-		private static void AddSerializationSupport(System.Type baseType, System.Type[] baseInterfaces, TypeBuilder typeBuilder, FieldInfo interceptorField, ConstructorBuilder defaultConstructor)
+		private static void AddSerializationSupport(System.Type baseType, IReadOnlyCollection<System.Type> baseInterfaces, TypeBuilder typeBuilder, FieldInfo interceptorField, ConstructorBuilder defaultConstructor)
 		{
 			ConstructorInfo serializableConstructor = typeof(SerializableAttribute).GetConstructor(new System.Type[0]);
 			var customAttributeBuilder = new CustomAttributeBuilder(serializableConstructor, new object[0]);


### PR DESCRIPTION
- use a correct implementation of cache
- reduce the number of allocations of ProxyCacheEntry
- reduce memory flow

ProxyCache has a weird, inefficient and _incorrect_ implementation. Replaced with just ConcurrentDictionary.
Removed unnecessary collections manipulations to get some perf boost.
Also, previously there were 4 instances of ProxyCacheEntry created per one call to CreateProxyType. But the constructor of ProxyCacheEntry is expensive in terms of both memory and CPU. 