### PR TITLE
Move MsSql constants from driver to dialect.

### DIFF
--- a/src/NHibernate.Test/DialectTest/MsSql2005DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/MsSql2005DialectFixture.cs
@@ -100,13 +100,13 @@ namespace NHibernate.Test.DialectTest
 			var t = d.GetTypeName(new BinarySqlType());
 			Assert.That(t, Is.EqualTo("VARBINARY(MAX)"));
 
-			t = d.GetTypeName(new BinarySqlType(), SqlClientDriver.MaxSizeForLengthLimitedBinary - 1, 0, 0);
-			Assert.That(t, Is.EqualTo(String.Format("VARBINARY({0})", SqlClientDriver.MaxSizeForLengthLimitedBinary - 1)));
+			t = d.GetTypeName(new BinarySqlType(), MsSql2000Dialect.MaxSizeForLengthLimitedBinary - 1, 0, 0);
+			Assert.That(t, Is.EqualTo(String.Format("VARBINARY({0})", MsSql2000Dialect.MaxSizeForLengthLimitedBinary - 1)));
 
-			t = d.GetTypeName(new BinarySqlType(), SqlClientDriver.MaxSizeForLengthLimitedBinary, 0, 0);
-			Assert.That(t, Is.EqualTo(String.Format("VARBINARY({0})", SqlClientDriver.MaxSizeForLengthLimitedBinary)));
+			t = d.GetTypeName(new BinarySqlType(), MsSql2000Dialect.MaxSizeForLengthLimitedBinary, 0, 0);
+			Assert.That(t, Is.EqualTo(String.Format("VARBINARY({0})", MsSql2000Dialect.MaxSizeForLengthLimitedBinary)));
 
-			t = d.GetTypeName(new BinarySqlType(), SqlClientDriver.MaxSizeForLengthLimitedBinary + 1, 0, 0);
+			t = d.GetTypeName(new BinarySqlType(), MsSql2000Dialect.MaxSizeForLengthLimitedBinary + 1, 0, 0);
 			Assert.That(t, Is.EqualTo("VARBINARY(MAX)"));
 		}
 

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -5,7 +5,6 @@ using System.Data.Common;
 using System.Text.RegularExpressions;
 using NHibernate.Dialect.Function;
 using NHibernate.Dialect.Schema;
-using NHibernate.Driver;
 using NHibernate.Engine;
 using NHibernate.Mapping;
 using NHibernate.SqlCommand;
@@ -42,6 +41,16 @@ namespace NHibernate.Dialect
 	/// </remarks>
 	public class MsSql2000Dialect : Dialect
 	{
+		public const int MaxSizeForAnsiClob = 2147483647; // int.MaxValue
+		public const int MaxSizeForClob = 1073741823; // int.MaxValue / 2
+		public const int MaxSizeForBlob = 2147483647; // int.MaxValue
+
+		public const int MaxSizeForLengthLimitedAnsiString = 8000;
+		public const int MaxSizeForLengthLimitedString = 4000;
+		public const int MaxSizeForLengthLimitedBinary = 8000;
+		public const byte MaxDateTime2 = 8;
+		public const byte MaxDateTimeOffset = 10;
+
 		public MsSql2000Dialect()
 		{
 			RegisterCharacterTypeMappings();
@@ -358,8 +367,8 @@ namespace NHibernate.Dialect
 		protected virtual void RegisterLargeObjectTypeMappings()
 		{
 			RegisterColumnType(DbType.Binary, "VARBINARY(8000)");
-			RegisterColumnType(DbType.Binary, SqlClientDriver.MaxSizeForLengthLimitedBinary, "VARBINARY($l)");
-			RegisterColumnType(DbType.Binary, SqlClientDriver.MaxSizeForBlob, "IMAGE");
+			RegisterColumnType(DbType.Binary, MaxSizeForLengthLimitedBinary, "VARBINARY($l)");
+			RegisterColumnType(DbType.Binary, MaxSizeForBlob, "IMAGE");
 		}
 
 		protected virtual void RegisterDateTimeTypeMappings()
@@ -389,13 +398,13 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.AnsiStringFixedLength, "CHAR(255)");
 			RegisterColumnType(DbType.AnsiStringFixedLength, 8000, "CHAR($l)");
 			RegisterColumnType(DbType.AnsiString, "VARCHAR(255)");
-			RegisterColumnType(DbType.AnsiString, SqlClientDriver.MaxSizeForLengthLimitedAnsiString, "VARCHAR($l)");
-			RegisterColumnType(DbType.AnsiString, SqlClientDriver.MaxSizeForAnsiClob, "TEXT");
+			RegisterColumnType(DbType.AnsiString, MaxSizeForLengthLimitedAnsiString, "VARCHAR($l)");
+			RegisterColumnType(DbType.AnsiString, MaxSizeForAnsiClob, "TEXT");
 			RegisterColumnType(DbType.StringFixedLength, "NCHAR(255)");
-			RegisterColumnType(DbType.StringFixedLength, SqlClientDriver.MaxSizeForLengthLimitedString, "NCHAR($l)");
+			RegisterColumnType(DbType.StringFixedLength, MaxSizeForLengthLimitedString, "NCHAR($l)");
 			RegisterColumnType(DbType.String, "NVARCHAR(255)");
-			RegisterColumnType(DbType.String, SqlClientDriver.MaxSizeForLengthLimitedString, "NVARCHAR($l)");
-			RegisterColumnType(DbType.String, SqlClientDriver.MaxSizeForClob, "NTEXT");
+			RegisterColumnType(DbType.String, MaxSizeForLengthLimitedString, "NVARCHAR($l)");
+			RegisterColumnType(DbType.String, MaxSizeForClob, "NTEXT");
 		}
 
 		public override string AddColumnString
@@ -447,7 +456,7 @@ namespace NHibernate.Dialect
 				"if exists (select * from dbo.sysobjects where id = object_id(N'{0}') and OBJECTPROPERTY(id, N'IsUserTable') = 1)" +
 				" drop table {0}";
 
-			return String.Format(dropTable, tableName);
+			return string.Format(dropTable, tableName);
 		}
 
 		public override string ForUpdateString

--- a/src/NHibernate/Dialect/MsSql2005Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2005Dialect.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using NHibernate.Driver;
 using NHibernate.Mapping;
 using NHibernate.SqlCommand;
 using NHibernate.Util;
@@ -8,6 +7,9 @@ namespace NHibernate.Dialect
 {
 	public class MsSql2005Dialect : MsSql2000Dialect
 	{
+		///<remarks>http://stackoverflow.com/a/7264795/259946</remarks>
+		public const int MaxSizeForXml = 2147483647; // int.MaxValue
+
 		public MsSql2005Dialect()
 		{
 			RegisterColumnType(DbType.Xml, "XML");
@@ -16,16 +18,16 @@ namespace NHibernate.Dialect
 		protected override void RegisterCharacterTypeMappings()
 		{
 			base.RegisterCharacterTypeMappings();
-			RegisterColumnType(DbType.String, SqlClientDriver.MaxSizeForClob, "NVARCHAR(MAX)");
-			RegisterColumnType(DbType.AnsiString, SqlClientDriver.MaxSizeForAnsiClob, "VARCHAR(MAX)");
+			RegisterColumnType(DbType.String, MaxSizeForClob, "NVARCHAR(MAX)");
+			RegisterColumnType(DbType.AnsiString, MaxSizeForAnsiClob, "VARCHAR(MAX)");
 		}
 
 		protected override void RegisterLargeObjectTypeMappings()
 		{
 			base.RegisterLargeObjectTypeMappings();
 			RegisterColumnType(DbType.Binary, "VARBINARY(MAX)");
-			RegisterColumnType(DbType.Binary, SqlClientDriver.MaxSizeForLengthLimitedBinary, "VARBINARY($l)");
-			RegisterColumnType(DbType.Binary, SqlClientDriver.MaxSizeForBlob, "VARBINARY(MAX)");
+			RegisterColumnType(DbType.Binary, MaxSizeForLengthLimitedBinary, "VARBINARY($l)");
+			RegisterColumnType(DbType.Binary, MaxSizeForBlob, "VARBINARY(MAX)");
 		}
 
 		protected override void RegisterKeywords()

--- a/src/NHibernate/Driver/DB2400Driver.cs
+++ b/src/NHibernate/Driver/DB2400Driver.cs
@@ -8,7 +8,7 @@ namespace NHibernate.Driver
 	public class DB2400Driver : ReflectionBasedDriver
 	{
 		/// <summary>
-		/// Initializes a new instance of the <see cref="DB2Driver"/> class.
+		/// Initializes a new instance of the <see cref="DB2400Driver"/> class.
 		/// </summary>
 		/// <exception cref="HibernateException">
 		/// Thrown when the <c>IBM.Data.DB2.iSeries</c> assembly can not be loaded.

--- a/src/NHibernate/Driver/FirebirdClientDriver.cs
+++ b/src/NHibernate/Driver/FirebirdClientDriver.cs
@@ -20,8 +20,8 @@ namespace NHibernate.Driver
 	{
 		private const string SELECT_CLAUSE_EXP = @"(?<=\bselect|\bwhere).*";
 		private const string CAST_PARAMS_EXP = @"(?<![=<>]\s?|first\s?|skip\s?|between\s|between\s@\bp\w+\b\sand\s)@\bp\w+\b(?!\s?[=<>])";
-		private readonly Regex _statementRegEx = new Regex(SELECT_CLAUSE_EXP, RegexOptions.IgnoreCase);
-		private readonly Regex _castCandidateRegEx = new Regex(CAST_PARAMS_EXP, RegexOptions.IgnoreCase);
+		private static readonly Regex _statementRegEx = new Regex(SELECT_CLAUSE_EXP, RegexOptions.IgnoreCase);
+		private static readonly Regex _castCandidateRegEx = new Regex(CAST_PARAMS_EXP, RegexOptions.IgnoreCase);
 		private readonly FirebirdDialect _fbDialect = new FirebirdDialect();
 
 		/// <summary>
@@ -37,7 +37,6 @@ namespace NHibernate.Driver
 				"FirebirdSql.Data.FirebirdClient.FbConnection",
 				"FirebirdSql.Data.FirebirdClient.FbCommand")
 		{
-
 		}
 
 		public override void Configure(IDictionary<string, string> settings)
@@ -46,20 +45,11 @@ namespace NHibernate.Driver
 			_fbDialect.Configure(settings);
 		}
 
-		public override bool UseNamedPrefixInSql
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInSql => true;
 
-		public override bool UseNamedPrefixInParameter
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInParameter => true;
 
-		public override string NamedPrefix
-		{
-			get { return "@"; }
-		}
+		public override string NamedPrefix => "@";
 
 		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
 		{
@@ -96,7 +86,7 @@ namespace NHibernate.Driver
 			return _statementRegEx.Match(commandText).Value;
 		}
 
-		private HashSet<string> GetCastCandidates(string statement)
+		private static HashSet<string> GetCastCandidates(string statement)
 		{
 			var candidates =
 				_castCandidateRegEx

--- a/src/NHibernate/Driver/MySqlDataDriver.cs
+++ b/src/NHibernate/Driver/MySqlDataDriver.cs
@@ -37,35 +37,23 @@ namespace NHibernate.Driver
 		/// MySql.Data uses named parameters in the sql.
 		/// </summary>
 		/// <value><see langword="true" /> - MySql uses <c>?</c> in the sql.</value>
-		public override bool UseNamedPrefixInSql
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInSql => true;
 
 		/// <summary></summary>
-		public override bool UseNamedPrefixInParameter
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInParameter => true;
 
 		/// <summary>
 		/// MySql.Data use the <c>?</c> to locate parameters in sql.
 		/// </summary>
 		/// <value><c>?</c> is used to locate parameters in sql.</value>
-		public override string NamedPrefix
-		{
-			get { return "?"; }
-		}
+		public override string NamedPrefix => "?";
 
 		/// <summary>
 		/// The MySql.Data driver does NOT support more than 1 open DbDataReader
 		/// with only 1 DbConnection.
 		/// </summary>
 		/// <value><see langword="false" /> - it is not supported.</value>
-		public override bool SupportsMultipleOpenReaders
-		{
-			get { return false; }
-		}
+		public override bool SupportsMultipleOpenReaders => false;
 
 		/// <summary>
 		/// MySql.Data does not support preparing of commands.
@@ -75,20 +63,14 @@ namespace NHibernate.Driver
 		/// With the Gamma MySql.Data provider it is throwing an exception with the 
 		/// message "Expected End of data packet" when a select command is prepared.
 		/// </remarks>
-		protected override bool SupportsPreparingCommands
-		{
-			get { return false; }
-		}
+		protected override bool SupportsPreparingCommands => false;
 
 		public override IResultSetsCommand GetResultSetsCommand(Engine.ISessionImplementor session)
 		{
 			return new BasicResultSetsCommand(session);
 		}
 
-		public override bool SupportsMultipleQueries
-		{
-			get { return true; }
-		}
+		public override bool SupportsMultipleQueries => true;
 
 		public override bool RequiresTimeSpanForTime => true;
 

--- a/src/NHibernate/Driver/NpgsqlDriver.cs
+++ b/src/NHibernate/Driver/NpgsqlDriver.cs
@@ -41,31 +41,18 @@ namespace NHibernate.Driver
 		{
 		}
 
-		public override bool UseNamedPrefixInSql
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInSql => true;
 
-		public override bool UseNamedPrefixInParameter
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInParameter => true;
 
-		public override string NamedPrefix
-		{
-			get { return ":"; }
-		}
+		public override string NamedPrefix => ":";
 
-		public override bool SupportsMultipleOpenReaders
-		{
-			get { return false; }
-		}
+		public override bool SupportsMultipleOpenReaders => false;
 
-		protected override bool SupportsPreparingCommands
-		{
-			// NH-2267 Patrick Earl
-			get { return true; }
-		}
+		/// <remarks>
+		/// NH-2267 Patrick Earl
+		/// </remarks>
+		protected override bool SupportsPreparingCommands => true;
 
 		public override bool SupportsNullEnlistment => false;
 
@@ -74,10 +61,7 @@ namespace NHibernate.Driver
 			return new BasicResultSetsCommand(session);
 		}
 
-		public override bool SupportsMultipleQueries
-		{
-			get { return true; }
-		}
+		public override bool SupportsMultipleQueries => true;
 
 		protected override void InitializeParameter(DbParameter dbParam, string name, SqlTypes.SqlType sqlType)
 		{

--- a/src/NHibernate/Driver/OracleDataClientDriverBase.cs
+++ b/src/NHibernate/Driver/OracleDataClientDriverBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Reflection;
 using NHibernate.AdoNet;
 using NHibernate.Engine.Query;
 using NHibernate.SqlTypes;

--- a/src/NHibernate/Driver/SQLite20Driver.cs
+++ b/src/NHibernate/Driver/SQLite20Driver.cs
@@ -35,46 +35,26 @@ namespace NHibernate.Driver
 		{
 		}
 
-        public override DbConnection CreateConnection()
-        {
-            var connection = base.CreateConnection();
-            connection.StateChange += Connection_StateChange;
-            return connection;
-        }
-
-        private static void Connection_StateChange(object sender, StateChangeEventArgs e)
-        {
-            if ((e.OriginalState == ConnectionState.Broken || e.OriginalState == ConnectionState.Closed || e.OriginalState == ConnectionState.Connecting) &&
-                e.CurrentState == ConnectionState.Open)
-            {
-                var connection = (DbConnection)sender;
-                using (var command = connection.CreateCommand())
-                {
-                    // Activated foreign keys if supported by SQLite.  Unknown pragmas are ignored.
-                    command.CommandText = "PRAGMA foreign_keys = ON";
-                    command.ExecuteNonQuery();
-                }
-            }
-        }
-
-		public override bool UseNamedPrefixInSql
+		public override DbConnection CreateConnection()
 		{
-			get { return true; }
+			var connection = base.CreateConnection();
+			connection.StateChange += Connection_StateChange;
+			return connection;
 		}
 
-		public override bool UseNamedPrefixInParameter
+		private static void Connection_StateChange(object sender, StateChangeEventArgs e)
 		{
-			get { return true; }
-		}
-
-		public override string NamedPrefix
-		{
-			get { return "@"; }
-		}
-
-		public override bool SupportsMultipleOpenReaders
-		{
-			get { return false; }
+			if ((e.OriginalState == ConnectionState.Broken || e.OriginalState == ConnectionState.Closed || e.OriginalState == ConnectionState.Connecting) &&
+				e.CurrentState == ConnectionState.Open)
+			{
+				var connection = (DbConnection)sender;
+				using (var command = connection.CreateCommand())
+				{
+					// Activated foreign keys if supported by SQLite.  Unknown pragmas are ignored.
+					command.CommandText = "PRAGMA foreign_keys = ON";
+					command.ExecuteNonQuery();
+				}
+			}
 		}
 
 		public override IResultSetsCommand GetResultSetsCommand(Engine.ISessionImplementor session)
@@ -82,11 +62,16 @@ namespace NHibernate.Driver
 			return new BasicResultSetsCommand(session);
 		}
 
-		public override bool SupportsMultipleQueries
-		{
-			get { return true; }
-		}
-		
+		public override bool UseNamedPrefixInSql => true;
+
+		public override bool UseNamedPrefixInParameter => true;
+
+		public override string NamedPrefix => "@";
+
+		public override bool SupportsMultipleOpenReaders => false;
+
+		public override bool SupportsMultipleQueries => true;
+
 		public override bool SupportsNullEnlistment => false;
 
 		public override bool HasDelayedDistributedTransactionCompletion => true;

--- a/src/NHibernate/Driver/SqlClientDriver.cs
+++ b/src/NHibernate/Driver/SqlClientDriver.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using System.Data.SqlClient;
 #endif
 using NHibernate.AdoNet;
+using NHibernate.Dialect;
 using NHibernate.Engine;
 using NHibernate.SqlTypes;
 
@@ -21,13 +22,29 @@ namespace NHibernate.Driver
 		: ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
 #endif
 	{
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxSizeForAnsiClob")]
 		public const int MaxSizeForAnsiClob = 2147483647; // int.MaxValue
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxSizeForClob")]
 		public const int MaxSizeForClob = 1073741823; // int.MaxValue / 2
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxSizeForBlob")]
 		public const int MaxSizeForBlob = 2147483647; // int.MaxValue
-		//http://stackoverflow.com/a/7264795/259946
+
+		///<remarks>http://stackoverflow.com/a/7264795/259946</remarks>
+		// Since v5.1
+		[Obsolete("Use MsSql2005Dialect.MaxSizeForXml")]
 		public const int MaxSizeForXml = 2147483647; // int.MaxValue
+
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxSizeForLengthLimitedAnsiString")]
 		public const int MaxSizeForLengthLimitedAnsiString = 8000;
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxSizeForLengthLimitedString")]
 		public const int MaxSizeForLengthLimitedString = 4000;
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxSizeForLengthLimitedBinary")]
 		public const int MaxSizeForLengthLimitedBinary = 8000;
 		// Since v5.1
 		[Obsolete("This member has no more usages and will be removed in a future version")]
@@ -35,7 +52,11 @@ namespace NHibernate.Driver
 		// Since v5.1
 		[Obsolete("This member has no more usages and will be removed in a future version")]
 		public const byte MaxScale = 5;
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxDateTime2")]
 		public const byte MaxDateTime2 = 8;
+		// Since v5.1
+		[Obsolete("Use MsSql2000Dialect.MaxDateTimeOffset")]
 		public const byte MaxDateTimeOffset = 10;
 
 		private Dialect.Dialect _dialect;
@@ -139,10 +160,10 @@ namespace NHibernate.Driver
 			{
 				case DbType.AnsiString:
 				case DbType.AnsiStringFixedLength:
-					dbParam.Size = IsAnsiText(dbParam, sqlType) ? MaxSizeForAnsiClob : MaxSizeForLengthLimitedAnsiString;
+					dbParam.Size = IsAnsiText(dbParam, sqlType) ? MsSql2000Dialect.MaxSizeForAnsiClob : MsSql2000Dialect.MaxSizeForLengthLimitedAnsiString;
 					break;
 				case DbType.Binary:
-					dbParam.Size = IsBlob(dbParam, sqlType) ? MaxSizeForBlob : MaxSizeForLengthLimitedBinary;
+					dbParam.Size = IsBlob(dbParam, sqlType) ? MsSql2000Dialect.MaxSizeForBlob : MsSql2000Dialect.MaxSizeForLengthLimitedBinary;
 					break;
 				case DbType.Decimal:
 					if (_dialect == null)
@@ -152,16 +173,16 @@ namespace NHibernate.Driver
 					break;
 				case DbType.String:
 				case DbType.StringFixedLength:
-					dbParam.Size = IsText(dbParam, sqlType) ? MaxSizeForClob : MaxSizeForLengthLimitedString;
+					dbParam.Size = IsText(dbParam, sqlType) ? MsSql2000Dialect.MaxSizeForClob : MsSql2000Dialect.MaxSizeForLengthLimitedString;
 					break;
 				case DbType.DateTime2:
-					dbParam.Size = MaxDateTime2;
+					dbParam.Size = MsSql2000Dialect.MaxDateTime2;
 					break;
 				case DbType.DateTimeOffset:
-					dbParam.Size = MaxDateTimeOffset;
+					dbParam.Size = MsSql2000Dialect.MaxDateTimeOffset;
 					break;
 				case DbType.Xml:
-					dbParam.Size = MaxSizeForXml;
+					dbParam.Size = MsSql2005Dialect.MaxSizeForXml;
 					break;
 			}
 
@@ -203,10 +224,10 @@ namespace NHibernate.Driver
 			{
 				case DbType.AnsiString:
 				case DbType.AnsiStringFixedLength:
-					dbParam.Size = IsAnsiText(dbParam, sqlType) ? MaxSizeForAnsiClob : MaxSizeForLengthLimitedAnsiString;
+					dbParam.Size = IsAnsiText(dbParam, sqlType) ? MsSql2000Dialect.MaxSizeForAnsiClob : MsSql2000Dialect.MaxSizeForLengthLimitedAnsiString;
 					break;
 				case DbType.Binary:
-					dbParam.Size = IsBlob(dbParam, sqlType) ? MaxSizeForBlob : MaxSizeForLengthLimitedBinary;
+					dbParam.Size = IsBlob(dbParam, sqlType) ? MsSql2000Dialect.MaxSizeForBlob : MsSql2000Dialect.MaxSizeForLengthLimitedBinary;
 					break;
 				case DbType.Decimal:
 					dbParam.Precision = MaxPrecision;
@@ -214,16 +235,16 @@ namespace NHibernate.Driver
 					break;
 				case DbType.String:
 				case DbType.StringFixedLength:
-					dbParam.Size = IsText(dbParam, sqlType) ? MaxSizeForClob : MaxSizeForLengthLimitedString;
+					dbParam.Size = IsText(dbParam, sqlType) ? MsSql2000Dialect.MaxSizeForClob : MsSql2000Dialect.MaxSizeForLengthLimitedString;
 					break;
 				case DbType.DateTime2:
-					dbParam.Size = MaxDateTime2;
+					dbParam.Size = MsSql2000Dialect.MaxDateTime2;
 					break;
 				case DbType.DateTimeOffset:
-					dbParam.Size = MaxDateTimeOffset;
+					dbParam.Size = MsSql2000Dialect.MaxDateTimeOffset;
 					break;
 				case DbType.Xml:
-					dbParam.Size = MaxSizeForXml;
+					dbParam.Size = MsSql2005Dialect.MaxSizeForXml;
 					break;
 			}
 		}
@@ -236,7 +257,7 @@ namespace NHibernate.Driver
 		/// <returns>True, if the parameter should be interpreted as a Clob, otherwise False</returns>
 		protected static bool IsAnsiText(DbParameter dbParam, SqlType sqlType)
 		{
-			return ((DbType.AnsiString == dbParam.DbType || DbType.AnsiStringFixedLength == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MaxSizeForLengthLimitedAnsiString));
+			return ((DbType.AnsiString == dbParam.DbType || DbType.AnsiStringFixedLength == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MsSql2000Dialect.MaxSizeForLengthLimitedAnsiString));
 		}
 
 		/// <summary>
@@ -247,7 +268,7 @@ namespace NHibernate.Driver
 		/// <returns>True, if the parameter should be interpreted as a Clob, otherwise False</returns>
 		protected static bool IsText(DbParameter dbParam, SqlType sqlType)
 		{
-			return (sqlType is StringClobSqlType) || ((DbType.String == dbParam.DbType || DbType.StringFixedLength == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MaxSizeForLengthLimitedString));
+			return (sqlType is StringClobSqlType) || ((DbType.String == dbParam.DbType || DbType.StringFixedLength == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MsSql2000Dialect.MaxSizeForLengthLimitedString));
 		}
 
 		/// <summary>
@@ -258,7 +279,7 @@ namespace NHibernate.Driver
 		/// <returns>True, if the parameter should be interpreted as a Blob, otherwise False</returns>
 		protected static bool IsBlob(DbParameter dbParam, SqlType sqlType)
 		{
-			return (sqlType is BinaryBlobSqlType) || ((DbType.Binary == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MaxSizeForLengthLimitedBinary));
+			return (sqlType is BinaryBlobSqlType) || ((DbType.Binary == dbParam.DbType) && sqlType.LengthDefined && (sqlType.Length > MsSql2000Dialect.MaxSizeForLengthLimitedBinary));
 		}
 
 

--- a/src/NHibernate/Driver/SqlServerCeDriver.cs
+++ b/src/NHibernate/Driver/SqlServerCeDriver.cs
@@ -42,10 +42,7 @@ namespace NHibernate.Driver
 		/// <remarks>
 		/// <see langword="true" /> because MsSql uses "<c>@</c>".
 		/// </remarks>
-		public override bool UseNamedPrefixInSql
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInSql => true;
 
 		/// <summary>
 		/// MsSql requires the use of a Named Prefix in the Parameter.  
@@ -53,10 +50,7 @@ namespace NHibernate.Driver
 		/// <remarks>
 		/// <see langword="true" /> because MsSql uses "<c>@</c>".
 		/// </remarks>
-		public override bool UseNamedPrefixInParameter
-		{
-			get { return true; }
-		}
+		public override bool UseNamedPrefixInParameter => true;
 
 		/// <summary>
 		/// The Named Prefix for parameters.  
@@ -64,10 +58,7 @@ namespace NHibernate.Driver
 		/// <value>
 		/// Sql Server uses <c>"@"</c>.
 		/// </value>
-		public override string NamedPrefix
-		{
-			get { return "@"; }
-		}
+		public override string NamedPrefix => "@";
 
 		/// <summary>
 		/// The SqlClient driver does NOT support more than 1 open DbDataReader
@@ -79,10 +70,7 @@ namespace NHibernate.Driver
 		/// attempted to be Opened.  When Yukon comes out a new Driver will be 
 		/// created for Yukon because it is supposed to support it.
 		/// </remarks>
-		public override bool SupportsMultipleOpenReaders
-		{
-			get { return false; }
-		}
+		public override bool SupportsMultipleOpenReaders => false;
 
 		protected override void SetCommandTimeout(DbCommand cmd)
 		{


### PR DESCRIPTION
This is a split off from #626 just incase I don't get that fully rebased in time for v5.1.  These changes are still valuable, but easy to review.

Also:
* Fix description of DB2400Driver.
* Driver code formatting tweaks.