### PR TITLE
Disable session tracking by default

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -1031,17 +1031,18 @@ var session = sessions.OpenSession(conn);
                             <literal>track_session_id</literal>
                         </entry>
                         <entry>
-                            Set whether the session id should be tracked in logs or not. When <literal>true</literal>, each
+                            Set whether the session id should be track-able in logs or not. When <literal>true</literal>, each
                             session will have an unique <literal>Guid</literal> that can be retrieved with
                             <literal>ISessionImplementor.SessionId</literal>, otherwise <literal>ISessionImplementor.SessionId</literal>
                             will be <literal>Guid.Empty</literal>.
                             <para>
                                 Session id is used for logging purpose and can also be retrieved on the static property
                                 <literal>NHibernate.Impl.SessionIdLoggingContext.SessionId</literal>, when tracking is enabled.
+                                Some third party tools depend on it, like NHibernate Profiler.
                             </para>
                             <para>
                                 Disabling tracking by setting <literal>track_session_id</literal> to <literal>false</literal>
-                                increases performances. Default is <literal>true</literal>.
+                                increases performances. Default is <literal>false</literal>.
                             </para>
                             <para>
                                 <emphasis role="strong">eg.</emphasis>

--- a/src/NHibernate.Test/Async/NHSpecificTest/Logs/LogsFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/Logs/LogsFixture.cs
@@ -48,6 +48,7 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 		{
 			base.Configure(configuration);
 			configuration.SetProperty(Cfg.Environment.UseSecondLevelCache, "false");
+			configuration.SetProperty(Cfg.Environment.TrackSessionId, "true");
 		}
 
 		protected override void OnSetUp()

--- a/src/NHibernate.Test/NHSpecificTest/GH1391/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1391/Fixture.cs
@@ -131,7 +131,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1391
 		[Test]
 		public void XmlConfiguration()
 		{
-			const string xml = @"<?xml version='1.0' encoding='utf-8' ?>
+			const string falseConfig = @"<?xml version='1.0' encoding='utf-8' ?>
 <hibernate-configuration xmlns='urn:nhibernate-configuration-2.2'>
 	<session-factory name='NHibernate.Test'>
 		<property name='track_session_id'>
@@ -139,15 +139,27 @@ namespace NHibernate.Test.NHSpecificTest.GH1391
 		</property>
 	</session-factory>
 </hibernate-configuration>";
-
-			var cfgXml = new XmlDocument();
-			cfgXml.LoadXml(xml);
+			const string trueConfig = @"<?xml version='1.0' encoding='utf-8' ?>
+<hibernate-configuration xmlns='urn:nhibernate-configuration-2.2'>
+	<session-factory name='NHibernate.Test'>
+		<property name='track_session_id'>
+		true
+		</property>
+	</session-factory>
+</hibernate-configuration>";
 
 			var cfg = new Configuration();
-			using (var xtr = new XmlTextReader(xml, XmlNodeType.Document, null))
+			using (var xtr = new XmlTextReader(falseConfig, XmlNodeType.Document, null))
 			{
 				cfg.Configure(xtr);
 				Assert.That(PropertiesHelper.GetBoolean(Environment.TrackSessionId, cfg.Properties, true), Is.False);
+			}
+
+			cfg = new Configuration();
+			using (var xtr = new XmlTextReader(trueConfig, XmlNodeType.Document, null))
+			{
+				cfg.Configure(xtr);
+				Assert.That(PropertiesHelper.GetBoolean(Environment.TrackSessionId, cfg.Properties, false), Is.True);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Logs/LogsFixture.cs
@@ -37,6 +37,7 @@ namespace NHibernate.Test.NHSpecificTest.Logs
 		{
 			base.Configure(configuration);
 			configuration.SetProperty(Cfg.Environment.UseSecondLevelCache, "false");
+			configuration.SetProperty(Cfg.Environment.TrackSessionId, "true");
 		}
 
 		protected override void OnSetUp()

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -259,14 +259,14 @@ namespace NHibernate.Cfg
 		public const string OracleUseNPrefixedTypesForUnicode = "oracle.use_n_prefixed_types_for_unicode";
 
 		/// <summary>
-		/// <para>Set whether tracking the session id or not. When <see langword="true"/>, each session 
-		/// will have an unique <see cref="Guid"/> that can be retrieved by <see cref="ISessionImplementor.SessionId"/>,
-		/// otherwise <see cref="ISessionImplementor.SessionId"/> will always be <see cref="Guid.Empty"/>. Session id 
-		/// is used for logging purpose that can be also retrieved in a static context by 
-		/// <see cref="NHibernate.Impl.SessionIdLoggingContext.SessionId"/>, where the current session id is stored,
-		/// when tracking is enabled.</para>
-		/// In case the current session id won't be used, it is recommended to disable it, in order to increase performance.
-		/// <para>Default is <see langword="true"/>.</para>
+		/// <para>Set whether the session id should be track-able in logs or not. When <see langword="true"/>, each session
+		/// will have an unique <see cref="Guid"/> that can be retrieved with <see cref="ISessionImplementor.SessionId"/>,
+		/// otherwise <see cref="ISessionImplementor.SessionId"/> will be <see cref="Guid.Empty"/>.</para>
+		/// <para>Session id is used for logging purpose and can also be retrieved on the static property
+		/// <see cref="NHibernate.Impl.SessionIdLoggingContext.SessionId"/>, when tracking is enabled.
+		/// Some third party tools depend on it, like NHibernate Profiler.</para>
+		/// <para>Disabling tracking by setting <c>track_session_id</c> to <see langword="false"/> increases performances.</para>
+		/// <para>Default is <see langword="false"/>.</para>
 		/// </summary>
 		public const string TrackSessionId = "track_session_id";
 

--- a/src/NHibernate/Cfg/SettingsFactory.cs
+++ b/src/NHibernate/Cfg/SettingsFactory.cs
@@ -304,7 +304,7 @@ namespace NHibernate.Cfg
 			// NHibernate-specific:
 			settings.IsolationLevel = isolation;
 			
-			bool trackSessionId = PropertiesHelper.GetBoolean(Environment.TrackSessionId, properties, true);
+			bool trackSessionId = PropertiesHelper.GetBoolean(Environment.TrackSessionId, properties, false);
 			log.Debug("Track session id: " + EnabledDisabled(trackSessionId));
 			settings.TrackSessionId = trackSessionId;
 

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -196,13 +196,15 @@
 								<xs:enumeration value="track_session_id">
 									<xs:annotation>
 										<xs:documentation>
-											Set whether tracking the session id or not. When true, each session will have an unique Guid
-											that can be retrieved by ISessionImplementor.SessionId, otherwise ISessionImplementor.SessionId will
-											always be Guid.Empty. Session id is used for logging purpose that can be also retrieved in a static 
-											context by SessionIdLoggingContext.SessionId, where the current session id is stored, when tracking 
-											is enabled. In case the current session id won't be used, it is recommended to disable it, in order 
-											to increase performance.
-											True by default.
+											Set whether the session id should be track-able in logs or not. When true, each
+											session will have an unique Guid that can be retrieved with
+											ISessionImplementor.SessionId, otherwise ISessionImplementor.SessionId
+											will be Guid.Empty.
+											Session id is used for logging purpose and can also be retrieved on the static property
+											NHibernate.Impl.SessionIdLoggingContext.SessionId, when tracking is enabled.
+											Some third party tools depend on it, like NHibernate Profiler.
+											Disabling tracking by setting track_session_id to false increases performances.
+											Default is false.
 										</xs:documentation>
 									</xs:annotation>
 								</xs:enumeration>


### PR DESCRIPTION
This enables #1391 by default (enabling a deactivation...), as proposed in #1446.

This is a grey area change for a minor: it will breaks NHProf users until they adjust their configuration for re-enabling it. (@ayende, maybe an update to NHProf could hint them about this setting.)