### PR TITLE
Upgrade Async Generator to a version compatible with VS 15.6.3

### DIFF
--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -7,7 +7,7 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net461" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="CSharpAsyncGenerator.CommandLine" version="0.8.2" targetFramework="net461" />
+  <package id="CSharpAsyncGenerator.CommandLine" version="0.8.2.1" targetFramework="net461" />
   <package id="vswhere" version="2.1.4" targetFramework="net461" />
   <package id="gitreleasemanager" version="0.7.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
We can no more generate async code after having upgraded to VS 15.6.3 otherwise.

Async files regenerated by the way. No new option were taken into account and adjusted in the yml.