### PR TITLE
Obsolete EqualsHelper

### DIFF
--- a/src/NHibernate.DomainModel/Async/CustomPersister.cs
+++ b/src/NHibernate.DomainModel/Async/CustomPersister.cs
@@ -37,7 +37,7 @@ namespace NHibernate.DomainModel
 		{
 			try
 			{
-				if (!EqualsHelper.Equals(currentState[0], previousState[0]))
+				if (!Equals(currentState[0], previousState[0]))
 				{
 					return Task.FromResult<int[]>(new int[] { 0 });
 				}
@@ -56,7 +56,7 @@ namespace NHibernate.DomainModel
 		{
 			try
 			{
-				if (!EqualsHelper.Equals(old[0], current[0]))
+				if (!Equals(old[0], current[0]))
 				{
 					return Task.FromResult<int[]>(new int[] { 0 });
 				}

--- a/src/NHibernate.DomainModel/CustomPersister.cs
+++ b/src/NHibernate.DomainModel/CustomPersister.cs
@@ -254,7 +254,7 @@ namespace NHibernate.DomainModel
 
 		public int[] FindDirty(object[] currentState, object[] previousState, object entity, ISessionImplementor session)
 		{
-			if (!EqualsHelper.Equals(currentState[0], previousState[0]))
+			if (!Equals(currentState[0], previousState[0]))
 			{
 				return new int[] { 0 };
 			}
@@ -266,7 +266,7 @@ namespace NHibernate.DomainModel
 
 		public int[] FindModified(object[] old, object[] current, object entity, ISessionImplementor session)
 		{
-			if (!EqualsHelper.Equals(old[0], current[0]))
+			if (!Equals(old[0], current[0]))
 			{
 				return new int[] { 0 };
 			}

--- a/src/NHibernate/Type/AbstractType.cs
+++ b/src/NHibernate/Type/AbstractType.cs
@@ -208,7 +208,7 @@ namespace NHibernate.Type
 
 		public virtual bool IsEqual(object x, object y)
 		{
-			return EqualsHelper.Equals(x, y);
+			return Equals(x, y);
 		}
 
 		public virtual bool IsEqual(object x, object y, ISessionFactoryImplementor factory)

--- a/src/NHibernate/Type/NullableType.cs
+++ b/src/NHibernate/Type/NullableType.cs
@@ -332,7 +332,7 @@ namespace NHibernate.Type
 
 		public override bool IsEqual(object x, object y)
 		{
-			return EqualsHelper.Equals(x, y);
+			return Equals(x, y);
 		}
 
 		#region override of System.Object Members

--- a/src/NHibernate/Util/EqualsHelper.cs
+++ b/src/NHibernate/Util/EqualsHelper.cs
@@ -1,10 +1,13 @@
+using System;
+
 namespace NHibernate.Util
 {
 	public static class EqualsHelper
 	{
+		[Obsolete("Please use object.Equals(object, object) instead.")]
 		public new static bool Equals(object x, object y)
 		{
-			return x == y || (x != null && y != null && x.Equals(y));
+			return object.Equals(x, y);
 		}
 	}
 }


### PR DESCRIPTION
The current implementation of EqualsHelper is exactly the same as `object.Equals`. So, it is replaced with object's version and advised users to use `object.Equals` instead.