### PR TITLE
Add missing NHibernateLogLevel.Info in example web project

### DIFF
--- a/src/NHibernate.Example.Web/Infrastructure/NHibernateToMicrosoftLogger.cs
+++ b/src/NHibernate.Example.Web/Infrastructure/NHibernateToMicrosoftLogger.cs
@@ -18,6 +18,7 @@ namespace NHibernate.Example.Web.Infrastructure
 		{
 			{ NHibernateLogLevel.Trace, LogLevel.Trace },
 			{ NHibernateLogLevel.Debug, LogLevel.Debug },
+			{ NHibernateLogLevel.Info, LogLevel.Information },
 			{ NHibernateLogLevel.Warn, LogLevel.Warning },
 			{ NHibernateLogLevel.Error, LogLevel.Error },
 			{ NHibernateLogLevel.Fatal, LogLevel.Critical },

--- a/src/NHibernate/Logging.cs
+++ b/src/NHibernate/Logging.cs
@@ -212,7 +212,7 @@ namespace NHibernate
 		public NHibernateLogValues(string format, object[] args)
 		{
 			_format = format ?? "[Null]";
-			_args = args;
+			_args = args ?? Array.Empty<object>();
 		}
 
 		/// <summary>


### PR DESCRIPTION
For logging, Serilog wasn't handling the `null` argument case correctly and there was a missing `NHibernateLogLevel.Info` in example web project