### PR TITLE
SQLite is bugged with distributed transactions: disable distributed t…

### DIFF
--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -398,6 +398,17 @@ namespace NHibernate.Dialect
 		/// </remarks>
 		public override bool SupportsConcurrentWritingConnections => false;
 
+		/// <summary>
+		/// Does this dialect supports distributed transaction? <c>false</c>.
+		/// </summary>
+		/// <remarks>
+		/// SQLite does not have a two phases commit and as such does not respect distributed transaction semantic.
+		/// But moreover, it fails handling the threading involved with distributed transactions (see
+		/// https://system.data.sqlite.org/index.html/tktview/5cee5409f84da5f62172 ).
+		/// It has moreover some flakyness in tests due to seemingly highly delayed (> 500ms) commits when distributed. 
+		/// </remarks>
+		public override bool SupportsDistributedTransactions => false;
+
 		// Said to be unlimited. http://sqlite.1065341.n5.nabble.com/Max-limits-on-the-following-td37859.html
 		/// <inheritdoc />
 		public override int MaxAliasLength => 128;


### PR DESCRIPTION
…ests.

SQLite does not actually implement two phases commit and has threading issues when participating into a distributed transaction.
https://system.data.sqlite.org/index.html/tktview/5cee5409f84da5f62172

An example of such threading issue is available [here](https://teamcity.jetbrains.com/viewLog.html?buildId=1262341&tab=buildResultsDiv&buildTypeId=bt877). This is a build from the period of time where the TeamCity build agent was dual cored. It seems the trouble does not occur (or way less) on single core instances.