### PR TITLE
Adjust ignore rules for not ignoring DebugHelpers folder and contents

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -22,9 +22,9 @@
 *.scc
 *.tokens
 [Bb]in
-[Db]ebug*/
+[Db]ebug/
 obj/
-[Rr]elease*/
+[Rr]elease/
 *resharper*
 _ReSharper*/
 [Tt]est[Rr]esult*


### PR DESCRIPTION
The `[Db]ebug*/` rule in `src\.gitignore` causes `NHibernate\DebugHelpers` to be ignored, although they are under source control and should be under it.

I am adjusting the release rule too for consistency.