### PR TITLE
Cleanup serialization

### DIFF
--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -365,7 +365,7 @@ namespace NHibernate.AdoNet
 		}
 
 		[SecurityCritical]
-		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("ownConnection", _ownConnection);
 			info.AddValue("session", Session, typeof(ISessionImplementor));

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -355,7 +355,7 @@ namespace NHibernate.AdoNet
 
 		#region Serialization
 
-		private ConnectionManager(SerializationInfo info, StreamingContext context)
+		protected ConnectionManager(SerializationInfo info, StreamingContext context)
 		{
 			_ownConnection = info.GetBoolean("ownConnection");
 			Session = (ISessionImplementor)info.GetValue("session", typeof(ISessionImplementor));

--- a/src/NHibernate/Async/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Async/Engine/StatefulPersistenceContext.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Engine
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class StatefulPersistenceContext : IPersistenceContext, ISerializable, IDeserializationCallback
+	public sealed partial class StatefulPersistenceContext : IPersistenceContext, ISerializable, IDeserializationCallback
 	{
 
 		#region IPersistenceContext Members

--- a/src/NHibernate/Bytecode/UnableToLoadProxyFactoryFactoryException.cs
+++ b/src/NHibernate/Bytecode/UnableToLoadProxyFactoryFactoryException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace NHibernate.Bytecode
 {
@@ -20,6 +21,7 @@ namespace NHibernate.Bytecode
 			typeName = info.GetString("typeName");
 		}
 
+		[SecurityCritical]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/NHibernate/Bytecode/UnableToLoadProxyFactoryFactoryException.cs
+++ b/src/NHibernate/Bytecode/UnableToLoadProxyFactoryFactoryException.cs
@@ -13,8 +13,19 @@ namespace NHibernate.Bytecode
 			this.typeName = typeName;
 		}
 
-		protected UnableToLoadProxyFactoryFactoryException(SerializationInfo info,
-		                      StreamingContext context) : base(info, context) {}
+		protected UnableToLoadProxyFactoryFactoryException(
+			SerializationInfo info,
+			StreamingContext context) : base(info, context)
+		{
+			typeName = info.GetString("typeName");
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue("typeName", typeName);
+		}
+
 		public override string Message
 		{
 			get

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -123,7 +123,7 @@ namespace NHibernate.Cfg
 		}
 
 		[SecurityCritical]
-		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			ConfigureProxyFactoryFactory();
 			SecondPassCompile();

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -80,7 +80,7 @@ namespace NHibernate.Cfg
 		protected internal SettingsFactory settingsFactory;
 
 		#region ISerializable Members
-		public Configuration(SerializationInfo info, StreamingContext context)
+		protected Configuration(SerializationInfo info, StreamingContext context)
 		{
 			Reset();
 

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -67,6 +67,8 @@ namespace NHibernate.Cfg
 		protected IList<IAuxiliaryDatabaseObject> auxiliaryDatabaseObjects;
 
 		private INamingStrategy namingStrategy = DefaultNamingStrategy.Instance;
+
+		[NonSerialized]
 		private MappingsQueue mappingsQueue;
 
 		private EventListeners eventListeners;
@@ -1889,6 +1891,7 @@ namespace NHibernate.Cfg
 
 		#endregion
 
+		[NonSerialized]
 		private XmlSchemas schemas;
 
 		private XmlSchemas Schemas

--- a/src/NHibernate/Cfg/Mappings.cs
+++ b/src/NHibernate/Cfg/Mappings.cs
@@ -11,7 +11,6 @@ namespace NHibernate.Cfg
 	/// A collection of mappings from classes and collections to relational database tables.
 	/// </summary>
 	/// <remarks>Represents a single <c>&lt;hibernate-mapping&gt;</c> element.</remarks>
-	[Serializable]
 	public class Mappings
 	{
 		#region Utility classes

--- a/src/NHibernate/Context/AsyncLocalSessionContext.cs
+++ b/src/NHibernate/Context/AsyncLocalSessionContext.cs
@@ -16,7 +16,6 @@ namespace NHibernate.Context
 	/// Provides a <see cref="ISessionFactory.GetCurrentSession()">current session</see>
 	/// for current asynchronous flow.
 	/// </summary>
-	[Serializable]
 	public class AsyncLocalSessionContext : CurrentSessionContext
 	{
 		private readonly AsyncLocal<ISession> _session = new AsyncLocal<ISession>();

--- a/src/NHibernate/Criterion/MatchMode.cs
+++ b/src/NHibernate/Criterion/MatchMode.cs
@@ -6,6 +6,7 @@ namespace NHibernate.Criterion
 	/// <summary>
 	/// Represents an strategy for matching strings using "like".
 	/// </summary>
+	[Serializable]
 	public abstract class MatchMode
 	{
 		private int _intCode;
@@ -89,6 +90,7 @@ namespace NHibernate.Criterion
 		/// <summary>
 		/// The <see cref="MatchMode"/> that matches the entire string to the pattern.
 		/// </summary>
+		[Serializable]
 		private class ExactMatchMode : MatchMode
 		{
 			/// <summary>
@@ -112,6 +114,7 @@ namespace NHibernate.Criterion
 		/// <summary>
 		/// The <see cref="MatchMode"/> that matches the start of the string to the pattern.
 		/// </summary>
+		[Serializable]
 		private class StartMatchMode : MatchMode
 		{
 			/// <summary>
@@ -135,6 +138,7 @@ namespace NHibernate.Criterion
 		/// <summary>
 		/// The <see cref="MatchMode"/> that matches the end of the string to the pattern.
 		/// </summary>
+		[Serializable]
 		private class EndMatchMode : MatchMode
 		{
 			/// <summary>
@@ -159,6 +163,7 @@ namespace NHibernate.Criterion
 		/// The <see cref="MatchMode"/> that exactly matches the string
 		/// by appending "<c>%</c>" to the beginning and end.
 		/// </summary>
+		[Serializable]
 		private class AnywhereMatchMode : MatchMode
 		{
 			/// <summary>

--- a/src/NHibernate/Dialect/BitwiseFunctionOperation.cs
+++ b/src/NHibernate/Dialect/BitwiseFunctionOperation.cs
@@ -14,7 +14,10 @@ namespace NHibernate.Dialect
 	public class BitwiseFunctionOperation : ISQLFunction
 	{
 		private readonly string _functionName;
+
+		[NonSerialized]
 		private SqlStringBuilder _sqlBuffer;
+
 		private Queue _args;
 
 		/// <summary>

--- a/src/NHibernate/Dialect/BitwiseNativeOperation.cs
+++ b/src/NHibernate/Dialect/BitwiseNativeOperation.cs
@@ -16,6 +16,8 @@ namespace NHibernate.Dialect
 		private readonly string _sqlOpToken;
 		private readonly bool _isNot;
         private Queue _args;
+
+		[NonSerialized]
 		private SqlStringBuilder _sqlBuffer;
 
 		/// <summary>

--- a/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
+++ b/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
@@ -23,6 +23,7 @@ namespace NHibernate.Dialect.Function
 		private const int InvalidArgumentIndex = -1;
 		private static readonly Regex SplitRegex = new Regex("(\\?[0-9]+)");
 
+		[Serializable]
 		private struct TemplateChunk
 		{
 			public string Text; // including prefix if parameter

--- a/src/NHibernate/DuplicateMappingException.cs
+++ b/src/NHibernate/DuplicateMappingException.cs
@@ -59,7 +59,7 @@ namespace NHibernate
 		/// <param name="context">
 		/// The <see cref="StreamingContext"/> that contains contextual information about the source or destination.
 		/// </param>
-		public DuplicateMappingException(SerializationInfo info, StreamingContext context)
+		protected DuplicateMappingException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
 		}

--- a/src/NHibernate/DuplicateMappingException.cs
+++ b/src/NHibernate/DuplicateMappingException.cs
@@ -62,6 +62,15 @@ namespace NHibernate
 		protected DuplicateMappingException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
+			type = info.GetString("type");
+			name = info.GetString("name");
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue("type", type);
+			info.AddValue("name", name);
 		}
 	}
 }

--- a/src/NHibernate/DuplicateMappingException.cs
+++ b/src/NHibernate/DuplicateMappingException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace NHibernate
 {
@@ -66,6 +67,7 @@ namespace NHibernate
 			name = info.GetString("name");
 		}
 
+		[SecurityCritical]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/NHibernate/Engine/CascadeStyle.cs
+++ b/src/NHibernate/Engine/CascadeStyle.cs
@@ -13,6 +13,11 @@ namespace NHibernate.Engine
 	{
 		/// <summary> package-protected constructor</summary>
 		internal CascadeStyle() {}
+
+		protected CascadeStyle(SerializationInfo info, StreamingContext context)
+		{
+		}
+
 		static CascadeStyle()
 		{
 			Styles["all"] = All;
@@ -261,7 +266,7 @@ namespace NHibernate.Engine
 				this.styles = styles;
 			}
 
-			private MultipleCascadeStyle(SerializationInfo info, StreamingContext context)
+			private MultipleCascadeStyle(SerializationInfo info, StreamingContext context) : base(info, context)
 			{
 				styles = (CascadeStyle[])info.GetValue("styles", typeof(CascadeStyle[]));
 			}

--- a/src/NHibernate/Engine/Query/NativeSQLQueryPlan.cs
+++ b/src/NHibernate/Engine/Query/NativeSQLQueryPlan.cs
@@ -20,7 +20,6 @@ using NHibernate.Util;
 namespace NHibernate.Engine.Query
 {
 	/// <summary> Defines a query execution plan for a native-SQL query. </summary>
-	[Serializable]
 	public partial class NativeSQLQueryPlan
 	{
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof(NativeSQLQueryPlan));

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -1475,7 +1475,7 @@ namespace NHibernate.Engine
 		#endregion
 
 		#region ISerializable Members
-		internal StatefulPersistenceContext(SerializationInfo info, StreamingContext context)
+		protected StatefulPersistenceContext(SerializationInfo info, StreamingContext context)
 		{
 			loadCounter = 0;
 			flushing = false;

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Engine
 	/// PersistentContext to drive their processing.
 	/// </remarks>
 	[Serializable]
-	public partial class StatefulPersistenceContext : IPersistenceContext, ISerializable, IDeserializationCallback
+	public sealed partial class StatefulPersistenceContext : IPersistenceContext, ISerializable, IDeserializationCallback
 	{
 		private const int InitCollectionSize = 8;
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof(StatefulPersistenceContext));
@@ -790,7 +790,7 @@ namespace NHibernate.Engine
 		/// The owner, if its entity ID is available from the collection's loaded key
 		/// and the owner entity is in the persistence context; otherwise, returns null
 		/// </returns>
-		public virtual object GetLoadedCollectionOwnerOrNull(IPersistentCollection collection)
+		public object GetLoadedCollectionOwnerOrNull(IPersistentCollection collection)
 		{
 			CollectionEntry ce = GetCollectionEntry(collection);
 			if (ce.LoadedPersister == null)
@@ -811,7 +811,7 @@ namespace NHibernate.Engine
 		/// <summary> Get the ID for the entity that owned this persistent collection when it was loaded </summary>
 		/// <param name="collection">The persistent collection </param>
 		/// <returns> the owner ID if available from the collection's loaded key; otherwise, returns null </returns>
-		public virtual object GetLoadedCollectionOwnerIdOrNull(IPersistentCollection collection)
+		public object GetLoadedCollectionOwnerIdOrNull(IPersistentCollection collection)
 		{
 			return GetLoadedCollectionOwnerIdOrNull(GetCollectionEntry(collection));
 		}
@@ -1475,7 +1475,7 @@ namespace NHibernate.Engine
 		#endregion
 
 		#region ISerializable Members
-		protected StatefulPersistenceContext(SerializationInfo info, StreamingContext context)
+		private StatefulPersistenceContext(SerializationInfo info, StreamingContext context)
 		{
 			loadCounter = 0;
 			flushing = false;

--- a/src/NHibernate/Event/AbstractCollectionEvent.cs
+++ b/src/NHibernate/Event/AbstractCollectionEvent.cs
@@ -6,7 +6,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> Defines a base class for events involving collections. </summary>
-	[Serializable]
 	public abstract class AbstractCollectionEvent : AbstractEvent
 	{
 		private readonly object affectedOwner;

--- a/src/NHibernate/Event/AbstractEvent.cs
+++ b/src/NHibernate/Event/AbstractEvent.cs
@@ -5,7 +5,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Defines a base class for Session generated events.
 	/// </summary>
-	[Serializable]
 	public class AbstractEvent : IDatabaseEventArgs
 	{
 		/// <summary> 

--- a/src/NHibernate/Event/AbstractPostDatabaseOperationEvent.cs
+++ b/src/NHibernate/Event/AbstractPostDatabaseOperationEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Represents an operation we performed against the database. 
 	/// </summary>
-	[Serializable]
 	public class AbstractPostDatabaseOperationEvent : AbstractEvent, IPostDatabaseOperationEventArgs
 	{
 		/// <summary> Constructs an event containing the pertinent information. </summary>

--- a/src/NHibernate/Event/AbstractPreDatabaseOperationEvent.cs
+++ b/src/NHibernate/Event/AbstractPreDatabaseOperationEvent.cs
@@ -7,7 +7,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Represents an operation we are about to perform against the database. 
 	/// </summary>
-	[Serializable]
 	public abstract class AbstractPreDatabaseOperationEvent : AbstractEvent, IPreDatabaseOperationEventArgs
 	{
 		/// <summary> Constructs an event containing the pertinent information. </summary>

--- a/src/NHibernate/Event/AutoFlushEvent.cs
+++ b/src/NHibernate/Event/AutoFlushEvent.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 namespace NHibernate.Event
 {
 	/// <summary>Defines an event class for the auto-flushing of a session. </summary>
-	[Serializable]
 	public class AutoFlushEvent : FlushEvent
 	{
 		private ISet<string> querySpaces;

--- a/src/NHibernate/Event/DeleteEvent.cs
+++ b/src/NHibernate/Event/DeleteEvent.cs
@@ -3,7 +3,6 @@ using System;
 namespace NHibernate.Event
 {
 	/// <summary>Defines an event class for the deletion of an entity. </summary>
-	[Serializable]
 	public class DeleteEvent : AbstractEvent
 	{
 		private readonly string entityName;

--- a/src/NHibernate/Event/DirtyCheckEvent.cs
+++ b/src/NHibernate/Event/DirtyCheckEvent.cs
@@ -3,7 +3,6 @@ using System;
 namespace NHibernate.Event
 {
 	/// <summary>Defines an event class for the dirty-checking of a session. </summary>
-	[Serializable]
 	public class DirtyCheckEvent : FlushEvent
 	{
 		public DirtyCheckEvent(IEventSource source) : base(source) { }

--- a/src/NHibernate/Event/EvictEvent.cs
+++ b/src/NHibernate/Event/EvictEvent.cs
@@ -3,7 +3,6 @@ using System;
 namespace NHibernate.Event
 {
 	/// <summary>  Defines an event class for the evicting of an entity. </summary>
-	[Serializable]
 	public class EvictEvent : AbstractEvent
 	{
 		private object entity;

--- a/src/NHibernate/Event/FlushEntityEvent.cs
+++ b/src/NHibernate/Event/FlushEntityEvent.cs
@@ -3,7 +3,6 @@ using NHibernate.Engine;
 
 namespace NHibernate.Event
 {
-	[Serializable]
 	public class FlushEntityEvent : AbstractEvent
 	{
 		private readonly object entity;

--- a/src/NHibernate/Event/FlushEvent.cs
+++ b/src/NHibernate/Event/FlushEvent.cs
@@ -3,7 +3,6 @@ using System;
 namespace NHibernate.Event
 {
 	/// <summary> Defines an event class for the flushing of a session. </summary>
-	[Serializable]
 	public class FlushEvent : AbstractEvent
 	{
 		public FlushEvent(IEventSource source) : base(source) { }

--- a/src/NHibernate/Event/LoadEvent.cs
+++ b/src/NHibernate/Event/LoadEvent.cs
@@ -3,7 +3,6 @@ using System;
 namespace NHibernate.Event
 {
 	/// <summary>Defines an event class for the loading of an entity. </summary>
-	[Serializable]
 	public class LoadEvent : AbstractEvent
 	{
 		public static readonly LockMode DefaultLockMode = LockMode.None;

--- a/src/NHibernate/Event/LockEvent.cs
+++ b/src/NHibernate/Event/LockEvent.cs
@@ -7,7 +7,6 @@ namespace NHibernate.Event
 	/// <summary>
 	/// Defines an event class for the locking of an entity.
 	/// </summary>
-	[Serializable]
 	public class LockEvent : AbstractEvent
 	{
 		private string entityName;

--- a/src/NHibernate/Event/MergeEvent.cs
+++ b/src/NHibernate/Event/MergeEvent.cs
@@ -4,7 +4,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// An event class for merge() and saveOrUpdateCopy()
 	/// </summary>
-	[Serializable]
 	public class MergeEvent : AbstractEvent
 	{
 		private object original;

--- a/src/NHibernate/Event/PostCollectionRecreateEvent.cs
+++ b/src/NHibernate/Event/PostCollectionRecreateEvent.cs
@@ -5,7 +5,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> An event that occurs after a collection is recreated </summary>
-	[Serializable]
 	public class PostCollectionRecreateEvent : AbstractCollectionEvent
 	{
 		public PostCollectionRecreateEvent(ICollectionPersister collectionPersister, IPersistentCollection collection,

--- a/src/NHibernate/Event/PostCollectionRemoveEvent.cs
+++ b/src/NHibernate/Event/PostCollectionRemoveEvent.cs
@@ -5,7 +5,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> An event that occurs after a collection is removed </summary>
-	[Serializable]
 	public class PostCollectionRemoveEvent : AbstractCollectionEvent
 	{
 		public PostCollectionRemoveEvent(ICollectionPersister collectionPersister, IPersistentCollection collection,

--- a/src/NHibernate/Event/PostCollectionUpdateEvent.cs
+++ b/src/NHibernate/Event/PostCollectionUpdateEvent.cs
@@ -5,7 +5,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> An event that occurs after a collection is updated </summary>
-	[Serializable]
 	public class PostCollectionUpdateEvent : AbstractCollectionEvent
 	{
 		public PostCollectionUpdateEvent(ICollectionPersister collectionPersister, IPersistentCollection collection,

--- a/src/NHibernate/Event/PostDeleteEvent.cs
+++ b/src/NHibernate/Event/PostDeleteEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Occurs after deleting an item from the datastore 
 	/// </summary>
-	[Serializable]
 	public class PostDeleteEvent : AbstractPostDatabaseOperationEvent
 	{
 		public PostDeleteEvent(object entity, object id, object[] deletedState, IEntityPersister persister, IEventSource source)

--- a/src/NHibernate/Event/PostInsertEvent.cs
+++ b/src/NHibernate/Event/PostInsertEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Occurs after inserting an item in the datastore 
 	/// </summary>
-	[Serializable]
 	public class PostInsertEvent : AbstractPostDatabaseOperationEvent
 	{
 		public PostInsertEvent(object entity, object id, object[] state, IEntityPersister persister, IEventSource source)

--- a/src/NHibernate/Event/PostLoadEvent.cs
+++ b/src/NHibernate/Event/PostLoadEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Occurs after an an entity instance is fully loaded.
 	/// </summary>
-	[Serializable]
 	public class PostLoadEvent : AbstractEvent, IPostDatabaseOperationEventArgs
 	{
 		private object entity;

--- a/src/NHibernate/Event/PostUpdateEvent.cs
+++ b/src/NHibernate/Event/PostUpdateEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Occurs after the datastore is updated
 	/// </summary>
-	[Serializable]
 	public class PostUpdateEvent : AbstractPostDatabaseOperationEvent
 	{
 		public PostUpdateEvent(object entity, object id, object[] state, object[] oldState, IEntityPersister persister, IEventSource source)

--- a/src/NHibernate/Event/PreCollectionRecreateEvent.cs
+++ b/src/NHibernate/Event/PreCollectionRecreateEvent.cs
@@ -5,7 +5,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> An event that occurs before a collection is recreated </summary>
-	[Serializable]
 	public class PreCollectionRecreateEvent : AbstractCollectionEvent
 	{
 		public PreCollectionRecreateEvent(ICollectionPersister collectionPersister, IPersistentCollection collection,

--- a/src/NHibernate/Event/PreCollectionRemoveEvent.cs
+++ b/src/NHibernate/Event/PreCollectionRemoveEvent.cs
@@ -5,7 +5,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> An event that occurs before a collection is removed </summary>
-	[Serializable]
 	public class PreCollectionRemoveEvent : AbstractCollectionEvent
 	{
 		public PreCollectionRemoveEvent(ICollectionPersister collectionPersister, IPersistentCollection collection,

--- a/src/NHibernate/Event/PreCollectionUpdateEvent.cs
+++ b/src/NHibernate/Event/PreCollectionUpdateEvent.cs
@@ -5,7 +5,6 @@ using NHibernate.Persister.Collection;
 namespace NHibernate.Event
 {
 	/// <summary> An event that occurs before a collection is updated </summary>
-	[Serializable]
 	public class PreCollectionUpdateEvent : AbstractCollectionEvent
 	{
 		public PreCollectionUpdateEvent(ICollectionPersister collectionPersister, IPersistentCollection collection,

--- a/src/NHibernate/Event/PreLoadEvent.cs
+++ b/src/NHibernate/Event/PreLoadEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// Called before injecting property values into a newly loaded entity instance.
 	/// </summary>
-	[Serializable]
 	public class PreLoadEvent : AbstractEvent, IPreDatabaseOperationEventArgs
 	{
 		private object entity;

--- a/src/NHibernate/Event/RefreshEvent.cs
+++ b/src/NHibernate/Event/RefreshEvent.cs
@@ -7,7 +7,6 @@ namespace NHibernate.Event
 	/// <summary>  
 	/// Defines an event class for the refreshing of an object.
 	/// </summary>
-	[Serializable]
 	public class RefreshEvent : AbstractEvent
 	{
 		private readonly LockMode lockMode= LockMode.Read;

--- a/src/NHibernate/Event/ReplicateEvent.cs
+++ b/src/NHibernate/Event/ReplicateEvent.cs
@@ -7,7 +7,6 @@ namespace NHibernate.Event
 	/// <summary>  
 	/// Defines an event class for the replication of an entity.
 	/// </summary>
-	[Serializable]
 	public class ReplicateEvent : AbstractEvent
 	{
 		private string entityName;

--- a/src/NHibernate/Event/SaveOrUpdateEvent.cs
+++ b/src/NHibernate/Event/SaveOrUpdateEvent.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Event
 	/// <summary> 
 	/// An event class for saveOrUpdate()
 	/// </summary>
-	[Serializable]
 	public class SaveOrUpdateEvent : AbstractEvent
 	{
 		private object entity;

--- a/src/NHibernate/Exceptions/ADOConnectionException.cs
+++ b/src/NHibernate/Exceptions/ADOConnectionException.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Exceptions
 	[Serializable]
 	public class ADOConnectionException : ADOException
 	{
-		public ADOConnectionException(SerializationInfo info, StreamingContext context) : base(info, context) {}
+		protected ADOConnectionException(SerializationInfo info, StreamingContext context) : base(info, context) {}
 		public ADOConnectionException(string message, Exception innerException, string sql) : base(message, innerException, sql) {}
 		public ADOConnectionException(string message, Exception innerException) : base(message, innerException) {}
 	}

--- a/src/NHibernate/Exceptions/ConstraintViolationException.cs
+++ b/src/NHibernate/Exceptions/ConstraintViolationException.cs
@@ -11,9 +11,6 @@ namespace NHibernate.Exceptions
 	public class ConstraintViolationException : ADOException
 	{
 		private readonly string constraintName;
-		protected ConstraintViolationException(SerializationInfo info, StreamingContext context)
-			: base(info, context) {}
-
 		public ConstraintViolationException(string message, Exception innerException, string sql, string constraintName)
 			: base(message, innerException, sql)
 		{
@@ -24,6 +21,18 @@ namespace NHibernate.Exceptions
 			: base(message, innerException)
 		{
 			this.constraintName = constraintName;
+		}
+
+		protected ConstraintViolationException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.constraintName = info.GetString("constraintName");
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue("constraintName", this.constraintName);
 		}
 
 		/// <summary> 

--- a/src/NHibernate/Exceptions/ConstraintViolationException.cs
+++ b/src/NHibernate/Exceptions/ConstraintViolationException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace NHibernate.Exceptions
 {
@@ -29,6 +30,7 @@ namespace NHibernate.Exceptions
 			this.constraintName = info.GetString("constraintName");
 		}
 
+		[SecurityCritical]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/NHibernate/Exceptions/ConstraintViolationException.cs
+++ b/src/NHibernate/Exceptions/ConstraintViolationException.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Exceptions
 	public class ConstraintViolationException : ADOException
 	{
 		private readonly string constraintName;
-		public ConstraintViolationException(SerializationInfo info, StreamingContext context)
+		protected ConstraintViolationException(SerializationInfo info, StreamingContext context)
 			: base(info, context) {}
 
 		public ConstraintViolationException(string message, Exception innerException, string sql, string constraintName)

--- a/src/NHibernate/Exceptions/DataException.cs
+++ b/src/NHibernate/Exceptions/DataException.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Exceptions
 	[Serializable]
 	public class DataException : ADOException
 	{
-		public DataException(SerializationInfo info, StreamingContext context) : base(info, context) {}
+		protected DataException(SerializationInfo info, StreamingContext context) : base(info, context) {}
 		public DataException(string message, Exception innerException, string sql) : base(message, innerException, sql) {}
 		public DataException(string message, Exception innerException) : base(message, innerException) {}
 	}

--- a/src/NHibernate/Exceptions/GenericADOException.cs
+++ b/src/NHibernate/Exceptions/GenericADOException.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Exceptions
 	    {
 	        
 	    }
-		public GenericADOException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+		protected GenericADOException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 		public GenericADOException(string message, Exception innerException, string sql) : base(message, innerException, sql) { }
 		public GenericADOException(string message, Exception innerException) : base(message, innerException) { }
 	}

--- a/src/NHibernate/Exceptions/LockAcquisitionException.cs
+++ b/src/NHibernate/Exceptions/LockAcquisitionException.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Exceptions
 	[Serializable]
 	public class LockAcquisitionException : ADOException
 	{
-		public LockAcquisitionException(SerializationInfo info, StreamingContext context) : base(info, context) {}
+		protected LockAcquisitionException(SerializationInfo info, StreamingContext context) : base(info, context) {}
 		public LockAcquisitionException(string message, Exception innerException, string sql) : base(message, innerException, sql) {}
 		public LockAcquisitionException(string message, Exception innerException) : base(message, innerException) {}
 	}

--- a/src/NHibernate/Exceptions/SQLGrammarException.cs
+++ b/src/NHibernate/Exceptions/SQLGrammarException.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Exceptions
 	[Serializable]
 	public class SQLGrammarException : ADOException
 	{
-		public SQLGrammarException(SerializationInfo info, StreamingContext context) : base(info, context) {}
+		protected SQLGrammarException(SerializationInfo info, StreamingContext context) : base(info, context) {}
 		public SQLGrammarException(string message, Exception innerException, string sql) : base(message, innerException, sql) {}
 		public SQLGrammarException(string message, Exception innerException) : base(message, innerException) {}
 	}

--- a/src/NHibernate/Exceptions/SqlParseException.cs
+++ b/src/NHibernate/Exceptions/SqlParseException.cs
@@ -1,13 +1,18 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace NHibernate.Exceptions
 {
-    public class SqlParseException : Exception 
-    {
+	[Serializable]
+	public class SqlParseException : Exception 
+	{
 
-        public SqlParseException(string Message) : base(Message)
-        {
-        }
+		public SqlParseException(string Message) : base(Message)
+		{
+		}
 
-    }
+		protected SqlParseException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
 }

--- a/src/NHibernate/Hql/Ast/ANTLR/DetailedSemanticException.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/DetailedSemanticException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace NHibernate.Hql.Ast.ANTLR
 {
+	[Serializable]
 	public class DetailedSemanticException : SemanticException
 	{
 		public DetailedSemanticException(string message) : base(message)
@@ -10,6 +12,10 @@ namespace NHibernate.Hql.Ast.ANTLR
 
 		public DetailedSemanticException(string message, Exception inner)
 			: base(message, inner)
+		{
+		}
+
+		protected DetailedSemanticException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 	}

--- a/src/NHibernate/Hql/Ast/ANTLR/InvalidPathException.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/InvalidPathException.cs
@@ -1,13 +1,21 @@
-﻿namespace NHibernate.Hql.Ast.ANTLR
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace NHibernate.Hql.Ast.ANTLR
 {
 	/// <summary>
 	/// Exception thrown when an invalid path is found in a query.
 	/// Author: josh
 	/// Ported by: Steve Strong
 	/// </summary>
+	[Serializable]
 	public class InvalidPathException : SemanticException 
 	{
 		public InvalidPathException(string s) : base(s) 
+		{
+		}
+
+		protected InvalidPathException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 	}

--- a/src/NHibernate/Hql/Ast/ANTLR/SemanticException.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/SemanticException.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Runtime.Serialization;
 using Antlr.Runtime;
 
 namespace NHibernate.Hql.Ast.ANTLR
 {
+	[Serializable]
 	public class SemanticException : QueryException
 	{
 		public SemanticException(string message) : base(message)
@@ -11,6 +13,10 @@ namespace NHibernate.Hql.Ast.ANTLR
 
 		public SemanticException(string message, Exception inner)
 			: base(message, inner)
+		{
+		}
+
+		protected SemanticException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 	}

--- a/src/NHibernate/Hql/QueryExecutionRequestException.cs
+++ b/src/NHibernate/Hql/QueryExecutionRequestException.cs
@@ -1,10 +1,16 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace NHibernate.Hql
 {
+	[Serializable]
 	public class QueryExecutionRequestException : QueryException
 	{
 		public QueryExecutionRequestException(string message, string queryString) : base(message, queryString)
+		{
+		}
+
+		protected QueryExecutionRequestException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 	}

--- a/src/NHibernate/InvalidProxyTypeException.cs
+++ b/src/NHibernate/InvalidProxyTypeException.cs
@@ -36,7 +36,7 @@ namespace NHibernate
 
 		#region Serialization
 
-		public InvalidProxyTypeException(SerializationInfo info, StreamingContext context)
+		protected InvalidProxyTypeException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
 			Errors = (ICollection<string>)info.GetValue("errors", typeof(ICollection));

--- a/src/NHibernate/LazyInitializationException.cs
+++ b/src/NHibernate/LazyInitializationException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Security;
 
 
 namespace NHibernate
@@ -80,6 +81,7 @@ namespace NHibernate
 			EntityId = info.GetValue("entityId", typeof(object));
 		}
 
+		[SecurityCritical]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/NHibernate/LazyInitializationException.cs
+++ b/src/NHibernate/LazyInitializationException.cs
@@ -76,6 +76,15 @@ namespace NHibernate
 		/// </param>
 		protected LazyInitializationException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
+			EntityName = info.GetString("entityName");
+			EntityId = info.GetValue("entityId", typeof(object));
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue("entityName", EntityName);
+			info.AddValue("entityId", EntityId, typeof(object));
 		}
 	}
 }

--- a/src/NHibernate/PropertyNotFoundException.cs
+++ b/src/NHibernate/PropertyNotFoundException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Security;
 using NHibernate.Util;
 
 namespace NHibernate
@@ -79,6 +80,7 @@ namespace NHibernate
 			this.accessorType = info.GetString("accessorType");
 		}
 
+		[SecurityCritical]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/NHibernate/Proxy/DynamicProxy/ProxyObjectReference.cs
+++ b/src/NHibernate/Proxy/DynamicProxy/ProxyObjectReference.cs
@@ -14,12 +14,12 @@ using System.Security;
 namespace NHibernate.Proxy.DynamicProxy
 {
 	[Serializable]
-	public class ProxyObjectReference : IObjectReference, ISerializable
+	public sealed class ProxyObjectReference : IObjectReference, ISerializable
 	{
 		private readonly System.Type _baseType;
 		private readonly IProxy _proxy;
 
-		protected ProxyObjectReference(SerializationInfo info, StreamingContext context)
+		private ProxyObjectReference(SerializationInfo info, StreamingContext context)
 		{
 			// Deserialize the base type using its assembly qualified name
 			string qualifiedName = info.GetString("__baseType");

--- a/src/NHibernate/SchemaValidationException.cs
+++ b/src/NHibernate/SchemaValidationException.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using System.Security;
 
 namespace NHibernate
 {
+	[Serializable]
 	public class SchemaValidationException : HibernateException
 	{
 		public ReadOnlyCollection<string> ValidationErrors { get; }

--- a/src/NHibernate/Tuple/Entity/EntityMetamodel.cs
+++ b/src/NHibernate/Tuple/Entity/EntityMetamodel.cs
@@ -11,7 +11,6 @@ using Array = NHibernate.Mapping.Array;
 
 namespace NHibernate.Tuple.Entity
 {
-	[Serializable]
 	public class EntityMetamodel
 	{
 		private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof(EntityMetamodel));

--- a/src/NHibernate/Tuple/IdentifierProperty.cs
+++ b/src/NHibernate/Tuple/IdentifierProperty.cs
@@ -12,7 +12,6 @@ namespace NHibernate.Tuple
 	/// <remarks>
 	/// Author: Steve Ebersole
 	/// </remarks>
-	[Serializable]
 	public class IdentifierProperty : Property
 	{
 		private readonly bool isVirtual;

--- a/src/NHibernate/Tuple/Property.cs
+++ b/src/NHibernate/Tuple/Property.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Tuple
 	/// <summary>
 	/// Defines the basic contract of a Property within the runtime metamodel.
 	/// </summary>
-	[Serializable]
 	public abstract class Property
 	{
 		private readonly string name;

--- a/src/NHibernate/Tuple/VersionProperty.cs
+++ b/src/NHibernate/Tuple/VersionProperty.cs
@@ -10,7 +10,6 @@ namespace NHibernate.Tuple
 	/// <remarks>
 	/// Author: Steve Ebersole
 	/// </remarks>
-	[Serializable]
 	public class VersionProperty : StandardProperty
 	{
 		private readonly VersionValue unsavedValue;

--- a/src/NHibernate/Util/TypeNameParser.cs
+++ b/src/NHibernate/Util/TypeNameParser.cs
@@ -1,14 +1,20 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 
 namespace NHibernate.Util
 {
+	[Serializable]
 	public class ParserException : Exception
 	{
 		public ParserException(string message) : base(message) { }
+
+		protected ParserException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
 	}
 
 	public class TypeNameParser


### PR DESCRIPTION
This is a split-off of what was #1425.

This focuses only on the clean up of attributes and overloads.  I used some Roslyn Analyzers that I wrote based on:

* [CA2229](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2229-implement-serialization-constructors)
* [CA2235](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2235-mark-all-non-serializable-fields)
* [CA2239](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2239-provide-deserialization-methods-for-optional-fields)
* [CA2240](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2240-implement-iserializable-correctly)

There are changes to visibility in the public API.