### PR TITLE
Deep removal of Fetch result operators when Any is used

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/AnyTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/AnyTests.cs
@@ -54,7 +54,26 @@ namespace NHibernate.Test.Linq.ByMethod
 		public void AnyWithFetch()
 		{
 			//NH-3241
-			var result = db.Orders.Fetch(x => x.Customer).FetchMany(x => x.OrderLines).Any();
+			Assert.DoesNotThrow(() =>
+				{
+				var result = db.Orders.Fetch(x => x.Customer).FetchMany(x => x.OrderLines).Any();
+				}
+			);
+		}
+
+		[Test]
+		public void AnyWithFetchInSubQuery()
+		{
+			Assert.DoesNotThrow(() =>
+				{
+					var result = db.Orders
+					               .Where(x => x.Customer.CustomerId == "Test")
+					               .Fetch(x => x.Customer)
+					               .FetchMany(x => x.OrderLines)
+					               .Where(x => x.Freight > 1)
+					               .Count();
+				}
+			);
 		}
 	}
 }

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -36,8 +36,7 @@ namespace NHibernate.Linq.ReWriters
 			}
 			if (resultOperator is AnyResultOperator)
 			{
-				Array.ForEach(queryModel.ResultOperators.OfType<FetchOneRequest>().ToArray(), op => queryModel.ResultOperators.Remove(op));
-				Array.ForEach(queryModel.ResultOperators.OfType<FetchManyRequest>().ToArray(), op => queryModel.ResultOperators.Remove(op));
+				ResultOperatorRemover.Remove(queryModel, x=>x is FetchRequestBase);
 			}
 			base.VisitResultOperator(resultOperator, queryModel, index);
 		}

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -36,7 +36,7 @@ namespace NHibernate.Linq.ReWriters
 			}
 			if (resultOperator is AnyResultOperator)
 			{
-				ResultOperatorRemover.Remove(queryModel, x=>x is FetchRequestBase);
+				ResultOperatorRemover.Remove(queryModel, x => x is FetchRequestBase);
 			}
 			base.VisitResultOperator(resultOperator, queryModel, index);
 		}

--- a/src/NHibernate/Linq/ReWriters/ResultOperatorRemover.cs
+++ b/src/NHibernate/Linq/ReWriters/ResultOperatorRemover.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using NHibernate.Linq.Visitors;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace NHibernate.Linq.ReWriters
+{
+	public class ResultOperatorRemover : NhQueryModelVisitorBase
+	{
+		private readonly Func<ResultOperatorBase, bool> _predicate;
+
+		private ResultOperatorRemover(Func<ResultOperatorBase, bool> predicate)
+		{
+			_predicate = predicate;
+		}
+
+		public static void Remove(QueryModel queryModel, Func<ResultOperatorBase, bool> predicate)
+		{
+			var rewriter = new ResultOperatorRemover(predicate);
+
+			rewriter.VisitQueryModel(queryModel);
+		}
+
+		public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
+		{
+			if (_predicate(resultOperator))
+			{
+				queryModel.ResultOperators.Remove(resultOperator);
+				return;
+			}
+			base.VisitResultOperator(resultOperator, queryModel, index);
+		}
+
+		public override void VisitAdditionalFromClause(AdditionalFromClause fromClause, QueryModel queryModel, int index)
+		{
+			var subQueryExpression = fromClause.FromExpression as SubQueryExpression;
+			if (subQueryExpression != null)
+				VisitQueryModel(subQueryExpression.QueryModel);
+			base.VisitAdditionalFromClause(fromClause, queryModel, index);
+		}
+
+		public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
+		{
+			var subQueryExpression = fromClause.FromExpression as SubQueryExpression;
+			if (subQueryExpression != null)
+				VisitQueryModel(subQueryExpression.QueryModel);
+			base.VisitMainFromClause(fromClause, queryModel);
+		}
+
+	}
+}


### PR DESCRIPTION
This was already partially fixed in #140 , but failed when a Fetch was used in a subquery. 