### PR TITLE
Purge more Invariant culture usages

### DIFF
--- a/src/NHibernate/Dialect/Function/AnsiTrimEmulationFunction.cs
+++ b/src/NHibernate/Dialect/Function/AnsiTrimEmulationFunction.cs
@@ -98,8 +98,8 @@ namespace NHibernate.Dialect.Function
 				//      so we trim leading and trailing spaces
 				return BothSpaceTrim.Render(args, factory);
 			}
-			
-			if (StringHelper.EqualsCaseInsensitive("from", firstArg))
+
+			if ("from".Equals(firstArg, StringComparison.OrdinalIgnoreCase))
 			{
 				// we have the form: trim(from trimSource).
 				//      This is functionally equivalent to trim(trimSource)
@@ -118,15 +118,15 @@ namespace NHibernate.Dialect.Function
 			// trim-specification has been specified.  we handle the
 			// exception to that explicitly
 			int potentialTrimCharacterArgIndex = 1;
-			if (StringHelper.EqualsCaseInsensitive("leading", firstArg))
+			if ("leading".Equals(firstArg, StringComparison.OrdinalIgnoreCase))
 			{
 				trailing = false;
 			}
-			else if (StringHelper.EqualsCaseInsensitive("trailing", firstArg))
+			else if ("trailing".Equals(firstArg, StringComparison.OrdinalIgnoreCase))
 			{
 				leading = false;
 			}
-			else if (StringHelper.EqualsCaseInsensitive("both", firstArg))
+			else if ("both".Equals(firstArg, StringComparison.OrdinalIgnoreCase))
 			{
 			}
 			else
@@ -135,7 +135,7 @@ namespace NHibernate.Dialect.Function
 			}
 
 			object potentialTrimCharacter = args[potentialTrimCharacterArgIndex];
-			if (StringHelper.EqualsCaseInsensitive("from", potentialTrimCharacter.ToString()))
+			if ("from".Equals(potentialTrimCharacter.ToString(), StringComparison.OrdinalIgnoreCase))
 			{
 				trimCharacter = "' '";
 				trimSource = args[potentialTrimCharacterArgIndex + 1];
@@ -148,7 +148,7 @@ namespace NHibernate.Dialect.Function
 			else
 			{
 				trimCharacter = potentialTrimCharacter;
-				if (StringHelper.EqualsCaseInsensitive("from", args[potentialTrimCharacterArgIndex + 1].ToString()))
+				if ("from".Equals(args[potentialTrimCharacterArgIndex + 1].ToString(), StringComparison.OrdinalIgnoreCase))
 				{
 					trimSource = args[potentialTrimCharacterArgIndex + 2];
 				}

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -92,7 +92,7 @@ namespace NHibernate.Dialect.Function
 
 		bool IFunctionGrammar.IsSeparator(string token)
 		{
-			return "as".Equals(token, StringComparison.InvariantCultureIgnoreCase);
+			return "as".Equals(token, StringComparison.OrdinalIgnoreCase);
 		}
 
 		bool IFunctionGrammar.IsKnownArgument(string token)

--- a/src/NHibernate/Dialect/Function/ClassicAggregateFunction.cs
+++ b/src/NHibernate/Dialect/Function/ClassicAggregateFunction.cs
@@ -77,8 +77,8 @@ namespace NHibernate.Dialect.Function
 			if (args.Count > 1)
 			{
 				object firstArg = args[0];
-				if (!StringHelper.EqualsCaseInsensitive("distinct", firstArg.ToString()) &&
-				    !StringHelper.EqualsCaseInsensitive("all", firstArg.ToString()))
+				if (!"distinct".Equals(firstArg.ToString(), StringComparison.OrdinalIgnoreCase) &&
+				    !"all".Equals(firstArg.ToString(), StringComparison.OrdinalIgnoreCase))
 				{
 					throw new QueryException(string.Format("Aggregate {0}(): token unknow {1}.", name, firstArg));
 				}

--- a/src/NHibernate/Driver/NDataReader.cs
+++ b/src/NHibernate/Driver/NDataReader.cs
@@ -612,7 +612,7 @@ namespace NHibernate.Driver
 
 				foreach (KeyValuePair<string, int> pair in fieldNameToIndex)
 				{
-					if (StringHelper.EqualsCaseInsensitive(pair.Key, colName))
+					if (string.Equals(pair.Key, colName, StringComparison.InvariantCultureIgnoreCase))
 					{
 						return pair.Value;
 					}

--- a/src/NHibernate/Hql/QuerySplitter.cs
+++ b/src/NHibernate/Hql/QuerySplitter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using NHibernate.Engine;
@@ -60,7 +59,6 @@ namespace NHibernate.Hql
 			string next = null;
 
 			templateQuery.Append(tokens[0]);
-			bool isSelectClause = StringHelper.EqualsCaseInsensitive("select", tokens[0]);
 
 			for (int i = 1; i < tokens.Length; i++)
 			{
@@ -69,9 +67,6 @@ namespace NHibernate.Hql
 				{
 					last = tokens[i - 1].ToLowerInvariant();
 				}
-
-				// select-range is terminated by declaration of "from"
-				isSelectClause = !StringHelper.EqualsCaseInsensitive("from", tokens[i]);
 
 				string token = tokens[i];
 				if (!ParserHelper.IsWhitespace(token) || last == null)
@@ -119,12 +114,6 @@ namespace NHibernate.Hql
 				log.Warn("no persistent classes found for query class: {0}", query);
 			}
 			return results;
-		}
-
-		private static bool IsPossiblyClassName(string last, string next)
-		{
-			return ParserHelper.EntityClass.Equals(last) ||
-				   (beforeClassTokens.Contains(last) && !notAfterClassTokens.Contains(next));
 		}
 	}
 }

--- a/src/NHibernate/Mapping/Column.cs
+++ b/src/NHibernate/Mapping/Column.cs
@@ -155,7 +155,7 @@ namespace NHibernate.Mapping
 			//    But I will leave it like this for now to make it look similar. /Oskar 2016-08-20
 			bool useRawName = name.Length + suffix.Length <= usableLength &&
 			                  !_quoted &&
-			                  !StringHelper.EqualsCaseInsensitive(name, "rowid");
+			                  !"rowid".Equals(name, StringComparison.OrdinalIgnoreCase);
 			if (!useRawName)
 			{
 				if (suffix.Length >= usableLength)

--- a/src/NHibernate/Mapping/ManyToOne.cs
+++ b/src/NHibernate/Mapping/ManyToOne.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Mapping
 				if (property == null)
 					throw new MappingException("Could not find property " + ReferencedPropertyName + " on " + ReferencedEntityName);
 
-				if (!HasFormula && !"none".Equals(ForeignKeyName, StringComparison.InvariantCultureIgnoreCase))
+				if (!HasFormula && !"none".Equals(ForeignKeyName, StringComparison.OrdinalIgnoreCase))
 				{
 
 					IEnumerable<Column> ce = new SafetyEnumerable<Column>(property.ColumnIterator);

--- a/src/NHibernate/Mapping/ReferenceDependantValue.cs
+++ b/src/NHibernate/Mapping/ReferenceDependantValue.cs
@@ -24,7 +24,7 @@ namespace NHibernate.Mapping
 
 		public override void CreateForeignKeyOfEntity(string entityName)
 		{
-			if (!HasFormula && !string.Equals("none", ForeignKeyName, StringComparison.InvariantCultureIgnoreCase))
+			if (!HasFormula && !string.Equals("none", ForeignKeyName, StringComparison.OrdinalIgnoreCase))
 			{
 				var referencedColumns = new List<Column>(_prototype.ColumnSpan);
 				foreach (Column column in _prototype.ColumnIterator)

--- a/src/NHibernate/Mapping/SimpleValue.cs
+++ b/src/NHibernate/Mapping/SimpleValue.cs
@@ -75,7 +75,7 @@ namespace NHibernate.Mapping
 
 		public virtual void CreateForeignKeyOfEntity(string entityName)
 		{
-			if (!HasFormula && ! "none".Equals(ForeignKeyName, StringComparison.InvariantCultureIgnoreCase))
+			if (!HasFormula && ! "none".Equals(ForeignKeyName, StringComparison.OrdinalIgnoreCase))
 			{
 				ForeignKey fk = table.CreateForeignKey(ForeignKeyName, ConstraintColumns, entityName);
 				fk.CascadeDeleteEnabled = cascadeDeleteEnabled;

--- a/src/NHibernate/SqlCommand/Parser/MsSqlSelectParser.cs
+++ b/src/NHibernate/SqlCommand/Parser/MsSqlSelectParser.cs
@@ -131,7 +131,7 @@ namespace NHibernate.SqlCommand.Parser
 					case SqlTokenType.Text:
 						if (blockLevel != 0) break;
 
-						if (token.Equals(",", StringComparison.InvariantCultureIgnoreCase))
+						if (token.Equals(",", StringComparison.Ordinal))
 						{
 							if (columnAliasToken != null)
 							{
@@ -139,7 +139,7 @@ namespace NHibernate.SqlCommand.Parser
 							}
 						}
 
-						if (token.Equals("from", StringComparison.InvariantCultureIgnoreCase))
+						if (token.Equals("from", StringComparison.OrdinalIgnoreCase))
 						{
 							if (columnAliasToken != null)
 							{
@@ -148,7 +148,7 @@ namespace NHibernate.SqlCommand.Parser
 							yield break;
 						}
 
-						if (token.Equals("as", StringComparison.InvariantCultureIgnoreCase))
+						if (token.Equals("as", StringComparison.OrdinalIgnoreCase))
 						{
 							columnEndToken = prevToken;
 						}
@@ -237,8 +237,8 @@ namespace NHibernate.SqlCommand.Parser
 					case SqlTokenType.Text:
 						if (blockLevel != 0) break;
 
-						if (token.Equals("asc", StringComparison.InvariantCultureIgnoreCase)
-							|| token.Equals("desc", StringComparison.InvariantCultureIgnoreCase))
+						if (token.Equals("asc", StringComparison.OrdinalIgnoreCase)
+							|| token.Equals("desc", StringComparison.OrdinalIgnoreCase))
 						{
 							orderEndToken = prevToken;
 							directionToken = token;
@@ -269,7 +269,7 @@ namespace NHibernate.SqlCommand.Parser
 		private OrderDefinition ParseOrderDefinition(SqlToken beginToken, SqlToken endToken, SqlToken directionToken)
 		{
 			var isDescending = directionToken != null &&
-							   directionToken.Equals("desc", StringComparison.InvariantCultureIgnoreCase);
+							   directionToken.Equals("desc", StringComparison.OrdinalIgnoreCase);
 
 			var columnNameOrIndex = beginToken == endToken
 				? beginToken.Value

--- a/src/NHibernate/SqlCommand/Parser/SqlTokenizerExtensions.cs
+++ b/src/NHibernate/SqlCommand/Parser/SqlTokenizerExtensions.cs
@@ -23,7 +23,7 @@ namespace NHibernate.SqlCommand.Parser
 							nestLevel--;
 							break;
 						case SqlTokenType.Text:
-							if (nestLevel == 0 && token.Equals(keyword, StringComparison.InvariantCultureIgnoreCase)) return true;
+							if (nestLevel == 0 && token.Equals(keyword, StringComparison.OrdinalIgnoreCase)) return true;
 							break;
 					}
 				}
@@ -34,9 +34,7 @@ namespace NHibernate.SqlCommand.Parser
 
 		public static bool TryParseUntilFirstMsSqlSelectColumn(this IEnumerator<SqlToken> tokenEnum)
 		{
-			SqlToken selectToken;
-			bool isDistinct;
-			return TryParseUntilFirstMsSqlSelectColumn(tokenEnum, out selectToken, out isDistinct);
+			return TryParseUntilFirstMsSqlSelectColumn(tokenEnum, out _, out _);
 		}
 
 		public static bool TryParseUntilFirstMsSqlSelectColumn(this IEnumerator<SqlToken> tokenEnum, out SqlToken selectToken, out bool isDistinct)
@@ -100,9 +98,7 @@ namespace NHibernate.SqlCommand.Parser
 				orderToken = tokenEnum.Current;
 				if (tokenEnum.MoveNext())
 				{
-					return tokenEnum.Current.Equals("by", StringComparison.InvariantCultureIgnoreCase)
-						? tokenEnum.MoveNext()
-						: false;
+					return tokenEnum.Current.Equals("by", StringComparison.OrdinalIgnoreCase) && tokenEnum.MoveNext();
 				}
 			}
 

--- a/src/NHibernate/SqlCommand/SqlString.cs
+++ b/src/NHibernate/SqlCommand/SqlString.cs
@@ -374,7 +374,7 @@ namespace NHibernate.SqlCommand
 		{
 			return value != null
 				&& value.Length <= _length
-				&& IndexOf(value, _length - value.Length, value.Length, StringComparison.CurrentCultureIgnoreCase) >= 0;
+				&& IndexOf(value, _length - value.Length, value.Length, StringComparison.InvariantCultureIgnoreCase) >= 0;
 		}
 
 		public IEnumerable<Parameter> GetParameters()

--- a/src/NHibernate/SqlCommand/SubselectClauseExtractor.cs
+++ b/src/NHibernate/SqlCommand/SubselectClauseExtractor.cs
@@ -111,7 +111,7 @@ namespace NHibernate.SqlCommand
 		private int FindFromClauseInPart(string part)
 		{
 			int afterLastClosingParenIndex = 0;
-			int fromIndex = StringHelper.IndexOfCaseInsensitive(part, FromClauseToken);
+			int fromIndex = part.IndexOf(FromClauseToken, StringComparison.OrdinalIgnoreCase);
 			
 			for (int i = 0; i < part.Length; i++)
 			{
@@ -133,13 +133,13 @@ namespace NHibernate.SqlCommand
 					}
 
 					afterLastClosingParenIndex = i + 1;
-					fromIndex = StringHelper.IndexOfCaseInsensitive(part, FromClauseToken, afterLastClosingParenIndex);
+					fromIndex = part.IndexOf(FromClauseToken, afterLastClosingParenIndex, StringComparison.OrdinalIgnoreCase);
 				}
 			}
 
 			if (afterLastClosingParenIndex == 0)
 			{
-				fromIndex = StringHelper.IndexOfCaseInsensitive(part, FromClauseToken);
+				fromIndex = part.IndexOf(FromClauseToken, StringComparison.OrdinalIgnoreCase);
 			}
 
 			if(parenNestCount > 0)
@@ -163,7 +163,7 @@ namespace NHibernate.SqlCommand
 			}
 
 			string partString = part as string;
-			int index = StringHelper.LastIndexOfCaseInsensitive(partString, OrderByToken);
+			int index = partString.LastIndexOf(OrderByToken, StringComparison.OrdinalIgnoreCase);
 			if (index >= 0)
 			{
 				lastOrderByPartIndex = builder.Count - 1;
@@ -175,8 +175,7 @@ namespace NHibernate.SqlCommand
 
 		private void IgnoreOrderByInSubselect(string partString)
 		{
-			int index;
-			index = StringHelper.LastIndexOfCaseInsensitive(partString, ")");
+			var index = partString.LastIndexOf(")", StringComparison.Ordinal);
 			if (index >= 0 && ParenIsAfterLastOrderBy(index))
 			{
 				lastOrderByPartIndex = -1;

--- a/src/NHibernate/Type/CharBooleanType.cs
+++ b/src/NHibernate/Type/CharBooleanType.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Type
 			}
 			else
 			{
-				return StringHelper.EqualsCaseInsensitive(code, TrueString);
+				return code.Equals(TrueString, StringComparison.InvariantCultureIgnoreCase);
 			}
 		}
 
@@ -68,11 +68,11 @@ namespace NHibernate.Type
 		/// <returns></returns>
 		public override object StringToObject(String xml)
 		{
-			if (StringHelper.EqualsCaseInsensitive(TrueString, xml))
+			if (string.Equals(TrueString, xml, StringComparison.InvariantCultureIgnoreCase))
 			{
 				return true;
 			}
-			else if (StringHelper.EqualsCaseInsensitive(FalseString, xml))
+			else if (string.Equals(FalseString, xml, StringComparison.InvariantCultureIgnoreCase))
 			{
 				return false;
 			}

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -658,31 +658,43 @@ namespace NHibernate.Util
 			return (loc < 0) ? qualifiedName : qualifiedName.Substring(loc + 1);
 		}
 
+		// Since 5.2
+		[Obsolete("This method has no more usage and will be removed in a future version")]
 		public static bool EqualsCaseInsensitive(string a, string b)
 		{
 			return StringComparer.InvariantCultureIgnoreCase.Compare(a, b) == 0;
 		}
 
+		// Since 5.2
+		[Obsolete("This method has no more usage and will be removed in a future version")]
 		public static int IndexOfCaseInsensitive(string source, string value)
 		{
 			return source.IndexOf(value, StringComparison.InvariantCultureIgnoreCase);
 		}
 
+		// Since 5.2
+		[Obsolete("This method has no more usage and will be removed in a future version")]
 		public static int IndexOfCaseInsensitive(string source, string value, int startIndex)
 		{
 			return source.IndexOf(value, startIndex, StringComparison.InvariantCultureIgnoreCase);
 		}
 
+		// Since 5.2
+		[Obsolete("This method has no more usage and will be removed in a future version")]
 		public static int IndexOfCaseInsensitive(string source, string value, int startIndex, int count)
 		{
 			return source.IndexOf(value, startIndex, count, StringComparison.InvariantCultureIgnoreCase);
 		}
 
+		// Since 5.2
+		[Obsolete("This method has no more usage and will be removed in a future version")]
 		public static int LastIndexOfCaseInsensitive(string source, string value)
 		{
 			return source.LastIndexOf(value, StringComparison.InvariantCultureIgnoreCase);
 		}
 
+		// Since 5.2
+		[Obsolete("This method has no more usage and will be removed in a future version")]
 		public static bool StartsWithCaseInsensitive(string source, string prefix)
 		{
 			return source.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase);


### PR DESCRIPTION
Comparing SQL keywords should be done with ordinal comparisons.
But invariant comparisons are kept for object names, because at least with SQL Server these comparisons are collation sensitive. (So ideally object names comparisons should even have their culture configurable...)

An undue current culture comparison for `SqlString.EndsWithCaseInsensitive` is also fixed.

Follow-up to #1567.