### PR TITLE
Have IFutureEnumerable.GetEnumerable executing immediatly the query

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">4</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">5</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -30,8 +30,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.0.4" overwrite="false" />
-	<property name="project.version.numeric" value="5.0.4" overwrite="false" />
+	<property name="project.version" value="5.0.5" overwrite="false" />
+	<property name="project.version.numeric" value="5.0.5" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,4 +1,12 @@
-﻿Build 5.0.4
+﻿Build 5.0.5
+=============================
+
+Release notes - NHibernate - Version 5.0.5
+
+** Bug
+    * #1665 Have IFutureEnumerable.GetEnumerable executing immediatly the query
+
+Build 5.0.4
 =============================
 
 Release notes - NHibernate - Version 5.0.4

--- a/src/NHibernate.Test/Async/Futures/FutureQueryFixture.cs
+++ b/src/NHibernate.Test/Async/Futures/FutureQueryFixture.cs
@@ -152,5 +152,25 @@ namespace NHibernate.Test.Futures
 				}
 			}
 		}
+
+		[Test]
+		public async Task FutureExecutedOnGetEnumerableAsync()
+		{
+			Sfi.Statistics.IsStatisticsEnabled = true;
+			try
+			{
+				using (var s = Sfi.OpenSession())
+				{
+					var persons = s.CreateQuery("from Person").Future<Person>();
+					Sfi.Statistics.Clear();
+					await (persons.GetEnumerableAsync());
+					Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
+				}
+			}
+			finally
+			{
+				Sfi.Statistics.IsStatisticsEnabled = false;
+			}
+		}
 	}
 }

--- a/src/NHibernate.Test/Futures/FutureQueryFixture.cs
+++ b/src/NHibernate.Test/Futures/FutureQueryFixture.cs
@@ -141,5 +141,25 @@ namespace NHibernate.Test.Futures
 				}
 			}
 		}
+
+		[Test]
+		public void FutureExecutedOnGetEnumerable()
+		{
+			Sfi.Statistics.IsStatisticsEnabled = true;
+			try
+			{
+				using (var s = Sfi.OpenSession())
+				{
+					var persons = s.CreateQuery("from Person").Future<Person>();
+					Sfi.Statistics.Clear();
+					persons.GetEnumerable();
+					Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
+				}
+			}
+			finally
+			{
+				Sfi.Statistics.IsStatisticsEnabled = false;
+			}
+		}
 	}
 }

--- a/src/NHibernate/Impl/DelayedEnumerator.cs
+++ b/src/NHibernate/Impl/DelayedEnumerator.cs
@@ -25,11 +25,7 @@ namespace NHibernate.Impl
 
 		public IEnumerable<T> GetEnumerable()
 		{
-			var value = _result();
-			foreach (T item in value)
-			{
-				yield return item;
-			}
+			return _result();
 		}
 
 		// Remove in 6.0


### PR DESCRIPTION
As raised in #1663, `IFutureEnumerable.GetEnumerable` does not actually execute the query, it is still a deferred `IEnumerable`. This contradicts its purpose and xml comment:

> Synchronously triggers the future query and all other pending future if the query was not already resolved, then returns a non-deferred enumerable of the query resulting items.

As this member has been introduced in 5.0, this PR targets the 5.0.x branch.

Update: the async file has been generated with the 0.8.2.1 AsyncGenerator instead of the 0.6.0, which cannot run with a recent MSBuild.