### PR TITLE
Lazy mapping schema loading

### DIFF
--- a/src/NHibernate/Cfg/XmlSchemas.cs
+++ b/src/NHibernate/Cfg/XmlSchemas.cs
@@ -11,7 +11,11 @@ namespace NHibernate.Cfg
 		private const string MappingSchemaResource = "NHibernate.nhibernate-mapping.xsd";
 
 		private static readonly XmlSchemaSet ConfigSchemaSet = ReadXmlSchemaFromEmbeddedResource(CfgSchemaResource);
-		private static readonly XmlSchemaSet MappingSchemaSet = ReadXmlSchemaFromEmbeddedResource(MappingSchemaResource);
+
+		private static class MappingSchemaHolder
+		{
+			public static readonly XmlSchemaSet MappingSchemaSet = ReadXmlSchemaFromEmbeddedResource(MappingSchemaResource);
+		}
 
 		public XmlReaderSettings CreateConfigReaderSettings()
 		{
@@ -23,7 +27,7 @@ namespace NHibernate.Cfg
 
 		public XmlReaderSettings CreateMappingReaderSettings()
 		{
-			return CreateXmlReaderSettings(MappingSchemaSet);
+			return CreateXmlReaderSettings(MappingSchemaHolder.MappingSchemaSet);
 		}
 
 		private static XmlSchemaSet ReadXmlSchemaFromEmbeddedResource(string resourceName)


### PR DESCRIPTION
Load mapping xsd schema only if hbm mapping is really used.

I was also thinking about does it need to be statically cached or not. Maybe we should introduce some method to allow user clean all statically cached objects that are used for session factory creation (mapping and configuration schema + XmlSerializer for hbm mapping are good candidates that comes to my mind now). So user will be able to clean memory if he doesn't need to create more factories.