### PR TITLE
Merge 5.0.4 into 5.1.x

### DIFF
--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -192,6 +192,14 @@ Release notes - NHibernate - Version 5.1.0
 As part of releasing 5.1.0, a missing 5.0.0 possible breaking change has been added about inequality semantic in LINQ
 queries. See 5.0.0 possible breaking changes.
 
+Build 5.0.4
+=============================
+
+Release notes - NHibernate - Version 5.0.4
+
+** Bug
+    * #1658 Add missing cache setting
+
 Build 5.0.3
 =============================
 

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -90,6 +90,15 @@
 								<xs:enumeration value="cache.region_prefix" />
 								<xs:enumeration value="cache.use_minimal_puts" />
 								<xs:enumeration value="cache.default_expiration" />
+								<xs:enumeration value="cache.use_sliding_expiration">
+									<xs:annotation>
+										<xs:documentation>
+											The use_sliding_expiration value is whether you wish to use a sliding expiration or not. Defaults
+											to false. Not all providers support this setting, it may be ignored. Check their respective
+											documentation.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
 								<xs:enumeration value="query.substitutions" />
 								<xs:enumeration value="query.factory_class" />
 								<xs:enumeration value="query.linq_provider_class" />


### PR DESCRIPTION
Should this be squashed or merged further? It looks like merging in such case may bloat the history with many merge commits.

And do we release 5.1.2 at once, or do we wait in case some other things are to be fixed in 5.1.x?