### PR TITLE
Reuse the same generic EmptyMapClass instance across the project

### DIFF
--- a/src/NHibernate.Test/Async/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/HqlFixture.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Test.Hql.Ast
 
 		protected HQLQueryPlan CreateQueryPlan(string hql, bool scalar)
 		{
-			return new QueryExpressionPlan(new StringQueryExpression(hql), scalar, new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
+			return new QueryExpressionPlan(new StringQueryExpression(hql), scalar, CollectionHelper.EmptyDictionary<string, IFilter>(), Sfi);
 		}
 
 		protected HQLQueryPlan CreateQueryPlan(string hql)

--- a/src/NHibernate.Test/BulkManipulation/BaseFixture.cs
+++ b/src/NHibernate.Test/BulkManipulation/BaseFixture.cs
@@ -7,7 +7,7 @@ namespace NHibernate.Test.BulkManipulation
 {
 	public class BaseFixture: TestCase
 	{
-		private readonly IDictionary<string, IFilter> emptyfilters = new CollectionHelper.EmptyMapClass<string, IFilter>();
+		private readonly IDictionary<string, IFilter> emptyfilters = CollectionHelper.EmptyDictionary<string, IFilter>();
 
 		#region Overrides of TestCase
 

--- a/src/NHibernate.Test/Hql/Ast/BaseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/BaseFixture.cs
@@ -7,7 +7,7 @@ namespace NHibernate.Test.Hql.Ast
 {
 	public class BaseFixture: TestCase
 	{
-		private readonly IDictionary<string, IFilter> emptyfilters = new CollectionHelper.EmptyMapClass<string, IFilter>();
+		private readonly IDictionary<string, IFilter> emptyfilters = CollectionHelper.EmptyDictionary<string, IFilter>();
 		
 		#region Overrides of TestCase
 

--- a/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.Hql.Ast
 
 		protected HQLQueryPlan CreateQueryPlan(string hql, bool scalar)
 		{
-			return new QueryExpressionPlan(new StringQueryExpression(hql), scalar, new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
+			return new QueryExpressionPlan(new StringQueryExpression(hql), scalar, CollectionHelper.EmptyDictionary<string, IFilter>(), Sfi);
 		}
 
 		protected HQLQueryPlan CreateQueryPlan(string hql)

--- a/src/NHibernate.Test/NHSpecificTest/NH1849/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1849/Fixture.cs
@@ -46,7 +46,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1849
 		{
 		 string hql = @"from Customer c where contains(c.Name, :smth)";
 
-		 HQLQueryPlan plan = new QueryExpressionPlan(new StringQueryExpression(hql), false, new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
+		 HQLQueryPlan plan = new QueryExpressionPlan(new StringQueryExpression(hql), false, CollectionHelper.EmptyDictionary<string, IFilter>(), Sfi);
 
 		 Assert.AreEqual(1, plan.ParameterMetadata.NamedParameterNames.Count);
 		 Assert.AreEqual(1, plan.QuerySpaces.Count);

--- a/src/NHibernate.Test/NHSpecificTest/NH2031/HqlModFuctionForMsSqlTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2031/HqlModFuctionForMsSqlTest.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2031
 
 		public string GetSql(string query)
 		{
-			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, Sfi).Parse(), new CollectionHelper.EmptyMapClass<string, IFilter>(), Sfi);
+			var qt = new QueryTranslatorImpl(null, new HqlParseEngine(query, false, Sfi).Parse(), CollectionHelper.EmptyDictionary<string, IFilter>(), Sfi);
 			qt.Compile(null, false);
 			return qt.SQLString;
 		}

--- a/src/NHibernate/Cfg/MappingSchema/AbstractDecoratable.cs
+++ b/src/NHibernate/Cfg/MappingSchema/AbstractDecoratable.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Cfg.MappingSchema
 	[Serializable]
 	public abstract class AbstractDecoratable : IDecoratable
 	{
-		private static readonly IDictionary<string, MetaAttribute> EmptyMetaData = new CollectionHelper.EmptyMapClass<string, MetaAttribute>();
+		private static readonly IDictionary<string, MetaAttribute> EmptyMetaData = CollectionHelper.EmptyDictionary<string, MetaAttribute>();
 
 		[NonSerialized]
 		[XmlIgnore]

--- a/src/NHibernate/Cfg/XmlHbmBinding/Binder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/Binder.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 		protected static readonly INHibernateLogger log = NHibernateLogger.For(typeof (Binder));
 
 		protected static readonly IDictionary<string, MetaAttribute> EmptyMeta =
-			new CollectionHelper.EmptyMapClass<string, MetaAttribute>();
+			CollectionHelper.EmptyDictionary<string, MetaAttribute>();
 
 		protected readonly Mappings mappings;
 

--- a/src/NHibernate/Cfg/XmlHbmBinding/ResultSetMappingBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/ResultSetMappingBinder.cs
@@ -309,7 +309,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 			{
 				newPropertyResults[entry.Key] = entry.Value;
 			}
-			return newPropertyResults.Count == 0 ? (IDictionary<string, string[]>)new CollectionHelper.EmptyMapClass<string, string[]>() : newPropertyResults;
+			return newPropertyResults.Count == 0 ? (IDictionary<string, string[]>)CollectionHelper.EmptyDictionary<string, string[]>() : newPropertyResults;
 		}
 
 		private static List<string> GetResultColumns(HbmReturnProperty returnPropertySchema)

--- a/src/NHibernate/Engine/JoinSequence.cs
+++ b/src/NHibernate/Engine/JoinSequence.cs
@@ -128,7 +128,7 @@ namespace NHibernate.Engine
 
 		public JoinFragment ToJoinFragment()
 		{
-			return ToJoinFragment(new CollectionHelper.EmptyMapClass<string, IFilter>(), true);
+			return ToJoinFragment(CollectionHelper.EmptyDictionary<string, IFilter>(), true);
 		}
 
 		public JoinFragment ToJoinFragment(IDictionary<string, IFilter> enabledFilters, bool includeExtraJoins)

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -393,7 +393,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 			if (persister.DiscriminatorType != null)
 			{
 				new SyntheticAndFactory(this)
-					.AddDiscriminatorWhereFragment(statement, persister, new CollectionHelper.EmptyMapClass<string, IFilter>(), fromElement.TableAlias);
+					.AddDiscriminatorWhereFragment(statement, persister, CollectionHelper.EmptyDictionary<string, IFilter>(), fromElement.TableAlias);
 			}
 		}
 

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -616,7 +616,7 @@ namespace NHibernate.Impl
 		public IType[] GetReturnTypes(String queryString)
 		{
 			return
-				queryPlanCache.GetHQLQueryPlan(queryString.ToQueryExpression(), false, new CollectionHelper.EmptyMapClass<string, IFilter>()).
+				queryPlanCache.GetHQLQueryPlan(queryString.ToQueryExpression(), false, CollectionHelper.EmptyDictionary<string, IFilter>()).
 					ReturnMetadata.ReturnTypes;
 		}
 
@@ -624,7 +624,7 @@ namespace NHibernate.Impl
 		public string[] GetReturnAliases(string queryString)
 		{
 			return
-				queryPlanCache.GetHQLQueryPlan(queryString.ToQueryExpression(), false, new CollectionHelper.EmptyMapClass<string, IFilter>()).
+				queryPlanCache.GetHQLQueryPlan(queryString.ToQueryExpression(), false, CollectionHelper.EmptyDictionary<string, IFilter>()).
 					ReturnMetadata.ReturnAliases;
 		}
 
@@ -1163,7 +1163,7 @@ namespace NHibernate.Impl
 				{
 					log.Debug("Checking named query: {0}", queryName);
 					//TODO: BUG! this currently fails for named queries for non-POJO entities
-					queryPlanCache.GetHQLQueryPlan(qd.QueryString.ToQueryExpression(), false, new CollectionHelper.EmptyMapClass<string, IFilter>());
+					queryPlanCache.GetHQLQueryPlan(qd.QueryString.ToQueryExpression(), false, CollectionHelper.EmptyDictionary<string, IFilter>());
 				}
 				catch (QueryException e)
 				{

--- a/src/NHibernate/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Impl/SqlQueryImpl.cs
@@ -93,7 +93,7 @@ namespace NHibernate.Impl
 			get
 			{
 				//we never need to apply locks to the SQL
-				return new CollectionHelper.EmptyMapClass<string, LockMode>();
+				return CollectionHelper.EmptyDictionary<string, LockMode>();
 			}
 		}
 
@@ -236,7 +236,7 @@ namespace NHibernate.Impl
 			string ownerAlias = path.Substring(0, loc);
 			string role = path.Substring(loc + 1);
 			queryReturns.Add(
-				new NativeSQLQueryJoinReturn(alias, ownerAlias, role, new CollectionHelper.EmptyMapClass<string, string[]>(), lockMode));
+				new NativeSQLQueryJoinReturn(alias, ownerAlias, role, CollectionHelper.EmptyDictionary<string, string[]>(), lockMode));
 			return this;
 		}
 

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -288,7 +288,7 @@ namespace NHibernate.Impl
 
 		public override IDictionary<string, IFilter> EnabledFilters
 		{
-			get { return new CollectionHelper.EmptyMapClass<string, IFilter>(); }
+			get { return CollectionHelper.EmptyDictionary<string, IFilter>(); }
 		}
 
 		public override IQueryTranslator[] GetQueries(IQueryExpression query, bool scalar)

--- a/src/NHibernate/Loader/AbstractEntityJoinWalker.cs
+++ b/src/NHibernate/Loader/AbstractEntityJoinWalker.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Loader
 			IList<OuterJoinableAssociation> allAssociations = new List<OuterJoinableAssociation>(associations);
 			allAssociations.Add(
 				new OuterJoinableAssociation(persister.EntityType, null, null, alias, JoinType.LeftOuterJoin, null, Factory,
-											 new CollectionHelper.EmptyMapClass<string, IFilter>()));
+											 CollectionHelper.EmptyDictionary<string, IFilter>()));
 
 			InitPersisters(allAssociations, lockMode);
 			InitStatementString(whereString, orderByString, lockMode);

--- a/src/NHibernate/Loader/Collection/OneToManyJoinWalker.cs
+++ b/src/NHibernate/Loader/Collection/OneToManyJoinWalker.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Loader.Collection
 			IList<OuterJoinableAssociation> allAssociations = new List<OuterJoinableAssociation>(associations);
 			allAssociations.Add(
 				new OuterJoinableAssociation(oneToManyPersister.CollectionType, null, null, alias, JoinType.LeftOuterJoin, null, Factory,
-				                             new CollectionHelper.EmptyMapClass<string, IFilter>()));
+				                             CollectionHelper.EmptyDictionary<string, IFilter>()));
 
 			InitPersisters(allAssociations, LockMode.None);
 			InitStatementString(elementPersister, alias, batchSize, subquery);

--- a/src/NHibernate/Loader/DefaultEntityAliases.cs
+++ b/src/NHibernate/Loader/DefaultEntityAliases.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Loader
 		private readonly IDictionary<string, string[]> userProvidedAliases;
 
 		public DefaultEntityAliases(ILoadable persister, string suffix)
-			: this(new CollectionHelper.EmptyMapClass<string, string[]>(), persister, suffix) {}
+			: this(CollectionHelper.EmptyDictionary<string, string[]>(), persister, suffix) {}
 
 		/// <summary>
 		/// Calculate and cache select-clause suffixes.

--- a/src/NHibernate/Loader/Entity/CascadeEntityJoinWalker.cs
+++ b/src/NHibernate/Loader/Entity/CascadeEntityJoinWalker.cs
@@ -12,12 +12,12 @@ namespace NHibernate.Loader.Entity
 
 		public CascadeEntityJoinWalker(IOuterJoinLoadable persister, CascadingAction action,
 		                               ISessionFactoryImplementor factory)
-			: base(persister, factory, new CollectionHelper.EmptyMapClass<string, IFilter>())
+			: base(persister, factory, CollectionHelper.EmptyDictionary<string, IFilter>())
 		{
 			cascadeAction = action;
 			SqlStringBuilder whereCondition = WhereString(Alias, persister.IdentifierColumnNames, 1)
 				//include the discriminator and class-level where, but not filters
-				.Add(persister.FilterFragment(Alias, new CollectionHelper.EmptyMapClass<string, IFilter>()));
+				.Add(persister.FilterFragment(Alias, CollectionHelper.EmptyDictionary<string, IFilter>()));
 
 			InitAll(whereCondition.ToSqlString(), SqlString.Empty, LockMode.Read);
 		}

--- a/src/NHibernate/Loader/Entity/CascadeEntityLoader.cs
+++ b/src/NHibernate/Loader/Entity/CascadeEntityLoader.cs
@@ -7,7 +7,7 @@ namespace NHibernate.Loader.Entity
 	public class CascadeEntityLoader : AbstractEntityLoader
 	{
 		public CascadeEntityLoader(IOuterJoinLoadable persister, CascadingAction action, ISessionFactoryImplementor factory)
-			: base(persister, persister.IdentifierType, factory, new CollectionHelper.EmptyMapClass<string, IFilter>())
+			: base(persister, persister.IdentifierType, factory, CollectionHelper.EmptyDictionary<string, IFilter>())
 		{
 			JoinWalker walker = new CascadeEntityJoinWalker(persister, action, factory);
 			InitFromWalker(walker);

--- a/src/NHibernate/Loader/Entity/EntityJoinWalker.cs
+++ b/src/NHibernate/Loader/Entity/EntityJoinWalker.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Loader.Entity
 
 			SqlStringBuilder whereCondition = WhereString(Alias, uniqueKey, batchSize)
 				//include the discriminator and class-level where, but not filters
-				.Add(persister.FilterFragment(Alias, new CollectionHelper.EmptyMapClass<string, IFilter>()));
+				.Add(persister.FilterFragment(Alias, CollectionHelper.EmptyDictionary<string, IFilter>()));
 
 			InitAll(whereCondition.ToSqlString(), SqlString.Empty, lockMode);
 		}

--- a/src/NHibernate/Loader/GeneratedCollectionAliases.cs
+++ b/src/NHibernate/Loader/GeneratedCollectionAliases.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Loader
 		}
 
 		public GeneratedCollectionAliases(ICollectionPersister persister, string str)
-			: this(new CollectionHelper.EmptyMapClass<string, string[]>(), persister, str) {}
+			: this(CollectionHelper.EmptyDictionary<string, string[]>(), persister, str) {}
 
 		private string[] GetUserProvidedCompositeElementAliases(string[] defaultAliases)
 		{

--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -559,7 +559,7 @@ namespace NHibernate.Persister.Collection
 		public void PostInstantiate()
 		{
 			initializer = queryLoaderName == null
-							? CreateCollectionInitializer(new CollectionHelper.EmptyMapClass<string, IFilter>())
+							? CreateCollectionInitializer(CollectionHelper.EmptyDictionary<string, IFilter>())
 							: new NamedQueryCollectionInitializer(queryLoaderName, this);
 		}
 

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -2118,7 +2118,7 @@ namespace NHibernate.Persister.Entity
 					//don't need filters for the static loaders
 					uniqueKeyLoaders[propertyNames[i]] =
 						CreateUniqueKeyLoader(propertyTypes[i], GetPropertyColumnNames(i),
-																	new CollectionHelper.EmptyMapClass<string, IFilter>());
+																	CollectionHelper.EmptyDictionary<string, IFilter>());
 				}
 			}
 		}
@@ -2197,7 +2197,7 @@ namespace NHibernate.Persister.Entity
 
 		protected IUniqueEntityLoader CreateEntityLoader(LockMode lockMode)
 		{
-			return CreateEntityLoader(lockMode, new CollectionHelper.EmptyMapClass<string, IFilter>());
+			return CreateEntityLoader(lockMode, CollectionHelper.EmptyDictionary<string, IFilter>());
 		}
 
 		protected bool Check(int rows, object id, int tableNumber, IExpectation expectation, DbCommand statement)

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -214,6 +214,12 @@ namespace NHibernate.Util
 
 		public static readonly IEnumerable EmptyEnumerable = new EmptyEnumerableClass();
 		public static readonly IDictionary EmptyMap = new EmptyMapClass();
+
+		public static IDictionary<TKey, TValue> EmptyDictionary<TKey, TValue>()
+		{
+			return EmptyDictionaryHolder<TKey, TValue>.Instance;
+		}
+
 		public static readonly ICollection EmptyCollection = EmptyMap;
 		// Since v5
 		[Obsolete("It has no more usages in NHibernate and will be removed in a future version.")]
@@ -455,6 +461,11 @@ namespace NHibernate.Util
 			}
 
 			#endregion
+		}
+
+		private static class EmptyDictionaryHolder<TKey, TValue>
+		{
+			public static readonly IDictionary<TKey, TValue> Instance = new EmptyMapClass<TKey, TValue>();
 		}
 
 		/// <summary>

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -217,7 +217,7 @@ namespace NHibernate.Util
 
 		public static IDictionary<TKey, TValue> EmptyDictionary<TKey, TValue>()
 		{
-			return EmptyDictionaryHolder<TKey, TValue>.Instance;
+			return EmptyMapClass<TKey, TValue>.Instance;
 		}
 
 		public static readonly ICollection EmptyCollection = EmptyMap;
@@ -463,18 +463,23 @@ namespace NHibernate.Util
 			#endregion
 		}
 
-		private static class EmptyDictionaryHolder<TKey, TValue>
-		{
-			public static readonly IDictionary<TKey, TValue> Instance = new EmptyMapClass<TKey, TValue>();
-		}
-
 		/// <summary>
 		/// A read-only dictionary that is always empty and permits lookup by <see langword="null" /> key.
 		/// </summary>
 		[Serializable]
 		public class EmptyMapClass<TKey, TValue> : IDictionary<TKey, TValue>
 		{
+#pragma warning disable 618 // Constructor is obsolete, to be switched to non-obsolete but private.
+			internal static readonly IDictionary<TKey, TValue> Instance = new EmptyMapClass<TKey, TValue>();
+#pragma warning restore 618
+
 			private static readonly EmptyEnumerator<TKey, TValue> emptyEnumerator = new EmptyEnumerator<TKey, TValue>();
+
+			// Since v5.1. To be switched to private.
+			[Obsolete("Please use CollectionHelper.EmptyDictionary<TKey, TValue>() instead.")]
+			public EmptyMapClass()
+			{
+			}
 
 			#region IDictionary<TKey,TValue> Members
 


### PR DESCRIPTION
This is simple "find and replace" kind of pull request to eliminate not needed instantiating of immutable EmptyMapClass instances.

Added `CollectionHelper.EmptyDictionary<TKey, TValue>()` helper mehtod that returns the same instance for given TKey and TValue and use it across the project instead of creating new instances.