### PR TITLE
Scoped table aliases to session factory configuration

### DIFF
--- a/lib/teamcity/oracle/oracle_installation.txt
+++ b/lib/teamcity/oracle/oracle_installation.txt
@@ -41,4 +41,10 @@ This is needed because NHibernate test uses the managed driver NuGet package, bu
 version needs to be removed from the GAC. Read more on https://stackoverflow.com/a/35176586/1178314.
 Not doing this may notably cause failures in distributed transaction tests.
 
+Adjust the connection string for the tests:
+The tests involve creating and dropping many tables, sometimes with the same names but different data
+types. This does not play well with Oracle meta data pooling, which needs to be disabled.
+Add into your ODP.NET connection string:
+Metadata Pooling=false;Self Tuning=false;
+
 Please note that some tests are dependent on the machine locales, and may fail if they are not English.

--- a/src/NHibernate.Test/MappingTest/ColumnFixture.cs
+++ b/src/NHibernate.Test/MappingTest/ColumnFixture.cs
@@ -81,7 +81,7 @@ namespace NHibernate.Test.MappingTest
 			// Test case is meant for a max length of 10, adjusts name if it is more.
 			columnName = AdjustColumnNameToMaxLength(columnName, dialect, 10);
 
-			var table = new Table();
+			var table = new Table() {UniqueInteger = 1};
 			var column = new Column(columnName);
 
 			string generatedAlias = column.GetAlias(dialect, table);

--- a/src/NHibernate.Test/MappingTest/TableFixture.cs
+++ b/src/NHibernate.Test/MappingTest/TableFixture.cs
@@ -61,45 +61,5 @@ namespace NHibernate.Test.MappingTest
 
 			Assert.AreEqual("[schema].name", tbl.GetQualifiedName(dialect));
 		}
-
-		[Test]
-		public void TablesUniquelyNamed()
-		{
-			Table tbl1 = new Table();
-			Table tbl2 = new Table();
-
-			Assert.AreEqual(tbl1.UniqueInteger + 1, tbl2.UniqueInteger);
-		}
-
-		[Test]
-		public void TablesUniquelyNamedOnlyWithinThread()
-		{
-			var uniqueIntegerList = new System.Collections.Concurrent.ConcurrentBag<int>();
-			var method = new ThreadStart(() =>
-			                             {
-				                             Table tbl1 = new Table();
-				                             Table tbl2 = new Table();
-
-				                             // Store these values for later comparison
-				                             uniqueIntegerList.Add(tbl1.UniqueInteger);
-				                             uniqueIntegerList.Add(tbl2.UniqueInteger);
-
-				                             // Ensure that within a thread we have unique integers
-				                             Assert.AreEqual(tbl1.UniqueInteger + 1, tbl2.UniqueInteger);
-			                             });
-
-			var thread1 = new CrossThreadTestRunner(method);
-			var thread2 = new CrossThreadTestRunner(method);
-
-			thread1.Start();
-			thread2.Start();
-
-			thread1.Join();
-			thread2.Join();
-
-			// There should in total be 4 tables, but only two distinct identifiers.
-			Assert.AreEqual(4, uniqueIntegerList.Count);
-			Assert.AreEqual(2, uniqueIntegerList.Distinct().Count());
-		}
 	}
 }

--- a/src/NHibernate/Cfg/Mappings.cs
+++ b/src/NHibernate/Cfg/Mappings.cs
@@ -271,6 +271,7 @@ namespace NHibernate.Cfg
 				table.Catalog = catalog;
 				table.Subselect = subselect;
 				table.SchemaActions = GetSchemaActions(schemaAction);
+				table.UniqueInteger = tables.Count;
 				tables[key] = table;
 			}
 			else
@@ -337,15 +338,17 @@ namespace NHibernate.Cfg
 												Subselect = subselect
 											};
 
-			Table existing;
-			if (tables.TryGetValue(key, out existing))
+			var tableIndex = tables.Count;
+			if (tables.TryGetValue(key, out var existing))
 			{
 				if (existing.IsPhysicalTable)
 				{
 					throw new DuplicateMappingException("table", name);
 				}
+				tableIndex = existing.UniqueInteger;
 			}
 
+			table.UniqueInteger = tableIndex;
 			tables[key] = table;
 			return table;
 		}

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Mapping
 		private readonly LinkedHashMap<string, Column> columns = new LinkedHashMap<string, Column>();
 		private readonly Dictionary<ForeignKeyKey, ForeignKey> foreignKeys = new Dictionary<ForeignKeyKey, ForeignKey>();
 		private readonly Dictionary<string, Index> indexes = new Dictionary<string, Index>();
-		private int uniqueInteger;
+		private int? uniqueInteger;
 		private readonly Dictionary<string, UniqueKey> uniqueKeys = new Dictionary<string, UniqueKey>();
 		private string catalog;
 		private string comment;
@@ -189,7 +189,7 @@ namespace NHibernate.Mapping
 		/// <value>The unique number of the Table.</value>
 		public int UniqueInteger
 		{
-			get { return uniqueInteger; }
+			get { return uniqueInteger ?? throw new InvalidOperationException(nameof(UniqueInteger) + " has not been supplied"); }
 			internal set { uniqueInteger = value; }
 		}
 

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Mapping
 		private readonly LinkedHashMap<string, Column> columns = new LinkedHashMap<string, Column>();
 		private readonly Dictionary<ForeignKeyKey, ForeignKey> foreignKeys = new Dictionary<ForeignKeyKey, ForeignKey>();
 		private readonly Dictionary<string, Index> indexes = new Dictionary<string, Index>();
-		private readonly int uniqueInteger;
+		private int uniqueInteger;
 		private readonly Dictionary<string, UniqueKey> uniqueKeys = new Dictionary<string, UniqueKey>();
 		private string catalog;
 		private string comment;
@@ -194,6 +194,7 @@ namespace NHibernate.Mapping
 		public int UniqueInteger
 		{
 			get { return uniqueInteger; }
+			internal set { uniqueInteger = value; }
 		}
 
 		/// <summary>

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -26,9 +26,6 @@ namespace NHibernate.Mapping
 	[Serializable]
 	public class Table : IRelationalModel
 	{
-		[ThreadStatic]
-		private static int tableCounter;
-
 		private readonly List<string> checkConstraints = new List<string>();
 		private readonly LinkedHashMap<string, Column> columns = new LinkedHashMap<string, Column>();
 		private readonly Dictionary<ForeignKeyKey, ForeignKey> foreignKeys = new Dictionary<ForeignKeyKey, ForeignKey>();
@@ -52,7 +49,6 @@ namespace NHibernate.Mapping
 		/// </summary>
 		public Table()
 		{
-			uniqueInteger = tableCounter++;
 		}
 
 		public Table(string name) : this()

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -185,12 +185,13 @@ namespace NHibernate.Mapping
 
 		/// <summary>
 		/// Gets the unique number of the Table.
+		/// Used for SQL alias generation
 		/// </summary>
 		/// <value>The unique number of the Table.</value>
 		public int UniqueInteger
 		{
 			get { return uniqueInteger ?? throw new InvalidOperationException(nameof(UniqueInteger) + " has not been supplied"); }
-			internal set { uniqueInteger = value; }
+			set { uniqueInteger = value; }
 		}
 
 		/// <summary>

--- a/teamcity.build
+++ b/teamcity.build
@@ -124,7 +124,7 @@
 	<target name="setup-teamcity-oracle32">
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
-		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
 		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
 		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 		<copy todir="${bin.dir}">
@@ -140,7 +140,7 @@
 		<property name="nunit-x64" value="true" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
-		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
 		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
 		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 		<copy todir="${bin.dir}">
@@ -155,7 +155,7 @@
 	<target name="setup-teamcity-oracle-managed32">
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleManagedDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
-		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
 		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
 		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 	</target>
@@ -164,7 +164,7 @@
 		<property name="nunit-x64" value="true" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleManagedDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
-		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
+		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
 		<!-- Teamcity Oracle test database is configured with a non-Unicode encoding -->
 		<property name="nhibernate.oracle.use_n_prefixed_types_for_unicode" value="true" />
 	</target>


### PR DESCRIPTION
Make table aliases generated for same mapping but from different session factories the same:
1) To make sure that the same queries are executed for the same database from different apps (I described this scenario [here](https://github.com/nhibernate/nhibernate-core/pull/1503#issuecomment-355638540))

2) To allow further code improvements (we can for instance start interning aliases/pre-generated queries for entities, as this data now should be the same for same mapping)

3) Fixes #1417.
~~Though tableCounter is still rise endlessly - but its value is not used for mapped tables stored in `Configuration.tables`.~~
It turns out that tableCounter is not really needed outside configuration (created table classes don't use UniqueInteger)  - so it's been removed.
  