### PR TITLE
Release 5.0.2

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -6,8 +6,13 @@ issue-labels-include:
  - "t: Improvement"
  - "t: Task"
 issue-labels-exclude:
+ - "r: Duplicate"
+ - "r: External Issue"
+ - "r: Not an Issue"
+ - "r: Obsolete"
  - "r: Rejected"
  - "r: Replaced"
+ - "t: Fix"
 issue-labels-alias:
  - name:   "t: Bug"
    header: Bug

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">2</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -30,8 +30,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.0.1" overwrite="false" />
-	<property name="project.version.numeric" value="5.0.1" overwrite="false" />
+	<property name="project.version" value="5.0.2" overwrite="false" />
+	<property name="project.version.numeric" value="5.0.2" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,4 +1,7 @@
-﻿Build 5.0.1
+﻿As part of releasing 5.0.2, a missing 5.0.0 possible breaking change has been added about Dialects requiring now
+to be configured. See 5.0.0 possible breaking changes.
+
+Build 5.0.1
 =============================
 
 Release notes - NHibernate - Version 5.0.1
@@ -85,6 +88,9 @@ Build 5.0.0
           the dialect. They resolve to 4000 length string and (28, 10) precision/scale decimals by default, and are
           trimmed down according to dialect. Those defaults can be overridden with query.default_cast_length,
           query.default_cast_precision and query.default_cast_scale settings.
+        * Dialects are now configurable. If you instantiate a dialect directly, make sure you call its Configure
+          method, with as argument the properties of a NHibernate Configuration object. You may use instead
+          Dialect.GetDialect methods, which configure the dialect before returning it.
         * Transaction scopes handling has undergone a major rework. See NH-4011 for full details.
           ** More transaction promotion to distributed may occur if you use the "flush on commit" feature with
              transaction scopes. Explicitly flush your session instead. Ensure it does not occur by disabling
@@ -155,9 +161,6 @@ Release notes - NHibernate - Version 5.0.0
     * [NH-3956] - Native SQL query plan may get wrong plan
     * [NH-3957] - Second level query cache may yields wrong cache entry
     * [NH-4001] - Remove ThreadSafeDictionary
-
-
-
 
 ** Bug
     * [NH-926] - Identity insert fails with SQL Ce dialect and aggressive connection release mode.

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -5,10 +5,8 @@ Release notes - NHibernate - Version 5.0.2
 
 ** Bug
     * #1456 NH-4052 - Add missing serializable implementation
-    * #1453 Eliminate unnecessary AsyncLocal allocation if SessionId isn't changed
-
-** Improvement
     * #1455 Reduces check session and set context id redundant calls
+    * #1453 Eliminate unnecessary AsyncLocal allocation if SessionId isn't changed
 
 ** Task
     * #1457 Release 5.0.2

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,4 +1,19 @@
-﻿As part of releasing 5.0.2, a missing 5.0.0 possible breaking change has been added about Dialects requiring now
+﻿Build 5.0.2
+=============================
+
+Release notes - NHibernate - Version 5.0.2
+
+** Bug
+    * #1456 NH-4052 - Add missing serializable implementation
+    * #1453 Eliminate unnecessary AsyncLocal allocation if SessionId isn't changed
+
+** Improvement
+    * #1455 Reduces check session and set context id redundant calls
+
+** Task
+    * #1457 Release 5.0.2
+
+As part of releasing 5.0.2, a missing 5.0.0 possible breaking change has been added about Dialects requiring now
 to be configured. See 5.0.0 possible breaking changes.
 
 Build 5.0.1


### PR DESCRIPTION
I guess we do not have more things to add in 5.0.2, so here is the release PR.

Release draft is view-able for NHibernate team [here](https://github.com/nhibernate/nhibernate-core/releases).

Elaborated from a draft generated with:
```
GitReleaseManager.exe create -o nhibernate -r nhibernate-core -m 5.0.2 -c 5.0.x -u username -p password
```
(If you test it, it announces 14 commits because it counts on master in spite of the `-c 5.0.x` which told it the branch. That parameter is still useful for correctly setting the target of the draft release.)

The GitReleaseManager settings have been updated for handling new tags.

I have also added a commit for retro-documenting a missing possible breaking change of 5.0.0.