### PR TITLE
Add a link to release notes in NuGet package

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -19,6 +19,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/nhibernate/nhibernate-core/master/logo/NHibernate-NuGet.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://raw.githubusercontent.com/nhibernate/nhibernate-core/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageReleaseNotes>https://github.com/nhibernate/nhibernate-core/blob/$(VersionPrefix)/releasenotes.txt</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/nhibernate/nhibernate-core.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 


### PR DESCRIPTION
As seen [here](https://www.nuget.org/packages/NHibernate.AspNet.Identity/), a raw url in package release notes tag yield a link on NuGet site.

Adding a link to NHibernate release notes there would boost its discoverability.