### PR TITLE
Fixed entity name retrieval for EntityProjection

### DIFF
--- a/src/NHibernate.Test/Async/Criteria/EntityProjectionsTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/EntityProjectionsTest.cs
@@ -25,7 +25,9 @@ namespace NHibernate.Test.Criteria
 	[TestFixture]
 	public class EntityProjectionsTestAsync : TestCaseMappingByCode
 	{
+		private const string customEntityName = "CustomEntityName";
 		private EntityWithCompositeId _entityWithCompositeId;
+		private EntityCustomEntityName _entityWithCustomEntityName;
 
 		protected override HbmMapping GetMappings()
 		{
@@ -76,6 +78,16 @@ namespace NHibernate.Test.Criteria
 
 					rc.Property(e => e.Name);
 				});
+
+			mapper.Class<EntityCustomEntityName>(
+				rc =>
+				{
+					rc.EntityName(customEntityName);
+
+					rc.Id(x => x.Id, m => m.Generator(Generators.GuidComb));
+					rc.Property(x => x.Name);
+				});
+
 			return mapper.CompileMappingForAllExplicitlyAddedEntities();
 		}
 
@@ -117,6 +129,11 @@ namespace NHibernate.Test.Criteria
 					}
 				};
 
+				_entityWithCustomEntityName = new EntityCustomEntityName()
+				{
+					Name = "EntityCustomEntityName"
+				};
+
 				_entityWithCompositeId = new EntityWithCompositeId
 				{
 					Key = new CompositeKey
@@ -132,6 +149,7 @@ namespace NHibernate.Test.Criteria
 				session.Save(parent.SameTypeChild);
 				session.Save(parent);
 				session.Save(_entityWithCompositeId);
+				session.Save(customEntityName, _entityWithCustomEntityName);
 
 				session.Flush();
 				transaction.Commit();
@@ -457,6 +475,23 @@ namespace NHibernate.Test.Criteria
 				Assert.That(composite, Is.Not.Null);
 				Assert.That(composite, Is.EqualTo(_entityWithCompositeId).Using((EntityWithCompositeId x, EntityWithCompositeId y) => (Equals(x.Key, y.Key)) ? 0 : 1));
 				Assert.That(NHibernateUtil.IsInitialized(composite), Is.False, "Object must be lazy loaded.");
+			}
+		}
+
+		[Test]
+		public async Task EntityProjectionForCustomEntityNameAsync()
+		{
+			using (var session = OpenSession())
+			{
+				var entity = await (session
+							.QueryOver<EntityCustomEntityName>(customEntityName)
+							.Select(Projections.RootEntity())
+							.Take(1).SingleOrDefaultAsync());
+
+				Assert.That(entity, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entity), Is.True, "Object must be initialized.");
+				Assert.That(entity.Id, Is.EqualTo(_entityWithCustomEntityName.Id));
+				Assert.That(entity.Name, Is.EqualTo(_entityWithCustomEntityName.Name));
 			}
 		}
 	}

--- a/src/NHibernate.Test/Criteria/EntityProjectionsEntities.cs
+++ b/src/NHibernate.Test/Criteria/EntityProjectionsEntities.cs
@@ -8,6 +8,12 @@ namespace NHibernate.Test.Criteria
 		public virtual Guid Id { get; set; }
 		public virtual string Name { get; set; }
 	}
+	
+	public class EntityCustomEntityName
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+	}
 
 	public class EntityComplex
 	{

--- a/src/NHibernate/Criterion/EntityProjection.cs
+++ b/src/NHibernate/Criterion/EntityProjection.cs
@@ -161,13 +161,14 @@ namespace NHibernate.Criterion
 				_entityAlias = criteria.Alias;
 			}
 
-			Persister = criteriaQuery.Factory.GetEntityPersister(_entityType.FullName) as IQueryable;
-			if (Persister == null)
-				throw new HibernateException($"Projecting to entities requires a '{typeof(IQueryable).FullName}' persister, '{_entityType.FullName}' does not have one.");
+			ICriteria subcriteria = criteria.GetCriteriaByAlias(_entityAlias)
+									?? throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' for entity projection is not found.");
 
-			ICriteria subcriteria = criteria.GetCriteriaByAlias(_entityAlias);
-			if (subcriteria == null)
-				throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' for entity projection is not found.");
+			var entityName = criteriaQuery.GetEntityName(subcriteria)
+							?? throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' is not associated with an entity.");
+
+			Persister = criteriaQuery.Factory.GetEntityPersister(entityName) as IQueryable
+						?? throw new HibernateException($"Projecting to entities requires a '{typeof(IQueryable).FullName}' persister, '{entityName}' does not have one.");
 
 			TableAlias = criteriaQuery.GetSQLAlias(
 				subcriteria,

--- a/src/NHibernate/Criterion/EntityProjection.cs
+++ b/src/NHibernate/Criterion/EntityProjection.cs
@@ -151,24 +151,27 @@ namespace NHibernate.Criterion
 				entityProjectionQuery.RegisterEntityProjection(this);
 			}
 
-			if (_entityType == null)
-			{
-				_entityType = criteria.GetRootEntityTypeIfAvailable();
-			}
-
 			if (_entityAlias == null)
 			{
 				_entityAlias = criteria.Alias;
 			}
 
-			ICriteria subcriteria = criteria.GetCriteriaByAlias(_entityAlias)
-									?? throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' for entity projection is not found.");
+			ICriteria subcriteria =
+				criteria.GetCriteriaByAlias(_entityAlias)
+				?? throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' for entity projection is not found.");
 
-			var entityName = criteriaQuery.GetEntityName(subcriteria)
-							?? throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' is not associated with an entity.");
+			var entityName =
+				criteriaQuery.GetEntityName(subcriteria)
+				?? throw new HibernateException($"Criteria\\QueryOver alias '{_entityAlias}' is not associated with an entity.");
 
-			Persister = criteriaQuery.Factory.GetEntityPersister(entityName) as IQueryable
-						?? throw new HibernateException($"Projecting to entities requires a '{typeof(IQueryable).FullName}' persister, '{entityName}' does not have one.");
+			Persister =
+				criteriaQuery.Factory.GetEntityPersister(entityName) as IQueryable
+				?? throw new HibernateException($"Projecting to entities requires a '{typeof(IQueryable).FullName}' persister, '{entityName}' does not have one.");
+
+			if (_entityType == null)
+			{
+				_entityType = Persister.Type.ReturnedClass;
+			}
 
 			TableAlias = criteriaQuery.GetSQLAlias(
 				subcriteria,


### PR DESCRIPTION
I've just realized that entity name should be retrieved from criteria instead of using `_entityType.FullName`. Otherwise queries with explicitly provided entity names won't work. I believe that existing tests in `EntityProjectionsTest` cover this change.