### PR TITLE
Reduces check session and set context id redundant calls

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/Logs/LogsFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/Logs/LogsFixture.cs
@@ -12,9 +12,13 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using NHibernate.Cfg;
 using NHibernate.Impl;
-
+using NHibernate.SqlCommand;
+using NHibernate.Type;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.NHSpecificTest.Logs
 {
@@ -26,7 +30,6 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 	using log4net.Core;
 	using log4net.Layout;
 	using log4net.Repository.Hierarchy;
-	using System.Threading.Tasks;
 
 	[TestFixture]
 	public class LogsFixtureAsync : TestCase
@@ -41,6 +44,33 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 			get { return "NHibernate.Test"; }
 		}
 
+		protected override void Configure(Configuration configuration)
+		{
+			base.Configure(configuration);
+			configuration.SetProperty(Cfg.Environment.UseSecondLevelCache, "false");
+		}
+
+		protected override void OnSetUp()
+		{
+			using (var s = Sfi.OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Save(new Person());
+				s.Save(new Person());
+				t.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = Sfi.OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CreateQuery("delete from Person").ExecuteUpdate();
+				t.Commit();
+			}
+		}
+
 		[Test]
 		public async Task WillGetSessionIdFromSessionLogsAsync()
 		{
@@ -49,12 +79,68 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
 			using (var s = Sfi.OpenSession())
 			{
-				var sessionId = ((SessionImpl)s).SessionId;
+				var sessionId = ((SessionImpl) s).SessionId;
 
-				await (s.GetAsync<Person>(1));//will execute some sql
+				await (s.GetAsync<Person>(1)); //will execute some sql
 
 				var loggingEvent = spy.GetWholeLog();
 				Assert.That(loggingEvent.Contains(sessionId.ToString()), Is.True);
+			}
+		}
+
+		[Test]
+		public async Task WillGetSessionIdFromConsecutiveSessionsLogsAsync()
+		{
+			GlobalContext.Properties["sessionId"] = new SessionIdCapturer();
+
+			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
+			{
+				var sessions = Enumerable.Range(1, 10).Select(i => Sfi.OpenSession()).ToArray();
+				try
+				{
+					for (var i = 0; i < 10; i++)
+					for (var j = 0; j < 10; j++)
+					{
+						var s = sessions[j];
+						await (s.GetAsync<Person>(i * 10 + j)); //will execute some sql
+					}
+				}
+				finally
+				{
+					foreach (var s in sessions)
+					{
+						s.Dispose();
+					}
+				}
+
+				var loggingEvent = spy.GetWholeLog();
+				for (var i = 0; i < 10; i++)
+				for (var j = 0; j < 10; j++)
+				{
+					var sessionId = sessions[j].GetSessionImplementation().SessionId;
+					Assert.That(loggingEvent, Does.Contain($"p0 = {i * 10 + j} [Type: Int32 (0:0:0)] | SessionId: {sessionId}"));
+				}
+			}
+		}
+
+		[Test]
+		public async Task WillGetSessionIdFromInterlacedSessionsLogsAsync()
+		{
+			GlobalContext.Properties["sessionId"] = new SessionIdCapturer();
+			var interceptor = new InterlacedSessionInterceptor(Sfi);
+			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
+			using (var s = Sfi.WithOptions().Interceptor(interceptor).OpenSession())
+			{
+				// Trigger an operation which will fire many interceptor events, before and after s own logging.
+				var persons = await (s.Query<Person>().ToListAsync());
+
+				var loggingEvent = spy.GetWholeLog();
+				for (var i = 0; i < interceptor.SessionIds.Count; i++)
+				{
+					var sessionId = interceptor.SessionIds[i];
+					Assert.That(loggingEvent, Does.Contain($"p0 = {i + 1} [Type: Int32 (0:0:0)] | SessionId: {sessionId}"));
+				}
+				Assert.That(loggingEvent, Does.Contain($"Person person0_ | SessionId: {s.GetSessionImplementation().SessionId}"));
 			}
 		}
 
@@ -63,13 +149,22 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 		{
 			GlobalContext.Properties["sessionId"] = new SessionIdCapturer();
 
-			var semaphore = new ManualResetEventSlim();
+			// Do not use a ManualResetEventSlim, it does not support async and exhausts the task thread pool in the
+			// async counterparts of this test. SemaphoreSlim has the async support and release the thread when waiting.
+			var semaphore = new SemaphoreSlim(0);
 			var failures = new ConcurrentBag<Exception>();
 			var sessionIds = new ConcurrentDictionary<int, Guid>();
-			var array = Enumerable.Range(1, 10).Select(
-				i => new Thread(
-					() =>
+			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
+			{
+				await (Task.WhenAll(Enumerable.Range(					1, 12).Select(					async i =>
 					{
+						if (i > 10)
+						{
+							// Give some time to threads for reaching the wait, having all of them ready to do most of their job concurrently.
+							await (Task.Delay(100));
+							semaphore.Release(10);
+							return;
+						}
 						try
 						{
 							using (var s = Sfi.OpenSession())
@@ -80,11 +175,11 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 									(ti, old) => throw new InvalidOperationException(
 										$"Thread number {ti} has already session id {old}, while attempting to set it to" +
 										$" {s.GetSessionImplementation().SessionId}"));
-								semaphore.Wait();
+								await (semaphore.WaitAsync());
 
 								for (int j = 0; j < 10; j++)
 								{
-									s.Get<Person>(i * 10 + j); //will execute some sql
+									await (s.GetAsync<Person>(i * 10 + j)); //will execute some sql
 								}
 							}
 						}
@@ -92,17 +187,9 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 						{
 							failures.Add(e);
 						}
-					})).ToArray();
+					})));
 
-			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
-			{
-				Array.ForEach(array, thread => thread.Start());
-				// Give some time to threads for reaching the wait, having all of them ready to do most of their job concurrently.
-				await (Task.Delay(100));
-				semaphore.Set();
-				Array.ForEach(array, thread => thread.Join());
-
-				Assert.That(failures, Is.Empty, $"{failures.Count} thread(s) failed.");
+				Assert.That(failures, Is.Empty, $"{failures.Count} task(s) failed.");
 
 				var loggingEvent = spy.GetWholeLog();
 				for (var i = 1; i < 11; i++)
@@ -141,7 +228,7 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 					Threshold = Level.All,
 					Writer = new StringWriter(stringBuilder)
 				};
-				loggerImpl = (Logger)LogManager.GetLogger(typeof(LogsFixtureAsync).Assembly, loggerName).Logger;
+				loggerImpl = (Logger) LogManager.GetLogger(typeof(LogsFixtureAsync).Assembly, loggerName).Logger;
 				loggerImpl.AddAppender(appender);
 				previousLevel = loggerImpl.Level;
 				loggerImpl.Level = Level.All;
@@ -158,7 +245,37 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 				loggerImpl.Level = previousLevel;
 			}
 		}
+
+		public class InterlacedSessionInterceptor : EmptyInterceptor
+		{
+			private readonly ISessionFactory _sfi;
+
+			public System.Collections.Generic.List<Guid> SessionIds { get; } = new System.Collections.Generic.List<Guid>();
+
+			public InterlacedSessionInterceptor(ISessionFactory sfi)
+			{
+				_sfi = sfi;
+			}
+
+			public override SqlString OnPrepareStatement(SqlString sql)
+			{
+				using (var s = _sfi.OpenSession())
+				{
+					SessionIds.Add(s.GetSessionImplementation().SessionId);
+					s.Get<Person>(SessionIds.Count); //will execute some sql
+				}
+				return base.OnPrepareStatement(sql);
+			}
+
+			public override bool OnLoad(object entity, object id, object[] state, string[] propertyNames, IType[] types)
+			{
+				using (var s = _sfi.OpenSession())
+				{
+					SessionIds.Add(s.GetSessionImplementation().SessionId);
+					s.Get<Person>(SessionIds.Count); //will execute some sql
+				}
+				return base.OnLoad(entity, id, state, propertyNames, types);
+			}
+		}
 	}
-
-
 }

--- a/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
@@ -1,5 +1,7 @@
 using System.Collections;
-
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
 using NHibernate.Impl;
 
 using NUnit.Framework;
@@ -42,6 +44,62 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 
 				var loggingEvent = spy.GetWholeLog();
 				Assert.That(loggingEvent.Contains(sessionId.ToString()), Is.True);
+			}
+		}
+
+		[Test]
+		public void WillGetSessionIdFromSessionLogsConcurrent()
+		{
+			GlobalContext.Properties["sessionId"] = new SessionIdCapturer();
+
+			var semaphore = new ManualResetEventSlim();
+			var failures = new ConcurrentBag<Exception>();
+			var sessionIds = new ConcurrentDictionary<int, Guid>();
+			var array = Enumerable.Range(1, 10).Select(
+				i => new Thread(
+					() =>
+					{
+						try
+						{
+							using (var s = Sfi.OpenSession())
+							{
+								sessionIds.AddOrUpdate(
+									i,
+									s.GetSessionImplementation().SessionId,
+									(ti, old) => throw new InvalidOperationException(
+										$"Thread number {ti} has already session id {old}, while attempting to set it to" +
+										$" {s.GetSessionImplementation().SessionId}"));
+								semaphore.Wait();
+
+								for (int j = 0; j < 10; j++)
+								{
+									s.Get<Person>(i * 10 + j); //will execute some sql
+								}
+							}
+						}
+						catch (Exception e)
+						{
+							failures.Add(e);
+						}
+					})).ToArray();
+
+			using (var spy = new TextLogSpy("NHibernate.SQL", "%message | SessionId: %property{sessionId}"))
+			{
+				Array.ForEach(array, thread => thread.Start());
+				// Give some time to threads for reaching the wait, having all of them ready to do most of their job concurrently.
+				Thread.Sleep(100);
+				semaphore.Set();
+				Array.ForEach(array, thread => thread.Join());
+
+				Assert.That(failures, Is.Empty, $"{failures.Count} thread(s) failed.");
+
+				var loggingEvent = spy.GetWholeLog();
+				for (var i = 1; i < 11; i++)
+				for (var j = 0; j < 10; j++)
+				{
+					var sessionId = sessionIds[i];
+					Assert.That(loggingEvent, Does.Contain($"p0 = {i * 10 + j} [Type: Int32 (0:0:0)] | SessionId: {sessionId}"));
+				}
 			}
 		}
 

--- a/src/NHibernate/Async/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Async/Engine/ISessionImplementor.cs
@@ -28,6 +28,7 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
+
 	public partial interface ISessionImplementor
 	{
 

--- a/src/NHibernate/Async/Event/IEventSource.cs
+++ b/src/NHibernate/Async/Event/IEventSource.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Event
 
 		/// <summary> Cascade refresh an entity instance</summary>
 		Task RefreshAsync(object obj, IDictionary refreshedAlready, CancellationToken cancellationToken);
-        
+
 		/// <summary> Cascade delete an entity instance</summary>
 		Task DeleteAsync(string entityName, object child, bool isCascadeDeleteEnabled, ISet<object> transientEntities, CancellationToken cancellationToken);
 	}

--- a/src/NHibernate/Async/Id/Insert/AbstractSelectingDelegate.cs
+++ b/src/NHibernate/Async/Id/Insert/AbstractSelectingDelegate.cs
@@ -54,7 +54,7 @@ namespace NHibernate.Id.Insert
 				}
 
 				var selectSql = SelectSQL;
-				using (new SessionIdLoggingContext(session.SessionId))
+				using (session.BeginProcess())
 				{
 					try
 					{

--- a/src/NHibernate/Async/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Async/Impl/AbstractSessionImpl.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Impl
 		public virtual async Task<IList<T>> ListAsync<T>(IQueryExpression query, QueryParameters parameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var results = new List<T>();
 				await (ListAsync(query, parameters, results, cancellationToken)).ConfigureAwait(false);
@@ -69,7 +69,7 @@ namespace NHibernate.Impl
 		public virtual async Task<IList<T>> ListAsync<T>(CriteriaImpl criteria, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var results = new List<T>();
 				await (ListAsync(criteria, results, cancellationToken)).ConfigureAwait(false);
@@ -82,7 +82,7 @@ namespace NHibernate.Impl
 		public virtual async Task<IList> ListAsync(CriteriaImpl criteria, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var results = new List<object>();
 				await (ListAsync(criteria, results, cancellationToken)).ConfigureAwait(false);
@@ -113,7 +113,7 @@ namespace NHibernate.Impl
 		public virtual async Task<IList> ListAsync(NativeSQLQuerySpecification spec, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var results = new List<object>();
 				await (ListAsync(spec, queryParameters, results, cancellationToken)).ConfigureAwait(false);
@@ -124,7 +124,7 @@ namespace NHibernate.Impl
 		public virtual async Task ListAsync(NativeSQLQuerySpecification spec, QueryParameters queryParameters, IList results, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var query = new SQLCustomQuery(
 					spec.SqlQueryReturns,
@@ -138,7 +138,7 @@ namespace NHibernate.Impl
 		public virtual async Task<IList<T>> ListAsync<T>(NativeSQLQuerySpecification spec, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var results = new List<T>();
 				await (ListAsync(spec, queryParameters, results, cancellationToken)).ConfigureAwait(false);
@@ -151,7 +151,7 @@ namespace NHibernate.Impl
 		public virtual async Task<IList<T>> ListCustomQueryAsync<T>(ICustomQuery customQuery, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var results = new List<T>();
 				await (ListCustomQueryAsync(customQuery, queryParameters, results, cancellationToken)).ConfigureAwait(false);
@@ -170,7 +170,7 @@ namespace NHibernate.Impl
 		protected async Task AfterOperationAsync(bool success, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				if (!ConnectionManager.IsInActiveTransaction)
 				{

--- a/src/NHibernate/Async/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Async/Impl/MultiCriteriaImpl.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Impl
 		public async Task<IList> ListAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				bool cacheable = session.Factory.Settings.IsQueryCacheEnabled && isCacheable;
 

--- a/src/NHibernate/Async/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/MultiQueryImpl.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Impl
 		public async Task<IList> ListAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				bool cacheable = session.Factory.Settings.IsQueryCacheEnabled && isCacheable;
 				combinedParameters = CreateCombinedQueryParameters();

--- a/src/NHibernate/Async/Impl/SessionImpl.cs
+++ b/src/NHibernate/Async/Impl/SessionImpl.cs
@@ -49,7 +49,7 @@ namespace NHibernate.Impl
 		public override async Task AfterTransactionCompletionAsync(bool success, ITransaction tx, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				log.Debug("transaction completion");
 
@@ -90,7 +90,7 @@ namespace NHibernate.Impl
 		public async Task<object> SaveAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return await (FireSaveAsync(new SaveOrUpdateEvent(null, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -99,7 +99,7 @@ namespace NHibernate.Impl
 		public async Task<object> SaveAsync(string entityName, object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return await (FireSaveAsync(new SaveOrUpdateEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -108,7 +108,7 @@ namespace NHibernate.Impl
 		public async Task SaveAsync(string entityName, object obj, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireSaveAsync(new SaveOrUpdateEvent(entityName, obj, id, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -123,7 +123,7 @@ namespace NHibernate.Impl
 		public async Task SaveAsync(object obj, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireSaveAsync(new SaveOrUpdateEvent(null, obj, id, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -137,7 +137,7 @@ namespace NHibernate.Impl
 		public async Task DeleteAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireDeleteAsync(new DeleteEvent(obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -147,7 +147,7 @@ namespace NHibernate.Impl
 		public async Task DeleteAsync(string entityName, object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireDeleteAsync(new DeleteEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -156,7 +156,7 @@ namespace NHibernate.Impl
 		public async Task UpdateAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireUpdateAsync(new SaveOrUpdateEvent(null, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -165,7 +165,7 @@ namespace NHibernate.Impl
 		public async Task UpdateAsync(string entityName, object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireUpdateAsync(new SaveOrUpdateEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -174,7 +174,7 @@ namespace NHibernate.Impl
 		public async Task UpdateAsync(string entityName, object obj, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireUpdateAsync(new SaveOrUpdateEvent(entityName, obj, id, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -183,7 +183,7 @@ namespace NHibernate.Impl
 		public async Task SaveOrUpdateAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireSaveOrUpdateAsync(new SaveOrUpdateEvent(null, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -192,7 +192,7 @@ namespace NHibernate.Impl
 		public async Task SaveOrUpdateAsync(string entityName, object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireSaveOrUpdateAsync(new SaveOrUpdateEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -201,7 +201,7 @@ namespace NHibernate.Impl
 		public async Task SaveOrUpdateAsync(string entityName, object obj, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireSaveOrUpdateAsync(new SaveOrUpdateEvent(entityName, obj, id, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -210,7 +210,7 @@ namespace NHibernate.Impl
 		public async Task UpdateAsync(object obj, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireUpdateAsync(new SaveOrUpdateEvent(null, obj, id, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -219,7 +219,7 @@ namespace NHibernate.Impl
 		async Task<IList> FindAsync(string query, object[] values, IType[] types, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return await (ListAsync(query.ToQueryExpression(), new QueryParameters(types, values), cancellationToken)).ConfigureAwait(false);
 			}
@@ -248,9 +248,8 @@ namespace NHibernate.Impl
 		private async Task ListAsync(IQueryExpression queryExpression, QueryParameters queryParameters, IList results, object filterConnection, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 
 				var isFilter = filterConnection != null;
@@ -290,7 +289,7 @@ namespace NHibernate.Impl
 		public override async Task<IQueryTranslator[]> GetQueriesAsync(IQueryExpression query, bool scalar, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var plan = Factory.QueryPlanCache.GetHQLQueryPlan(query, scalar, enabledFilters);
 				await (AutoFlushIfRequiredAsync(plan.QuerySpaces, cancellationToken)).ConfigureAwait(false);
@@ -301,9 +300,8 @@ namespace NHibernate.Impl
 		public override async Task<IEnumerable<T>> EnumerableAsync<T>(IQueryExpression queryExpression, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				var plan = GetHQLQueryPlan(queryExpression, true);
 				await (AutoFlushIfRequiredAsync(plan.QuerySpaces, cancellationToken)).ConfigureAwait(false);
@@ -318,9 +316,8 @@ namespace NHibernate.Impl
 		public override async Task<IEnumerable> EnumerableAsync(IQueryExpression queryExpression, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				var plan = GetHQLQueryPlan(queryExpression, true);
 				await (AutoFlushIfRequiredAsync(plan.QuerySpaces, cancellationToken)).ConfigureAwait(false);
@@ -334,35 +331,33 @@ namespace NHibernate.Impl
 
 		// TODO: Scroll(string query, QueryParameters queryParameters)
 
-		public async Task<int> DeleteAsync(string query, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<int> DeleteAsync(string query, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				return await (DeleteAsync(query, NoArgs, NoTypes, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<int>(cancellationToken);
 			}
+			return DeleteAsync(query, NoArgs, NoTypes, cancellationToken);
 		}
 
-		public async Task<int> DeleteAsync(string query, object value, IType type, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<int> DeleteAsync(string query, object value, IType type, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				return await (DeleteAsync(query, new[] { value }, new[] { type }, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<int>(cancellationToken);
 			}
+			return DeleteAsync(query, new[] { value }, new[] { type }, cancellationToken);
 		}
 
 		public async Task<int> DeleteAsync(string query, object[] values, IType[] types, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (string.IsNullOrEmpty(query))
 				{
 					throw new ArgumentNullException("query", "attempt to perform delete-by-query with null query");
 				}
-
-				CheckAndUpdateSessionStatus();
 
 				if (log.IsDebugEnabled)
 				{
@@ -386,7 +381,7 @@ namespace NHibernate.Impl
 		public async Task LockAsync(object obj, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireLockAsync(new LockEvent(obj, lockMode, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -395,7 +390,7 @@ namespace NHibernate.Impl
 		public async Task LockAsync(string entityName, object obj, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireLockAsync(new LockEvent(entityName, obj, lockMode, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -404,10 +399,8 @@ namespace NHibernate.Impl
 		public async Task<IQuery> CreateFilterAsync(object collection, string queryString, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				var plan = await (GetFilterQueryPlanAsync(collection, queryString, null, false, cancellationToken)).ConfigureAwait(false);
 				var filter = new CollectionFilterImpl(queryString, collection, this, plan.ParameterMetadata);
 				//filter.SetComment(queryString);
@@ -418,10 +411,8 @@ namespace NHibernate.Impl
 		public override async Task<IQuery> CreateFilterAsync(object collection, IQueryExpression queryExpression, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				var plan = await (GetFilterQueryPlanAsync(collection, queryExpression, null, false, cancellationToken)).ConfigureAwait(false);
 				var filter = new ExpressionFilterImpl(plan.QueryExpression, collection, this, plan.ParameterMetadata);
 				return filter;
@@ -446,18 +437,22 @@ namespace NHibernate.Impl
 			return GetFilterQueryPlanAsync(collection, parameters, shallow, filter, null, cancellationToken);
 		}
 
-		private async Task<IQueryExpressionPlan> GetFilterQueryPlanAsync(object collection, QueryParameters parameters, bool shallow,
+		private Task<IQueryExpressionPlan> GetFilterQueryPlanAsync(object collection, QueryParameters parameters, bool shallow,
 			string filter, IQueryExpression queryExpression, CancellationToken cancellationToken)
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (collection == null)
+				throw new ArgumentNullException(nameof(collection), "null collection passed to filter");
+			if (filter != null && queryExpression != null)
+				throw new ArgumentException($"Either {nameof(filter)} or {nameof(queryExpression)} must be specified, not both.");
+			if (filter == null && queryExpression == null)
+				throw new ArgumentException($"{nameof(filter)} and {nameof(queryExpression)} were both null.");
+			if (cancellationToken.IsCancellationRequested)
 			{
-				if (collection == null)
-					throw new ArgumentNullException(nameof(collection), "null collection passed to filter");
-				if (filter != null && queryExpression != null)
-					throw new ArgumentException($"Either {nameof(filter)} or {nameof(queryExpression)} must be specified, not both.");
-				if (filter == null && queryExpression == null)
-					throw new ArgumentException($"{nameof(filter)} and {nameof(queryExpression)} were both null.");
+				return Task.FromCanceled<IQueryExpressionPlan>(cancellationToken);
+			}
+			return InternalGetFilterQueryPlanAsync();
+			async Task<IQueryExpressionPlan> InternalGetFilterQueryPlanAsync()
+			{
 
 				var entry = persistenceContext.GetCollectionEntryOrNull(collection);
 				var roleBeforeFlush = entry?.LoadedPersister;
@@ -513,9 +508,8 @@ namespace NHibernate.Impl
 		public async Task ForceFlushAsync(EntityEntry entityEntry, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (log.IsDebugEnabled)
 				{
 					log.Debug("flushing to force deletion of re-saved object: " +
@@ -538,7 +532,7 @@ namespace NHibernate.Impl
 		public async Task MergeAsync(string entityName, object obj, IDictionary copiedAlready, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireMergeAsync(copiedAlready, new MergeEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -548,7 +542,7 @@ namespace NHibernate.Impl
 		public async Task PersistAsync(string entityName, object obj, IDictionary createdAlready, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FirePersistAsync(createdAlready, new PersistEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -558,7 +552,7 @@ namespace NHibernate.Impl
 		public async Task PersistOnFlushAsync(string entityName, object obj, IDictionary copiedAlready, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FirePersistOnFlushAsync(copiedAlready, new PersistEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -568,7 +562,7 @@ namespace NHibernate.Impl
 		public async Task RefreshAsync(object obj, IDictionary refreshedAlready, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireRefreshAsync(refreshedAlready, new RefreshEvent(obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -578,7 +572,7 @@ namespace NHibernate.Impl
 		public async Task DeleteAsync(string entityName, object child, bool isCascadeDeleteEnabled, ISet<object> transientEntities, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireDeleteAsync(new DeleteEvent(entityName, child, isCascadeDeleteEnabled, this), transientEntities, cancellationToken)).ConfigureAwait(false);
 			}
@@ -589,7 +583,7 @@ namespace NHibernate.Impl
 		public async Task<object> MergeAsync(string entityName, object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return await (FireMergeAsync(new MergeEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -607,57 +601,56 @@ namespace NHibernate.Impl
 			return (T)await (MergeAsync(entityName, (object)entity, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public async Task<object> MergeAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<object> MergeAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				return await (MergeAsync(null, obj, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<object>(cancellationToken);
 			}
+			return MergeAsync(null, obj, cancellationToken);
 		}
 
 		public async Task PersistAsync(string entityName, object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FirePersistAsync(new PersistEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
 		}
 
-		public async Task PersistAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
+		public Task PersistAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				await (PersistAsync(null, obj, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<object>(cancellationToken);
 			}
+			return PersistAsync(null, obj, cancellationToken);
 		}
 
 		public async Task PersistOnFlushAsync(string entityName, object obj, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FirePersistOnFlushAsync(new PersistEvent(entityName, obj, this), cancellationToken)).ConfigureAwait(false);
 			}
 		}
 
-		public async Task PersistOnFlushAsync(object obj, CancellationToken cancellationToken)
+		public Task PersistOnFlushAsync(object obj, CancellationToken cancellationToken)
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				await (PersistAsync(null, obj, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<object>(cancellationToken);
 			}
+			return PersistAsync(null, obj, cancellationToken);
 		}
 
 		public override async Task<object> GetEntityUsingInterceptorAsync(EntityKey key, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				// todo : should this get moved to PersistentContext?
 				// logically, is PersistentContext the "thing" to which an interceptor gets attached?
 				object result = persistenceContext.GetEntity(key);
@@ -688,9 +681,8 @@ namespace NHibernate.Impl
 		private async Task<bool> AutoFlushIfRequiredAsync(ISet<string> querySpaces, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (!ConnectionManager.IsInActiveTransaction)
 				{
 					// do not auto-flush while outside a transaction
@@ -711,7 +703,7 @@ namespace NHibernate.Impl
 		public async Task LoadAsync(object obj, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				LoadEvent loadEvent = new LoadEvent(id, obj, this);
 				await (FireLoadAsync(loadEvent, LoadEventListener.Reload, cancellationToken)).ConfigureAwait(false);
@@ -721,7 +713,7 @@ namespace NHibernate.Impl
 		public async Task<T> LoadAsync<T>(object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)await (LoadAsync(typeof(T), id, cancellationToken)).ConfigureAwait(false);
 			}
@@ -730,7 +722,7 @@ namespace NHibernate.Impl
 		public async Task<T> LoadAsync<T>(object id, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)await (LoadAsync(typeof(T), id, lockMode, cancellationToken)).ConfigureAwait(false);
 			}
@@ -751,19 +743,19 @@ namespace NHibernate.Impl
 		/// <exception cref="ObjectNotFoundException">
 		/// Thrown when the object with the specified id does not exist in the database.
 		/// </exception>
-		public async Task<object> LoadAsync(System.Type entityClass, object id, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<object> LoadAsync(System.Type entityClass, object id, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				return await (LoadAsync(entityClass.FullName, id, lockMode, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<object>(cancellationToken);
 			}
+			return LoadAsync(entityClass.FullName, id, lockMode, cancellationToken);
 		}
 
 		public async Task<object> LoadAsync(string entityName, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (id == null)
 				{
@@ -792,7 +784,7 @@ namespace NHibernate.Impl
 		public async Task<object> LoadAsync(string entityName, object id, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var @event = new LoadEvent(id, entityName, lockMode, this);
 				await (FireLoadAsync(@event, LoadEventListener.Load, cancellationToken)).ConfigureAwait(false);
@@ -800,19 +792,19 @@ namespace NHibernate.Impl
 			}
 		}
 
-		public async Task<object> LoadAsync(System.Type entityClass, object id, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<object> LoadAsync(System.Type entityClass, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				return await (LoadAsync(entityClass.FullName, id, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<object>(cancellationToken);
 			}
+			return LoadAsync(entityClass.FullName, id, cancellationToken);
 		}
 
 		public async Task<T> GetAsync<T>(object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)await (GetAsync(typeof(T), id, cancellationToken)).ConfigureAwait(false);
 			}
@@ -821,19 +813,19 @@ namespace NHibernate.Impl
 		public async Task<T> GetAsync<T>(object id, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)await (GetAsync(typeof(T), id, lockMode, cancellationToken)).ConfigureAwait(false);
 			}
 		}
 
-		public async Task<object> GetAsync(System.Type entityClass, object id, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<object> GetAsync(System.Type entityClass, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
 			{
-				return await (GetAsync(entityClass.FullName, id, cancellationToken)).ConfigureAwait(false);
+				return Task.FromCanceled<object>(cancellationToken);
 			}
+			return GetAsync(entityClass.FullName, id, cancellationToken);
 		}
 
 		/// <summary>
@@ -851,7 +843,7 @@ namespace NHibernate.Impl
 		public async Task<object> GetAsync(System.Type clazz, object id, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				LoadEvent loadEvent = new LoadEvent(id, clazz.FullName, lockMode, this);
 				await (FireLoadAsync(loadEvent, LoadEventListener.Get, cancellationToken)).ConfigureAwait(false);
@@ -862,10 +854,8 @@ namespace NHibernate.Impl
 		public async Task<string> GetEntityNameAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				if (obj.IsProxy())
 				{
 					var proxy = obj as INHibernateProxy;
@@ -893,7 +883,7 @@ namespace NHibernate.Impl
 		public async Task<object> GetAsync(string entityName, object id, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				LoadEvent loadEvent = new LoadEvent(id, entityName, false, this);
 				bool success = false;
@@ -918,7 +908,7 @@ namespace NHibernate.Impl
 		public override async Task<object> ImmediateLoadAsync(string entityName, object id, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (log.IsDebugEnabled)
 				{
@@ -940,7 +930,7 @@ namespace NHibernate.Impl
 		public override async Task<object> InternalLoadAsync(string entityName, object id, bool eager, bool isNullable, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				// todo : remove
 				LoadType type = isNullable
@@ -961,7 +951,7 @@ namespace NHibernate.Impl
 		public async Task RefreshAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireRefreshAsync(new RefreshEvent(obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -970,7 +960,7 @@ namespace NHibernate.Impl
 		public async Task RefreshAsync(object obj, LockMode lockMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireRefreshAsync(new RefreshEvent(obj, lockMode, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -1001,9 +991,8 @@ namespace NHibernate.Impl
 		public override async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (persistenceContext.CascadeLevel > 0)
 				{
 					throw new HibernateException("Flush during cascade is dangerous");
@@ -1022,10 +1011,8 @@ namespace NHibernate.Impl
 		public async Task<bool> IsDirtyAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				log.Debug("checking session dirtiness");
 				if (actionQueue.AreInsertionsOrDeletionsQueued)
 				{
@@ -1054,9 +1041,8 @@ namespace NHibernate.Impl
 		public override async Task InitializeCollectionAsync(IPersistentCollection collection, bool writing, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IInitializeCollectionEventListener[] listener = listeners.InitializeCollectionEventListeners;
 				for (int i = 0; i < listener.Length; i++)
 				{
@@ -1068,9 +1054,8 @@ namespace NHibernate.Impl
 		private async Task FilterAsync(object collection, string filter, QueryParameters queryParameters, IList results, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = await (GetFilterQueryPlanAsync(collection, filter, queryParameters, false, cancellationToken)).ConfigureAwait(false);
 
 				bool success = false;
@@ -1101,31 +1086,24 @@ namespace NHibernate.Impl
 		public override async Task<IList> ListFilterAsync(object collection, string filter, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				var results = new List<object>();
-				await (FilterAsync(collection, filter, queryParameters, results, cancellationToken)).ConfigureAwait(false);
-				return results;
-			}
+			var results = new List<object>();
+			await (FilterAsync(collection, filter, queryParameters, results, cancellationToken)).ConfigureAwait(false);
+			return results;
 		}
 
 		public override async Task<IList<T>> ListFilterAsync<T>(object collection, string filter, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				List<T> results = new List<T>();
-				await (FilterAsync(collection, filter, queryParameters, results, cancellationToken)).ConfigureAwait(false);
-				return results;
-			}
+			List<T> results = new List<T>();
+			await (FilterAsync(collection, filter, queryParameters, results, cancellationToken)).ConfigureAwait(false);
+			return results;
 		}
 
 		public override async Task<IEnumerable> EnumerableFilterAsync(object collection, string filter, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = await (GetFilterQueryPlanAsync(collection, filter, queryParameters, true, cancellationToken)).ConfigureAwait(false);
 				return await (plan.PerformIterateAsync(queryParameters, this, cancellationToken)).ConfigureAwait(false);
 			}
@@ -1134,9 +1112,8 @@ namespace NHibernate.Impl
 		public override async Task<IEnumerable<T>> EnumerableFilterAsync<T>(object collection, string filter, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = await (GetFilterQueryPlanAsync(collection, filter, queryParameters, true, cancellationToken)).ConfigureAwait(false);
 				return await (plan.PerformIterateAsync<T>(queryParameters, this, cancellationToken)).ConfigureAwait(false);
 			}
@@ -1145,10 +1122,8 @@ namespace NHibernate.Impl
 		public override async Task ListAsync(CriteriaImpl criteria, IList results, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				string[] implementors = Factory.GetImplementors(criteria.EntityOrClassName);
 				int size = implementors.Length;
 
@@ -1207,7 +1182,7 @@ namespace NHibernate.Impl
 		public async Task EvictAsync(object obj, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireEvictAsync(new EvictEvent(obj, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -1216,10 +1191,8 @@ namespace NHibernate.Impl
 		public override async Task ListCustomQueryAsync(ICustomQuery customQuery, QueryParameters queryParameters, IList results, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				CustomLoader loader = new CustomLoader(customQuery, Factory);
 				await (AutoFlushIfRequiredAsync(loader.QuerySpaces, cancellationToken)).ConfigureAwait(false);
 
@@ -1242,7 +1215,7 @@ namespace NHibernate.Impl
 		public async Task ReplicateAsync(object obj, ReplicationMode replicationMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireReplicateAsync(new ReplicateEvent(obj, replicationMode, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -1251,7 +1224,7 @@ namespace NHibernate.Impl
 		public async Task ReplicateAsync(string entityName, object obj, ReplicationMode replicationMode, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				await (FireReplicateAsync(new ReplicateEvent(entityName, obj, replicationMode, this), cancellationToken)).ConfigureAwait(false);
 			}
@@ -1260,7 +1233,7 @@ namespace NHibernate.Impl
 		public override async Task BeforeTransactionCompletionAsync(ITransaction tx, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				log.Debug("before transaction completion");
 				var context = TransactionContext;
@@ -1283,22 +1256,29 @@ namespace NHibernate.Impl
 			}
 		}
 
-		public override async Task FlushBeforeTransactionCompletionAsync(CancellationToken cancellationToken)
+		public override Task FlushBeforeTransactionCompletionAsync(CancellationToken cancellationToken)
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromCanceled<object>(cancellationToken);
+			}
+			try
 			{
 				if (FlushMode != FlushMode.Manual)
-					await (FlushAsync(cancellationToken)).ConfigureAwait(false);
+					return FlushAsync(cancellationToken);
+				return Task.CompletedTask;
+			}
+			catch (Exception ex)
+			{
+				return Task.FromException<object>(ex);
 			}
 		}
 
 		private async Task FireDeleteAsync(DeleteEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IDeleteEventListener[] deleteEventListener = listeners.DeleteEventListeners;
 				for (int i = 0; i < deleteEventListener.Length; i++)
 				{
@@ -1310,9 +1290,8 @@ namespace NHibernate.Impl
 		private async Task FireDeleteAsync(DeleteEvent @event, ISet<object> transientEntities, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IDeleteEventListener[] deleteEventListener = listeners.DeleteEventListeners;
 				for (int i = 0; i < deleteEventListener.Length; i++)
 				{
@@ -1324,9 +1303,8 @@ namespace NHibernate.Impl
 		private async Task FireEvictAsync(EvictEvent evictEvent, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IEvictEventListener[] evictEventListener = listeners.EvictEventListeners;
 				for (int i = 0; i < evictEventListener.Length; i++)
 				{
@@ -1338,9 +1316,8 @@ namespace NHibernate.Impl
 		private async Task FireLoadAsync(LoadEvent @event, LoadType loadType, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ILoadEventListener[] loadEventListener = listeners.LoadEventListeners;
 				for (int i = 0; i < loadEventListener.Length; i++)
 				{
@@ -1352,9 +1329,8 @@ namespace NHibernate.Impl
 		private async Task FireLockAsync(LockEvent lockEvent, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ILockEventListener[] lockEventListener = listeners.LockEventListeners;
 				for (int i = 0; i < lockEventListener.Length; i++)
 				{
@@ -1366,9 +1342,8 @@ namespace NHibernate.Impl
 		private async Task<object> FireMergeAsync(MergeEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IMergeEventListener[] mergeEventListener = listeners.MergeEventListeners;
 				for (int i = 0; i < mergeEventListener.Length; i++)
 				{
@@ -1381,9 +1356,8 @@ namespace NHibernate.Impl
 		private async Task FireMergeAsync(IDictionary copiedAlready, MergeEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IMergeEventListener[] mergeEventListener = listeners.MergeEventListeners;
 				for (int i = 0; i < mergeEventListener.Length; i++)
 				{
@@ -1395,9 +1369,8 @@ namespace NHibernate.Impl
 		private async Task FirePersistAsync(IDictionary copiedAlready, PersistEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] persistEventListener = listeners.PersistEventListeners;
 				for (int i = 0; i < persistEventListener.Length; i++)
 				{
@@ -1409,9 +1382,8 @@ namespace NHibernate.Impl
 		private async Task FirePersistAsync(PersistEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] createEventListener = listeners.PersistEventListeners;
 				for (int i = 0; i < createEventListener.Length; i++)
 				{
@@ -1423,9 +1395,8 @@ namespace NHibernate.Impl
 		private async Task FirePersistOnFlushAsync(IDictionary copiedAlready, PersistEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] persistEventListener = listeners.PersistOnFlushEventListeners;
 				for (int i = 0; i < persistEventListener.Length; i++)
 				{
@@ -1437,9 +1408,8 @@ namespace NHibernate.Impl
 		private async Task FirePersistOnFlushAsync(PersistEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] createEventListener = listeners.PersistOnFlushEventListeners;
 				for (int i = 0; i < createEventListener.Length; i++)
 				{
@@ -1451,9 +1421,8 @@ namespace NHibernate.Impl
 		private async Task FireRefreshAsync(RefreshEvent refreshEvent, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IRefreshEventListener[] refreshEventListener = listeners.RefreshEventListeners;
 				for (int i = 0; i < refreshEventListener.Length; i++)
 				{
@@ -1465,9 +1434,8 @@ namespace NHibernate.Impl
 		private async Task FireRefreshAsync(IDictionary refreshedAlready, RefreshEvent refreshEvent, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IRefreshEventListener[] refreshEventListener = listeners.RefreshEventListeners;
 				for (int i = 0; i < refreshEventListener.Length; i++)
 				{
@@ -1479,9 +1447,8 @@ namespace NHibernate.Impl
 		private async Task FireReplicateAsync(ReplicateEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IReplicateEventListener[] replicateEventListener = listeners.ReplicateEventListeners;
 				for (int i = 0; i < replicateEventListener.Length; i++)
 				{
@@ -1493,9 +1460,8 @@ namespace NHibernate.Impl
 		private async Task<object> FireSaveAsync(SaveOrUpdateEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ISaveOrUpdateEventListener[] saveEventListener = listeners.SaveEventListeners;
 				for (int i = 0; i < saveEventListener.Length; i++)
 				{
@@ -1508,9 +1474,8 @@ namespace NHibernate.Impl
 		private async Task FireSaveOrUpdateAsync(SaveOrUpdateEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ISaveOrUpdateEventListener[] saveOrUpdateEventListener = listeners.SaveOrUpdateEventListeners;
 				for (int i = 0; i < saveOrUpdateEventListener.Length; i++)
 				{
@@ -1522,9 +1487,8 @@ namespace NHibernate.Impl
 		private async Task FireUpdateAsync(SaveOrUpdateEvent @event, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ISaveOrUpdateEventListener[] updateEventListener = listeners.UpdateEventListeners;
 				for (int i = 0; i < updateEventListener.Length; i++)
 				{
@@ -1536,9 +1500,8 @@ namespace NHibernate.Impl
 		public override async Task<int> ExecuteNativeUpdateAsync(NativeSQLQuerySpecification nativeQuerySpecification, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				NativeSQLQueryPlan plan = GetNativeSQLQueryPlan(nativeQuerySpecification);
 
@@ -1562,9 +1525,8 @@ namespace NHibernate.Impl
 		public override async Task<int> ExecuteUpdateAsync(IQueryExpression queryExpression, QueryParameters queryParameters, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				var plan = GetHQLQueryPlan(queryExpression, false);
 				await (AutoFlushIfRequiredAsync(plan.QuerySpaces, cancellationToken)).ConfigureAwait(false);

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -239,7 +239,7 @@ namespace NHibernate.Loader
 		private async Task<IList> DoQueryAsync(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, IResultTransformer forcedResultTransformer, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				RowSelection selection = queryParameters.RowSelection;
 				int maxRows = HasMaxRows(selection) ? selection.MaxRows : int.MaxValue;

--- a/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
@@ -67,7 +67,7 @@ namespace NHibernate.Persister.Entity
 				log.Debug("Getting current persistent state for: " + MessageHelper.InfoString(this, id, Factory));
 			}
 
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				var st = await (session.Batcher.PrepareCommandAsync(CommandType.Text, SQLSnapshotSelectString, IdentifierType.SqlTypes(factory), cancellationToken)).ConfigureAwait(false);
@@ -187,7 +187,7 @@ namespace NHibernate.Persister.Entity
 			{
 				log.Debug("Getting version: " + MessageHelper.InfoString(this, id, Factory));
 			}
-			using(new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				var st = session.Batcher.PrepareQueryCommand(CommandType.Text, VersionSelectString, IdentifierType.SqlTypes(Factory));
@@ -331,7 +331,7 @@ namespace NHibernate.Persister.Entity
 			DbCommand sequentialSelect = null;
 			DbDataReader sequentialResultSet = null;
 			bool sequentialSelectEmpty = false;
-			using (new SessionIdLoggingContext(session.SessionId)) 
+			using (session.BeginProcess())
 			try
 			{
 				if (hasDeferred)
@@ -1160,7 +1160,7 @@ namespace NHibernate.Persister.Entity
 			ISessionImplementor session, SqlString selectionSQL, ValueInclusion[] generationInclusions, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(session.SessionId)) 
+			using (session.BeginProcess())
 			try
 			{
 				var cmd = session.Batcher.PrepareQueryCommand(CommandType.Text, selectionSQL, IdentifierType.SqlTypes(Factory));
@@ -1280,7 +1280,7 @@ namespace NHibernate.Persister.Entity
 				///////////////////////////////////////////////////////////////////////
 
 				object[] snapshot = new object[naturalIdPropertyCount];
-				using (new SessionIdLoggingContext(session.SessionId)) 
+				using (session.BeginProcess())
 				try
 				{
 					var ps = await (session.Batcher.PrepareCommandAsync(CommandType.Text, sql, IdentifierType.SqlTypes(factory), cancellationToken)).ConfigureAwait(false);

--- a/src/NHibernate/Async/Transaction/AdoNetTransactionFactory.cs
+++ b/src/NHibernate/Async/Transaction/AdoNetTransactionFactory.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Transaction
 				}
 				catch (Exception t)
 				{
-					using (new SessionIdLoggingContext(session.SessionId))
+					using (session.BeginContext())
 					{
 						try
 						{

--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -26,17 +26,14 @@ namespace NHibernate.Transaction
 		private async Task AfterTransactionCompletionAsync(bool successful, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(sessionId))
-			{
-				session.ConnectionManager.AfterTransaction();
-				await (session.AfterTransactionCompletionAsync(successful, this, cancellationToken)).ConfigureAwait(false);
-				NotifyLocalSynchsAfterTransactionCompletion(successful);
-				foreach (var dependentSession in session.ConnectionManager.DependentSessions)
-					await (dependentSession.AfterTransactionCompletionAsync(successful, this, cancellationToken)).ConfigureAwait(false);
-
-				session = null;
-				begun = false;
-			}
+			session.ConnectionManager.AfterTransaction();
+			await (session.AfterTransactionCompletionAsync(successful, this, cancellationToken)).ConfigureAwait(false);
+			NotifyLocalSynchsAfterTransactionCompletion(successful);
+			foreach (var dependentSession in session.ConnectionManager.DependentSessions)
+				await (dependentSession.AfterTransactionCompletionAsync(successful, this, cancellationToken)).ConfigureAwait(false);
+	
+			session = null;
+			begun = false;
 		}
 
 		/// <summary>
@@ -51,7 +48,7 @@ namespace NHibernate.Transaction
 		public async Task CommitAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(sessionId))
+			using (session.BeginProcess())
 			{
 				CheckNotDisposed();
 				CheckBegun();

--- a/src/NHibernate/Async/Type/DbTimestampType.cs
+++ b/src/NHibernate/Async/Type/DbTimestampType.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Type
 			var tsSelect = new SqlString(timestampSelectString);
 			DbCommand ps = null;
 			DbDataReader rs = null;
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				try
 				{

--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -16,12 +16,34 @@ using NHibernate.Type;
 
 namespace NHibernate.Engine
 {
+	// 6.0 TODO: Convert to interface methods
+	internal static class SessionImplementorExtensions
+	{
+		internal static IDisposable BeginContext(this ISessionImplementor session)
+		{
+			if (session == null)
+				return null;
+			return (session as AbstractSessionImpl)?.BeginContext() ?? new SessionIdLoggingContext(session.SessionId);
+		}
+
+		internal static IDisposable BeginProcess(this ISessionImplementor session)
+		{
+			if (session == null)
+				return null;
+			return (session as AbstractSessionImpl)?.BeginProcess() ??
+				// This method has only replaced bare call to setting the id, so this fallback is enough for avoiding a
+				// breaking change in case in custom session implementation is used.
+				new SessionIdLoggingContext(session.SessionId);
+		}
+	}
+
 	/// <summary>
 	/// Defines the internal contract between the <c>Session</c> and other parts of NHibernate
 	/// such as implementors of <c>Type</c> or <c>ClassPersister</c>
 	/// </summary>
 	public partial interface ISessionImplementor
 	{
+		// 5.1 TODO: obsolete Initialize, it has no more usages.
 		/// <summary>
 		/// Initialize the session after its construction was complete
 		/// </summary>

--- a/src/NHibernate/Event/IEventSource.cs
+++ b/src/NHibernate/Event/IEventSource.cs
@@ -36,10 +36,11 @@ namespace NHibernate.Event
 
 		/// <summary> Cascade refresh an entity instance</summary>
 		void Refresh(object obj, IDictionary refreshedAlready);
-        
+
 		/// <summary> Cascade delete an entity instance</summary>
 		void Delete(string entityName, object child, bool isCascadeDeleteEnabled, ISet<object> transientEntities);
 
+		// 6.0 TODO: yield null if already suspended.
 		/// <summary>
 		/// Suspend auto-flushing, yielding a disposable to dispose when auto flush should be restored. Supports
 		/// being called multiple times.

--- a/src/NHibernate/Id/Insert/AbstractSelectingDelegate.cs
+++ b/src/NHibernate/Id/Insert/AbstractSelectingDelegate.cs
@@ -54,7 +54,7 @@ namespace NHibernate.Id.Insert
 				}
 
 				var selectSql = SelectSQL;
-				using (new SessionIdLoggingContext(session.SessionId))
+				using (session.BeginProcess())
 				{
 					try
 					{

--- a/src/NHibernate/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Impl/MultiCriteriaImpl.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Impl
 
 		public IList List()
 		{
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				bool cacheable = session.Factory.Settings.IsQueryCacheEnabled && isCacheable;
 

--- a/src/NHibernate/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Impl/MultiQueryImpl.cs
@@ -406,7 +406,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		public IList List()
 		{
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				bool cacheable = session.Factory.Settings.IsQueryCacheEnabled && isCacheable;
 				combinedParameters = CreateCombinedQueryParameters();

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -184,7 +184,7 @@ namespace NHibernate.Impl
 		internal SessionImpl(SessionFactoryImpl factory, ISessionCreationOptions options)
 			: base(factory, options)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				actionQueue = new ActionQueue(this);
 				persistenceContext = new StatefulPersistenceContext(this);
@@ -283,7 +283,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		public DbConnection Close()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				log.Debug("closing session");
 				if (IsClosed)
@@ -318,7 +318,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		public override void AfterTransactionCompletion(bool success, ITransaction tx)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				log.Debug("transaction completion");
 
@@ -352,21 +352,16 @@ namespace NHibernate.Impl
 
 		private void Cleanup()
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				// Let the after tran clear that if we are still in an active system transaction.
-				if (TransactionContext?.IsInActiveTransaction == true)
-					return;
-				persistenceContext.Clear();
-			}
+			// Let the after tran clear that if we are still in an active system transaction.
+			if (TransactionContext?.IsInActiveTransaction == true)
+				return;
+			persistenceContext.Clear();
 		}
 
 		public LockMode GetCurrentLockMode(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				if (obj == null)
 				{
 					throw new ArgumentNullException("obj", "null object passed to GetCurrentLockMode");
@@ -408,7 +403,7 @@ namespace NHibernate.Impl
 		/// <returns></returns>
 		public object Save(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return FireSave(new SaveOrUpdateEvent(null, obj, this));
 			}
@@ -416,7 +411,7 @@ namespace NHibernate.Impl
 
 		public object Save(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return FireSave(new SaveOrUpdateEvent(entityName, obj, this));
 			}
@@ -424,7 +419,7 @@ namespace NHibernate.Impl
 
 		public void Save(string entityName, object obj, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireSave(new SaveOrUpdateEvent(entityName, obj, id, this));
 			}
@@ -437,7 +432,7 @@ namespace NHibernate.Impl
 		/// <param name="id"></param>
 		public void Save(object obj, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireSave(new SaveOrUpdateEvent(null, obj, id, this));
 			}
@@ -449,7 +444,7 @@ namespace NHibernate.Impl
 		/// <param name="obj"></param>
 		public void Delete(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireDelete(new DeleteEvent(obj, this));
 			}
@@ -458,7 +453,7 @@ namespace NHibernate.Impl
 		/// <summary> Delete a persistent object (by explicit entity name)</summary>
 		public void Delete(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireDelete(new DeleteEvent(entityName, obj, this));
 			}
@@ -466,7 +461,7 @@ namespace NHibernate.Impl
 
 		public void Update(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireUpdate(new SaveOrUpdateEvent(null, obj, this));
 			}
@@ -474,7 +469,7 @@ namespace NHibernate.Impl
 
 		public void Update(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireUpdate(new SaveOrUpdateEvent(entityName, obj, this));
 			}
@@ -482,7 +477,7 @@ namespace NHibernate.Impl
 
 		public void Update(string entityName, object obj, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireUpdate(new SaveOrUpdateEvent(entityName, obj, id, this));
 			}
@@ -490,7 +485,7 @@ namespace NHibernate.Impl
 
 		public void SaveOrUpdate(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireSaveOrUpdate(new SaveOrUpdateEvent(null, obj, this));
 			}
@@ -498,7 +493,7 @@ namespace NHibernate.Impl
 
 		public void SaveOrUpdate(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireSaveOrUpdate(new SaveOrUpdateEvent(entityName, obj, this));
 			}
@@ -506,7 +501,7 @@ namespace NHibernate.Impl
 
 		public void SaveOrUpdate(string entityName, object obj, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireSaveOrUpdate(new SaveOrUpdateEvent(entityName, obj, id, this));
 			}
@@ -514,7 +509,7 @@ namespace NHibernate.Impl
 
 		public void Update(object obj, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireUpdate(new SaveOrUpdateEvent(null, obj, id, this));
 			}
@@ -525,7 +520,7 @@ namespace NHibernate.Impl
 
 		IList Find(string query, object[] values, IType[] types)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return List(query.ToQueryExpression(), new QueryParameters(types, values));
 			}
@@ -538,9 +533,8 @@ namespace NHibernate.Impl
 
 		public override IQuery CreateQuery(IQueryExpression queryExpression)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = GetHQLQueryPlan(queryExpression, false);
 				var query = new ExpressionQueryImpl(plan.QueryExpression, this, plan.ParameterMetadata);
 				query.SetComment("[expression]");
@@ -562,9 +556,8 @@ namespace NHibernate.Impl
 
 		private void List(IQueryExpression queryExpression, QueryParameters queryParameters, IList results, object filterConnection)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 
 				var isFilter = filterConnection != null;
@@ -603,7 +596,7 @@ namespace NHibernate.Impl
 
 		public override IQueryTranslator[] GetQueries(IQueryExpression query, bool scalar)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var plan = Factory.QueryPlanCache.GetHQLQueryPlan(query, scalar, enabledFilters);
 				AutoFlushIfRequired(plan.QuerySpaces);
@@ -613,9 +606,8 @@ namespace NHibernate.Impl
 
 		public override IEnumerable<T> Enumerable<T>(IQueryExpression queryExpression, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				var plan = GetHQLQueryPlan(queryExpression, true);
 				AutoFlushIfRequired(plan.QuerySpaces);
@@ -629,9 +621,8 @@ namespace NHibernate.Impl
 
 		public override IEnumerable Enumerable(IQueryExpression queryExpression, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				var plan = GetHQLQueryPlan(queryExpression, true);
 				AutoFlushIfRequired(plan.QuerySpaces);
@@ -647,30 +638,22 @@ namespace NHibernate.Impl
 
 		public int Delete(string query)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return Delete(query, NoArgs, NoTypes);
-			}
+			return Delete(query, NoArgs, NoTypes);
 		}
 
 		public int Delete(string query, object value, IType type)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return Delete(query, new[] { value }, new[] { type });
-			}
+			return Delete(query, new[] { value }, new[] { type });
 		}
 
 		public int Delete(string query, object[] values, IType[] types)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (string.IsNullOrEmpty(query))
 				{
 					throw new ArgumentNullException("query", "attempt to perform delete-by-query with null query");
 				}
-
-				CheckAndUpdateSessionStatus();
 
 				if (log.IsDebugEnabled)
 				{
@@ -693,7 +676,7 @@ namespace NHibernate.Impl
 
 		public void Lock(object obj, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireLock(new LockEvent(obj, lockMode, this));
 			}
@@ -701,7 +684,7 @@ namespace NHibernate.Impl
 
 		public void Lock(string entityName, object obj, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireLock(new LockEvent(entityName, obj, lockMode, this));
 			}
@@ -709,10 +692,8 @@ namespace NHibernate.Impl
 
 		public IQuery CreateFilter(object collection, string queryString)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				var plan = GetFilterQueryPlan(collection, queryString, null, false);
 				var filter = new CollectionFilterImpl(queryString, collection, this, plan.ParameterMetadata);
 				//filter.SetComment(queryString);
@@ -722,10 +703,8 @@ namespace NHibernate.Impl
 
 		public override IQuery CreateFilter(object collection, IQueryExpression queryExpression)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				var plan = GetFilterQueryPlan(collection, queryExpression, null, false);
 				var filter = new ExpressionFilterImpl(plan.QueryExpression, collection, this, plan.ParameterMetadata);
 				return filter;
@@ -745,62 +724,59 @@ namespace NHibernate.Impl
 		private IQueryExpressionPlan GetFilterQueryPlan(object collection, QueryParameters parameters, bool shallow,
 			string filter, IQueryExpression queryExpression)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			if (collection == null)
+				throw new ArgumentNullException(nameof(collection), "null collection passed to filter");
+			if (filter != null && queryExpression != null)
+				throw new ArgumentException($"Either {nameof(filter)} or {nameof(queryExpression)} must be specified, not both.");
+			if (filter == null && queryExpression == null)
+				throw new ArgumentException($"{nameof(filter)} and {nameof(queryExpression)} were both null.");
+
+			var entry = persistenceContext.GetCollectionEntryOrNull(collection);
+			var roleBeforeFlush = entry?.LoadedPersister;
+
+			IQueryExpressionPlan plan;
+			if (roleBeforeFlush == null)
 			{
-				if (collection == null)
-					throw new ArgumentNullException(nameof(collection), "null collection passed to filter");
-				if (filter != null && queryExpression != null)
-					throw new ArgumentException($"Either {nameof(filter)} or {nameof(queryExpression)} must be specified, not both.");
-				if (filter == null && queryExpression == null)
-					throw new ArgumentException($"{nameof(filter)} and {nameof(queryExpression)} were both null.");
-
-				var entry = persistenceContext.GetCollectionEntryOrNull(collection);
-				var roleBeforeFlush = entry?.LoadedPersister;
-
-				IQueryExpressionPlan plan;
-				if (roleBeforeFlush == null)
+				// if it was previously unreferenced, we need to flush in order to
+				// get its state into the database in order to execute query
+				Flush();
+				entry = persistenceContext.GetCollectionEntryOrNull(collection);
+				var roleAfterFlush = entry?.LoadedPersister;
+				if (roleAfterFlush == null)
 				{
-					// if it was previously unreferenced, we need to flush in order to
-					// get its state into the database in order to execute query
-					Flush();
+					throw new QueryException("The collection was unreferenced");
+				}
+				plan = GetFilterQueryPlan(roleAfterFlush.Role, shallow, filter, queryExpression);
+			}
+			else
+			{
+				// otherwise, we only need to flush if there are in-memory changes
+				// to the queried tables
+				plan = GetFilterQueryPlan(roleBeforeFlush.Role, shallow, filter, queryExpression);
+				if (AutoFlushIfRequired(plan.QuerySpaces))
+				{
+					// might need to run a different filter entirely after the flush
+					// because the collection role may have changed
 					entry = persistenceContext.GetCollectionEntryOrNull(collection);
 					var roleAfterFlush = entry?.LoadedPersister;
-					if (roleAfterFlush == null)
+					if (roleBeforeFlush != roleAfterFlush)
 					{
-						throw new QueryException("The collection was unreferenced");
-					}
-					plan = GetFilterQueryPlan(roleAfterFlush.Role, shallow, filter, queryExpression);
-				}
-				else
-				{
-					// otherwise, we only need to flush if there are in-memory changes
-					// to the queried tables
-					plan = GetFilterQueryPlan(roleBeforeFlush.Role, shallow, filter, queryExpression);
-					if (AutoFlushIfRequired(plan.QuerySpaces))
-					{
-						// might need to run a different filter entirely after the flush
-						// because the collection role may have changed
-						entry = persistenceContext.GetCollectionEntryOrNull(collection);
-						var roleAfterFlush = entry?.LoadedPersister;
-						if (roleBeforeFlush != roleAfterFlush)
+						if (roleAfterFlush == null)
 						{
-							if (roleAfterFlush == null)
-							{
-								throw new QueryException("The collection was dereferenced");
-							}
-							plan = GetFilterQueryPlan(roleAfterFlush.Role, shallow, filter, queryExpression);
+							throw new QueryException("The collection was dereferenced");
 						}
+						plan = GetFilterQueryPlan(roleAfterFlush.Role, shallow, filter, queryExpression);
 					}
 				}
-
-				if (parameters != null)
-				{
-					parameters.PositionalParameterValues[0] = entry.LoadedKey;
-					parameters.PositionalParameterTypes[0] = entry.LoadedPersister.KeyType;
-				}
-
-				return plan;
 			}
+
+			if (parameters != null)
+			{
+				parameters.PositionalParameterValues[0] = entry.LoadedKey;
+				parameters.PositionalParameterTypes[0] = entry.LoadedPersister.KeyType;
+			}
+
+			return plan;
 		}
 
 		private IQueryExpressionPlan GetFilterQueryPlan(string role, bool shallow, string filter, IQueryExpression queryExpression)
@@ -812,7 +788,7 @@ namespace NHibernate.Impl
 
 		public override object Instantiate(string clazz, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return Instantiate(Factory.GetEntityPersister(clazz), id);
 			}
@@ -836,9 +812,8 @@ namespace NHibernate.Impl
 		/// <returns></returns>
 		public object Instantiate(IEntityPersister persister, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				ErrorIfClosed();
 				object result = Interceptor.Instantiate(persister.EntityName, id);
 				if (result == null)
 				{
@@ -852,9 +827,8 @@ namespace NHibernate.Impl
 		/// <summary> Force an immediate flush</summary>
 		public void ForceFlush(EntityEntry entityEntry)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (log.IsDebugEnabled)
 				{
 					log.Debug("flushing to force deletion of re-saved object: " +
@@ -876,7 +850,7 @@ namespace NHibernate.Impl
 		/// <summary> Cascade merge an entity instance</summary>
 		public void Merge(string entityName, object obj, IDictionary copiedAlready)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireMerge(copiedAlready, new MergeEvent(entityName, obj, this));
 			}
@@ -885,7 +859,7 @@ namespace NHibernate.Impl
 		/// <summary> Cascade persist an entity instance</summary>
 		public void Persist(string entityName, object obj, IDictionary createdAlready)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FirePersist(createdAlready, new PersistEvent(entityName, obj, this));
 			}
@@ -894,7 +868,7 @@ namespace NHibernate.Impl
 		/// <summary> Cascade persist an entity instance during the flush process</summary>
 		public void PersistOnFlush(string entityName, object obj, IDictionary copiedAlready)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FirePersistOnFlush(copiedAlready, new PersistEvent(entityName, obj, this));
 			}
@@ -903,7 +877,7 @@ namespace NHibernate.Impl
 		/// <summary> Cascade refresh an entity instance</summary>
 		public void Refresh(object obj, IDictionary refreshedAlready)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireRefresh(refreshedAlready, new RefreshEvent(obj, this));
 			}
@@ -912,7 +886,7 @@ namespace NHibernate.Impl
 		/// <summary> Cascade delete an entity instance</summary>
 		public void Delete(string entityName, object child, bool isCascadeDeleteEnabled, ISet<object> transientEntities)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireDelete(new DeleteEvent(entityName, child, isCascadeDeleteEnabled, this), transientEntities);
 			}
@@ -950,7 +924,7 @@ namespace NHibernate.Impl
 
 		public object Merge(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return FireMerge(new MergeEvent(entityName, obj, this));
 			}
@@ -968,15 +942,12 @@ namespace NHibernate.Impl
 
 		public object Merge(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return Merge(null, obj);
-			}
+			return Merge(null, obj);
 		}
 
 		public void Persist(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FirePersist(new PersistEvent(entityName, obj, this));
 			}
@@ -984,15 +955,12 @@ namespace NHibernate.Impl
 
 		public void Persist(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				Persist(null, obj);
-			}
+			Persist(null, obj);
 		}
 
 		public void PersistOnFlush(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FirePersistOnFlush(new PersistEvent(entityName, obj, this));
 			}
@@ -1000,10 +968,7 @@ namespace NHibernate.Impl
 
 		public void PersistOnFlush(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				Persist(null, obj);
-			}
+			Persist(null, obj);
 		}
 
 		// Obsolete in v5, and was already having no usages previously.
@@ -1012,7 +977,7 @@ namespace NHibernate.Impl
 
 		public override string BestGuessEntityName(object entity)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				if (entity.IsProxy())
 				{
@@ -1047,7 +1012,7 @@ namespace NHibernate.Impl
 
 		public override string GuessEntityName(object entity)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				string entityName = Interceptor.GetEntityName(entity);
 				if (entityName == null)
@@ -1069,9 +1034,8 @@ namespace NHibernate.Impl
 
 		public override object GetEntityUsingInterceptor(EntityKey key)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				// todo : should this get moved to PersistentContext?
 				// logically, is PersistentContext the "thing" to which an interceptor gets attached?
 				object result = persistenceContext.GetEntity(key);
@@ -1109,9 +1073,8 @@ namespace NHibernate.Impl
 		/// <returns></returns>
 		private bool AutoFlushIfRequired(ISet<string> querySpaces)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (!ConnectionManager.IsInActiveTransaction)
 				{
 					// do not auto-flush while outside a transaction
@@ -1131,7 +1094,7 @@ namespace NHibernate.Impl
 
 		public void Load(object obj, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				LoadEvent loadEvent = new LoadEvent(id, obj, this);
 				FireLoad(loadEvent, LoadEventListener.Reload);
@@ -1140,7 +1103,7 @@ namespace NHibernate.Impl
 
 		public T Load<T>(object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)Load(typeof(T), id);
 			}
@@ -1148,7 +1111,7 @@ namespace NHibernate.Impl
 
 		public T Load<T>(object id, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)Load(typeof(T), id, lockMode);
 			}
@@ -1170,15 +1133,12 @@ namespace NHibernate.Impl
 		/// </exception>
 		public object Load(System.Type entityClass, object id, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return Load(entityClass.FullName, id, lockMode);
-			}
+			return Load(entityClass.FullName, id, lockMode);
 		}
 
 		public object Load(string entityName, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (id == null)
 				{
@@ -1206,7 +1166,7 @@ namespace NHibernate.Impl
 
 		public object Load(string entityName, object id, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				var @event = new LoadEvent(id, entityName, lockMode, this);
 				FireLoad(@event, LoadEventListener.Load);
@@ -1216,15 +1176,12 @@ namespace NHibernate.Impl
 
 		public object Load(System.Type entityClass, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return Load(entityClass.FullName, id);
-			}
+			return Load(entityClass.FullName, id);
 		}
 
 		public T Get<T>(object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)Get(typeof(T), id);
 			}
@@ -1232,7 +1189,7 @@ namespace NHibernate.Impl
 
 		public T Get<T>(object id, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return (T)Get(typeof(T), id, lockMode);
 			}
@@ -1240,10 +1197,7 @@ namespace NHibernate.Impl
 
 		public object Get(System.Type entityClass, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return Get(entityClass.FullName, id);
-			}
+			return Get(entityClass.FullName, id);
 		}
 
 		/// <summary>
@@ -1259,7 +1213,7 @@ namespace NHibernate.Impl
 		/// <returns></returns>
 		public object Get(System.Type clazz, object id, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				LoadEvent loadEvent = new LoadEvent(id, clazz.FullName, lockMode, this);
 				FireLoad(loadEvent, LoadEventListener.Get);
@@ -1269,10 +1223,8 @@ namespace NHibernate.Impl
 
 		public string GetEntityName(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				if (obj.IsProxy())
 				{
 					var proxy = obj as INHibernateProxy;
@@ -1299,7 +1251,7 @@ namespace NHibernate.Impl
 
 		public object Get(string entityName, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				LoadEvent loadEvent = new LoadEvent(id, entityName, false, this);
 				bool success = false;
@@ -1323,7 +1275,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		public override object ImmediateLoad(string entityName, object id)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (log.IsDebugEnabled)
 				{
@@ -1344,7 +1296,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		public override object InternalLoad(string entityName, object id, bool eager, bool isNullable)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				// todo : remove
 				LoadType type = isNullable
@@ -1364,7 +1316,7 @@ namespace NHibernate.Impl
 
 		public void Refresh(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireRefresh(new RefreshEvent(obj, this));
 			}
@@ -1372,7 +1324,7 @@ namespace NHibernate.Impl
 
 		public void Refresh(object obj, LockMode lockMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireRefresh(new RefreshEvent(obj, lockMode, this));
 			}
@@ -1380,7 +1332,7 @@ namespace NHibernate.Impl
 
 		public ITransaction BeginTransaction(IsolationLevel isolationLevel)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (_transactionCoordinatorShared)
 				{
@@ -1389,14 +1341,13 @@ namespace NHibernate.Impl
 					log.Warn("Transaction started on non-root session");
 				}
 
-				CheckAndUpdateSessionStatus();
 				return connectionManager.BeginTransaction(isolationLevel);
 			}
 		}
 
 		public ITransaction BeginTransaction()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (_transactionCoordinatorShared)
 				{
@@ -1405,7 +1356,6 @@ namespace NHibernate.Impl
 					log.Warn("Transaction started on non-root session");
 				}
 
-				CheckAndUpdateSessionStatus();
 				return connectionManager.BeginTransaction();
 			}
 		}
@@ -1438,9 +1388,8 @@ namespace NHibernate.Impl
 		/// </remarks>
 		public override void Flush()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (persistenceContext.CascadeLevel > 0)
 				{
 					throw new HibernateException("Flush during cascade is dangerous");
@@ -1463,10 +1412,8 @@ namespace NHibernate.Impl
 
 		public bool IsDirty()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				log.Debug("checking session dirtiness");
 				if (actionQueue.AreInsertionsOrDeletionsQueued)
 				{
@@ -1493,9 +1440,8 @@ namespace NHibernate.Impl
 		/// <returns></returns>
 		public object GetIdentifier(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				// Actually the case for proxies will probably work even with
 				// the session closed, but do the check here anyway, so that
 				// the behavior is uniform.
@@ -1529,7 +1475,7 @@ namespace NHibernate.Impl
 		/// <returns></returns>
 		public override object GetContextEntityIdentifier(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				if (obj.IsProxy())
 				{
@@ -1547,7 +1493,7 @@ namespace NHibernate.Impl
 
 		internal ICollectionPersister GetCollectionPersister(string role)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				return Factory.GetCollectionPersister(role);
 			}
@@ -1560,9 +1506,8 @@ namespace NHibernate.Impl
 		/// <param name="writing"></param>
 		public override void InitializeCollection(IPersistentCollection collection, bool writing)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IInitializeCollectionEventListener[] listener = listeners.InitializeCollectionEventListeners;
 				for (int i = 0; i < listener.Length; i++)
 				{
@@ -1595,9 +1540,8 @@ namespace NHibernate.Impl
 		/// <summary></summary>
 		public DbConnection Disconnect()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				log.Debug("disconnecting session");
 				return connectionManager.Disconnect();
 			}
@@ -1605,9 +1549,8 @@ namespace NHibernate.Impl
 
 		public void Reconnect()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				log.Debug("reconnecting session");
 				connectionManager.Reconnect();
 			}
@@ -1615,9 +1558,8 @@ namespace NHibernate.Impl
 
 		public void Reconnect(DbConnection conn)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				log.Debug("reconnecting session");
 				connectionManager.Reconnect(conn);
 			}
@@ -1640,7 +1582,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		public void Dispose()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				log.DebugFormat("[session-id={0}] running ISession.Dispose()", SessionId);
 				// Ensure we are not disposing concurrently to transaction completion, which would
@@ -1671,7 +1613,7 @@ namespace NHibernate.Impl
 		/// </remarks>
 		private void Dispose(bool isDisposing)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				if (IsAlreadyDisposed)
 				{
@@ -1701,9 +1643,8 @@ namespace NHibernate.Impl
 
 		private void Filter(object collection, string filter, QueryParameters queryParameters, IList results)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = GetFilterQueryPlan(collection, filter, queryParameters, false);
 
 				bool success = false;
@@ -1733,29 +1674,22 @@ namespace NHibernate.Impl
 
 		public override IList ListFilter(object collection, string filter, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				var results = new List<object>();
-				Filter(collection, filter, queryParameters, results);
-				return results;
-			}
+			var results = new List<object>();
+			Filter(collection, filter, queryParameters, results);
+			return results;
 		}
 
 		public override IList<T> ListFilter<T>(object collection, string filter, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				List<T> results = new List<T>();
-				Filter(collection, filter, queryParameters, results);
-				return results;
-			}
+			List<T> results = new List<T>();
+			Filter(collection, filter, queryParameters, results);
+			return results;
 		}
 
 		public override IEnumerable EnumerableFilter(object collection, string filter, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = GetFilterQueryPlan(collection, filter, queryParameters, true);
 				return plan.PerformIterate(queryParameters, this);
 			}
@@ -1763,9 +1697,8 @@ namespace NHibernate.Impl
 
 		public override IEnumerable<T> EnumerableFilter<T>(object collection, string filter, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				var plan = GetFilterQueryPlan(collection, filter, queryParameters, true);
 				return plan.PerformIterate<T>(queryParameters, this);
 			}
@@ -1773,72 +1706,58 @@ namespace NHibernate.Impl
 
 		public ICriteria CreateCriteria<T>() where T : class
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return CreateCriteria(typeof(T));
-			}
+			return CreateCriteria(typeof(T));
 		}
 
 		public ICriteria CreateCriteria(System.Type persistentClass)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				return new CriteriaImpl(persistentClass, this);
 			}
 		}
 
 		public ICriteria CreateCriteria<T>(string alias) where T : class
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				return CreateCriteria(typeof(T), alias);
-			}
+			return CreateCriteria(typeof(T), alias);
 		}
 
 		public ICriteria CreateCriteria(System.Type persistentClass, string alias)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				return new CriteriaImpl(persistentClass, alias, this);
 			}
 		}
 
 		public ICriteria CreateCriteria(string entityName, string alias)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				return new CriteriaImpl(entityName, alias, this);
 			}
 		}
 
 		public ICriteria CreateCriteria(string entityName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				return new CriteriaImpl(entityName, this);
 			}
 		}
 
 		public IQueryOver<T, T> QueryOver<T>() where T : class
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				return new QueryOver<T, T>(new CriteriaImpl(typeof(T), this));
 			}
 		}
 
 		public IQueryOver<T, T> QueryOver<T>(Expression<Func<T>> alias) where T : class
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				string aliasPath = ExpressionProcessor.FindMemberExpression(alias.Body);
 				return new QueryOver<T, T>(new CriteriaImpl(typeof(T), aliasPath, this));
 			}
@@ -1846,18 +1765,16 @@ namespace NHibernate.Impl
 
 		public IQueryOver<T, T> QueryOver<T>(string entityName) where T : class
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				return new QueryOver<T, T>(new CriteriaImpl(entityName, this));
 			}
 		}
 
 		public IQueryOver<T, T> QueryOver<T>(string entityName, Expression<Func<T>> alias) where T : class
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				string aliasPath = ExpressionProcessor.FindMemberExpression(alias.Body);
 				return new QueryOver<T, T>(new CriteriaImpl(entityName, aliasPath, this));
 			}
@@ -1865,10 +1782,8 @@ namespace NHibernate.Impl
 
 		public override void List(CriteriaImpl criteria, IList results)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				string[] implementors = Factory.GetImplementors(criteria.EntityOrClassName);
 				int size = implementors.Length;
 
@@ -1920,10 +1835,8 @@ namespace NHibernate.Impl
 
 		public bool Contains(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				if (obj.IsProxy())
 				{
 					var proxy = obj as INHibernateProxy;
@@ -1963,27 +1876,16 @@ namespace NHibernate.Impl
 		/// <param name="obj"></param>
 		public void Evict(object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireEvict(new EvictEvent(obj, this));
 			}
 		}
 
-		public override ISQLQuery CreateSQLQuery(string sql)
-		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				CheckAndUpdateSessionStatus();
-				return base.CreateSQLQuery(sql);
-			}
-		}
-
 		public override void ListCustomQuery(ICustomQuery customQuery, QueryParameters queryParameters, IList results)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				CustomLoader loader = new CustomLoader(customQuery, Factory);
 				AutoFlushIfRequired(loader.QuerySpaces);
 
@@ -2010,9 +1912,8 @@ namespace NHibernate.Impl
 
 		public void Clear()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				actionQueue.Clear();
 				persistenceContext.Clear();
 			}
@@ -2020,7 +1921,7 @@ namespace NHibernate.Impl
 
 		public void Replicate(object obj, ReplicationMode replicationMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireReplicate(new ReplicateEvent(obj, replicationMode, this));
 			}
@@ -2028,7 +1929,7 @@ namespace NHibernate.Impl
 
 		public void Replicate(string entityName, object obj, ReplicationMode replicationMode)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				FireReplicate(new ReplicateEvent(entityName, obj, replicationMode, this));
 			}
@@ -2041,19 +1942,16 @@ namespace NHibernate.Impl
 
 		public void CancelQuery()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
-
 				Batcher.CancelLastQuery();
 			}
 		}
 
 		public IFilter GetEnabledFilter(string filterName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IFilter result;
 				enabledFilters.TryGetValue(filterName, out result);
 				return result;
@@ -2062,9 +1960,8 @@ namespace NHibernate.Impl
 
 		public IFilter EnableFilter(string filterName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				FilterImpl filter = new FilterImpl(Factory.GetFilterDefinition(filterName));
 				enabledFilters[filterName] = filter;
 				if (!enabledFilterNames.Contains(filterName))
@@ -2077,9 +1974,8 @@ namespace NHibernate.Impl
 
 		public void DisableFilter(string filterName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				enabledFilters.Remove(filterName);
 				enabledFilterNames.Remove(filterName);
 			}
@@ -2087,9 +1983,8 @@ namespace NHibernate.Impl
 
 		public override Object GetFilterParameterValue(string filterParameterName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				string[] parsed = ParseFilterParameterName(filterParameterName);
 				IFilter ifilter;
 				enabledFilters.TryGetValue(parsed[0], out ifilter);
@@ -2104,9 +1999,8 @@ namespace NHibernate.Impl
 
 		public override IType GetFilterParameterType(string filterParameterName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				string[] parsed = ParseFilterParameterName(filterParameterName);
 				FilterDefinition filterDef = Factory.GetFilterDefinition(parsed[0]);
 				if (filterDef == null)
@@ -2140,17 +2034,14 @@ namespace NHibernate.Impl
 
 		private string[] ParseFilterParameterName(string filterParameterName)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			int dot = filterParameterName.IndexOf(".");
+			if (dot <= 0)
 			{
-				int dot = filterParameterName.IndexOf(".");
-				if (dot <= 0)
-				{
-					throw new ArgumentException("Invalid filter-parameter name format", "filterParameterName");
-				}
-				string filterName = filterParameterName.Substring(0, dot);
-				string parameterName = filterParameterName.Substring(dot + 1);
-				return new[] { filterName, parameterName };
+				throw new ArgumentException("Invalid filter-parameter name format", "filterParameterName");
 			}
+			string filterName = filterParameterName.Substring(0, dot);
+			string parameterName = filterParameterName.Substring(dot + 1);
+			return new[] { filterName, parameterName };
 		}
 
 		public override ConnectionManager ConnectionManager
@@ -2160,7 +2051,7 @@ namespace NHibernate.Impl
 
 		public IMultiQuery CreateMultiQuery()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return new MultiQueryImpl(this);
 			}
@@ -2168,7 +2059,7 @@ namespace NHibernate.Impl
 
 		public IMultiCriteria CreateMultiCriteria()
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
 				return new MultiCriteriaImpl(this, Factory);
 			}
@@ -2185,16 +2076,15 @@ namespace NHibernate.Impl
 
 		public override void AfterTransactionBegin(ITransaction tx)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				Interceptor.AfterTransactionBegin(tx);
 			}
 		}
 
 		public override void BeforeTransactionCompletion(ITransaction tx)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginContext())
 			{
 				log.Debug("before transaction completion");
 				var context = TransactionContext;
@@ -2219,11 +2109,8 @@ namespace NHibernate.Impl
 
 		public override void FlushBeforeTransactionCompletion()
 		{
-			using (new SessionIdLoggingContext(SessionId))
-			{
-				if (FlushMode != FlushMode.Manual)
-					Flush();
-			}
+			if (FlushMode != FlushMode.Manual)
+				Flush();
 		}
 
 		public ISession SetBatchSize(int batchSize)
@@ -2282,9 +2169,8 @@ namespace NHibernate.Impl
 		/// <inheritdoc />
 		public void SetReadOnly(object entityOrProxy, bool readOnly)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				persistenceContext.SetReadOnly(entityOrProxy, readOnly);
 			}
 		}
@@ -2300,15 +2186,13 @@ namespace NHibernate.Impl
 		public bool IsReadOnly(object entityOrProxy)
 		{
 			ErrorIfClosed();
-			// CheckTransactionSynchStatus();
 			return persistenceContext.IsReadOnly(entityOrProxy);
 		}
 
 		private void FireDelete(DeleteEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IDeleteEventListener[] deleteEventListener = listeners.DeleteEventListeners;
 				for (int i = 0; i < deleteEventListener.Length; i++)
 				{
@@ -2319,9 +2203,8 @@ namespace NHibernate.Impl
 
 		private void FireDelete(DeleteEvent @event, ISet<object> transientEntities)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IDeleteEventListener[] deleteEventListener = listeners.DeleteEventListeners;
 				for (int i = 0; i < deleteEventListener.Length; i++)
 				{
@@ -2332,9 +2215,8 @@ namespace NHibernate.Impl
 
 		private void FireEvict(EvictEvent evictEvent)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IEvictEventListener[] evictEventListener = listeners.EvictEventListeners;
 				for (int i = 0; i < evictEventListener.Length; i++)
 				{
@@ -2345,9 +2227,8 @@ namespace NHibernate.Impl
 
 		private void FireLoad(LoadEvent @event, LoadType loadType)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ILoadEventListener[] loadEventListener = listeners.LoadEventListeners;
 				for (int i = 0; i < loadEventListener.Length; i++)
 				{
@@ -2358,9 +2239,8 @@ namespace NHibernate.Impl
 
 		private void FireLock(LockEvent lockEvent)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ILockEventListener[] lockEventListener = listeners.LockEventListeners;
 				for (int i = 0; i < lockEventListener.Length; i++)
 				{
@@ -2371,9 +2251,8 @@ namespace NHibernate.Impl
 
 		private object FireMerge(MergeEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IMergeEventListener[] mergeEventListener = listeners.MergeEventListeners;
 				for (int i = 0; i < mergeEventListener.Length; i++)
 				{
@@ -2385,9 +2264,8 @@ namespace NHibernate.Impl
 
 		private void FireMerge(IDictionary copiedAlready, MergeEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IMergeEventListener[] mergeEventListener = listeners.MergeEventListeners;
 				for (int i = 0; i < mergeEventListener.Length; i++)
 				{
@@ -2398,9 +2276,8 @@ namespace NHibernate.Impl
 
 		private void FirePersist(IDictionary copiedAlready, PersistEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] persistEventListener = listeners.PersistEventListeners;
 				for (int i = 0; i < persistEventListener.Length; i++)
 				{
@@ -2411,9 +2288,8 @@ namespace NHibernate.Impl
 
 		private void FirePersist(PersistEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] createEventListener = listeners.PersistEventListeners;
 				for (int i = 0; i < createEventListener.Length; i++)
 				{
@@ -2424,9 +2300,8 @@ namespace NHibernate.Impl
 
 		private void FirePersistOnFlush(IDictionary copiedAlready, PersistEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] persistEventListener = listeners.PersistOnFlushEventListeners;
 				for (int i = 0; i < persistEventListener.Length; i++)
 				{
@@ -2437,9 +2312,8 @@ namespace NHibernate.Impl
 
 		private void FirePersistOnFlush(PersistEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IPersistEventListener[] createEventListener = listeners.PersistOnFlushEventListeners;
 				for (int i = 0; i < createEventListener.Length; i++)
 				{
@@ -2450,9 +2324,8 @@ namespace NHibernate.Impl
 
 		private void FireRefresh(RefreshEvent refreshEvent)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IRefreshEventListener[] refreshEventListener = listeners.RefreshEventListeners;
 				for (int i = 0; i < refreshEventListener.Length; i++)
 				{
@@ -2463,9 +2336,8 @@ namespace NHibernate.Impl
 
 		private void FireRefresh(IDictionary refreshedAlready, RefreshEvent refreshEvent)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IRefreshEventListener[] refreshEventListener = listeners.RefreshEventListeners;
 				for (int i = 0; i < refreshEventListener.Length; i++)
 				{
@@ -2476,9 +2348,8 @@ namespace NHibernate.Impl
 
 		private void FireReplicate(ReplicateEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				IReplicateEventListener[] replicateEventListener = listeners.ReplicateEventListeners;
 				for (int i = 0; i < replicateEventListener.Length; i++)
 				{
@@ -2489,9 +2360,8 @@ namespace NHibernate.Impl
 
 		private object FireSave(SaveOrUpdateEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ISaveOrUpdateEventListener[] saveEventListener = listeners.SaveEventListeners;
 				for (int i = 0; i < saveEventListener.Length; i++)
 				{
@@ -2503,9 +2373,8 @@ namespace NHibernate.Impl
 
 		private void FireSaveOrUpdate(SaveOrUpdateEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ISaveOrUpdateEventListener[] saveOrUpdateEventListener = listeners.SaveOrUpdateEventListeners;
 				for (int i = 0; i < saveOrUpdateEventListener.Length; i++)
 				{
@@ -2516,9 +2385,8 @@ namespace NHibernate.Impl
 
 		private void FireUpdate(SaveOrUpdateEvent @event)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				ISaveOrUpdateEventListener[] updateEventListener = listeners.UpdateEventListeners;
 				for (int i = 0; i < updateEventListener.Length; i++)
 				{
@@ -2529,9 +2397,8 @@ namespace NHibernate.Impl
 
 		public override int ExecuteNativeUpdate(NativeSQLQuerySpecification nativeQuerySpecification, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				NativeSQLQueryPlan plan = GetNativeSQLQueryPlan(nativeQuerySpecification);
 
@@ -2554,9 +2421,8 @@ namespace NHibernate.Impl
 
 		public override int ExecuteUpdate(IQueryExpression queryExpression, QueryParameters queryParameters)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				queryParameters.ValidateParameters();
 				var plan = GetHQLQueryPlan(queryExpression, false);
 				AutoFlushIfRequired(plan.QuerySpaces);
@@ -2578,9 +2444,8 @@ namespace NHibernate.Impl
 
 		public override IEntityPersister GetEntityPersister(string entityName, object obj)
 		{
-			using (new SessionIdLoggingContext(SessionId))
+			using (BeginProcess())
 			{
-				CheckAndUpdateSessionStatus();
 				if (entityName == null)
 				{
 					return Factory.GetEntityPersister(GuessEntityName(obj));

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -423,7 +423,7 @@ namespace NHibernate.Loader
 
 		private IList DoQuery(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, IResultTransformer forcedResultTransformer)
 		{
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				RowSelection selection = queryParameters.RowSelection;
 				int maxRows = HasMaxRows(selection) ? selection.MaxRows : int.MaxValue;

--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -1512,12 +1512,12 @@ namespace NHibernate.Persister.Collection
 
 		public int GetSize(object key, ISessionImplementor session)
 		{
-			using(new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				if(session.EnabledFilters.Count > 0)
 				{
-					
+					// The above call validates the filters
 				}
 
 				var st = session.Batcher.PrepareCommand(CommandType.Text, GenerateSelectSizeString(session), KeyType.SqlTypes(factory));
@@ -1554,7 +1554,7 @@ namespace NHibernate.Persister.Collection
 		private bool Exists(object key, object indexOrElement, IType indexOrElementType, SqlString sql,
 							ISessionImplementor session)
 		{
-			using(new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				List<SqlType> sqlTl = new List<SqlType>(KeyType.SqlTypes(factory));
@@ -1594,7 +1594,7 @@ namespace NHibernate.Persister.Collection
 
 		public virtual object GetElementByIndex(object key, object index, ISessionImplementor session, object owner)
 		{
-			using(new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				List<SqlType> sqlTl = new List<SqlType>(KeyType.SqlTypes(factory));

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1270,7 +1270,7 @@ namespace NHibernate.Persister.Entity
 
 			log.Debug("initializing lazy properties from datastore");
 
-			using (new SessionIdLoggingContext(session.SessionId)) 
+			using (session.BeginProcess())
 			try
 			{
 				object result = null;
@@ -1447,7 +1447,7 @@ namespace NHibernate.Persister.Entity
 				log.Debug("Getting current persistent state for: " + MessageHelper.InfoString(this, id, Factory));
 			}
 
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				var st = session.Batcher.PrepareCommand(CommandType.Text, SQLSnapshotSelectString, IdentifierType.SqlTypes(factory));
@@ -1702,7 +1702,7 @@ namespace NHibernate.Persister.Entity
 			{
 				log.Debug("Getting version: " + MessageHelper.InfoString(this, id, Factory));
 			}
-			using(new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			try
 			{
 				var st = session.Batcher.PrepareQueryCommand(CommandType.Text, VersionSelectString, IdentifierType.SqlTypes(Factory));
@@ -2489,7 +2489,7 @@ namespace NHibernate.Persister.Entity
 			DbCommand sequentialSelect = null;
 			DbDataReader sequentialResultSet = null;
 			bool sequentialSelectEmpty = false;
-			using (new SessionIdLoggingContext(session.SessionId)) 
+			using (session.BeginProcess())
 			try
 			{
 				if (hasDeferred)
@@ -4103,7 +4103,7 @@ namespace NHibernate.Persister.Entity
 		private void ProcessGeneratedPropertiesWithGeneratedSql(object id, object entity, object[] state,
 			ISessionImplementor session, SqlString selectionSQL, ValueInclusion[] generationInclusions)
 		{
-			using (new SessionIdLoggingContext(session.SessionId)) 
+			using (session.BeginProcess())
 			try
 			{
 				var cmd = session.Batcher.PrepareQueryCommand(CommandType.Text, selectionSQL, IdentifierType.SqlTypes(Factory));
@@ -4210,7 +4210,7 @@ namespace NHibernate.Persister.Entity
 			///////////////////////////////////////////////////////////////////////
 
 			object[] snapshot = new object[naturalIdPropertyCount];
-			using (new SessionIdLoggingContext(session.SessionId)) 
+			using (session.BeginProcess())
 			try
 			{
 				var ps = session.Batcher.PrepareCommand(CommandType.Text, sql, IdentifierType.SqlTypes(factory));

--- a/src/NHibernate/Transaction/AdoNetTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetTransactionFactory.cs
@@ -83,7 +83,7 @@ namespace NHibernate.Transaction
 			}
 			catch (Exception t)
 			{
-				using (new SessionIdLoggingContext(session.SessionId))
+				using (session.BeginContext())
 				{
 					try
 					{

--- a/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
@@ -309,7 +309,7 @@ namespace NHibernate.Transaction
 			/// <param name="preparingEnlistment">The object for notifying the prepare phase outcome.</param>
 			public virtual void Prepare(PreparingEnlistment preparingEnlistment)
 			{
-				using (new SessionIdLoggingContext(_session.SessionId))
+				using (_session.BeginContext())
 				{
 					try
 					{
@@ -378,7 +378,7 @@ namespace NHibernate.Transaction
 			/// callback, <see langword="null"/> if this is an in-doubt callback.</param>
 			protected virtual void ProcessSecondPhase(Enlistment enlistment, bool? success)
 			{
-				using (new SessionIdLoggingContext(_session.SessionId))
+				using (_session.BeginContext())
 				{
 					_logger.Debug(
 						success.HasValue
@@ -414,7 +414,7 @@ namespace NHibernate.Transaction
 				{
 					// Allow transaction completed actions to run while others stay blocked.
 					_bypassLock.Value = true;
-					using (new SessionIdLoggingContext(_session.SessionId))
+					using (_session.BeginContext())
 					{
 						// Flag active as false before running actions, otherwise the session may not cleanup as much
 						// as possible.

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -108,7 +108,7 @@ namespace NHibernate.Transaction
 		/// </exception>
 		public void Begin(IsolationLevel isolationLevel)
 		{
-			using (new SessionIdLoggingContext(sessionId))
+			using (session.BeginProcess())
 			{
 				if (begun)
 				{
@@ -161,17 +161,14 @@ namespace NHibernate.Transaction
 
 		private void AfterTransactionCompletion(bool successful)
 		{
-			using (new SessionIdLoggingContext(sessionId))
-			{
-				session.ConnectionManager.AfterTransaction();
-				session.AfterTransactionCompletion(successful, this);
-				NotifyLocalSynchsAfterTransactionCompletion(successful);
-				foreach (var dependentSession in session.ConnectionManager.DependentSessions)
-					dependentSession.AfterTransactionCompletion(successful, this);
-
-				session = null;
-				begun = false;
-			}
+			session.ConnectionManager.AfterTransaction();
+			session.AfterTransactionCompletion(successful, this);
+			NotifyLocalSynchsAfterTransactionCompletion(successful);
+			foreach (var dependentSession in session.ConnectionManager.DependentSessions)
+				dependentSession.AfterTransactionCompletion(successful, this);
+	
+			session = null;
+			begun = false;
 		}
 
 		/// <summary>
@@ -184,7 +181,7 @@ namespace NHibernate.Transaction
 		/// </exception>
 		public void Commit()
 		{
-			using (new SessionIdLoggingContext(sessionId))
+			using (session.BeginProcess())
 			{
 				CheckNotDisposed();
 				CheckBegun();

--- a/src/NHibernate/Transaction/ITransactionContext.cs
+++ b/src/NHibernate/Transaction/ITransactionContext.cs
@@ -25,7 +25,8 @@ namespace NHibernate.Transaction
 		/// <summary>
 		/// With some transaction factory, synchronization of session may be required. This method should be called
 		/// by session before each of its usage where a concurrent transaction completion action could cause a thread
-		/// safety issue. This method is already called by <see cref="AbstractSessionImpl.CheckAndUpdateSessionStatus"/>.
+		/// safety issue. This method is already called by <see cref="AbstractSessionImpl.CheckAndUpdateSessionStatus"/>
+		/// and <see cref="AbstractSessionImpl.BeginProcess"/>.
 		/// </summary>
 		/// <remarks>
 		/// <para>

--- a/src/NHibernate/Type/DbTimestampType.cs
+++ b/src/NHibernate/Type/DbTimestampType.cs
@@ -53,7 +53,7 @@ namespace NHibernate.Type
 			var tsSelect = new SqlString(timestampSelectString);
 			DbCommand ps = null;
 			DbDataReader rs = null;
-			using (new SessionIdLoggingContext(session.SessionId))
+			using (session.BeginProcess())
 			{
 				try
 				{


### PR DESCRIPTION
 * Reduces object allocations.

Two helper methods have been added on the abstract session impl: `BeginProcess` and `BeginContext`.
Both yields an `IDisposable` if we are not already in a "processing", otherwise they yield `null`. `using` supports this. This avoids allocating that small helper object when there is no work to do. ~~The suspend auto flush helper has been changed accordingly~~ (debatable, see review comment to come).
If not already processing, `BeginProcess` does check the status of the session, stores its id in context, then flag the session as "processing". `BeginContext` just stores its id in context if we are not already processing. `BeginContext` neither alters the processing flag, nor has a flag of its own (for simplicity).

For the session id context, skipping setting it again when it has already been set through an ongoing "processing" should not change anything to the feature (excepted its impact on perf): if, through some event or interceptor, it is changed by another session usage in such an event/interceptor while the first session is processing, its current logic will set back the first session id when ending the other session usage, which will forcibly occurs before the event or interceptor ends. (Unless an await on that other session is missing, but that would be a user bug even without this change.)

For the `CheckAndUpdateSessionStatus` status case, not running it again during a processing may weaken the error handling in case the user exploits an event or an interceptor to close the session or start a scope without completing it, while the session is "processing". I think it is acceptable. Closing the session during one of its event or interceptor call is clearly calling for troubles, so long for the user. Starting a scope outside of a using and inside an event or interceptor call is a bit exotic too.

`CheckAndUpdateSessionStatus` is still there and directly called in some cases (mainly properties access), and is now a no-op if the session is already "processing".
`new SessionIdLoggingContext(sessionId)` is now only directly called by `AbstractSessionImpl` and by the `AdoTransaction` which some methods may have to work without a session but with a stored session id.

`BeginProcess` and `BeginContext` are to be added to `ISessionImplementor` at some later point, but are now added as just extension methods of `ISessionImplementor` (avoiding a breaking change).

Many cases who were just setting the session id have been converted to `BeginProcess`, because they were calling some methods ending up doing that. In such case, better call `BeginProcess` the soonest, for reducing the most session id calls.
Some cases were pointlessly setting the id or checking the status, because their were doing nothing susceptible to log anything or actually do some processing, excepted calling a single method which was already doing the `BeginProcess`. (If it calls many methods doing it, then it should still call `BeginProcess` for achieving best savings.) They have been cleaned up of the call.
Some cases were calling the check status or were setting the id while being private and always called by methods doing it themselves.  They have been cleaned up of the call.