### PR TITLE
Refactored DefaultEntityAliases to avoid unnecessary calculations

### DIFF
--- a/src/NHibernate/Loader/DefaultEntityAliases.cs
+++ b/src/NHibernate/Loader/DefaultEntityAliases.cs
@@ -12,13 +12,9 @@ namespace NHibernate.Loader
 	/// </summary>
 	public class DefaultEntityAliases : IEntityAliases
 	{
-		private readonly string[] suffixedKeyColumns;
-		private readonly string[] suffixedVersionColumn;
-		private readonly string[][] suffixedPropertyColumns;
-		private readonly string suffixedDiscriminatorColumn;
-		private readonly string suffix;
-		private string rowIdAlias;
-		private readonly IDictionary<string, string[]> userProvidedAliases;
+		private readonly string _suffix;
+		private string _rowIdAlias;
+		private readonly IDictionary<string, string[]> _userProvidedAliases;
 
 		public DefaultEntityAliases(ILoadable persister, string suffix)
 			: this(null, persister, suffix) {}
@@ -28,20 +24,20 @@ namespace NHibernate.Loader
 		/// </summary>
 		public DefaultEntityAliases(IDictionary<string, string[]> userProvidedAliases, ILoadable persister, string suffix)
 		{
-			this.suffix = suffix;
-			this.userProvidedAliases = userProvidedAliases?.Count > 0 ? userProvidedAliases : null;
+			_suffix = suffix;
+			_userProvidedAliases = userProvidedAliases?.Count > 0 ? userProvidedAliases : null;
 
-			suffixedKeyColumns = DetermineKeyAliases(persister, suffix);
-			suffixedPropertyColumns = GetSuffixedPropertyAliases(persister);
-			suffixedDiscriminatorColumn = DetermineDiscriminatorAlias(persister, suffix);
+			SuffixedKeyAliases = DetermineKeyAliases(persister, suffix);
+			SuffixedPropertyAliases = GetSuffixedPropertyAliases(persister);
+			SuffixedDiscriminatorAlias = DetermineDiscriminatorAlias(persister, suffix);
 
-			suffixedVersionColumn = persister.IsVersioned ? suffixedPropertyColumns[persister.VersionProperty] : null;
+			SuffixedVersionAliases = persister.IsVersioned ? SuffixedPropertyAliases[persister.VersionProperty] : null;
 			//rowIdAlias is generated on demand in property
 		}
 
 		private string[] DetermineKeyAliases(ILoadable persister, string suffix)
 		{
-			if (userProvidedAliases == null)
+			if (_userProvidedAliases == null)
 				return GetIdentifierAliases(persister, suffix);
 
 			return GetUserProvidedAliases(persister.IdentifierPropertyName)
@@ -51,7 +47,7 @@ namespace NHibernate.Loader
 
 		private string DetermineDiscriminatorAlias(ILoadable persister, string suffix)
 		{
-			if (userProvidedAliases == null)
+			if (_userProvidedAliases == null)
 				return GetDiscriminatorAlias(persister, suffix);
 
 			return GetUserProvidedAlias(AbstractEntityPersister.EntityClass)
@@ -78,7 +74,7 @@ namespace NHibernate.Loader
 
 		protected virtual string[] GetPropertyAliases(ILoadable persister, int j)
 		{
-			return persister.GetPropertyAliases(suffix, j);
+			return persister.GetPropertyAliases(_suffix, j);
 		}
 
 		private string[] GetUserProvidedAliases(string propertyPath)
@@ -87,7 +83,7 @@ namespace NHibernate.Loader
 				return null;
 
 			string[] result;
-			userProvidedAliases.TryGetValue(propertyPath, out result);
+			_userProvidedAliases.TryGetValue(propertyPath, out result);
 			return result;
 		}
 
@@ -102,7 +98,7 @@ namespace NHibernate.Loader
 		/// </summary>
 		public string[][] GetSuffixedPropertyAliases(ILoadable persister)
 		{
-			if (userProvidedAliases == null)
+			if (_userProvidedAliases == null)
 				return GetPropertiesAliases(persister);
 
 			int size = persister.PropertyNames.Length;
@@ -114,30 +110,15 @@ namespace NHibernate.Loader
 			return suffixedPropertyAliases;
 		}
 
-		public string[] SuffixedVersionAliases
-		{
-			get { return suffixedVersionColumn; }
-		}
+		public string[] SuffixedVersionAliases { get; }
 
-		public string[][] SuffixedPropertyAliases
-		{
-			get { return suffixedPropertyColumns; }
-		}
+		public string[][] SuffixedPropertyAliases { get; }
 
-		public string SuffixedDiscriminatorAlias
-		{
-			get { return suffixedDiscriminatorColumn; }
-		}
+		public string SuffixedDiscriminatorAlias { get; }
 
-		public string[] SuffixedKeyAliases
-		{
-			get { return suffixedKeyColumns; }
-		}
+		public string[] SuffixedKeyAliases { get; }
 
-		public string RowIdAlias
-		{
-			// TODO: not visible to the user!
-			get { return rowIdAlias ?? (rowIdAlias = Loadable.RowIdAlias + suffix); }
-		}
+		// TODO: not visible to the user!
+		public string RowIdAlias => _rowIdAlias ?? (_rowIdAlias = Loadable.RowIdAlias + _suffix);
 	}
 }

--- a/src/NHibernate/Loader/DefaultEntityAliases.cs
+++ b/src/NHibernate/Loader/DefaultEntityAliases.cs
@@ -27,31 +27,31 @@ namespace NHibernate.Loader
 			_suffix = suffix;
 			_userProvidedAliases = userProvidedAliases?.Count > 0 ? userProvidedAliases : null;
 
-			SuffixedKeyAliases = DetermineKeyAliases(persister, suffix);
+			SuffixedKeyAliases = DetermineKeyAliases(persister);
 			SuffixedPropertyAliases = GetSuffixedPropertyAliases(persister);
-			SuffixedDiscriminatorAlias = DetermineDiscriminatorAlias(persister, suffix);
+			SuffixedDiscriminatorAlias = DetermineDiscriminatorAlias(persister);
 
 			SuffixedVersionAliases = persister.IsVersioned ? SuffixedPropertyAliases[persister.VersionProperty] : null;
 			//rowIdAlias is generated on demand in property
 		}
 
-		private string[] DetermineKeyAliases(ILoadable persister, string suffix)
+		private string[] DetermineKeyAliases(ILoadable persister)
 		{
 			if (_userProvidedAliases == null)
-				return GetIdentifierAliases(persister, suffix);
+				return GetIdentifierAliases(persister, _suffix);
 
 			return GetUserProvidedAliases(persister.IdentifierPropertyName)
 					?? GetUserProvidedAliases(EntityPersister.EntityID)
-					?? GetIdentifierAliases(persister, suffix);
+					?? GetIdentifierAliases(persister, _suffix);
 		}
 
-		private string DetermineDiscriminatorAlias(ILoadable persister, string suffix)
+		private string DetermineDiscriminatorAlias(ILoadable persister)
 		{
 			if (_userProvidedAliases == null)
-				return GetDiscriminatorAlias(persister, suffix);
+				return GetDiscriminatorAlias(persister, _suffix);
 
 			return GetUserProvidedAlias(AbstractEntityPersister.EntityClass)
-					?? GetDiscriminatorAlias(persister, suffix);
+					?? GetDiscriminatorAlias(persister, _suffix);
 		}
 
 		/// <summary>


### PR DESCRIPTION
DefaultEntityAliases is actively used for generating column aliases  for entities in T-SQL SELECT statements.

My refactorings:
1) Avoided default alias calculation if user provided alias is present;

2) Added early exits if no user provided aliases exist (to avoid lookup for all columns on empty dic);

4) Made RowIdAlias lazy (other fields are used one way or another but this one is dialect specific);

3) Removed `string.IsIntern` calls for each generated alias. I didn't find any places where aliases can be interned inside NHibernate project (and can prepare a pull request that shows that string.IsIntern for aliases always returns null for all tests). According to  b1500ea97f17609866d8e5118f3cd6895c2e2040 `string.IsIntern` was introduced instead of `string.Intern` to avoid excessive memory usage. But I don't understand why NHibernate should expect interned aliases - `string.IsIntern` doesn't look right to me here.