### PR TITLE
Fix NuGet push script

### DIFF
--- a/ReleaseProcedure.txt
+++ b/ReleaseProcedure.txt
@@ -36,13 +36,14 @@ Tools\gitreleasemanager.0.7.0\tools\GitReleaseManager.exe create -o nhibernate -
   * Upload binary and source zip files to SourceForge. Update the "latest
     release".
 
-  * Update download link on nhibernate.info.
+  * Update download link on nhibernate.info. Update the reference documentation
+    if needed.
 
   * Push nuget packages including the symbol packages.
 
   * In GitHub, mark the milestone as released and publish the release draft,
     creating the release tag by the way. (It should match the tag in the
-    releasenots link of the release description.)
+    releasenotes link of the release description.)
 
   * Post release announcement to nhusers, nhibernate-development and as
     project news on SourceForge.

--- a/default.build
+++ b/default.build
@@ -319,10 +319,21 @@
 			<in>
 				<items>
 					<include name="${nuget.nupackages.dir}/*.nupkg"/>
+					<exclude name="${nuget.nupackages.dir}/*.symbols.nupkg"/>
 				</items>
 			</in>
 			<do>
-				<echo message="nuget push ${filename} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
+				<echo message="nuget push -source https://nuget.org/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
+			</do>
+		</foreach>
+		<foreach item="File" property="filename">
+			<in>
+				<items>
+					<include name="${nuget.nupackages.dir}/*.symbols.nupkg"/>
+				</items>
+			</in>
+			<do>
+				<echo message="nuget push -source https://nuget.smbsrc.net/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
 			</do>
 		</foreach>
 	</target>


### PR DESCRIPTION
The nuget push bat is generating obsolete command lines which are no more accepted by NuGet.
The release procedure is lacking a point and has a typo.