### PR TITLE
Fix api documentation assets path

### DIFF
--- a/doc/NHibernate.shfbproj.template
+++ b/doc/NHibernate.shfbproj.template
@@ -25,8 +25,8 @@
     <IndentHtml>False</IndentHtml>
     <HelpFileVersion>${project.version.numeric}</HelpFileVersion>
     <DocumentationSources>
-      <DocumentationSource sourceFile="${root.dir}/src/NHibernate/bin/${build.config}/NHibernate.dll" />
-      <DocumentationSource sourceFile="${root.dir}/src/NHibernate/bin/${build.config}/Nhibernate.xml" />
+      <DocumentationSource sourceFile="${root.dir}/src/NHibernate/bin/${build.config}/net461/NHibernate.dll" />
+      <DocumentationSource sourceFile="${root.dir}/src/NHibernate/bin/${build.config}/net461/Nhibernate.xml" />
     </DocumentationSources>
   </PropertyGroup>
   <!-- There are no properties for these two groups but they need to appear in


### PR DESCRIPTION
The `api` nant target in `doc` folder was broken. (This target is not executed by the package build.)