### PR TITLE
 Fix CollectionHelper.GetHashCode ignoring values of dictionaries

### DIFF
--- a/src/NHibernate.Test/UtilityTest/CollectionHelperFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/CollectionHelperFixture.cs
@@ -122,6 +122,41 @@ namespace NHibernate.Test.UtilityTest
 			Assert.That(CollectionHelper.DictionaryEquals<string, string>(d2, d1), Is.False);
 		}
 
+		[Test]
+		public void MapsWithSameContentShouldHaveSameHashCode()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			Assert.That(CollectionHelper.GetHashCode(d1), Is.EqualTo(CollectionHelper.GetHashCode(d2)));
+		}
+
+		// Failure of following tests is not an error from GetHashCode semantic viewpoint, but it causes it
+		// to be potentially inefficients for usages in dictionnaries or hashset.
+
+		[Test]
+		public void MapsWithSameCountButDistinctKeysShouldNotHaveSameHashCode()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" }, { "4", "3" } };
+			Assert.That(CollectionHelper.GetHashCode(d1), Is.Not.EqualTo(CollectionHelper.GetHashCode(d2)));
+		}
+
+		[Test]
+		public void MapsWithSameCountButDistinctValuesShouldNotHaveSameHashCode()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" }, { "3", "3" } };
+			Assert.That(CollectionHelper.GetHashCode(d1), Is.Not.EqualTo(CollectionHelper.GetHashCode(d2)));
+		}
+
+		[Test]
+		public void MapsWithoutSameCountShouldNotHaveSameHashCode()
+		{
+			var d1 = new Dictionary<string, string> { { "1", "2" }, { "3", "4" } };
+			var d2 = new Dictionary<string, string> { { "1", "2" } };
+			Assert.That(CollectionHelper.GetHashCode(d1), Is.Not.EqualTo(CollectionHelper.GetHashCode(d2)));
+		}
+
 		#endregion
 
 		#region Set

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -613,7 +613,7 @@ namespace NHibernate.Util
 		/// individual elements key xored with their value if any, so that the value is independent of the
 		/// collection iteration order.
 		/// </remarks>
-		public static int GetHashCode<TK, TV>(IEnumerable<KeyValuePair<TK, TV>> coll)
+		internal static int GetHashCode<TK, TV>(IEnumerable<KeyValuePair<TK, TV>> coll)
 		{
 			unchecked
 			{

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -602,6 +602,38 @@ namespace NHibernate.Util
 			}
 		}
 
+		// KeyValuePair<TK, TV>.GetHashCode default implementation is inadequate, see https://stackoverflow.com/a/5927853/1178314
+		// If one of its type is a reference type, it may ignore it for computing the hashcode, leading to potentially
+		// a lot of hashcode collisions. It is not a bug from GetHashCode semantic viewpoint, but it causes them
+		// to be potentially inefficients for usages in dictionnaries or hashset.
+		/// <summary>
+		/// Computes a hash code for <paramref name="coll"/>.
+		/// </summary>
+		/// <remarks>The hash code is computed as the sum of hash codes of
+		/// individual elements key xored with their value if any, so that the value is independent of the
+		/// collection iteration order.
+		/// </remarks>
+		public static int GetHashCode<TK, TV>(IEnumerable<KeyValuePair<TK, TV>> coll)
+		{
+			unchecked
+			{
+				var result = 0;
+
+				foreach (var obj in coll)
+				{
+					if (obj.Equals(default(KeyValuePair<TK, TV>)))
+						continue;
+
+					var itemHash = obj.Key.GetHashCode() * 397;
+					if (obj.Value != null)
+						itemHash = itemHash ^ (obj.Value.GetHashCode() * 17);
+					result += itemHash;
+				}
+
+				return result;
+			}
+		}
+
 		/// <summary>
 		/// Determines if two sets have equal elements. Supports <c>null</c> arguments.
 		/// </summary>


### PR DESCRIPTION
This is causing `FilterKey` and `QueryKey` for the same queries but having different parameter values to always have the same hashcode, which is inefficient for keys lookup.

~~This PR is build over #1612, which includes the first four commits we can currently see here.~~