### PR TITLE
Chaining scopes with ODBC is bugged: disabling the test.

### DIFF
--- a/src/NHibernate.Test/Async/SystemTransactions/SystemTransactionFixture.cs
+++ b/src/NHibernate.Test/Async/SystemTransactions/SystemTransactionFixture.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Threading;
 using System.Transactions;
 using NHibernate.Cfg;
+using NHibernate.Driver;
 using NHibernate.Engine;
 using NHibernate.Linq;
 using NHibernate.Test.TransactionTest;
@@ -186,6 +187,12 @@ namespace NHibernate.Test.SystemTransactions
 		public async Task CanUseSessionWithManyScopesAsync(bool explicitFlush)
 		{
 			IgnoreIfUnsupported(explicitFlush);
+			// ODBC with SQL-Server always causes scopes to go distributed, which causes their transaction completion to run
+			// asynchronously. But ODBC enlistment also check the previous transaction in a way that do not guard against it
+			// being concurrently disposed of. See https://github.com/nhibernate/nhibernate-core/pull/1505 for more details.
+			Assume.That(!(Sfi.ConnectionProvider.Driver is OdbcDriver),
+			            "ODBC sometimes fails on second scope by checking the previous transaction status, which may yield an object disposed exception");
+
 			using (var s = WithOptions().ConnectionReleaseMode(ConnectionReleaseMode.OnClose).OpenSession())
 			{
 				using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))

--- a/src/NHibernate.Test/SystemTransactions/SystemTransactionFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/SystemTransactionFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Transactions;
 using NHibernate.Cfg;
+using NHibernate.Driver;
 using NHibernate.Engine;
 using NHibernate.Linq;
 using NHibernate.Test.TransactionTest;
@@ -175,6 +176,12 @@ namespace NHibernate.Test.SystemTransactions
 		public void CanUseSessionWithManyScopes(bool explicitFlush)
 		{
 			IgnoreIfUnsupported(explicitFlush);
+			// ODBC with SQL-Server always causes scopes to go distributed, which causes their transaction completion to run
+			// asynchronously. But ODBC enlistment also check the previous transaction in a way that do not guard against it
+			// being concurrently disposed of. See https://github.com/nhibernate/nhibernate-core/pull/1505 for more details.
+			Assume.That(!(Sfi.ConnectionProvider.Driver is OdbcDriver),
+			            "ODBC sometimes fails on second scope by checking the previous transaction status, which may yield an object disposed exception");
+
 			using (var s = WithOptions().ConnectionReleaseMode(ConnectionReleaseMode.OnClose).OpenSession())
 			{
 				using (var tx = new TransactionScope())


### PR DESCRIPTION
~~It enlists in a disposed transaction~~ Its transaction enlistment checks the previous transaction which may be disposed, causing a failure.

This test is flaky with ODBC. It fails sometime on dual core VM (which AppVeyor is, and I believe to have seen it on TeamCity when it was an Azure BS2, but I am not finding a build showing it).
Example failure here:
https://ci.appveyor.com/project/fredericDelaporte/nhibernate-core/build/5.1.0.46/job/kwp2bah4pxf8evuk/tests