### PR TITLE
Supply expected values to GetIdentitySelectString

### DIFF
--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -990,14 +990,14 @@ namespace NHibernate.Dialect
 			return insertString;
 		}
 
-		/// <summary> 
+		/// <summary>
 		/// Get the select command to use to retrieve the last generated IDENTITY
-		/// value for a particular table 
+		/// value for a particular table.
 		/// </summary>
-		/// <param name="tableName">The table into which the insert was done </param>
-		/// <param name="identityColumn">The PK column. </param>
-		/// <param name="type">The <see cref="DbType"/> type code. </param>
-		/// <returns> The appropriate select command </returns>
+		/// <param name="identityColumn">The PK column.</param>
+		/// <param name="tableName">The table into which the insert was done.</param>
+		/// <param name="type">The <see cref="DbType"/> type code.</param>
+		/// <returns>The appropriate select command.</returns>
 		public virtual string GetIdentitySelectString(string identityColumn, string tableName, DbType type)
 		{
 			return IdentitySelectString;

--- a/src/NHibernate/Dialect/InformixDialect.cs
+++ b/src/NHibernate/Dialect/InformixDialect.cs
@@ -275,14 +275,7 @@ namespace NHibernate.Dialect
 			get { return false; }
 		}
 
-		/// <summary> 
-		/// Get the select command to use to retrieve the last generated IDENTITY
-		/// value for a particular table 
-		/// </summary>
-		/// <param name="tableName">The table into which the insert was done </param>
-		/// <param name="identityColumn">The PK column. </param>
-		/// <param name="type">The <see cref="DbType"/> type code. </param>
-		/// <returns> The appropriate select command </returns>
+		/// <inheritdoc />
 		public override string GetIdentitySelectString(string identityColumn, string tableName, DbType type)
 		{
 			return type == DbType.Int64

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -755,8 +755,8 @@ namespace NHibernate.Persister.Entity
 			{
 				if (identitySelectString == null)
 					identitySelectString =
-						Factory.Dialect.GetIdentitySelectString(GetTableName(0), GetKeyColumns(0)[0],
-																										IdentifierType.SqlTypes(Factory)[0].DbType);
+						Factory.Dialect.GetIdentitySelectString(GetKeyColumns(0)[0], GetTableName(0),
+						                                        IdentifierType.SqlTypes(Factory)[0].DbType);
 				return identitySelectString;
 			}
 		}


### PR DESCRIPTION
The entity persister was supplying the table name as the column
parameter and the column name as the table parameter. This has no effect
on NHibernate tests because GetIdentitySelectString does not use its
parameters by default and no built-in dialects overrides it for using
them.

Fix #1635