### PR TITLE
Avoid a null reference exception in ExpressionKeyVisitor

### DIFF
--- a/src/NHibernate/Linq/Visitors/ExpressionKeyVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionKeyVisitor.cs
@@ -81,6 +81,8 @@ namespace NHibernate.Linq.Visitors
 		{
 			NamedParameter param;
 
+			if (_constantToParameterMap == null)
+				throw new InvalidOperationException("Cannot visit a constant without a constant to parameter map.");
 			if (_constantToParameterMap.TryGetValue(expression, out param) && insideSelectClause == false)
 			{
 				// Nulls generate different query plans.  X = variable generates a different query depending on if variable is null or not.


### PR DESCRIPTION
As seen within #1532, `ExpressionKeyVisitor.Visit` may blow with a null reference exception when a null `constantToParameterMap` is transmitted. But some code path always transmit this parameter as `null`, because they work on `MemberExpression` which does not have the trouble.

So we need to keep accepting `null`, but throw a better exception when a `constantToParameterMap` was indeed required.