### PR TITLE
Substitute DbType.Currency with DbType.Decimal in OracleManagedDataClientDriver and OracleDataClientDriver

### DIFF
--- a/src/NHibernate.Test/Async/TypesTest/CurrencyTypeFixture.cs
+++ b/src/NHibernate.Test/Async/TypesTest/CurrencyTypeFixture.cs
@@ -26,9 +26,6 @@ namespace NHibernate.Test.TypesTest
 		[Test]
 		public async Task ReadWriteAsync()
 		{
-			if (Dialect is Oracle8iDialect)
-				Assert.Ignore("The Oracle dialect maps currency as Number(20, 2), this test can only fail.");
-
 			const decimal expected = 5.6435M;
 
 			var basic = new CurrencyClass {CurrencyValue = expected};

--- a/src/NHibernate.Test/TypesTest/CurrencyTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/CurrencyTypeFixture.cs
@@ -40,9 +40,6 @@ namespace NHibernate.Test.TypesTest
 		[Test]
 		public void ReadWrite()
 		{
-			if (Dialect is Oracle8iDialect)
-				Assert.Ignore("The Oracle dialect maps currency as Number(20, 2), this test can only fail.");
-
 			const decimal expected = 5.6435M;
 
 			var basic = new CurrencyClass {CurrencyValue = expected};

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -182,7 +182,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.UInt32, "NUMBER(10,0)");
 			RegisterColumnType(DbType.UInt64, "NUMBER(20,0)");
 
-			RegisterColumnType(DbType.Currency, "NUMBER(20,2)");
+			RegisterColumnType(DbType.Currency, "NUMBER(22,4)");
 			RegisterColumnType(DbType.Single, "FLOAT(24)");
 			RegisterColumnType(DbType.Double, "DOUBLE PRECISION");
 			// Oracle max precision is 39-40, but .Net is limited to 28-29.

--- a/src/NHibernate/Driver/OracleDataClientDriverBase.cs
+++ b/src/NHibernate/Driver/OracleDataClientDriverBase.cs
@@ -129,6 +129,9 @@ namespace NHibernate.Driver
 					else
 						base.InitializeParameter(dbParam, name, sqlType);
 					break;
+				case DbType.Currency:
+					base.InitializeParameter(dbParam, name, SqlTypeFactory.Decimal);
+					break;
 				default:
 					base.InitializeParameter(dbParam, name, sqlType);
 					break;


### PR DESCRIPTION
- Align DbType.Currency registration in Oracle8iDialect to other dialects & DbType.Currency specification

Fixes #1052