### PR TITLE
Fix some HQL functions registration

### DIFF
--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -535,6 +535,8 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task CeilingAsync()
 		{
+			Assume.That(Dialect.Functions.ContainsKey("ceiling"), Is.True, Dialect + " doesn't support ceiling function.");
+
 			using (var s = OpenSession())
 			{
 				var a1 = new Animal("a1", 1.3f);
@@ -661,8 +663,34 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public async Task AsciiAsync()
+		{
+			Assume.That(Dialect.Functions.ContainsKey("ascii"), Is.True, Dialect + " doesn't support ascii function.");
+
+			using (var s = OpenSession())
+			{
+				var m = new MaterialResource(" ", "000", MaterialResource.MaterialState.Available);
+				await (s.SaveAsync(m));
+				await (s.FlushAsync());
+			}
+			using (var s = OpenSession())
+			{
+				var space = await (s.CreateQuery("select ascii(m.Description) from MaterialResource m").UniqueResultAsync<int>());
+				Assert.That(space, Is.EqualTo(32));
+				var count =
+					await (s
+						.CreateQuery("select count(*) from MaterialResource m where ascii(m.Description) = :c")
+						.SetInt32("c", 32)
+						.UniqueResultAsync<long>());
+				Assert.That(count, Is.EqualTo(1));
+			}
+		}
+
+		[Test]
 		public async Task ChrAsync()
 		{
+			Assume.That(Dialect.Functions.ContainsKey("chr"), Is.True, Dialect + " doesn't support chr function.");
+
 			using (var s = OpenSession())
 			{
 				var m = new MaterialResource("Blah", "000", (MaterialResource.MaterialState)32);
@@ -1037,7 +1065,7 @@ namespace NHibernate.Test.Hql
 		public async Task IifAsync()
 		{
 			if (!Dialect.Functions.ContainsKey("iif"))
-				Assert.Ignore(Dialect + "doesn't support iif function.");
+				Assert.Ignore(Dialect + " doesn't support iif function.");
 			using (ISession s = OpenSession())
 			{
 				await (s.SaveAsync(new MaterialResource("Flash card 512MB", "A001/07", MaterialResource.MaterialState.Available)));

--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using NHibernate.Dialect;
 using NUnit.Framework;
 
@@ -24,42 +23,6 @@ namespace NHibernate.Test.Hql
 	[TestFixture]
 	public class HQLFunctionsAsync : TestCase
 	{
-		private static readonly Dictionary<string, HashSet<System.Type>> DialectsNotSupportingStandardFunction;
-
-		static HQLFunctionsAsync()
-		{
-			DialectsNotSupportingStandardFunction =
-				new Dictionary<string, HashSet<System.Type>>
-				{
-					{"locate", new HashSet<System.Type> {typeof (SQLiteDialect)}},
-					{"bit_length", new HashSet<System.Type> {typeof (SQLiteDialect)}},
-					{"extract", new HashSet<System.Type> {typeof (SQLiteDialect)}},
-					{
-						"nullif",
-						new HashSet<System.Type>
-						{
-							// Actually not supported by the db engine. (Well, could likely still be done with a case when override.)
-							typeof (MsSqlCeDialect),
-							typeof (MsSqlCe40Dialect)
-						}}
-				};
-		}
-
-		private void AssumeSupported(string functionName)
-		{
-			Assume.That(
-				Sfi.SQLFunctionRegistry.HasFunction(functionName),
-				Is.True,
-				$"{Dialect} doesn't support {functionName} function.");
-
-			if (!DialectsNotSupportingStandardFunction.TryGetValue(functionName, out var dialects))
-				return;
-			Assume.That(
-				dialects,
-				Does.Not.Contain(Dialect.GetType()),
-				$"{Dialect} doesn't support {functionName} standard function.");
-		}
-
 		protected override string MappingsAssembly
 		{
 			get { return "NHibernate.Test"; }
@@ -257,7 +220,7 @@ namespace NHibernate.Test.Hql
 			// the two-parameter overload - emulating it by generating the 
 			// third parameter (length) if the database requires three parameters.
 
-			AssumeSupported("substring");
+			AssumeFunctionSupported("substring");
 
 			using (ISession s = OpenSession())
 			{
@@ -295,7 +258,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task SubStringAsync()
 		{
-			AssumeSupported("substring");
+			AssumeFunctionSupported("substring");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -347,7 +310,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task LocateAsync()
 		{
-			AssumeSupported("locate");
+			AssumeFunctionSupported("locate");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -369,7 +332,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task TrimAsync()
 		{
-			AssumeSupported("trim");
+			AssumeFunctionSupported("trim");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abc   ", 1);
@@ -427,7 +390,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task LengthAsync()
 		{
-			AssumeSupported("length");
+			AssumeFunctionSupported("length");
 
 			using (ISession s = OpenSession())
 			{
@@ -452,7 +415,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task Bit_lengthAsync()
 		{
-			AssumeSupported("bit_length");
+			AssumeFunctionSupported("bit_length");
 
 			// test only the parser
 			using (ISession s = OpenSession())
@@ -468,7 +431,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task CoalesceAsync()
 		{
-			AssumeSupported("coalesce");
+			AssumeFunctionSupported("coalesce");
 			// test only the parser and render
 			using (ISession s = OpenSession())
 			{
@@ -483,7 +446,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task NullifAsync()
 		{
-			AssumeSupported("nullif");
+			AssumeFunctionSupported("nullif");
 			string hql1, hql2;
 			if(!(Dialect is Oracle8iDialect))
 			{
@@ -507,7 +470,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task AbsAsync()
 		{
-			AssumeSupported("abs");
+			AssumeFunctionSupported("abs");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("Dog", 9);
@@ -536,7 +499,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task CeilingAsync()
 		{
-			AssumeSupported("ceiling");
+			AssumeFunctionSupported("ceiling");
 
 			using (var s = OpenSession())
 			{
@@ -560,7 +523,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task ModAsync()
 		{
-			AssumeSupported("mod");
+			AssumeFunctionSupported("mod");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -586,7 +549,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task SqrtAsync()
 		{
-			AssumeSupported("sqrt");
+			AssumeFunctionSupported("sqrt");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 65536f);
@@ -608,7 +571,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task UpperAsync()
 		{
-			AssumeSupported("upper");
+			AssumeFunctionSupported("upper");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1f);
@@ -637,7 +600,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task LowerAsync()
 		{
-			AssumeSupported("lower");
+			AssumeFunctionSupported("lower");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("ABCDEF", 1f);
@@ -666,7 +629,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task AsciiAsync()
 		{
-			AssumeSupported("ascii");
+			AssumeFunctionSupported("ascii");
 
 			using (var s = OpenSession())
 			{
@@ -690,7 +653,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task ChrAsync()
 		{
-			AssumeSupported("chr");
+			AssumeFunctionSupported("chr");
 
 			using (var s = OpenSession())
 			{
@@ -716,7 +679,7 @@ namespace NHibernate.Test.Hql
 		{
 			const double magicResult = 7 + 123 - 5*1.3d;
 
-			AssumeSupported("cast");
+			AssumeFunctionSupported("cast");
 			// The cast is used to test various cases of a function render
 			// Cast was selected because represent a special case for:
 			// 1) Has more then 1 argument
@@ -894,7 +857,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task CastNH1446Async()
 		{
-			AssumeSupported("cast");
+			AssumeFunctionSupported("cast");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -914,7 +877,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task CastNH1979Async()
 		{
-			AssumeSupported("cast");
+			AssumeFunctionSupported("cast");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -932,7 +895,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task Current_TimeStampAsync()
 		{
-			AssumeSupported("current_timestamp");
+			AssumeFunctionSupported("current_timestamp");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -952,7 +915,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task Current_TimeStamp_OffsetAsync()
 		{
-			AssumeSupported("current_timestamp_offset");
+			AssumeFunctionSupported("current_timestamp_offset");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -969,8 +932,8 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task ExtractAsync()
 		{
-			AssumeSupported("extract");
-			AssumeSupported("current_timestamp");
+			AssumeFunctionSupported("extract");
+			AssumeFunctionSupported("current_timestamp");
 
 			// test only the parser and render
 			using (ISession s = OpenSession())
@@ -986,7 +949,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task ConcatAsync()
 		{
-			AssumeSupported("concat");
+			AssumeFunctionSupported("concat");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1f);
@@ -1012,10 +975,10 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task HourMinuteSecondAsync()
 		{
-			AssumeSupported("second");
-			AssumeSupported("minute");
-			AssumeSupported("hour");
-			AssumeSupported("current_timestamp");
+			AssumeFunctionSupported("second");
+			AssumeFunctionSupported("minute");
+			AssumeFunctionSupported("hour");
+			AssumeFunctionSupported("current_timestamp");
 			// test only the parser and render
 			using (ISession s = OpenSession())
 			{
@@ -1027,9 +990,9 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task DayMonthYearAsync()
 		{
-			AssumeSupported("day");
-			AssumeSupported("month");
-			AssumeSupported("year");
+			AssumeFunctionSupported("day");
+			AssumeFunctionSupported("month");
+			AssumeFunctionSupported("year");
 			// test only the parser and render
 			using (ISession s = OpenSession())
 			{
@@ -1041,7 +1004,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task StrAsync()
 		{
-			AssumeSupported("str");
+			AssumeFunctionSupported("str");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -1063,7 +1026,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task IifAsync()
 		{
-			AssumeSupported("Iif");
+			AssumeFunctionSupported("Iif");
 			using (ISession s = OpenSession())
 			{
 				await (s.SaveAsync(new MaterialResource("Flash card 512MB", "A001/07", MaterialResource.MaterialState.Available)));
@@ -1106,7 +1069,7 @@ group by mr.Description";
 		[Test]
 		public async Task NH1725Async()
 		{
-			AssumeSupported("iif");
+			AssumeFunctionSupported("iif");
 			// Only to test the parser
 			using (ISession s = OpenSession())
 			{

--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -75,6 +75,7 @@ namespace NHibernate.Test.Hql
 			{
 				s.Delete("from Human");
 				s.Delete("from Animal");
+				s.Delete("from MaterialResource");
 				s.Flush();
 			}
 		}
@@ -532,6 +533,28 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public async Task CeilingAsync()
+		{
+			using (var s = OpenSession())
+			{
+				var a1 = new Animal("a1", 1.3f);
+				await (s.SaveAsync(a1));
+				await (s.FlushAsync());
+			}
+			using (var s = OpenSession())
+			{
+				var ceiling = await (s.CreateQuery("select ceiling(a.BodyWeight) from Animal a").UniqueResultAsync<float>());
+				Assert.That(ceiling, Is.EqualTo(2));
+				var count =
+					await (s
+						.CreateQuery("select count(*) from Animal a where ceiling(a.BodyWeight) = :c")
+						.SetInt32("c", 2)
+						.UniqueResultAsync<long>());
+				Assert.That(count, Is.EqualTo(1));
+			}
+		}
+
+		[Test]
 		public async Task ModAsync()
 		{
 			IgnoreIfNotSupported("mod");
@@ -634,6 +657,28 @@ namespace NHibernate.Test.Hql
 					hql = "select lower(an.Description) from Animal an group by lower(an.Description) having lower(an.Description)='abcdef'";
 					lresult = await (s.CreateQuery(hql).ListAsync());
 				}
+			}
+		}
+
+		[Test]
+		public async Task ChrAsync()
+		{
+			using (var s = OpenSession())
+			{
+				var m = new MaterialResource("Blah", "000", (MaterialResource.MaterialState)32);
+				await (s.SaveAsync(m));
+				await (s.FlushAsync());
+			}
+			using (var s = OpenSession())
+			{
+				var space = await (s.CreateQuery("select chr(m.State) from MaterialResource m").UniqueResultAsync<char>());
+				Assert.That(space, Is.EqualTo(' '));
+				var count =
+					await (s
+						.CreateQuery("select count(*) from MaterialResource m where chr(m.State) = :c")
+						.SetCharacter("c", ' ')
+						.UniqueResultAsync<long>());
+				Assert.That(count, Is.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -524,6 +524,8 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Ceiling()
 		{
+			Assume.That(Dialect.Functions.ContainsKey("ceiling"), Is.True, Dialect + " doesn't support ceiling function.");
+
 			using (var s = OpenSession())
 			{
 				var a1 = new Animal("a1", 1.3f);
@@ -650,8 +652,34 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public void Ascii()
+		{
+			Assume.That(Dialect.Functions.ContainsKey("ascii"), Is.True, Dialect + " doesn't support ascii function.");
+
+			using (var s = OpenSession())
+			{
+				var m = new MaterialResource(" ", "000", MaterialResource.MaterialState.Available);
+				s.Save(m);
+				s.Flush();
+			}
+			using (var s = OpenSession())
+			{
+				var space = s.CreateQuery("select ascii(m.Description) from MaterialResource m").UniqueResult<int>();
+				Assert.That(space, Is.EqualTo(32));
+				var count =
+					s
+						.CreateQuery("select count(*) from MaterialResource m where ascii(m.Description) = :c")
+						.SetInt32("c", 32)
+						.UniqueResult<long>();
+				Assert.That(count, Is.EqualTo(1));
+			}
+		}
+
+		[Test]
 		public void Chr()
 		{
+			Assume.That(Dialect.Functions.ContainsKey("chr"), Is.True, Dialect + " doesn't support chr function.");
+
 			using (var s = OpenSession())
 			{
 				var m = new MaterialResource("Blah", "000", (MaterialResource.MaterialState)32);
@@ -1026,7 +1054,7 @@ namespace NHibernate.Test.Hql
 		public void Iif()
 		{
 			if (!Dialect.Functions.ContainsKey("iif"))
-				Assert.Ignore(Dialect + "doesn't support iif function.");
+				Assert.Ignore(Dialect + " doesn't support iif function.");
 			using (ISession s = OpenSession())
 			{
 				s.Save(new MaterialResource("Flash card 512MB", "A001/07", MaterialResource.MaterialState.Available));

--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -64,6 +64,7 @@ namespace NHibernate.Test.Hql
 			{
 				s.Delete("from Human");
 				s.Delete("from Animal");
+				s.Delete("from MaterialResource");
 				s.Flush();
 			}
 		}
@@ -521,6 +522,28 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public void Ceiling()
+		{
+			using (var s = OpenSession())
+			{
+				var a1 = new Animal("a1", 1.3f);
+				s.Save(a1);
+				s.Flush();
+			}
+			using (var s = OpenSession())
+			{
+				var ceiling = s.CreateQuery("select ceiling(a.BodyWeight) from Animal a").UniqueResult<float>();
+				Assert.That(ceiling, Is.EqualTo(2));
+				var count =
+					s
+						.CreateQuery("select count(*) from Animal a where ceiling(a.BodyWeight) = :c")
+						.SetInt32("c", 2)
+						.UniqueResult<long>();
+				Assert.That(count, Is.EqualTo(1));
+			}
+		}
+
+		[Test]
 		public void Mod()
 		{
 			IgnoreIfNotSupported("mod");
@@ -623,6 +646,28 @@ namespace NHibernate.Test.Hql
 					hql = "select lower(an.Description) from Animal an group by lower(an.Description) having lower(an.Description)='abcdef'";
 					lresult = s.CreateQuery(hql).List();
 				}
+			}
+		}
+
+		[Test]
+		public void Chr()
+		{
+			using (var s = OpenSession())
+			{
+				var m = new MaterialResource("Blah", "000", (MaterialResource.MaterialState)32);
+				s.Save(m);
+				s.Flush();
+			}
+			using (var s = OpenSession())
+			{
+				var space = s.CreateQuery("select chr(m.State) from MaterialResource m").UniqueResult<char>();
+				Assert.That(space, Is.EqualTo(' '));
+				var count =
+					s
+						.CreateQuery("select count(*) from MaterialResource m where chr(m.State) = :c")
+						.SetCharacter("c", ' ')
+						.UniqueResult<long>();
+				Assert.That(count, Is.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using NHibernate.Dialect;
 using NUnit.Framework;
 
@@ -13,42 +12,6 @@ namespace NHibernate.Test.Hql
 	[TestFixture]
 	public class HQLFunctions : TestCase
 	{
-		private static readonly Dictionary<string, HashSet<System.Type>> DialectsNotSupportingStandardFunction;
-
-		static HQLFunctions()
-		{
-			DialectsNotSupportingStandardFunction =
-				new Dictionary<string, HashSet<System.Type>>
-				{
-					{"locate", new HashSet<System.Type> {typeof (SQLiteDialect)}},
-					{"bit_length", new HashSet<System.Type> {typeof (SQLiteDialect)}},
-					{"extract", new HashSet<System.Type> {typeof (SQLiteDialect)}},
-					{
-						"nullif",
-						new HashSet<System.Type>
-						{
-							// Actually not supported by the db engine. (Well, could likely still be done with a case when override.)
-							typeof (MsSqlCeDialect),
-							typeof (MsSqlCe40Dialect)
-						}}
-				};
-		}
-
-		private void AssumeSupported(string functionName)
-		{
-			Assume.That(
-				Sfi.SQLFunctionRegistry.HasFunction(functionName),
-				Is.True,
-				$"{Dialect} doesn't support {functionName} function.");
-
-			if (!DialectsNotSupportingStandardFunction.TryGetValue(functionName, out var dialects))
-				return;
-			Assume.That(
-				dialects,
-				Does.Not.Contain(Dialect.GetType()),
-				$"{Dialect} doesn't support {functionName} standard function.");
-		}
-
 		protected override string MappingsAssembly
 		{
 			get { return "NHibernate.Test"; }
@@ -246,7 +209,7 @@ namespace NHibernate.Test.Hql
 			// the two-parameter overload - emulating it by generating the 
 			// third parameter (length) if the database requires three parameters.
 
-			AssumeSupported("substring");
+			AssumeFunctionSupported("substring");
 
 			using (ISession s = OpenSession())
 			{
@@ -284,7 +247,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void SubString()
 		{
-			AssumeSupported("substring");
+			AssumeFunctionSupported("substring");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -336,7 +299,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Locate()
 		{
-			AssumeSupported("locate");
+			AssumeFunctionSupported("locate");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -358,7 +321,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Trim()
 		{
-			AssumeSupported("trim");
+			AssumeFunctionSupported("trim");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abc   ", 1);
@@ -416,7 +379,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Length()
 		{
-			AssumeSupported("length");
+			AssumeFunctionSupported("length");
 
 			using (ISession s = OpenSession())
 			{
@@ -441,7 +404,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Bit_length()
 		{
-			AssumeSupported("bit_length");
+			AssumeFunctionSupported("bit_length");
 
 			// test only the parser
 			using (ISession s = OpenSession())
@@ -457,7 +420,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Coalesce()
 		{
-			AssumeSupported("coalesce");
+			AssumeFunctionSupported("coalesce");
 			// test only the parser and render
 			using (ISession s = OpenSession())
 			{
@@ -472,7 +435,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Nullif()
 		{
-			AssumeSupported("nullif");
+			AssumeFunctionSupported("nullif");
 			string hql1, hql2;
 			if(!(Dialect is Oracle8iDialect))
 			{
@@ -496,7 +459,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Abs()
 		{
-			AssumeSupported("abs");
+			AssumeFunctionSupported("abs");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("Dog", 9);
@@ -525,7 +488,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Ceiling()
 		{
-			AssumeSupported("ceiling");
+			AssumeFunctionSupported("ceiling");
 
 			using (var s = OpenSession())
 			{
@@ -549,7 +512,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Mod()
 		{
-			AssumeSupported("mod");
+			AssumeFunctionSupported("mod");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -575,7 +538,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Sqrt()
 		{
-			AssumeSupported("sqrt");
+			AssumeFunctionSupported("sqrt");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 65536f);
@@ -597,7 +560,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Upper()
 		{
-			AssumeSupported("upper");
+			AssumeFunctionSupported("upper");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1f);
@@ -626,7 +589,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Lower()
 		{
-			AssumeSupported("lower");
+			AssumeFunctionSupported("lower");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("ABCDEF", 1f);
@@ -655,7 +618,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Ascii()
 		{
-			AssumeSupported("ascii");
+			AssumeFunctionSupported("ascii");
 
 			using (var s = OpenSession())
 			{
@@ -679,7 +642,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Chr()
 		{
-			AssumeSupported("chr");
+			AssumeFunctionSupported("chr");
 
 			using (var s = OpenSession())
 			{
@@ -705,7 +668,7 @@ namespace NHibernate.Test.Hql
 		{
 			const double magicResult = 7 + 123 - 5*1.3d;
 
-			AssumeSupported("cast");
+			AssumeFunctionSupported("cast");
 			// The cast is used to test various cases of a function render
 			// Cast was selected because represent a special case for:
 			// 1) Has more then 1 argument
@@ -883,7 +846,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void CastNH1446()
 		{
-			AssumeSupported("cast");
+			AssumeFunctionSupported("cast");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -903,7 +866,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void CastNH1979()
 		{
-			AssumeSupported("cast");
+			AssumeFunctionSupported("cast");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -921,7 +884,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Current_TimeStamp()
 		{
-			AssumeSupported("current_timestamp");
+			AssumeFunctionSupported("current_timestamp");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -941,7 +904,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Current_TimeStamp_Offset()
 		{
-			AssumeSupported("current_timestamp_offset");
+			AssumeFunctionSupported("current_timestamp_offset");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1.3f);
@@ -958,8 +921,8 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Extract()
 		{
-			AssumeSupported("extract");
-			AssumeSupported("current_timestamp");
+			AssumeFunctionSupported("extract");
+			AssumeFunctionSupported("current_timestamp");
 
 			// test only the parser and render
 			using (ISession s = OpenSession())
@@ -975,7 +938,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Concat()
 		{
-			AssumeSupported("concat");
+			AssumeFunctionSupported("concat");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 1f);
@@ -1001,10 +964,10 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void HourMinuteSecond()
 		{
-			AssumeSupported("second");
-			AssumeSupported("minute");
-			AssumeSupported("hour");
-			AssumeSupported("current_timestamp");
+			AssumeFunctionSupported("second");
+			AssumeFunctionSupported("minute");
+			AssumeFunctionSupported("hour");
+			AssumeFunctionSupported("current_timestamp");
 			// test only the parser and render
 			using (ISession s = OpenSession())
 			{
@@ -1016,9 +979,9 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void DayMonthYear()
 		{
-			AssumeSupported("day");
-			AssumeSupported("month");
-			AssumeSupported("year");
+			AssumeFunctionSupported("day");
+			AssumeFunctionSupported("month");
+			AssumeFunctionSupported("year");
 			// test only the parser and render
 			using (ISession s = OpenSession())
 			{
@@ -1030,7 +993,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Str()
 		{
-			AssumeSupported("str");
+			AssumeFunctionSupported("str");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);
@@ -1052,7 +1015,7 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Iif()
 		{
-			AssumeSupported("Iif");
+			AssumeFunctionSupported("Iif");
 			using (ISession s = OpenSession())
 			{
 				s.Save(new MaterialResource("Flash card 512MB", "A001/07", MaterialResource.MaterialState.Available));
@@ -1095,7 +1058,7 @@ group by mr.Description";
 		[Test]
 		public void NH1725()
 		{
-			AssumeSupported("iif");
+			AssumeFunctionSupported("iif");
 			// Only to test the parser
 			using (ISession s = OpenSession())
 			{

--- a/src/NHibernate.Test/Linq/MathTests.cs
+++ b/src/NHibernate.Test/Linq/MathTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
-using NHibernate.Dialect;
 using NHibernate.DomainModel.Northwind.Entities;
 using NUnit.Framework;
 
@@ -11,12 +10,6 @@ namespace NHibernate.Test.Linq
 	public class MathTests : LinqTestCase
 	{
 		private IQueryable<OrderLine> _orderLines;
-
-		private void IgnoreIfNotSupported(string function)
-		{
-			if (!Dialect.Functions.ContainsKey(function))
-				Assert.Ignore("Dialect {0} does not support '{1}' function", Dialect.GetType(), function);
-		}
 
 		protected override void OnSetUp()
 		{
@@ -29,7 +22,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void SignAllPositiveTest()
 		{
-			IgnoreIfNotSupported("sign");
+			AssumeFunctionSupported("sign");
 			var signs = (from o in db.OrderLines
 						 select Math.Sign(o.UnitPrice)).ToList();
 
@@ -39,7 +32,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void SignAllNegativeTest()
 		{
-			IgnoreIfNotSupported("sign");
+			AssumeFunctionSupported("sign");
 			var signs = (from o in db.OrderLines
 						 select Math.Sign(0m - o.UnitPrice)).ToList();
 
@@ -49,77 +42,77 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void SinTest()
 		{
-			IgnoreIfNotSupported("sin");
+			AssumeFunctionSupported("sin");
 			Test(o => Math.Round(Math.Sin((double) o.UnitPrice), 5));
 		}
 
 		[Test]
 		public void CosTest()
 		{
-			IgnoreIfNotSupported("cos");
+			AssumeFunctionSupported("cos");
 			Test(o => Math.Round(Math.Cos((double)o.UnitPrice), 5));
 		}
 
 		[Test]
 		public void TanTest()
 		{
-			IgnoreIfNotSupported("tan");
+			AssumeFunctionSupported("tan");
 			Test(o => Math.Round(Math.Tan((double)o.Discount), 5));
 		}
 
 		[Test]
 		public void SinhTest()
 		{
-			IgnoreIfNotSupported("sinh");
+			AssumeFunctionSupported("sinh");
 			Test(o => Math.Round(Math.Sinh((double)o.Discount), 5));
 		}
 
 		[Test]
 		public void CoshTest()
 		{
-			IgnoreIfNotSupported("cosh");
+			AssumeFunctionSupported("cosh");
 			Test(o => Math.Round(Math.Cosh((double)o.Discount), 5));
 		}
 
 		[Test]
 		public void TanhTest()
 		{
-			IgnoreIfNotSupported("tanh");
+			AssumeFunctionSupported("tanh");
 			Test(o => Math.Round(Math.Tanh((double)o.Discount), 5));
 		}
 
 		[Test]
 		public void AsinTest()
 		{
-			IgnoreIfNotSupported("asin");
+			AssumeFunctionSupported("asin");
 			Test(o => Math.Round(Math.Asin((double)o.Discount), 5));
 		}
 
 		[Test]
 		public void AcosTest()
 		{
-			IgnoreIfNotSupported("acos");
+			AssumeFunctionSupported("acos");
 			Test(o => Math.Round(Math.Acos((double)o.Discount), 5));
 		}
 
 		[Test]
 		public void AtanTest()
 		{
-			IgnoreIfNotSupported("atan");
+			AssumeFunctionSupported("atan");
 			Test(o => Math.Round(Math.Atan((double)o.UnitPrice), 5));
 		}
 
 		[Test]
 		public void Atan2Test()
 		{
-			IgnoreIfNotSupported("atan2");
+			AssumeFunctionSupported("atan2");
 			Test(o => Math.Round(Math.Atan2((double)o.Discount, 0.5d), 5));
 		}
 
 		[Test]
 		public void PowTest()
 		{
-			IgnoreIfNotSupported("power");
+			AssumeFunctionSupported("power");
 			Test(o => Math.Round(Math.Pow((double)o.Discount, 0.5d), 5));
 		}
 

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
 using log4net;
@@ -13,6 +14,7 @@ using NHibernate.Type;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using System.Text;
+using NHibernate.Dialect;
 using NHibernate.Driver;
 
 namespace NHibernate.Test
@@ -438,7 +440,43 @@ namespace NHibernate.Test
 		{
 			return AbstractDateTimeType.Round(value, Dialect.TimestampResolutionInTicks);
 		}
-		
+
+		private static readonly Dictionary<string, HashSet<System.Type>> DialectsNotSupportingStandardFunction =
+			new Dictionary<string, HashSet<System.Type>>
+			{
+				{"locate", new HashSet<System.Type> {typeof (SQLiteDialect)}},
+				{"bit_length", new HashSet<System.Type> {typeof (SQLiteDialect)}},
+				{"extract", new HashSet<System.Type> {typeof (SQLiteDialect)}},
+				{
+					"nullif",
+					new HashSet<System.Type>
+					{
+						// Actually not supported by the db engine. (Well, could likely still be done with a case when override.)
+						typeof (MsSqlCeDialect),
+						typeof (MsSqlCe40Dialect)
+					}}
+			};
+
+		protected void AssumeFunctionSupported(string functionName)
+		{
+			// We could test Sfi.SQLFunctionRegistry.HasFunction(functionName) which has the advantage of
+			// accounting for additionnal functions added in configuration. But Dialect is normally never
+			// null, while Sfi could be not yet initialized, depending from where this function is called.
+			// Furtermore there are currently no additionnal functions added in configuration for NHibernate
+			// tests.
+			Assume.That(
+				Dialect.Functions,
+				Does.ContainKey(functionName),
+				$"{Dialect} doesn't support {functionName} function.");
+
+			if (!DialectsNotSupportingStandardFunction.TryGetValue(functionName, out var dialects))
+				return;
+			Assume.That(
+				dialects,
+				Does.Not.Contain(Dialect.GetType()),
+				$"{Dialect} doesn't support {functionName} standard function.");
+		}
+
 		#endregion
 	}
 }

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -115,6 +115,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("smallint", new StandardSQLFunction("smallint", NHibernateUtil.Int16));
 
 			RegisterFunction("digits", new StandardSQLFunction("digits", NHibernateUtil.String));
+			RegisterFunction("ascii", new StandardSQLFunction("ascii", NHibernateUtil.Int32));
 			RegisterFunction("chr", new StandardSQLFunction("chr", NHibernateUtil.Character));
 			RegisterFunction("upper", new StandardSQLFunction("upper"));
 			RegisterFunction("ucase", new StandardSQLFunction("ucase"));

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -454,6 +454,7 @@ namespace NHibernate.Dialect
 		{
 			RegisterFunction("abs", new StandardSQLFunction("abs", NHibernateUtil.Double));
 			RegisterFunction("ceiling", new StandardSQLFunction("ceiling", NHibernateUtil.Double));
+			RegisterFunction("ceil", new StandardSQLFunction("ceil", NHibernateUtil.Double));
 			RegisterFunction("div", new StandardSQLFunction("div", NHibernateUtil.Double));
 			RegisterFunction("dpower", new StandardSQLFunction("dpower", NHibernateUtil.Double));
 			RegisterFunction("ln", new StandardSQLFunction("ln", NHibernateUtil.Double));
@@ -486,7 +487,9 @@ namespace NHibernate.Dialect
 		private void RegisterStringAndCharFunctions()
 		{
 			RegisterFunction("ascii_char", new StandardSQLFunction("ascii_char"));
+			RegisterFunction("chr", new StandardSQLFunction("ascii_char"));
 			RegisterFunction("ascii_val", new StandardSQLFunction("ascii_val", NHibernateUtil.Int16));
+			RegisterFunction("ascii", new StandardSQLFunction("ascii_val", NHibernateUtil.Int16));
 			RegisterFunction("lpad", new StandardSQLFunction("lpad"));
 			RegisterFunction("ltrim", new StandardSQLFunction("ltrim"));
 			RegisterFunction("sright", new StandardSQLFunction("sright"));

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -453,8 +453,8 @@ namespace NHibernate.Dialect
 		private void RegisterMathematicalFunctions()
 		{
 			RegisterFunction("abs", new StandardSQLFunction("abs", NHibernateUtil.Double));
-			RegisterFunction("ceiling", new StandardSQLFunction("ceiling", NHibernateUtil.Double));
-			RegisterFunction("ceil", new StandardSQLFunction("ceil", NHibernateUtil.Double));
+			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));
+			RegisterFunction("ceil", new StandardSQLFunction("ceil"));
 			RegisterFunction("div", new StandardSQLFunction("div", NHibernateUtil.Double));
 			RegisterFunction("dpower", new StandardSQLFunction("dpower", NHibernateUtil.Double));
 			RegisterFunction("ln", new StandardSQLFunction("ln", NHibernateUtil.Double));
@@ -465,7 +465,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("sign", new StandardSQLFunction("sign", NHibernateUtil.Int32));
 			RegisterFunction("sqtr", new StandardSQLFunction("sqtr", NHibernateUtil.Double));
 			RegisterFunction("truncate", new StandardSQLFunction("truncate"));
-			RegisterFunction("floor", new StandardSafeSQLFunction("floor", NHibernateUtil.Double, 1));
+			RegisterFunction("floor", new StandardSQLFunction("floor"));
 			RegisterFunction("round", new StandardSQLFunction("round"));
 		}
 
@@ -486,10 +486,10 @@ namespace NHibernate.Dialect
 
 		private void RegisterStringAndCharFunctions()
 		{
-			RegisterFunction("ascii_char", new StandardSQLFunction("ascii_char"));
-			RegisterFunction("chr", new StandardSQLFunction("ascii_char"));
-			RegisterFunction("ascii_val", new StandardSQLFunction("ascii_val", NHibernateUtil.Int16));
-			RegisterFunction("ascii", new StandardSQLFunction("ascii_val", NHibernateUtil.Int16));
+			RegisterFunction("ascii_char", new StandardSQLFunction("ascii_char", NHibernateUtil.Character));
+			RegisterFunction("chr", new StandardSQLFunction("ascii_char", NHibernateUtil.Character));
+			RegisterFunction("ascii_val", new StandardSQLFunction("ascii_val", NHibernateUtil.Int32));
+			RegisterFunction("ascii", new StandardSQLFunction("ascii_val", NHibernateUtil.Int32));
 			RegisterFunction("lpad", new StandardSQLFunction("lpad"));
 			RegisterFunction("ltrim", new StandardSQLFunction("ltrim"));
 			RegisterFunction("sright", new StandardSQLFunction("sright"));

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -284,7 +284,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("sign", new StandardSQLFunction("sign", NHibernateUtil.Int32));
 
 			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));
-			RegisterFunction("ceil", new StandardSQLFunction("ceil"));
+			RegisterFunction("ceil", new StandardSQLFunction("ceiling"));
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
 			RegisterFunction("round", new StandardSQLFunction("round"));
 
@@ -326,7 +326,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("date", new SQLFunctionTemplate(NHibernateUtil.Date, "dateadd(dd, 0, datediff(dd, 0, ?1))"));
 			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", "+", ")"));
 			RegisterFunction("digits", new StandardSQLFunction("digits", NHibernateUtil.String));
-			RegisterFunction("chr", new StandardSQLFunction("chr", NHibernateUtil.Character));
+			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
 			RegisterFunction("upper", new StandardSQLFunction("upper"));
 			RegisterFunction("ucase", new StandardSQLFunction("ucase"));
 			RegisterFunction("lcase", new StandardSQLFunction("lcase"));

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -326,6 +326,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("date", new SQLFunctionTemplate(NHibernateUtil.Date, "dateadd(dd, 0, datediff(dd, 0, ?1))"));
 			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", "+", ")"));
 			RegisterFunction("digits", new StandardSQLFunction("digits", NHibernateUtil.String));
+			RegisterFunction("ascii", new StandardSQLFunction("ascii", NHibernateUtil.Int32));
 			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
 			RegisterFunction("upper", new StandardSQLFunction("upper"));
 			RegisterFunction("ucase", new StandardSQLFunction("ucase"));

--- a/src/NHibernate/Dialect/MySQLDialect.cs
+++ b/src/NHibernate/Dialect/MySQLDialect.cs
@@ -284,7 +284,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("ucase", new StandardSQLFunction("ucase"));
 			RegisterFunction("lcase", new StandardSQLFunction("lcase"));
 
-			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
+			RegisterFunction("chr", new SQLFunctionTemplate(NHibernateUtil.Character, "cast(char(?1) as char)"));
 			RegisterFunction("ascii", new StandardSQLFunction("ascii", NHibernateUtil.Int32));
 			RegisterFunction("instr", new StandardSQLFunction("instr", NHibernateUtil.Int32));
 			RegisterFunction("lpad", new StandardSQLFunction("lpad", NHibernateUtil.String));

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -230,6 +230,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("round", new StandardSQLFunction("round"));
 			RegisterFunction("trunc", new StandardSQLFunction("trunc"));
 			RegisterFunction("ceil", new StandardSQLFunction("ceil"));
+			RegisterFunction("ceiling", new StandardSQLFunction("ceil"));
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
 
 			RegisterFunction("chr", new StandardSQLFunction("chr", NHibernateUtil.Character));

--- a/src/NHibernate/Dialect/OracleLiteDialect.cs
+++ b/src/NHibernate/Dialect/OracleLiteDialect.cs
@@ -69,6 +69,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("round", new StandardSQLFunction("round"));
 			RegisterFunction("trunc", new StandardSQLFunction("trunc"));
 			RegisterFunction("ceil", new StandardSQLFunction("ceil"));
+			RegisterFunction("ceiling", new StandardSQLFunction("ceil"));
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
 
 			RegisterFunction("chr", new StandardSQLFunction("chr", NHibernateUtil.Character));

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -79,6 +79,12 @@ namespace NHibernate.Dialect
 
 			RegisterFunction("power", new StandardSQLFunction("power", NHibernateUtil.Double));
 
+			RegisterFunction("floor", new StandardSQLFunction("floor"));
+			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));
+			RegisterFunction("ceil", new StandardSQLFunction("ceil"));
+			RegisterFunction("chr", new StandardSQLFunction("chr", NHibernateUtil.Character));
+			RegisterFunction("ascii", new StandardSQLFunction("ascii", NHibernateUtil.Int32));
+
 			// Register the date function, since when used in LINQ select clauses, NH must know the data type.
 			RegisterFunction("date", new SQLFunctionTemplate(NHibernateUtil.Date, "cast(?1 as date)"));
 

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -78,6 +78,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("left", new SQLFunctionTemplate(NHibernateUtil.String, "substr(?1,1,?2)"));
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));
+			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
 
 			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
 


### PR DESCRIPTION
 * ceiling was not registered for Oracle, while it needs to be transcripted to ceil
 * ceil was registered as ceil for SQL-Server, which only supports ceiling
 * chr was wrongly registered as chr for SQL-Server, it needs to be registered as char
 * More registrations of ascii, chr, floor, ceiling, ceil
 * Fix type registrations for ceiling, floor, chr, ascii in Firebird
 * Fix registrations of chr in MySql
 * Fixes #837
 * Consolidate function support test logic in Test project