### PR TITLE
Various string manipulation optimizations

### DIFF
--- a/src/NHibernate/AdoNet/Util/BasicFormatter.cs
+++ b/src/NHibernate/AdoNet/Util/BasicFormatter.cs
@@ -430,7 +430,7 @@ namespace NHibernate.AdoNet.Util
 
 			private static bool IsWhitespace(string token)
 			{
-				return StringHelper.WhiteSpace.IndexOf(token) >= 0;
+				return StringHelper.WhiteSpace.IndexOf(token, StringComparison.Ordinal) >= 0;
 			}
 
 			private void Newline()

--- a/src/NHibernate/AdoNet/Util/DdlFormatter.cs
+++ b/src/NHibernate/AdoNet/Util/DdlFormatter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NHibernate.Util;
@@ -18,15 +19,15 @@ namespace NHibernate.AdoNet.Util
 		/// </summary>
 		public virtual string Format(string sql)
 		{
-			if (sql.ToLowerInvariant().StartsWith("create table"))
+			if (sql.StartsWith("create table", StringComparison.OrdinalIgnoreCase))
 			{
 				return FormatCreateTable(sql);
 			}
-			else if (sql.ToLowerInvariant().StartsWith("alter table"))
+			else if (sql.StartsWith("alter table", StringComparison.OrdinalIgnoreCase))
 			{
 				return FormatAlterTable(sql);
 			}
-			else if (sql.ToLowerInvariant().StartsWith("comment on"))
+			else if (sql.StartsWith("comment on", StringComparison.OrdinalIgnoreCase))
 			{
 				return FormatCommentOn(sql);
 			}

--- a/src/NHibernate/Cfg/XmlHbmBinding/CollectionBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/CollectionBinder.cs
@@ -221,7 +221,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 
 			//ORPHAN DELETE (used for programmer error detection)
 			var cascadeAtt = collectionMapping.Cascade;
-			if (!string.IsNullOrEmpty(cascadeAtt) && cascadeAtt.IndexOf("delete-orphan") >= 0)
+			if (!string.IsNullOrEmpty(cascadeAtt) && cascadeAtt.IndexOf("delete-orphan", StringComparison.Ordinal) >= 0)
 				model.HasOrphanDelete = true;
 
 			// GENERIC

--- a/src/NHibernate/Engine/Query/CallableParser.cs
+++ b/src/NHibernate/Engine/Query/CallableParser.cs
@@ -37,13 +37,20 @@ namespace NHibernate.Engine.Query
 
 			callableDetail.FunctionName = functionMatch.Groups[1].Value;
 
-			callableDetail.HasReturn = indexOfCall > 0 &&
-										sqlString.IndexOf('?') > 0 &&
-										sqlString.IndexOf('=') > 0 &&
-										sqlString.IndexOf('?') < indexOfCall &&
-										sqlString.IndexOf('=') < indexOfCall;
+			callableDetail.HasReturn = HasReturnParameter(sqlString, indexOfCall);
 
 			return callableDetail;
+		}
+
+		internal static bool HasReturnParameter(string sqlString, int indexOfCall)
+		{
+			int indexOfQuestionMark;
+			int indexOfEqual;
+			return indexOfCall > 0 &&
+					(indexOfQuestionMark = sqlString.IndexOf('?')) > 0 &&
+					(indexOfEqual = sqlString.IndexOf('=')) > 0 &&
+					indexOfQuestionMark < indexOfCall &&
+					indexOfEqual < indexOfCall;
 		}
 	}
 }

--- a/src/NHibernate/Engine/Query/CallableParser.cs
+++ b/src/NHibernate/Engine/Query/CallableParser.cs
@@ -21,9 +21,9 @@ namespace NHibernate.Engine.Query
 		{
 			Detail callableDetail = new Detail();
 
-			callableDetail.IsCallable = sqlString.IndexOf("{") == 0 &&
-										sqlString.IndexOf("}") == (sqlString.Length - 1) &&
-										sqlString.IndexOf("call") > 0;
+			callableDetail.IsCallable = sqlString.IndexOf('{') == 0 &&
+										sqlString.IndexOf('}') == (sqlString.Length - 1) &&
+										sqlString.IndexOf("call", StringComparison.Ordinal) > 0;
 
 			if (!callableDetail.IsCallable)
 				return callableDetail;
@@ -35,11 +35,11 @@ namespace NHibernate.Engine.Query
 
 			callableDetail.FunctionName = functionMatch.Groups[1].Value;
 
-			callableDetail.HasReturn = sqlString.IndexOf("call") > 0 &&
-										sqlString.IndexOf("?") > 0 &&
-										sqlString.IndexOf("=") > 0 &&
-										sqlString.IndexOf("?") < sqlString.IndexOf("call") &&
-										sqlString.IndexOf("=") < sqlString.IndexOf("call");
+			callableDetail.HasReturn = sqlString.IndexOf("call", StringComparison.Ordinal) > 0 &&
+										sqlString.IndexOf('?') > 0 &&
+										sqlString.IndexOf('=') > 0 &&
+										sqlString.IndexOf('?') < sqlString.IndexOf("call", StringComparison.Ordinal) &&
+										sqlString.IndexOf('=') < sqlString.IndexOf("call", StringComparison.Ordinal);
 
 			return callableDetail;
 		}

--- a/src/NHibernate/Engine/Query/CallableParser.cs
+++ b/src/NHibernate/Engine/Query/CallableParser.cs
@@ -21,9 +21,11 @@ namespace NHibernate.Engine.Query
 		{
 			Detail callableDetail = new Detail();
 
-			callableDetail.IsCallable = sqlString.IndexOf('{') == 0 &&
-										sqlString.IndexOf('}') == (sqlString.Length - 1) &&
-										sqlString.IndexOf("call", StringComparison.Ordinal) > 0;
+			int indexOfCall = -1;
+			callableDetail.IsCallable = sqlString.Length > 5 && // to be able to check sqlString[0] we at least need to make sure that string has at least 1 character. The simplest case all other conditions are true is "{call}" which is 6 characters, so check it.
+										sqlString[0] == '{' &&
+										sqlString[sqlString.Length - 1] == '}' &&
+										(indexOfCall = sqlString.IndexOf("call", StringComparison.Ordinal)) > 0;
 
 			if (!callableDetail.IsCallable)
 				return callableDetail;
@@ -35,11 +37,11 @@ namespace NHibernate.Engine.Query
 
 			callableDetail.FunctionName = functionMatch.Groups[1].Value;
 
-			callableDetail.HasReturn = sqlString.IndexOf("call", StringComparison.Ordinal) > 0 &&
+			callableDetail.HasReturn = indexOfCall > 0 &&
 										sqlString.IndexOf('?') > 0 &&
 										sqlString.IndexOf('=') > 0 &&
-										sqlString.IndexOf('?') < sqlString.IndexOf("call", StringComparison.Ordinal) &&
-										sqlString.IndexOf('=') < sqlString.IndexOf("call", StringComparison.Ordinal);
+										sqlString.IndexOf('?') < indexOfCall &&
+										sqlString.IndexOf('=') < indexOfCall;
 
 			return callableDetail;
 		}

--- a/src/NHibernate/Engine/Query/NativeSQLQueryPlan.cs
+++ b/src/NHibernate/Engine/Query/NativeSQLQueryPlan.cs
@@ -120,7 +120,7 @@ namespace NHibernate.Engine.Query
 		private SqlString ExpandDynamicFilterParameters(SqlString sqlString, ICollection<IParameterSpecification> parameterSpecs, ISessionImplementor session)
 		{
 			var enabledFilters = session.EnabledFilters;
-			if (enabledFilters.Count == 0 || sqlString.ToString().IndexOf(ParserHelper.HqlVariablePrefix) < 0)
+			if (enabledFilters.Count == 0 || !ParserHelper.HasHqlVariable(sqlString))
 			{
 				return sqlString;
 			}
@@ -143,7 +143,7 @@ namespace NHibernate.Engine.Query
 
 				foreach (string token in tokens)
 				{
-					if (token.StartsWith(ParserHelper.HqlVariablePrefix))
+					if (ParserHelper.IsHqlVariable(token))
 					{
 						string filterParameterName = token.Substring(1);
 						string[] parts = StringHelper.ParseFilterParameterName(filterParameterName);

--- a/src/NHibernate/Engine/Query/ParameterParser.cs
+++ b/src/NHibernate/Engine/Query/ParameterParser.cs
@@ -42,11 +42,11 @@ namespace NHibernate.Engine.Query
 		public static void Parse(string sqlString, IRecognizer recognizer)
 		{
 			// TODO: WTF? "CALL"... it may work for ORACLE but what about others RDBMS ? (by FM)
-			bool hasMainOutputParameter = sqlString.IndexOf("call") > 0 &&
-										  sqlString.IndexOf("?") > 0 &&
-										  sqlString.IndexOf("=") > 0 &&
-										  sqlString.IndexOf("?") < sqlString.IndexOf("call") &&
-										  sqlString.IndexOf("=") < sqlString.IndexOf("call");
+			bool hasMainOutputParameter = sqlString.IndexOf("call", StringComparison.Ordinal) > 0 &&
+										  sqlString.IndexOf('?') > 0 &&
+										  sqlString.IndexOf('=') > 0 &&
+										  sqlString.IndexOf('?') < sqlString.IndexOf("call", StringComparison.Ordinal) &&
+										  sqlString.IndexOf('=') < sqlString.IndexOf("call", StringComparison.Ordinal);
 			bool foundMainOutputParam = false;
 
 			int stringLength = sqlString.Length;

--- a/src/NHibernate/Engine/Query/ParameterParser.cs
+++ b/src/NHibernate/Engine/Query/ParameterParser.cs
@@ -43,11 +43,7 @@ namespace NHibernate.Engine.Query
 		{
 			// TODO: WTF? "CALL"... it may work for ORACLE but what about others RDBMS ? (by FM)
 			var indexOfCall = sqlString.IndexOf("call", StringComparison.Ordinal);
-			bool hasMainOutputParameter = indexOfCall > 0 &&
-										  sqlString.IndexOf('?') > 0 &&
-										  sqlString.IndexOf('=') > 0 &&
-										  sqlString.IndexOf('?') < indexOfCall &&
-										  sqlString.IndexOf('=') < indexOfCall;
+			bool hasMainOutputParameter = CallableParser.HasReturnParameter(sqlString, indexOfCall);
 			bool foundMainOutputParam = false;
 
 			int stringLength = sqlString.Length;

--- a/src/NHibernate/Hql/Ast/ANTLR/Util/JoinProcessor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Util/JoinProcessor.cs
@@ -168,12 +168,12 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 
 		private static bool HasDynamicFilterParam(SqlString sqlFragment)
 		{
-			return sqlFragment.IndexOfCaseInsensitive(ParserHelper.HqlVariablePrefix) < 0;
+			return !ParserHelper.HasHqlVariable(sqlFragment);
 		}
 
 		private static bool HasCollectionFilterParam(SqlString sqlFragment)
 		{
-			return sqlFragment.IndexOfCaseInsensitive("?") < 0;
+			return sqlFragment.IndexOfOrdinal("?") < 0;
 		}
 
 		private class JoinSequenceSelector : JoinSequence.ISelector

--- a/src/NHibernate/Hql/Ast/ANTLR/Util/SyntheticAndFactory.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Util/SyntheticAndFactory.cs
@@ -74,7 +74,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 			if (hqlSqlWalker.IsFilter())
 			{
 				//if (whereFragment.IndexOfCaseInsensitive("?") >= 0)
-                if (whereFragment.ToString().IndexOf("?") >= 0)
+                if (whereFragment.IndexOfOrdinal("?") >= 0)
                 {
 					IType collectionFilterKeyType = hqlSqlWalker.SessionFactoryHelper
 							.RequireQueryableCollection(hqlSqlWalker.CollectionFilterRole)

--- a/src/NHibernate/Hql/ParserHelper.cs
+++ b/src/NHibernate/Hql/ParserHelper.cs
@@ -1,3 +1,6 @@
+using System;
+using NHibernate.SqlCommand;
+
 namespace NHibernate.Hql
 {
 	public static class ParserHelper
@@ -13,7 +16,22 @@ namespace NHibernate.Hql
 
 		public static bool IsWhitespace(string str)
 		{
-			return Whitespace.IndexOf(str) > - 1;
+			return Whitespace.IndexOf(str, StringComparison.Ordinal) > - 1;
+		}
+
+		internal static bool HasHqlVariable(string value)
+		{
+			return value.IndexOf(HqlVariablePrefix, StringComparison.Ordinal) >= 0;
+		}
+		
+		internal static bool HasHqlVariable(SqlString value)
+		{
+			return value.IndexOfOrdinal(HqlVariablePrefix) >= 0;
+		}
+
+		internal static bool IsHqlVariable(string value)
+		{
+			return value.StartsWith(HqlVariablePrefix, StringComparison.Ordinal);
 		}
 	}
 }

--- a/src/NHibernate/Hql/ParserHelper.cs
+++ b/src/NHibernate/Hql/ParserHelper.cs
@@ -8,6 +8,7 @@ namespace NHibernate.Hql
 		public const string HqlVariablePrefix = ":";
 
 		public const string HqlSeparators = " \n\r\f\t,()=<>&|+-=/*'^![]#~\\;";
+		internal static readonly char[] HqlSeparatorsAsCharArray = HqlSeparators.ToCharArray();
 		//NOTICE: no " or . since they are part of (compound) identifiers
 		
 		public const string Whitespace = " \n\r\f\t";

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -2034,7 +2034,7 @@ namespace NHibernate.Impl
 
 		private string[] ParseFilterParameterName(string filterParameterName)
 		{
-			int dot = filterParameterName.IndexOf(".");
+			int dot = filterParameterName.IndexOf('.');
 			if (dot <= 0)
 			{
 				throw new ArgumentException("Invalid filter-parameter name format", "filterParameterName");

--- a/src/NHibernate/Loader/Criteria/CriteriaQueryTranslator.cs
+++ b/src/NHibernate/Loader/Criteria/CriteriaQueryTranslator.cs
@@ -344,10 +344,9 @@ namespace NHibernate.Loader.Criteria
 			// some messy, complex stuff here, since createCriteria() can take an
 			// aliased path, or a path rooted at the creating criteria instance
 			ICriteria parent = null;
-			if (path.IndexOf('.') > 0)
+			if (StringHelper.IsNotRoot(path, out var testAlias))
 			{
 				// if it is a compound path
-				string testAlias = StringHelper.Root(path);
 				if (!testAlias.Equals(subcriteria.Alias))
 				{
 					// and the qualifier is not the alias of this criteria
@@ -678,9 +677,8 @@ namespace NHibernate.Loader.Criteria
 
 		public string GetEntityName(ICriteria subcriteria, string propertyName)
 		{
-			if (propertyName.IndexOf('.') > 0)
+			if (StringHelper.IsNotRoot(propertyName, out var root))
 			{
-				string root = StringHelper.Root(propertyName);
 				ICriteria crit = GetAliasedCriteria(root);
 				if (crit != null)
 				{
@@ -692,9 +690,8 @@ namespace NHibernate.Loader.Criteria
 
 		public string GetSQLAlias(ICriteria criteria, string propertyName)
 		{
-			if (propertyName.IndexOf('.') > 0)
+			if (StringHelper.IsNotRoot(propertyName, out var root))
 			{
-				string root = StringHelper.Root(propertyName);
 				ICriteria subcriteria = GetAliasedCriteria(root);
 				if (subcriteria != null)
 				{
@@ -706,9 +703,8 @@ namespace NHibernate.Loader.Criteria
 
 		public string GetPropertyName(string propertyName)
 		{
-			if (propertyName.IndexOf('.') > 0)
+			if (StringHelper.IsNotRoot(propertyName, out var root))
 			{
-				string root = StringHelper.Root(propertyName);
 				ICriteria crit = GetAliasedCriteria(root);
 				if (crit != null)
 				{

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1753,7 +1753,7 @@ namespace NHibernate.Loader
 		protected SqlString ExpandDynamicFilterParameters(SqlString sqlString, ICollection<IParameterSpecification> parameterSpecs, ISessionImplementor session)
 		{
 			var enabledFilters = session.EnabledFilters;
-			if (enabledFilters.Count == 0 || sqlString.ToString().IndexOf(ParserHelper.HqlVariablePrefix) < 0)
+			if (enabledFilters.Count == 0 || !ParserHelper.HasHqlVariable(sqlString))
 			{
 				return sqlString;
 			}
@@ -1776,7 +1776,7 @@ namespace NHibernate.Loader
 
 				foreach (string token in tokens)
 				{
-					if (token.StartsWith(ParserHelper.HqlVariablePrefix))
+					if (ParserHelper.IsHqlVariable(token))
 					{
 						string filterParameterName = token.Substring(1);
 						string[] parts = StringHelper.ParseFilterParameterName(filterParameterName);

--- a/src/NHibernate/SqlCommand/SqlString.cs
+++ b/src/NHibernate/SqlCommand/SqlString.cs
@@ -404,6 +404,11 @@ namespace NHibernate.SqlCommand
 			return IndexOf(text, 0, _length, StringComparison.InvariantCultureIgnoreCase);
 		}
 
+		internal int IndexOfOrdinal(string text)
+		{
+			return IndexOf(text, 0, _length, StringComparison.Ordinal);
+		}
+
 		/// <summary>
 		/// Returns the index of the first occurrence of <paramref name="text" />, case-insensitive.
 		/// </summary>

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -203,7 +203,7 @@ namespace NHibernate.Util
 				// for the same generic-entity implementation
 				return GetClassname(qualifiedName);
 			}
-			return Unqualify(qualifiedName, ".");
+			return Unqualify(qualifiedName, '.');
 		}
 
 		/// <summary>
@@ -213,6 +213,11 @@ namespace NHibernate.Util
 		/// <param name="seperator"></param>
 		/// <returns></returns>
 		public static string Unqualify(string qualifiedName, string seperator)
+		{
+			return qualifiedName.Substring(qualifiedName.LastIndexOf(seperator) + 1);
+		}
+		
+		internal static string Unqualify(string qualifiedName, char seperator)
 		{
 			return qualifiedName.Substring(qualifiedName.LastIndexOf(seperator) + 1);
 		}
@@ -257,7 +262,7 @@ namespace NHibernate.Util
 		/// <returns></returns>
 		public static string Qualifier(string qualifiedName)
 		{
-			int loc = qualifiedName.LastIndexOf(".");
+			int loc = qualifiedName.LastIndexOf('.');
 			if (loc < 0)
 			{
 				return String.Empty;
@@ -328,10 +333,26 @@ namespace NHibernate.Util
 		/// <returns></returns>
 		public static string Root(string qualifiedName)
 		{
-			int loc = qualifiedName.IndexOf(".");
+			int loc = qualifiedName.IndexOf('.');
 			return (loc < 0)
 					? qualifiedName
 					: qualifiedName.Substring(0, loc);
+		}
+
+		/// <summary>
+		/// Returns true if given name is not root property name
+		/// </summary>
+		/// <param name="qualifiedName"></param>
+		/// <param name="root">Returns root name</param>
+		internal static bool IsNotRoot(string qualifiedName, out string root)
+		{
+			root = qualifiedName;
+			int loc = qualifiedName.IndexOf('.');
+			if (loc < 0)
+				return false;
+
+			root = qualifiedName.Substring(0, loc);
+			return true;
 		}
 
 		/// <summary>
@@ -628,7 +649,7 @@ namespace NHibernate.Util
 
 		public static string Unroot(string qualifiedName)
 		{
-			int loc = qualifiedName.IndexOf(".");
+			int loc = qualifiedName.IndexOf('.');
 			return (loc < 0) ? qualifiedName : qualifiedName.Substring(loc + 1);
 		}
 
@@ -723,7 +744,7 @@ namespace NHibernate.Util
 
 		public static string[] ParseFilterParameterName(string filterParameterName)
 		{
-			int dot = filterParameterName.IndexOf(".");
+			int dot = filterParameterName.IndexOf('.');
 			if (dot <= 0)
 			{
 				throw new ArgumentException("Invalid filter-parameter name format; the name should be a property path.", "filterParameterName");

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -548,7 +548,12 @@ namespace NHibernate.Util
 
 		public static int FirstIndexOfChar(string sqlString, string str, int startIndex)
 		{
-			return sqlString.IndexOfAny(str.ToCharArray(), startIndex);
+			return FirstIndexOfChar(sqlString, str.ToCharArray(), startIndex);
+		}
+		
+		internal static int FirstIndexOfChar(string sqlString, char[] chars, int startIndex)
+		{
+			return sqlString.IndexOfAny(chars, startIndex);
 		}
 
 		public static string Truncate(string str, int length)


### PR DESCRIPTION
I've started with 'StringHelper.Root' refactoring to avoid double search. But somehow ended up 
with bunch of other string related changes :)

1) StringHelper.Root refactored to get rid of double search;
2) string.IndexOf - use ordinal comparison where applicable;
3) No need to convert full string to lowercase for StartsWith comparison;
4) Avoid SqlString.ToString conversion;
5) Optimized and generalized HqlVariablePrefix usage;

It's better to review per commit to better understand the scope of changes.