### PR TITLE
Fix round registration

### DIFF
--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -521,6 +521,65 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public async Task RoundAsync()
+		{
+			AssumeFunctionSupported("round");
+
+			using (var s = OpenSession())
+			{
+				var a1 = new Animal("a1", 1.87f);
+				await (s.SaveAsync(a1));
+				var m1 = new MaterialResource("m1", "18", MaterialResource.MaterialState.Available) { Cost = 51.76m };
+				await (s.SaveAsync(m1));
+				await (s.FlushAsync());
+			}
+			using (var s = OpenSession())
+			{
+				var roundF = await (s.CreateQuery("select round(a.BodyWeight) from Animal a").UniqueResultAsync<float>());
+				Assert.That(roundF, Is.EqualTo(2), "Selecting round(double) failed.");
+				var countF =
+					await (s
+						.CreateQuery("select count(*) from Animal a where round(a.BodyWeight) = :c")
+						.SetInt32("c", 2)
+						.UniqueResultAsync<long>());
+				Assert.That(countF, Is.EqualTo(1), "Filtering round(double) failed.");
+				
+				roundF = await (s.CreateQuery("select round(a.BodyWeight, 1) from Animal a").UniqueResultAsync<float>());
+				Assert.That(roundF, Is.EqualTo(1.9f).Within(0.01f), "Selecting round(double, 1) failed.");
+				countF =
+					await (s
+						.CreateQuery("select count(*) from Animal a where round(a.BodyWeight, 1) between :c1 and :c2")
+						.SetDouble("c1", 1.89)
+						.SetDouble("c2", 1.91)
+						.UniqueResultAsync<long>());
+				Assert.That(countF, Is.EqualTo(1), "Filtering round(double, 1) failed.");
+
+				var roundD = await (s.CreateQuery("select round(m.Cost) from MaterialResource m").UniqueResultAsync<decimal?>());
+				Assert.That(roundD, Is.EqualTo(52), "Selecting round(decimal) failed.");
+				var count =
+					await (s
+						.CreateQuery("select count(*) from MaterialResource m where round(m.Cost) = :c")
+						.SetInt32("c", 52)
+						.UniqueResultAsync<long>());
+				Assert.That(count, Is.EqualTo(1), "Filtering round(decimal) failed.");
+
+				roundD = await (s.CreateQuery("select round(m.Cost, 1) from MaterialResource m").UniqueResultAsync<decimal?>());
+				Assert.That(roundD, Is.EqualTo(51.8m), "Selecting round(decimal, 1) failed.");
+
+				if (TestDialect.HasBrokenDecimalType)
+					// SQLite fails the equality test due to using double instead, wich requires a tolerance.
+					return;
+
+				count =
+					await (s
+						.CreateQuery("select count(*) from MaterialResource m where round(m.Cost, 1) = :c")
+						.SetDecimal("c", 51.8m)
+						.UniqueResultAsync<long>());
+				Assert.That(count, Is.EqualTo(1), "Filtering round(decimal, 1) failed.");
+			}
+		}
+
+		[Test]
 		public async Task ModAsync()
 		{
 			AssumeFunctionSupported("mod");

--- a/src/NHibernate.Test/Hql/MaterialResource.cs
+++ b/src/NHibernate.Test/Hql/MaterialResource.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace NHibernate.Test.Hql
 {
 	public class MaterialResource
@@ -51,5 +49,6 @@ namespace NHibernate.Test.Hql
 			set { _state = value; }
 		}
 
+		public virtual decimal? Cost { get; set; }
 	}
 }

--- a/src/NHibernate.Test/Hql/MaterialResource.hbm.xml
+++ b/src/NHibernate.Test/Hql/MaterialResource.hbm.xml
@@ -12,5 +12,6 @@
 		<property name="Description"/>
 		<property name="SerialNumber" length="20"/>
 		<property name="State" type="int"/>
+		<property name="Cost" access="property"/>
 	</class>
 </hibernate-mapping>

--- a/src/NHibernate/Dialect/Function/RoundFunction.cs
+++ b/src/NHibernate/Dialect/Function/RoundFunction.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using NHibernate.Engine;
+using NHibernate.SqlCommand;
+using NHibernate.Type;
+using System;
+
+namespace NHibernate.Dialect.Function
+{
+	/// <summary>
+	/// Provides a round implementation that supports single parameter round by translating to two parameters round.
+	/// </summary>
+	[Serializable]
+	public class RoundEmulatingSingleParameterFunction : ISQLFunction
+	{
+		private static readonly ISQLFunction SingleParamRound = new SQLFunctionTemplate(null, "round(?1, 0)");
+
+		private static readonly ISQLFunction Round = new StandardSQLFunction("round");
+
+		public IType ReturnType(IType columnType, IMapping mapping) => columnType;
+
+		public bool HasArguments => true;
+
+		public bool HasParenthesesIfNoArguments => true;
+
+		public SqlString Render(IList args, ISessionFactoryImplementor factory)
+		{
+			return args.Count == 1 ? SingleParamRound.Render(args, factory) : Round.Render(args, factory);
+		}
+
+		public override string ToString() => "round";
+	}
+}

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -286,7 +286,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));
 			RegisterFunction("ceil", new StandardSQLFunction("ceiling"));
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
-			RegisterFunction("round", new StandardSQLFunction("round"));
+			RegisterFunction("round", new RoundEmulatingSingleParameterFunction());
 
 			RegisterFunction("power", new StandardSQLFunction("power", NHibernateUtil.Double));
 

--- a/src/NHibernate/Dialect/MsSqlCeDialect.cs
+++ b/src/NHibernate/Dialect/MsSqlCeDialect.cs
@@ -194,7 +194,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", "+", ")"));
 			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
 
-			RegisterFunction("round", new StandardSQLFunction("round"));
+			RegisterFunction("round", new RoundEmulatingSingleParameterFunction());
 
 			RegisterFunction("bit_length", new SQLFunctionTemplate(NHibernateUtil.Int32, "datalength(?1) * 8"));
 			RegisterFunction("extract", new SQLFunctionTemplate(NHibernateUtil.Int32, "datepart(?1, ?3)"));

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -1,10 +1,14 @@
+using System;
+using System.Collections;
 using System.Data;
 using System.Data.Common;
-using NHibernate.Cfg;
 using NHibernate.Dialect.Function;
 using NHibernate.Dialect.Schema;
+using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
+using NHibernate.Type;
+using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Dialect
 {
@@ -65,7 +69,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
 
 			RegisterFunction("sign", new StandardSQLFunction("sign", NHibernateUtil.Int32));
-			RegisterFunction("round", new SQLFunctionTemplate(NHibernateUtil.Double, "round(cast(?1 as numeric), ?2)"));
+			RegisterFunction("round", new RoundFunction());
 
 			// Trigonometric functions.
 			RegisterFunction("acos", new StandardSQLFunction("acos", NHibernateUtil.Double));
@@ -313,5 +317,30 @@ namespace NHibernate.Dialect
 		public override bool SupportsUnboundedLobLocatorMaterialization => false;
 
 		#endregion
+
+		[Serializable]
+		private class RoundFunction : ISQLFunction
+		{
+			private static readonly ISQLFunction Round = new StandardSQLFunction("round");
+
+			// PostgreSQL round with two arguments only accepts decimal as input, thus the cast.
+			// It also yields only decimal, but for emulating similar behavior to other databases, we need
+			// to have it converted to the original input type, which will be done by NHibernate thanks to
+			// not specifying the function type.
+			private static readonly ISQLFunction RoundWith2Params = new SQLFunctionTemplate(null, "round(cast(?1 as numeric), ?2)");
+
+			public IType ReturnType(IType columnType, IMapping mapping) => columnType;
+
+			public bool HasArguments => true;
+
+			public bool HasParenthesesIfNoArguments => true;
+
+			public SqlString Render(IList args, ISessionFactoryImplementor factory)
+			{
+				return args.Count == 2 ? RoundWith2Params.Render(args, factory) : Round.Render(args, factory);
+			}
+
+			public override string ToString() => "round";
+		}
 	}
 }


### PR DESCRIPTION
 * PostgreSQL:
   * It was yielding double on decimal columns.
   * It was failing on no-second-argument round.
 * SQL Server and SQL Server Compact Edition:
   * They were not supporting single argument round.