### PR TITLE
More reliable SQLite handling in tests.

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -55,6 +55,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup Condition=" '$(NuGetPackageRoot)' != '' ">
+    <NativeBinaries Include="$(NuGetPackageRoot)system.data.sqlite.core\1.0.105.2\build\net46\**\*.*" />
+    <Content Include="@(NativeBinaries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NHibernate.DomainModel\NHibernate.DomainModel.csproj" />
     <ProjectReference Include="..\NHibernate\NHibernate.csproj" />

--- a/src/NHibernate.TestDatabaseSetup/TestDatabaseSetup.cs
+++ b/src/NHibernate.TestDatabaseSetup/TestDatabaseSetup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Odbc;
 using System.Data.SqlClient;
 using System.Data.SqlServerCe;
+using System.Data.SQLite;
 using System.IO;
 using FirebirdSql.Data.FirebirdClient;
 using NHibernate.Test;
@@ -182,8 +183,19 @@ namespace NHibernate.TestDatabaseSetup
 
 		private static void SetupSQLite(Cfg.Configuration cfg)
 		{
-			if (File.Exists("NHibernate.db"))
-				File.Delete("NHibernate.db");
+			var connStr = cfg.Properties[Cfg.Environment.ConnectionString];
+
+			try
+			{
+				var connStrBuilder = new SQLiteConnectionStringBuilder(connStr);
+				var dataSource = connStrBuilder.DataSource;
+				if (File.Exists(dataSource))
+					File.Delete(dataSource);
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+			}
 		}
 
 		private static void SetupOracle(Cfg.Configuration cfg)


### PR DESCRIPTION
 * Get file to delete from connection string instead of having it hard-coded.
 * Ensure SQLite required libraries are deployed for dependent projects too (VB Tests).

This is still done for my AppVeyor tests, but as this will benefit any build/testing configuration, it is worth merging it independently.

I have tagged it improvement but it could be considered bug too, as the library thing could cause issue for testing Visual Basic with SQLite.