### PR TITLE
Remove a redundant argument in Linq provider ExecuteQuery.

### DIFF
--- a/src/NHibernate/Async/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Async/Linq/DefaultQueryProvider.cs
@@ -31,6 +31,8 @@ namespace NHibernate.Linq
 	public partial class DefaultQueryProvider : INhQueryProvider, IQueryProviderWithOptions
 	{
 
+		// Since v5.1
+		[Obsolete("Use ExecuteQuery(NhLinqExpression nhLinqExpression, IQuery query) instead")]
 		protected virtual async Task<object> ExecuteQueryAsync(NhLinqExpression nhLinqExpression, IQuery query, NhLinqExpression nhQuery, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -54,6 +56,18 @@ namespace NHibernate.Linq
 			}
 
 			return results[0];
+		}
+
+		protected virtual Task<object> ExecuteQueryAsync(NhLinqExpression nhLinqExpression, IQuery query, CancellationToken cancellationToken)
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromCanceled<object>(cancellationToken);
+			}
+			// For avoiding breaking derived classes, call the obsolete method until it is dropped.
+#pragma warning disable 618
+			return ExecuteQueryAsync(nhLinqExpression, query, nhLinqExpression, cancellationToken);
+#pragma warning restore 618
 		}
 
 		public Task<int> ExecuteDmlAsync<T>(QueryMode queryMode, Expression expression, CancellationToken cancellationToken)

--- a/src/NHibernate/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Linq/DefaultQueryProvider.cs
@@ -77,10 +77,9 @@ namespace NHibernate.Linq
 
 		public virtual object Execute(Expression expression)
 		{
-			IQuery query;
-			NhLinqExpression nhLinqExpression = PrepareQuery(expression, out query);
+			NhLinqExpression nhLinqExpression = PrepareQuery(expression, out var query);
 
-			return ExecuteQuery(nhLinqExpression, query, nhLinqExpression);
+			return ExecuteQuery(nhLinqExpression, query);
 		}
 
 		public TResult Execute<TResult>(Expression expression)
@@ -153,7 +152,7 @@ namespace NHibernate.Linq
 			try
 			{
 				var nhLinqExpression = PrepareQuery(expression, out var query);
-				return ExecuteQueryAsync(nhLinqExpression, query, nhLinqExpression, cancellationToken);
+				return ExecuteQueryAsync(nhLinqExpression, query, cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -181,6 +180,8 @@ namespace NHibernate.Linq
 			return nhLinqExpression;
 		}
 
+		// Since v5.1
+		[Obsolete("Use ExecuteQuery(NhLinqExpression nhLinqExpression, IQuery query) instead")]
 		protected virtual object ExecuteQuery(NhLinqExpression nhLinqExpression, IQuery query, NhLinqExpression nhQuery)
 		{
 			IList results = query.List();
@@ -203,6 +204,14 @@ namespace NHibernate.Linq
 			}
 
 			return results[0];
+		}
+
+		protected virtual object ExecuteQuery(NhLinqExpression nhLinqExpression, IQuery query)
+		{
+			// For avoiding breaking derived classes, call the obsolete method until it is dropped.
+#pragma warning disable 618
+			return ExecuteQuery(nhLinqExpression, query, nhLinqExpression);
+#pragma warning restore 618
 		}
 
 		private static void SetParameters(IQuery query, IDictionary<string, Tuple<object, IType>> parameters)


### PR DESCRIPTION
Just a small simplification.

But it was while thinking about it that I realize #448 has made breaking changes by obsoleting overridable methods and ceasing using them. Here the change is done in a non-breaking way, even for deriving classes.