### PR TITLE
NH-3084 - Remove Sql statement logging from Loader

### DIFF
--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -843,7 +843,6 @@ namespace NHibernate.Loader
 			DbDataReader rs = null;
 			try
 			{
-				Log.Info(st.CommandText);
 				// TODO NH: Callable
 				rs = await (session.Batcher.ExecuteReaderAsync(st, cancellationToken)).ConfigureAwait(false);
 

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1271,7 +1271,6 @@ namespace NHibernate.Loader
 			DbDataReader rs = null;
 			try
 			{
-				Log.Info(st.CommandText);
 				// TODO NH: Callable
 				rs = session.Batcher.ExecuteReader(st);
 


### PR DESCRIPTION
Fix #1119
Is `Log.Info(st.CommandText)` really needed in `Loader.cs` since we call `session.Batcher.ExecuteReader` right after which logs the sql statement(using `SqlStatementLogger`)?



  
  
  