### PR TITLE
Assert for a null reference in a flaky test.

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3634/FixtureByCode.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3634/FixtureByCode.cs
@@ -129,6 +129,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .Where(p => p.Connection == componentToCompare)
 								   .SingleOrDefaultAsync<Person>());
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}
@@ -164,6 +165,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 				                   .Add(Restrictions.Eq("Connection", componentToCompare))
 				                   .UniqueResultAsync<Person>());
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}
@@ -187,6 +189,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResultAsync<CachedPerson>());
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
 				Assert.That(cached.Connection.PortName, Is.Null);
 
@@ -234,6 +237,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResultAsync<CachedPerson>());
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNotNull"));
 				Assert.That(cached.Connection.PortName, Is.Not.Null);
 
@@ -281,6 +285,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResultAsync<CachedPerson>());
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
 				Assert.That(cached.Connection.PortName, Is.Null);
 
@@ -303,6 +308,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResultAsync<CachedPerson>());
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
 				Assert.That(cached.Connection.PortName, Is.Null);
 
@@ -332,6 +338,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 				                   .And(p => p.Connection.ConnectionType == "http")
 				                   .SingleOrDefaultAsync<Person>());
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}
@@ -349,6 +356,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 				                   .Add(Restrictions.Eq("Connection.ConnectionType", "http"))
 				                   .UniqueResultAsync<Person>());
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/FixtureByCode.cs
@@ -118,6 +118,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .Where(p => p.Connection == componentToCompare)
 								   .SingleOrDefault<Person>();
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}
@@ -153,6 +154,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 				                   .Add(Restrictions.Eq("Connection", componentToCompare))
 				                   .UniqueResult<Person>();
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}
@@ -176,6 +178,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResult<CachedPerson>();
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
 				Assert.That(cached.Connection.PortName, Is.Null);
 
@@ -223,6 +226,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResult<CachedPerson>();
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNotNull"));
 				Assert.That(cached.Connection.PortName, Is.Not.Null);
 
@@ -270,6 +274,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResult<CachedPerson>();
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
 				Assert.That(cached.Connection.PortName, Is.Null);
 
@@ -292,6 +297,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 								   .SetCacheable(true)
 								   .UniqueResult<CachedPerson>();
 
+				Assert.That(cached, Is.Not.Null);
 				Assert.That(cached.Name, Is.EqualTo("CachedNull"));
 				Assert.That(cached.Connection.PortName, Is.Null);
 
@@ -321,6 +327,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 				                   .And(p => p.Connection.ConnectionType == "http")
 				                   .SingleOrDefault<Person>();
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}
@@ -338,6 +345,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 				                   .Add(Restrictions.Eq("Connection.ConnectionType", "http"))
 				                   .UniqueResult<Person>();
 
+				Assert.That(sally, Is.Not.Null);
 				Assert.That(sally.Name, Is.EqualTo("Sally"));
 				Assert.That(sally.Connection.PortName, Is.Null);
 			}


### PR DESCRIPTION
As seen [here](https://teamcity.jetbrains.com/viewLog.html?buildId=1301284&buildTypeId=bt877), this test sometimes fails with a `NullReferenceException`. 

This change does not fix its flakyness, but at least fix its asserts for avoiding the null reference exception.