### PR TITLE
Add a missing short circuit in query parameter expansion.

### DIFF
--- a/src/NHibernate/Impl/ExpressionQueryImpl.cs
+++ b/src/NHibernate/Impl/ExpressionQueryImpl.cs
@@ -66,6 +66,13 @@ namespace NHibernate.Impl
 				map.Add(name, aliases);
 			}
 
+			if (map.Count == 0)
+			{
+				// No list parameter needs to be replaced: they are all single valued. They just need
+				// to be retyped, which has been done above.
+				return QueryExpression;
+			}
+
 			//TODO: Do we need to translate expression one more time here?
 			var newTree = ParameterExpander.Expand(QueryExpression.Translate(Session.Factory, false), map);
 			var key = new StringBuilder(QueryExpression.Key);


### PR DESCRIPTION
 * This should have been the fix for NH-3050.

As explained in #1547 first commit rationals, queries having a list parameter need some additional processing once its value is known. This parameter (having a list value) may need to be removed in case of empty list, or replaced by a list of parameters representing one value of the list each.

But when the list has only one value, the parameter is not replaced but just retyped to the list element type, with its value changed from the list to the single value. In such case the query is not changed.

This was already rightfully short-circuited for `AbstractQueryImpl`, by yielding back the same query string. But for `ExpressionQueryImpl` (used by LINQ queries), a new `IQueryExpression` was computed anyway, while being in fine identical to the original one. (Its type excepted, leading to NH-3050: you can check its test cases, they use on purpose a single value list parameter, otherwise they could not reproduce the trouble.)

So here an additional short-circuit has been added to just yield the original query in this case. (NH-3050 test cases do indeed test this change by the way.)

NH-3050 original solution could be reverted with this change, but on its principles its solution stays also valid (it does include query expression type in the plan key). So better leave it in place.