### PR TITLE
Avoid unnecessary persister lookup in Loader

### DIFF
--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -706,7 +706,9 @@ namespace NHibernate.Loader
 			object id = key.Identifier;
 
 			// Get the persister for the _subclass_
-			ILoadable persister = (ILoadable)Factory.GetEntityPersister(instanceClass);
+			ILoadable persister = ReferenceEquals(instanceClass, rootPersister.EntityName)
+				? rootPersister
+				: (ILoadable) Factory.GetEntityPersister(instanceClass);
 
 			if (Log.IsDebugEnabled())
 			{

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -706,7 +706,7 @@ namespace NHibernate.Loader
 			object id = key.Identifier;
 
 			// Get the persister for the _subclass_
-			ILoadable persister = ReferenceEquals(instanceClass, rootPersister.EntityName)
+			ILoadable persister = instanceClass == rootPersister.EntityName
 				? rootPersister
 				: (ILoadable) Factory.GetEntityPersister(instanceClass);
 

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1062,7 +1062,9 @@ namespace NHibernate.Loader
 			object id = key.Identifier;
 
 			// Get the persister for the _subclass_
-			ILoadable persister = (ILoadable)Factory.GetEntityPersister(instanceClass);
+			ILoadable persister = ReferenceEquals(instanceClass, rootPersister.EntityName)
+				? rootPersister
+				: (ILoadable) Factory.GetEntityPersister(instanceClass);
 
 			if (Log.IsDebugEnabled())
 			{

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1062,7 +1062,7 @@ namespace NHibernate.Loader
 			object id = key.Identifier;
 
 			// Get the persister for the _subclass_
-			ILoadable persister = ReferenceEquals(instanceClass, rootPersister.EntityName)
+			ILoadable persister = instanceClass == rootPersister.EntityName
 				? rootPersister
 				: (ILoadable) Factory.GetEntityPersister(instanceClass);
 


### PR DESCRIPTION
Additional persister lookup is really required only for subclasses (`rootPersister.HasSubclasses && rootPersister.EntityName != instanceClass`, also see `GetInstanceClass`  where `instanceClass` is retrieved) 

But let's simply check if given entity name comes directly from provided persister.