### PR TITLE
Raise maximal decimal precision from 28 to 29

### DIFF
--- a/src/NHibernate.Test/DriverTest/SqlClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/SqlClientDriverFixture.cs
@@ -161,7 +161,7 @@ namespace NHibernate.Test.DriverTest
 		[Test]
 		public void DefaultPrecisionScale()
 		{
-			const byte defaultPrecision = 28;
+			const byte defaultPrecision = 29;
 			const byte defaultScale = 10;
 			var driver = Sfi.ConnectionProvider.Driver;
 			try

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -226,7 +226,7 @@ namespace NHibernate.Cfg
 
 		/// <summary>
 		/// Set the default precision used in casting when the target type is decimal and
-		/// does not specify it. <c>28</c> by default, automatically trimmed down according to dialect type registration.
+		/// does not specify it. <c>29</c> by default, automatically trimmed down according to dialect type registration.
 		/// </summary>
 		public const string QueryDefaultCastPrecision = "query.default_cast_precision";
 

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -35,12 +35,12 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Binary, 2147483647, "BLOB");
 			RegisterColumnType(DbType.Boolean, "SMALLINT");
 			RegisterColumnType(DbType.Byte, "SMALLINT");
-			RegisterColumnType(DbType.Currency, "DECIMAL(16,4)");
+			RegisterColumnType(DbType.Currency, "DECIMAL(18,4)");
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "TIMESTAMP");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)");
 			// DB2 max precision is 31, but .Net is 28-29 anyway.
-			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INTEGER");

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -201,7 +201,7 @@ namespace NHibernate.Dialect
 		public virtual void Configure(IDictionary<string, string> settings)
 		{
 			DefaultCastLength = PropertiesHelper.GetInt32(Environment.QueryDefaultCastLength, settings, 4000);
-			DefaultCastPrecision = PropertiesHelper.GetByte(Environment.QueryDefaultCastPrecision, settings, null) ?? 28;
+			DefaultCastPrecision = PropertiesHelper.GetByte(Environment.QueryDefaultCastPrecision, settings, null) ?? 29;
 			DefaultCastScale = PropertiesHelper.GetByte(Environment.QueryDefaultCastScale, settings, null) ?? 10;
 		}
 

--- a/src/NHibernate/Dialect/InformixDialect.cs
+++ b/src/NHibernate/Dialect/InformixDialect.cs
@@ -45,13 +45,13 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Binary, 2147483647, "BYTE");
 			RegisterColumnType(DbType.Binary, "BYTE");
 			RegisterColumnType(DbType.Boolean, "BOOLEAN");
-			RegisterColumnType(DbType.Currency, "DECIMAL(16,4)");
+			RegisterColumnType(DbType.Currency, "DECIMAL(18,4)");
 			RegisterColumnType(DbType.Byte, "SMALLINT");
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "datetime year to fraction(5)");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19, 5)");
 			// Informix max precision is 32, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INTEGER");

--- a/src/NHibernate/Dialect/IngresDialect.cs
+++ b/src/NHibernate/Dialect/IngresDialect.cs
@@ -32,12 +32,12 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Binary, 2147483647, "bytea");
 			RegisterColumnType(DbType.Boolean, "boolean");
 			RegisterColumnType(DbType.Byte, "int2");
-			RegisterColumnType(DbType.Currency, "decimal(16,4)");
+			RegisterColumnType(DbType.Currency, "decimal(18,4)");
 			RegisterColumnType(DbType.Date, "date");
 			RegisterColumnType(DbType.DateTime, "timestamp");
 			RegisterColumnType(DbType.Decimal, "decimal(19,5)");
 			// Ingres max precision is 31, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "decimal($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "decimal($p, $s)");
 			RegisterColumnType(DbType.Double, "float8");
 			RegisterColumnType(DbType.Int16, "int2");
 			RegisterColumnType(DbType.Int32, "int4");

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -376,7 +376,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Currency, "MONEY");
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)");
 			// SQL Server max precision is 38, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Double, "FLOAT(53)");
 			RegisterColumnType(DbType.Int16, "SMALLINT");
 			RegisterColumnType(DbType.Int32, "INT");

--- a/src/NHibernate/Dialect/MsSqlCeDialect.cs
+++ b/src/NHibernate/Dialect/MsSqlCeDialect.cs
@@ -151,7 +151,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.DateTime, "DATETIME");
 			RegisterColumnType(DbType.Decimal, "NUMERIC(19,5)");
 			// SQL Server CE max precision is 38, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "NUMERIC($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "NUMERIC($p, $s)");
 			RegisterColumnType(DbType.Double, "FLOAT");
 			RegisterColumnType(DbType.Guid, "UNIQUEIDENTIFIER");
 			RegisterColumnType(DbType.Int16, "SMALLINT");

--- a/src/NHibernate/Dialect/MySQL5Dialect.cs
+++ b/src/NHibernate/Dialect/MySQL5Dialect.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Dialect
 		{
 			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)");
 			// My SQL supports precision up to 65, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p, $s)");
 			RegisterColumnType(DbType.Guid, "BINARY(16)");
 		}
 
@@ -18,7 +18,7 @@ namespace NHibernate.Dialect
 			// MySql 5 also supports DECIMAL as a cast type target
 			// http://dev.mysql.com/doc/refman/5.0/en/cast-functions.html
 			RegisterCastType(DbType.Decimal, "DECIMAL(19,5)");
-			RegisterCastType(DbType.Decimal, 28, "DECIMAL($p, $s)");
+			RegisterCastType(DbType.Decimal, 29, "DECIMAL($p, $s)");
 			RegisterCastType(DbType.Double, "DECIMAL(19,5)");
 			RegisterCastType(DbType.Single, "DECIMAL(19,5)");
 			RegisterCastType(DbType.Guid, "BINARY(16)");

--- a/src/NHibernate/Dialect/MySQLDialect.cs
+++ b/src/NHibernate/Dialect/MySQLDialect.cs
@@ -78,7 +78,9 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Byte, "TINYINT UNSIGNED");
 			RegisterColumnType(DbType.Currency, "NUMERIC(18,4)");
 			RegisterColumnType(DbType.Decimal, "NUMERIC(19,5)");
-			RegisterColumnType(DbType.Decimal, 19, "NUMERIC($p, $s)");
+			// Prior to version 5, decimal was stored as a string, so it was supporting a huge precision. Limiting to
+			// .Net capabilities.
+			RegisterColumnType(DbType.Decimal, 29, "NUMERIC($p, $s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			//The signed range is -32768 to 32767. The unsigned range is 0 to 65535. 
 			RegisterColumnType(DbType.Int16, "SMALLINT");

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -182,13 +182,14 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.UInt32, "NUMBER(10,0)");
 			RegisterColumnType(DbType.UInt64, "NUMBER(20,0)");
 
+			// 6.0 TODO: bring down to 18,4 for consistency with other dialects.
 			RegisterColumnType(DbType.Currency, "NUMBER(22,4)");
 			RegisterColumnType(DbType.Single, "FLOAT(24)");
 			RegisterColumnType(DbType.Double, "DOUBLE PRECISION");
-			// Oracle max precision is 39-40, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Double, 28, "NUMBER($p,$s)");
+			RegisterColumnType(DbType.Double, 40, "NUMBER($p,$s)");
 			RegisterColumnType(DbType.Decimal, "NUMBER(19,5)");
-			RegisterColumnType(DbType.Decimal, 28, "NUMBER($p,$s)");
+			// Oracle max precision is 39-40, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 29, "NUMBER($p,$s)");
 		}
 
 		protected virtual void RegisterDateTimeTypeMappings()

--- a/src/NHibernate/Dialect/OracleLiteDialect.cs
+++ b/src/NHibernate/Dialect/OracleLiteDialect.cs
@@ -39,12 +39,13 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Binary, 2147483647, "BLOB");
 			RegisterColumnType(DbType.Boolean, "NUMBER(1,0)");
 			RegisterColumnType(DbType.Byte, "NUMBER(3,0)");
-			RegisterColumnType(DbType.Currency, "NUMBER(19,1)");
+			// 6.0 TODO: bring down to 18,4 for consistency with other dialects.
+			RegisterColumnType(DbType.Currency, "NUMBER(22,4)");
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "TIMESTAMP(4)");
 			RegisterColumnType(DbType.Decimal, "NUMBER(19,5)");
 			// Oracle max precision is 39-40, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "NUMBER($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "NUMBER($p, $s)");
 			// having problems with both ODP and OracleClient from MS not being able
 			// to read values out of a field that is DOUBLE PRECISION
 			RegisterColumnType(DbType.Double, "DOUBLE PRECISION"); //"FLOAT(53)" );

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -44,10 +44,10 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Binary, 2147483647, "bytea");
 			RegisterColumnType(DbType.Boolean, "boolean");
 			RegisterColumnType(DbType.Byte, "int2");
-			RegisterColumnType(DbType.Currency, "decimal(16,4)");
+			RegisterColumnType(DbType.Currency, "decimal(18,4)");
 			RegisterColumnType(DbType.Decimal, "decimal(19,5)");
 			// PostgreSQL max precision is unlimited, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "decimal($p, $s)");
+			RegisterColumnType(DbType.Decimal, 29, "decimal($p, $s)");
 			RegisterColumnType(DbType.Double, "float8");
 			RegisterColumnType(DbType.Int16, "int2");
 			RegisterColumnType(DbType.Int32, "int4");

--- a/src/NHibernate/Dialect/SybaseASA9Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASA9Dialect.cs
@@ -50,9 +50,9 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Currency, "DECIMAL(18,4)");
 			RegisterColumnType(DbType.Date, "DATE");
 			RegisterColumnType(DbType.DateTime, "TIMESTAMP");
-			RegisterColumnType(DbType.Decimal, "DECIMAL(18,5)"); // NUMERIC(18,5) is equivalent to DECIMAL(18,5)
+			RegisterColumnType(DbType.Decimal, "DECIMAL(19,5)"); // NUMERIC(18,5) is equivalent to DECIMAL(18,5)
 			// Sybase max precision is 38, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "DECIMAL($p,$s)");
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p,$s)");
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Guid, "CHAR(16)");
 			RegisterColumnType(DbType.Int16, "SMALLINT");

--- a/src/NHibernate/Dialect/SybaseASE15Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASE15Dialect.cs
@@ -36,7 +36,10 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Int16, 255, "tinyint");
 			RegisterColumnType(DbType.Int32, "int");
 			RegisterColumnType(DbType.Int64, "bigint");
-			RegisterColumnType(DbType.Decimal, "numeric(18,0)");
+			// 6.0 TODO: bring down to 19,5 for consistency with other dialects.
+			RegisterColumnType(DbType.Decimal, "numeric(23,5)");
+			// Maximal precision is said to be 38, but .Net is limited to 28-29.
+			RegisterColumnType(DbType.Decimal, 29, "numeric($p,$s)");
 			RegisterColumnType(DbType.Single, "real");
 			RegisterColumnType(DbType.Double, "float");
 			RegisterColumnType(DbType.AnsiStringFixedLength, "char(255)");

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -92,7 +92,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.Double, "DOUBLE");
 			RegisterColumnType(DbType.Decimal, "NUMERIC(19,5)"); // Precision ranges from 0-127
 			// Anywhere max precision is 127, but .Net is limited to 28-29.
-			RegisterColumnType(DbType.Decimal, 28, "NUMERIC($p, $s)"); // Precision ranges from 0-127
+			RegisterColumnType(DbType.Decimal, 29, "NUMERIC($p, $s)"); // Precision ranges from 0-127
 		}
 
 		protected virtual void RegisterDateTimeTypeMappings()

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -187,7 +187,7 @@
 									<xs:annotation>
 										<xs:documentation>
 											Set the default precision used in casting when the target type is decimal and
-											does not specify it. 28 by default, automatically trimmed down according to dialect type registration.
+											does not specify it. 29 by default, automatically trimmed down according to dialect type registration.
 										</xs:documentation>
 									</xs:annotation>
 								</xs:enumeration>


### PR DESCRIPTION
 * Adjust default registrations of decimal and currency accross dialects for consistency.
 * Cease applying the decimal limit to Oracle double.
 * Fixes #1606

Details:

 * MySQL prior to version 5: it seems it was stored as string so with a huge precision, bumping 19 to 29.
 * SQLite: it does not handle precision/scale, it stores decimal in the same binary format than double. (Thus the `HasBrokenDecimal` set to true for SQLite, since it does not have a true decimal handling.) What should be changed then?
 * Oracle: double raised to 40 by the way, because it stores them as decimal but read them as .Net double, so it should not be limited to .Net decimal capabilities.
 * SybaseAsa9: default was 18,5 instead of 19,5.
 * SybaseAse15: default was 18,0 instead of 19,5. Set as 23,5 for avoiding a possible breaking change for those storing 10^18 numbers with the previous default.
 * Also standardizes Currency registration.