### PR TITLE
Prevent substitute garbage collection

### DIFF
--- a/src/NHibernate.Test/Linq/ByMethod/WithOptionsTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/WithOptionsTests.cs
@@ -41,6 +41,10 @@ namespace NHibernate.Test.Linq.ByMethod
 			query.Received(1).SetCacheMode(CacheMode.Normal);
 			query.Received(1).SetCacheRegion("testregion");
 			query.Received(1).SetTimeout(10);
+
+			// Prevent garbage collection of session substitute before end of test, since the Linq query provider
+			// only has a weak reference on it.
+			Assert.That(session, Is.Not.Null);
 		}
 		
 		[Test]
@@ -72,6 +76,10 @@ namespace NHibernate.Test.Linq.ByMethod
 			query.Received(1).SetCacheMode(CacheMode.Normal);
 			query.Received(1).SetCacheRegion("testregion");
 			query.Received(1).SetTimeout(10);
+
+			// Prevent garbage collection of session substitute before end of test, since the Linq query provider
+			// only has a weak reference on it.
+			Assert.That(session, Is.Not.Null);
 		}
 
 		[Test]
@@ -101,6 +109,10 @@ namespace NHibernate.Test.Linq.ByMethod
 			query.Received(1).SetCacheMode(CacheMode.Normal);
 			query.Received(1).SetCacheRegion("testregion");
 			query.Received(1).SetTimeout(10);
+
+			// Prevent garbage collection of session substitute before end of test, since the Linq query provider
+			// only has a weak reference on it.
+			Assert.That(session, Is.Not.Null);
 		}
 		
 		[Test]
@@ -133,6 +145,10 @@ namespace NHibernate.Test.Linq.ByMethod
 			query.Received(1).SetCacheMode(CacheMode.Normal);
 			query.Received(1).SetCacheRegion("testregion");
 			query.Received(1).SetTimeout(10);
+
+			// Prevent garbage collection of session substitute before end of test, since the Linq query provider
+			// only has a weak reference on it.
+			Assert.That(session, Is.Not.Null);
 		}
 	}
 }


### PR DESCRIPTION
As seen in this [build](https://teamcity.jetbrains.com/viewLog.html?buildId=1335400&buildTypeId=NHibernate_NHibernateReleasePackage), the session substitute may be garbage collected before the end of some tests, causing them to be flaky.

Example stacktrace:
```
System.InvalidOperationException : Session has already been garbage collected
   at NHibernate.Linq.DefaultQueryProvider.get_Session() in D:\BuildAgent\work\30546188361a242\src\NHibernate\Linq\DefaultQueryProvider.cs:line 73
   at NHibernate.Linq.DefaultQueryProvider.PrepareQuery(Expression expression, IQuery& query) in D:\BuildAgent\work\30546188361a242\src\NHibernate\Linq\DefaultQueryProvider.cs:line 165
   at NHibernate.Linq.DefaultQueryProvider.Execute(Expression expression) in D:\BuildAgent\work\30546188361a242\src\NHibernate\Linq\DefaultQueryProvider.cs:line 80
   at NHibernate.Linq.DefaultQueryProvider.Execute[TResult](Expression expression) in D:\BuildAgent\work\30546188361a242\src\NHibernate\Linq\DefaultQueryProvider.cs:line 87
   at Remotion.Linq.QueryableBase`1.GetEnumerator()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at NHibernate.Test.Linq.ByMethod.WithOptionsTests.DoNotContaminateQueryWithOptions() in D:\BuildAgent\work\30546188361a242\src\NHibernate.Test\Linq\ByMethod\WithOptionsTests.cs:line 60
```

Adding an assert on the session at the end of the test should prevent this.