### PR TITLE
NH-3119 - fix test not supporting optimization

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3119/FixtureByCode.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3119/FixtureByCode.cs
@@ -11,23 +11,18 @@
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+using NHibernate.Bytecode;
+using NHibernate.Bytecode.Lightweight;
 using NHibernate.Cfg;
 using NHibernate.Cfg.MappingSchema;
-using NHibernate.Linq;
 using NHibernate.Mapping.ByCode;
+using NHibernate.Properties;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.NHSpecificTest.NH3119
 {
 	using System.Threading.Tasks;
-	/// <summary>
-	/// Fixture using 'by code' mappings
-	/// </summary>
-	/// <remarks>
-	/// This fixture is identical to <see cref="Fixture" /> except the <see cref="Entity" /> mapping is performed 
-	/// by code in the GetMappings method, and does not require the <c>Mappings.hbm.xml</c> file. Use this approach
-	/// if you prefer.
-	/// </remarks>
 	[TestFixture]
 	public class ByCodeFixtureAsync : TestCaseMappingByCode
 	{
@@ -47,9 +42,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 			return mapper.CompileMappingForAllExplicitlyAddedEntities();
 		}
 
+		private static IBytecodeProvider _backupByteCodeProvider;
+
 		protected override void OnSetUp()
 		{
-			if (!Cfg.Environment.UseReflectionOptimizer)
+			_backupByteCodeProvider = Environment.BytecodeProvider;
+
+			if (!Environment.UseReflectionOptimizer)
 			{
 				Assert.Ignore("Test only works with reflection optimization enabled");
 			}
@@ -63,10 +62,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 				session.Flush();
 				transaction.Commit();
 			}
+
+			// Change refelection optimizer and recreate the configuration and factory
+			Environment.BytecodeProvider = new TestBytecodeProviderImpl();
+			Configure();
+			RebuildSessionFactory();
 		}
 
 		protected override void OnTearDown()
 		{
+			Environment.BytecodeProvider = _backupByteCodeProvider;
+
 			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
@@ -83,11 +89,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 			using (ISession freshSession = OpenSession())
 			using (freshSession.BeginTransaction())
 			{
-				Entity entity = await (freshSession.Query<Entity>().SingleAsync());
-
-				string stackTrace = entity.Component.LastCtorStackTrace;
-
-				StringAssert.Contains("NHibernate.Bytecode.Lightweight.ReflectionOptimizer.CreateInstance", stackTrace);
+				ComponentTestReflectionOptimizer.IsCalledForComponent = false;
+				await (freshSession.Query<Entity>().SingleAsync());
+				Assert.That(ComponentTestReflectionOptimizer.IsCalledForComponent, Is.True);
 			}
 		}
 
@@ -106,11 +110,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 			using (ISession deserializedSession = factoryFromDeserializedConfig.OpenSession())
 			using (deserializedSession.BeginTransaction())
 			{
-				Entity entity = await (deserializedSession.Query<Entity>().SingleAsync());
-
-				string stackTrace = entity.Component.LastCtorStackTrace;
-
-				StringAssert.Contains("NHibernate.Bytecode.Lightweight.ReflectionOptimizer.CreateInstance", stackTrace);
+				ComponentTestReflectionOptimizer.IsCalledForComponent = false;
+				await (deserializedSession.Query<Entity>().SingleAsync());
+				Assert.That(ComponentTestReflectionOptimizer.IsCalledForComponent, Is.True);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH3119/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3119/Entity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 
 namespace NHibernate.Test.NHSpecificTest.NH3119
 {
@@ -12,12 +11,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 
 	public class Component
 	{
-		public Component()
-		{
-			LastCtorStackTrace = new StackTrace().ToString();
-		}
-
 		public string Value { get; set; }
-		public string LastCtorStackTrace { get; private set; }
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH3119/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3119/FixtureByCode.cs
@@ -1,22 +1,16 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+using NHibernate.Bytecode;
+using NHibernate.Bytecode.Lightweight;
 using NHibernate.Cfg;
 using NHibernate.Cfg.MappingSchema;
-using NHibernate.Linq;
 using NHibernate.Mapping.ByCode;
+using NHibernate.Properties;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH3119
 {
-	/// <summary>
-	/// Fixture using 'by code' mappings
-	/// </summary>
-	/// <remarks>
-	/// This fixture is identical to <see cref="Fixture" /> except the <see cref="Entity" /> mapping is performed 
-	/// by code in the GetMappings method, and does not require the <c>Mappings.hbm.xml</c> file. Use this approach
-	/// if you prefer.
-	/// </remarks>
 	[TestFixture]
 	public class ByCodeFixture : TestCaseMappingByCode
 	{
@@ -36,9 +30,13 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 			return mapper.CompileMappingForAllExplicitlyAddedEntities();
 		}
 
+		private static IBytecodeProvider _backupByteCodeProvider;
+
 		protected override void OnSetUp()
 		{
-			if (!Cfg.Environment.UseReflectionOptimizer)
+			_backupByteCodeProvider = Environment.BytecodeProvider;
+
+			if (!Environment.UseReflectionOptimizer)
 			{
 				Assert.Ignore("Test only works with reflection optimization enabled");
 			}
@@ -52,10 +50,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 				session.Flush();
 				transaction.Commit();
 			}
+
+			// Change refelection optimizer and recreate the configuration and factory
+			Environment.BytecodeProvider = new TestBytecodeProviderImpl();
+			Configure();
+			RebuildSessionFactory();
 		}
 
 		protected override void OnTearDown()
 		{
+			Environment.BytecodeProvider = _backupByteCodeProvider;
+
 			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
@@ -72,11 +77,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 			using (ISession freshSession = OpenSession())
 			using (freshSession.BeginTransaction())
 			{
-				Entity entity = freshSession.Query<Entity>().Single();
-
-				string stackTrace = entity.Component.LastCtorStackTrace;
-
-				StringAssert.Contains("NHibernate.Bytecode.Lightweight.ReflectionOptimizer.CreateInstance", stackTrace);
+				ComponentTestReflectionOptimizer.IsCalledForComponent = false;
+				freshSession.Query<Entity>().Single();
+				Assert.That(ComponentTestReflectionOptimizer.IsCalledForComponent, Is.True);
 			}
 		}
 
@@ -95,12 +98,38 @@ namespace NHibernate.Test.NHSpecificTest.NH3119
 			using (ISession deserializedSession = factoryFromDeserializedConfig.OpenSession())
 			using (deserializedSession.BeginTransaction())
 			{
-				Entity entity = deserializedSession.Query<Entity>().Single();
-
-				string stackTrace = entity.Component.LastCtorStackTrace;
-
-				StringAssert.Contains("NHibernate.Bytecode.Lightweight.ReflectionOptimizer.CreateInstance", stackTrace);
+				ComponentTestReflectionOptimizer.IsCalledForComponent = false;
+				deserializedSession.Query<Entity>().Single();
+				Assert.That(ComponentTestReflectionOptimizer.IsCalledForComponent, Is.True);
 			}
+		}
+	}
+
+	public class TestBytecodeProviderImpl : AbstractBytecodeProvider
+	{
+		public override IReflectionOptimizer GetReflectionOptimizer(System.Type mappedClass, IGetter[] getters, ISetter[] setters)
+		{
+			return new ComponentTestReflectionOptimizer(mappedClass, getters, setters);
+		}
+	}
+
+	public class ComponentTestReflectionOptimizer : ReflectionOptimizer
+	{
+		private readonly bool _logCall;
+		
+		public static bool IsCalledForComponent { get; set; }
+		
+		public ComponentTestReflectionOptimizer(System.Type mappedType, IGetter[] getters, ISetter[] setters) :
+			base(mappedType, getters, setters)
+		{
+			_logCall = mappedType == typeof(Component);
+		}
+
+		public override object CreateInstance()
+		{
+			if (_logCall)
+				IsCalledForComponent = true;
+			return base.CreateInstance();
 		}
 	}
 }

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -85,6 +85,7 @@ namespace NHibernate.Test
 
 		protected void RebuildSessionFactory()
 		{
+			Sfi?.Close();
 			_sessionFactory = BuildSessionFactory();
 		}
 


### PR DESCRIPTION
It was relying on the stack trace, which is not reliable when calls can be inlined.