### PR TITLE
Obsolete an unused method.

### DIFF
--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -43,10 +43,11 @@ namespace NHibernate.Engine
 	/// </summary>
 	public partial interface ISessionImplementor
 	{
-		// 5.1 TODO: obsolete Initialize, it has no more usages.
 		/// <summary>
 		/// Initialize the session after its construction was complete
 		/// </summary>
+		// Since v5.1
+		[Obsolete("This method has no more usages in NHibernate and will be removed.")]
 		void Initialize();
 
 		/// <summary>

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -55,6 +55,8 @@ namespace NHibernate.Impl
 
 		#region ISessionImplementor Members
 
+		// Since v5.1
+		[Obsolete("This method has no more usages in NHibernate and will be removed.")]
 		public void Initialize()
 		{
 			BeginProcess()?.Dispose();


### PR DESCRIPTION
Kind of follow up to #1455, in which this method was spotted as being dead code, no more called and having its purpose handled directly in constructors.