### PR TITLE
Fix default types

### DIFF
--- a/src/NHibernate.Test/NHibernateUtilTest.cs
+++ b/src/NHibernate.Test/NHibernateUtilTest.cs
@@ -10,36 +10,56 @@ namespace NHibernate.Test
 		[Test]
 		public void CanGuessTypeOfInt32ByValue()
 		{
-			Assert.AreEqual(NHibernateUtil.Int32, NHibernateUtil.GuessType(15));
+			Assert.That(NHibernateUtil.GuessType(15), Is.EqualTo(NHibernateUtil.Int32));
 		}
 
 		[Test]
 		public void CanGuessTypeOfInt32ByType()
 		{
-			Assert.AreEqual(NHibernateUtil.Int32,
-				NHibernateUtil.GuessType(typeof(int)));
+			Assert.That(NHibernateUtil.GuessType(typeof(int)), Is.EqualTo(NHibernateUtil.Int32));
 		}
 
 		[Test]
 		public void CanGuessTypeOfNullableInt32ByType()
 		{
-			Assert.AreEqual(NHibernateUtil.Int32,
-				NHibernateUtil.GuessType(typeof(int?)));
+			Assert.That(NHibernateUtil.GuessType(typeof(int?)), Is.EqualTo(NHibernateUtil.Int32));
 		}
 
 		[Test]
 		public void CanGuessTypeOfNullableInt32ByValue()
 		{
 			int? val = 15;
-			Assert.AreEqual(NHibernateUtil.Int32,
-				NHibernateUtil.GuessType(val));
+			Assert.That(NHibernateUtil.GuessType(val), Is.EqualTo(NHibernateUtil.Int32));
 		}
 
 		[Test]
 		public void CanGuessTypeOfDateTime()
 		{
-			Assert.AreEqual(NHibernateUtil.DateTime,
-				NHibernateUtil.GuessType(typeof(DateTime)));
+			Assert.That(NHibernateUtil.GuessType(typeof(DateTime)), Is.EqualTo(NHibernateUtil.DateTime));
+		}
+
+		[Test]
+		public void CanGuessTypeOfString()
+		{
+			Assert.That(NHibernateUtil.GuessType(typeof(string)), Is.EqualTo(NHibernateUtil.String));
+		}
+
+		[Test]
+		public void CanGuessTypeOfBoolean()
+		{
+			Assert.That(NHibernateUtil.GuessType(typeof(bool)), Is.EqualTo(NHibernateUtil.Boolean));
+		}
+
+		[Test]
+		public void CanGuessTypeOfDecimal()
+		{
+			Assert.That(NHibernateUtil.GuessType(typeof(decimal)), Is.EqualTo(NHibernateUtil.Decimal));
+		}
+
+		[Test]
+		public void CanGuessTypeOfTimeSpan()
+		{
+			Assert.That(NHibernateUtil.GuessType(typeof(TimeSpan)), Is.EqualTo(NHibernateUtil.TimeSpan));
 		}
 	}
 }

--- a/src/NHibernate/Async/NHibernateUtil.cs
+++ b/src/NHibernate/Async/NHibernateUtil.cs
@@ -20,11 +20,8 @@ using NHibernate.Util;
 
 namespace NHibernate
 {
-	using System.Collections.Generic;
-	using System.Reflection;
 	using System.Threading.Tasks;
 	using System.Threading;
-
 	public static partial class NHibernateUtil
 	{
 
@@ -47,13 +44,13 @@ namespace NHibernate
 				{
 					return Task.CompletedTask;
 				}
-				else if (proxy.IsProxy())
+				if (proxy.IsProxy())
 				{
 					return ((INHibernateProxy)proxy).HibernateLazyInitializer.InitializeAsync(cancellationToken);
 				}
-				else if (proxy is IPersistentCollection)
+				else if (proxy is IPersistentCollection coll)
 				{
-					return ((IPersistentCollection)proxy).ForceInitializationAsync(cancellationToken);
+					return coll.ForceInitializationAsync(cancellationToken);
 				}
 				return Task.CompletedTask;
 			}

--- a/src/NHibernate/NHibernateUtil.cs
+++ b/src/NHibernate/NHibernateUtil.cs
@@ -10,9 +10,6 @@ using NHibernate.Util;
 
 namespace NHibernate
 {
-	using System.Collections.Generic;
-	using System.Reflection;
-
 	/// <summary>
 	/// Provides access to the full range of NHibernate built-in types.
 	/// IType instances may be used to bind values to query parameters.
@@ -21,26 +18,6 @@ namespace NHibernate
 	/// </summary>
 	public static partial class NHibernateUtil
 	{
-		static private readonly Dictionary<System.Type, IType> clrTypeToNHibernateType = new Dictionary<System.Type, IType>();
-
-		static NHibernateUtil()
-		{
-			FieldInfo[] fields = typeof(NHibernateUtil).GetFields();
-			foreach (FieldInfo info in fields)
-			{
-				if (typeof(IType).IsAssignableFrom(info.FieldType) == false)
-					continue;
-				IType type = (IType)info.GetValue(null);
-				clrTypeToNHibernateType[type.ReturnedClass] = type;
-			}
-
-			// There are multiple possibilites for boolean, strings and datetime.
-			// Override so that we use the most natural mapping.
-			clrTypeToNHibernateType[Boolean.ReturnedClass] = Boolean;
-			clrTypeToNHibernateType[String.ReturnedClass] = String;
-			clrTypeToNHibernateType[DateTime.ReturnedClass] = DateTime;
-		}
-
 		/// <summary>
 		/// Guesses the IType of this object
 		/// </summary>
@@ -61,8 +38,8 @@ namespace NHibernate
 		{
 			type = type.UnwrapIfNullable();
 
-			IType value;
-			if (clrTypeToNHibernateType.TryGetValue(type, out value))
+			var value = TypeFactory.GetDefaultTypeFor(type);
+			if (value != null)
 				return value;
 			
 			if (type.IsEnum)
@@ -73,7 +50,7 @@ namespace NHibernate
 			{
 				return Custom(type);
 			}
-			
+
 			return Entity(type);
 		}
 
@@ -401,13 +378,13 @@ namespace NHibernate
 			{
 				return;
 			}
-			else if (proxy.IsProxy())
+			if (proxy.IsProxy())
 			{
 				((INHibernateProxy)proxy).HibernateLazyInitializer.Initialize();
 			}
-			else if (proxy is IPersistentCollection)
+			else if (proxy is IPersistentCollection coll)
 			{
-				((IPersistentCollection)proxy).ForceInitialization();
+				coll.ForceInitialization();
 			}
 		}
 
@@ -533,7 +510,7 @@ namespace NHibernate
 			EnumerableImpl hibernateEnumerator = enumerator as EnumerableImpl;
 			if (hibernateEnumerator == null)
 			{
-				throw new ArgumentException("Not a NHibernate enumerator", "enumerator");
+				throw new ArgumentException("Not a NHibernate enumerator", nameof(enumerator));
 			}
 			hibernateEnumerator.Dispose();
 		}
@@ -547,7 +524,7 @@ namespace NHibernate
 			EnumerableImpl hibernateEnumerable = enumerable as EnumerableImpl;
 			if (hibernateEnumerable == null)
 			{
-				throw new ArgumentException("Not a NHibernate enumerable", "enumerable");
+				throw new ArgumentException("Not a NHibernate enumerable", nameof(enumerable));
 			}
 			hibernateEnumerable.Dispose();
 		}

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -613,6 +613,15 @@ namespace NHibernate.Type
 			return GetSerializableType(typeClass);
 		}
 
+		/// <summary>
+		/// Get the current default NHibernate type for a .Net type.
+		/// </summary>
+		/// <param name="type">The .Net type for which to get the corresponding default NHibernate type.</param>
+		/// <returns>The current default NHibernate type for a .Net type if any, otherwise <see langword="null" />.</returns>
+		public static IType GetDefaultTypeFor(System.Type type)
+		{
+			return typeByTypeOfName.TryGetValue(type.FullName, out var nhType) ? nhType : null;
+		}
 
 		[MethodImpl(MethodImplOptions.Synchronized)]
 		public static NullableType GetAnsiStringType(int length)


### PR DESCRIPTION
 * Remove logic duplication for getting default NHibernate type for a CLR type.
 * Test all defaults for CLR type having many possibilities.
 * Clean-up.

The test for `decimal` was failing, it was yielding `Currency` instead of `Decimal`.