### PR TITLE
Set MySqlClientBatchingBatcher as a default batcher for MySqlDataDriver

### DIFF
--- a/src/NHibernate/AdoNet/MySqlClientBatchingBatcher.cs
+++ b/src/NHibernate/AdoNet/MySqlClientBatchingBatcher.cs
@@ -39,6 +39,10 @@ namespace NHibernate.AdoNet
 
 		public override void AddToBatch(IExpectation expectation)
 		{
+			// MySql batcher cannot be initiated if a data reader is still open: check them.
+			if (CountOfStatementsInCurrentBatch == 0)
+				CheckReaders();
+
 			totalExpectedRowsAffected += expectation.ExpectedRowCount;
 			var batchUpdate = CurrentCommand;
 			Prepare(batchUpdate);

--- a/src/NHibernate/AdoNet/MySqlClientSqlCommandSet.cs
+++ b/src/NHibernate/AdoNet/MySqlClientSqlCommandSet.cs
@@ -51,19 +51,12 @@ namespace NHibernate.AdoNet
 
 		public int ExecuteNonQuery()
 		{
-			try
+			if (CountOfCommands == 0)
 			{
-				if (CountOfCommands == 0)
-				{
-					return 0;
-				}
+				return 0;
+			}
 
-				return doExecuteNonQuery(instance);
-			}
-			catch (Exception exception)
-			{
-				throw new HibernateException("An exception occured when executing batch queries", exception);
-			}
+			return doExecuteNonQuery(instance);
 		}
 
 		public int CountOfCommands

--- a/src/NHibernate/Async/AdoNet/MySqlClientBatchingBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/MySqlClientBatchingBatcher.cs
@@ -24,6 +24,10 @@ namespace NHibernate.AdoNet
 		public override async Task AddToBatchAsync(IExpectation expectation, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
+			// MySql batcher cannot be initiated if a data reader is still open: check them.
+			if (CountOfStatementsInCurrentBatch == 0)
+				await (CheckReadersAsync(cancellationToken)).ConfigureAwait(false);
+
 			totalExpectedRowsAffected += expectation.ExpectedRowCount;
 			var batchUpdate = CurrentCommand;
 			await (PrepareAsync(batchUpdate, cancellationToken)).ConfigureAwait(false);

--- a/src/NHibernate/Driver/MySqlDataDriver.cs
+++ b/src/NHibernate/Driver/MySqlDataDriver.cs
@@ -1,4 +1,5 @@
 using System;
+using NHibernate.AdoNet;
 
 namespace NHibernate.Driver
 {
@@ -16,7 +17,7 @@ namespace NHibernate.Driver
 	/// for any updates and/or documentation regarding MySQL.
 	/// </para>
 	/// </remarks>
-	public class MySqlDataDriver : ReflectionBasedDriver
+	public class MySqlDataDriver : ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="MySqlDataDriver"/> class.
@@ -95,5 +96,7 @@ namespace NHibernate.Driver
 		// https://dev.mysql.com/doc/refman/5.7/en/datetime.html
 		/// <inheritdoc />
 		public override DateTime MinDate => new DateTime(1000, 1, 1);
+
+		System.Type IEmbeddedBatcherFactoryProvider.BatcherFactoryClass => typeof(MySqlClientBatchingBatcherFactory);
 	}
 }


### PR DESCRIPTION
Setting MySql batcher as the default batcher seems to have been forgotten when it was added. (At least no one answered my [question about this on its ticket](https://nhibernate.jira.com/browse/NH-2778?focusedCommentId=54804&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-54804).)

Also fix #1604 (no translation of data provider exception) and fix #1605 (may not close pending data reader before initiating a batch).