### PR TITLE
Aggregate named queries validation exceptions.

### DIFF
--- a/src/NHibernate.Test/QueryTest/BadNamedQueriesFixture.cs
+++ b/src/NHibernate.Test/QueryTest/BadNamedQueriesFixture.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections;
+using NHibernate.Cfg;
+using NHibernate.Exceptions;
+using NUnit.Framework;
+
+namespace NHibernate.Test.QueryTest
+{
+	[TestFixture]
+	public class BadNamedQueriesFixture : TestCase
+	{
+		protected override IList Mappings => new[] { "QueryTest.BadNamedQueriesFixture.hbm.xml" };
+
+		protected override string MappingsAssembly => "NHibernate.Test";
+
+		protected override void Configure(Configuration configuration)
+		{
+			// Allow building of default session factory
+			configuration.SetProperty(Cfg.Environment.QueryStartupChecking, "false");
+		}
+
+		protected override void OnSetUp()
+		{
+			cfg.SetProperty(Cfg.Environment.QueryStartupChecking, "true");
+		}
+
+		protected override void OnTearDown()
+		{
+			cfg.SetProperty(Cfg.Environment.QueryStartupChecking, "false");
+		}
+
+		[Test]
+		public void StartupCheck()
+		{
+			Assert.That(
+				BuildSessionFactory,
+				Throws
+					.InstanceOf<AggregateHibernateException>()
+					.And.Property(nameof(AggregateHibernateException.InnerExceptions)).Count.EqualTo(2));
+		}
+	}
+}

--- a/src/NHibernate.Test/QueryTest/BadNamedQueriesFixture.hbm.xml
+++ b/src/NHibernate.Test/QueryTest/BadNamedQueriesFixture.hbm.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
+                   namespace="NHibernate.Test.QueryTest"
+                   assembly="NHibernate.Test">
+  <query name="Bad1">
+    from NonExistent
+  </query>
+  <query name="Bad2">
+    blah
+  </query>
+</hibernate-mapping>

--- a/src/NHibernate/Exceptions/AggregateHibernateException.cs
+++ b/src/NHibernate/Exceptions/AggregateHibernateException.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Security;
+using System.Text;
+
+namespace NHibernate.Exceptions
+{
+	/// <summary>
+	/// Exception aggregating exceptions that occurs in the O-R persistence layer.
+	/// </summary>
+	[Serializable]
+	public class AggregateHibernateException : HibernateException
+	{
+		public ReadOnlyCollection<Exception> InnerExceptions { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AggregateHibernateException"/> class.
+		/// </summary>
+		/// <param name="innerExceptions">The exceptions to aggregate.</param>
+		public AggregateHibernateException(IEnumerable<Exception> innerExceptions) :
+			this(
+				$"Exceptions occurred in the persistence layer, check {nameof(InnerExceptions)} property.",
+				innerExceptions)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AggregateHibernateException"/> class.
+		/// </summary>
+		/// <param name="innerExceptions">The exceptions to aggregate.</param>
+		public AggregateHibernateException(params Exception[] innerExceptions) :
+			this(innerExceptions?.ToList())
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="HibernateException"/> class.
+		/// </summary>
+		/// <param name="message">The message that describes the error.</param>
+		/// <param name="innerExceptions">The exceptions to aggregate.</param>
+		public AggregateHibernateException(string message, IEnumerable<Exception> innerExceptions) :
+			this(message, innerExceptions?.ToList())
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="HibernateException"/> class.
+		/// </summary>
+		/// <param name="message">The message that describes the error.</param>
+		/// <param name="innerExceptions">The exceptions to aggregate.</param>
+		public AggregateHibernateException(string message, params Exception[] innerExceptions) :
+			this(message, innerExceptions?.ToList())
+		{
+		}
+
+		private AggregateHibernateException(string message, IList<Exception> innerExceptions) :
+			base(
+				message,
+				innerExceptions?.FirstOrDefault())
+		{
+			if (innerExceptions == null)
+				throw new ArgumentNullException(nameof(innerExceptions));
+			if (innerExceptions.Count == 0)
+				throw new ArgumentException("Exceptions list to aggregate is empty", nameof(innerExceptions));
+			if (innerExceptions.Any(e => e == null))
+				throw new ArgumentException("Exceptions list to aggregate contains a null exception", nameof(innerExceptions));
+			InnerExceptions = new ReadOnlyCollection<Exception>(innerExceptions);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AggregateHibernateException"/> class
+		/// with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The <see cref="SerializationInfo"/> that holds the serialized object
+		/// data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The <see cref="StreamingContext"/> that contains contextual information about the source or destination.
+		/// </param>
+		protected AggregateHibernateException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+			InnerExceptions = (ReadOnlyCollection<Exception>) info.GetValue("InnerExceptions", typeof(ReadOnlyCollection<Exception>));
+		}
+
+		[SecurityCritical]
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue("InnerExceptions", InnerExceptions);
+		}
+
+		/// <summary>
+		/// Return a string representation of the aggregate exception.
+		/// </summary>
+		/// <returns>A string representation with inner exceptions.</returns>
+		public override string ToString()
+		{
+			var str = new StringBuilder(base.ToString());
+			for (var i = 0; i < InnerExceptions.Count; i++)
+			{
+				str
+					.AppendLine()
+					.Append("---> (Inner exception #").Append(i).Append(") ")
+					.Append(InnerExceptions[i]).AppendLine("<---");
+			}
+			return str.ToString();
+		}
+	}
+}

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -402,7 +402,7 @@ namespace NHibernate.Impl
 						failingQueries.Append('{').Append(pair.Key).Append('}');
 						log.Error(pair.Value, "Error in named query: {0}", pair.Key);
 					}
-					throw new HibernateException(failingQueries.ToString());
+					throw new AggregateHibernateException(failingQueries.ToString(), errors.Values);
 				}
 			}
 			#endregion


### PR DESCRIPTION
 They were only logged, which is unpractical for applications not having NHibernate logs enabled, and is also unpractical when debugging.