### PR TITLE
Preserve original snapshot mode.

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1553/MsSQL/SnapshotIsolationUpdateConflictTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1553/MsSQL/SnapshotIsolationUpdateConflictTest.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Data;
 using NHibernate.Cfg;
 using NHibernate.Dialect;
@@ -15,6 +16,7 @@ using NHibernate.Driver;
 using NHibernate.Engine;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
+using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 {
@@ -40,40 +42,34 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 
 		private async Task<Person> LoadPersonAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tr = BeginTransaction(session))
 			{
-				using (ITransaction tr = BeginTransaction(session))
-				{
-					var p = await (session.GetAsync<Person>(person.Id, cancellationToken));
-					await (tr.CommitAsync(cancellationToken));
-					return p;
-				}
+				var p = await (session.GetAsync<Person>(person.Id, cancellationToken));
+				await (tr.CommitAsync(cancellationToken));
+				return p;
 			}
 		}
 
 		private async Task SavePersonAsync(Person p, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tr = BeginTransaction(session))
 			{
-				using (ITransaction tr = BeginTransaction(session))
-				{
-					await (session.SaveOrUpdateAsync(p, cancellationToken));
-					await (session.FlushAsync(cancellationToken));
-					await (tr.CommitAsync(cancellationToken));
-				}
+				await (session.SaveOrUpdateAsync(p, cancellationToken));
+				await (session.FlushAsync(cancellationToken));
+				await (tr.CommitAsync(cancellationToken));
 			}
 		}
 
 		private void SavePerson(Person p)
 		{
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tr = BeginTransaction(session))
 			{
-				using (ITransaction tr = BeginTransaction(session))
-				{
-					session.SaveOrUpdate(p);
-					session.Flush();
-					tr.Commit();
-				}
+				session.SaveOrUpdate(p);
+				session.Flush();
+				tr.Commit();
 			}
 		}
 
@@ -159,13 +155,27 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 			return factory.ConnectionProvider.Driver is SqlClientDriver;
 		}
 
+		private bool _isSnapshotIsolationAlreadyAllowed;
+
+		private void CheckAllowSnapshotIsolation()
+		{
+			using (var session = OpenSession())
+			using (var command = session.Connection.CreateCommand())
+			{
+				command.CommandText = $@"select snapshot_isolation_state_desc from sys.databases 
+	where name = '{session.Connection.Database}'";
+				_isSnapshotIsolationAlreadyAllowed =
+					StringComparer.OrdinalIgnoreCase.Equals(command.ExecuteScalar() as string, "on");
+			}
+		}
+
 		private void SetAllowSnapshotIsolation(bool on)
 		{
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var command = session.Connection.CreateCommand())
 			{
-				var command = session.Connection.CreateCommand();
 				command.CommandText = "ALTER DATABASE " + session.Connection.Database + " set allow_snapshot_isolation "
-				                      + (on ? "on" : "off");
+					+ (on ? "on" : "off");
 				command.ExecuteNonQuery();
 			}
 		}
@@ -174,7 +184,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 		{
 			base.OnSetUp();
 
-			SetAllowSnapshotIsolation(true);
+			CheckAllowSnapshotIsolation();
+			if (!_isSnapshotIsolationAlreadyAllowed)
+				SetAllowSnapshotIsolation(true);
 
 			person = new Person();
 			person.IdentificationNumber = 123;
@@ -183,18 +195,15 @@ namespace NHibernate.Test.NHSpecificTest.NH1553.MsSQL
 
 		protected override void OnTearDown()
 		{
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tr = session.BeginTransaction(IsolationLevel.Serializable))
 			{
-				using (ITransaction tr = session.BeginTransaction(IsolationLevel.Serializable))
-				{
-					string hql = "from Person";
-					session.Delete(hql);
-					session.Flush();
-					tr.Commit();
-				}
+				session.Delete("from Person");
+				tr.Commit();
 			}
 
-			SetAllowSnapshotIsolation(false);
+			if (!_isSnapshotIsolationAlreadyAllowed)
+				SetAllowSnapshotIsolation(false);
 
 			base.OnTearDown();
 		}


### PR DESCRIPTION
As shown [here](https://ci.appveyor.com/project/nhibernate/nhibernate-core/build/5.1.0.104/job/bu3hoy20acramkyh/tests) or [here](https://ci.appveyor.com/project/nhibernate/nhibernate-core/build/5.1.0.105/job/gk3wn75135s1j248/tests), there are some tests which fail sometimes unexpectedly with an error stating `Snapshot isolation transaction failed accessing database 'nhibernate' because snapshot isolation is not allowed in this database.`.

There is one fixture which may disable it, because its setup always enables it and its teardown always disables it, as if assuming the feature can only be off by default. This PR fix it for having this fixture no more touching it if it is already enabled.