### PR TITLE
Bitwise operator adjustments

### DIFF
--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -448,14 +448,6 @@ namespace NHibernate.Test
 				{"bit_length", new HashSet<System.Type> {typeof (SQLiteDialect)}},
 				{"extract", new HashSet<System.Type> {typeof (SQLiteDialect)}},
 				{
-					"bxor",
-					new HashSet<System.Type>
-					{
-						// Could be supported like Oracle, with a template
-						typeof (SQLiteDialect)
-					}
-				},
-				{
 					"nullif",
 					new HashSet<System.Type>
 					{

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -452,12 +452,7 @@ namespace NHibernate.Test
 					new HashSet<System.Type>
 					{
 						// Could be supported like Oracle, with a template
-						typeof (SQLiteDialect),
-						// Could be supported by overriding registration with # instead of ^
-						typeof (PostgreSQLDialect),
-						typeof (PostgreSQL81Dialect),
-						typeof (PostgreSQL82Dialect),
-						typeof (PostgreSQL83Dialect)
+						typeof (SQLiteDialect)
 					}
 				},
 				{

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -117,10 +117,10 @@ namespace NHibernate.Dialect
 			RegisterFunction("year", new SQLFunctionTemplate(NHibernateUtil.Int32, "extract(year from ?1)"));
 
 			// Bitwise operations
-			RegisterFunction("band", new BitwiseNativeOperation("&"));
-			RegisterFunction("bor", new BitwiseNativeOperation("|"));
-			RegisterFunction("bxor", new BitwiseNativeOperation("^"));
-			RegisterFunction("bnot", new BitwiseNativeOperation("~", true));
+			RegisterFunction("band", new Function.BitwiseNativeOperation("&"));
+			RegisterFunction("bor", new Function.BitwiseNativeOperation("|"));
+			RegisterFunction("bxor", new Function.BitwiseNativeOperation("^"));
+			RegisterFunction("bnot", new Function.BitwiseNativeOperation("~", true));
 
 			RegisterFunction("str", new SQLFunctionTemplate(NHibernateUtil.String, "cast(?1 as char)"));
 

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -422,10 +422,10 @@ namespace NHibernate.Dialect
 			RegisterFunction("sysdate", new CastedFunction("today", NHibernateUtil.Date));
 			RegisterFunction("date", new SQLFunctionTemplate(NHibernateUtil.Date, "cast(?1 as date)"));
 			// Bitwise operations
-			RegisterFunction("band", new BitwiseFunctionOperation("bin_and"));
-			RegisterFunction("bor", new BitwiseFunctionOperation("bin_or"));
-			RegisterFunction("bxor", new BitwiseFunctionOperation("bin_xor"));
-			RegisterFunction("bnot", new BitwiseFunctionOperation("bin_not"));
+			RegisterFunction("band", new Function.BitwiseFunctionOperation("bin_and"));
+			RegisterFunction("bor", new Function.BitwiseFunctionOperation("bin_or"));
+			RegisterFunction("bxor", new Function.BitwiseFunctionOperation("bin_xor"));
+			RegisterFunction("bnot", new Function.BitwiseFunctionOperation("bin_not"));
 		}
 
 		private void RegisterFirebirdServerEmbeddedFunctions()

--- a/src/NHibernate/Dialect/Function/BitwiseFunctionOperation.cs
+++ b/src/NHibernate/Dialect/Function/BitwiseFunctionOperation.cs
@@ -1,11 +1,27 @@
 using System;
 using System.Collections;
-using NHibernate.Dialect.Function;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
 
+// 6.0 TODO: remove NHibernate.Dialect.BitwiseFunctionOperation,
+// and remove "Function." prefix where the non obsolete one is used.
 namespace NHibernate.Dialect
+{
+	/// <inheritdoc />
+	[Serializable]
+	// Since 5.2
+	[Obsolete("Use NHibernate.Dialect.Function.BitwiseFunctionOperation instead")]
+	public class BitwiseFunctionOperation : Function.BitwiseFunctionOperation
+	{
+		/// <inheritdoc />
+		public BitwiseFunctionOperation(string functionName): base(functionName)
+		{
+		}
+	}
+}
+
+namespace NHibernate.Dialect.Function
 {
 	/// <summary>
 	/// Treats bitwise operations as SQL function calls.

--- a/src/NHibernate/Dialect/Function/BitwiseNativeOperation.cs
+++ b/src/NHibernate/Dialect/Function/BitwiseNativeOperation.cs
@@ -1,11 +1,32 @@
 using System;
 using System.Collections;
-using NHibernate.Dialect.Function;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
 
+// 6.0 TODO: remove NHibernate.Dialect.BitwiseNativeOperation,
+// and remove "Function." prefix where the non obsolete one is used.
 namespace NHibernate.Dialect
+{
+	/// <inheritdoc />
+	[Serializable]
+	// Since 5.2
+	[Obsolete("Use NHibernate.Dialect.Function.BitwiseNativeOperation instead")]
+	public class BitwiseNativeOperation : Function.BitwiseNativeOperation
+	{
+		/// <inheritdoc />
+		public BitwiseNativeOperation(string sqlOpToken) : base(sqlOpToken)
+		{
+		}
+
+		/// <inheritdoc />
+		public BitwiseNativeOperation(string sqlOpToken, bool isNot) : base(sqlOpToken, isNot)
+		{
+		}
+	}
+}
+
+namespace NHibernate.Dialect.Function
 {
 	/// <summary>
 	/// Treats bitwise operations as native operations.
@@ -14,7 +35,7 @@ namespace NHibernate.Dialect
 	public class BitwiseNativeOperation : ISQLFunction
 	{
 		private readonly string _sqlOpToken;
-		private readonly bool _isNot;
+		private readonly bool _isUnary;
 
 		/// <summary>
 		/// Creates an instance using the giving token.
@@ -34,11 +55,11 @@ namespace NHibernate.Dialect
 		/// Creates an instance using the giving token and the flag indicating if it is an unary operator.
 		/// </summary>
 		/// <param name="sqlOpToken">The operation token.</param>
-		/// <param name="isNot">Whether the operation is unary or not.</param>
-		public BitwiseNativeOperation(string sqlOpToken, bool isNot)
+		/// <param name="isUnary">Whether the operation is unary or not.</param>
+		public BitwiseNativeOperation(string sqlOpToken, bool isUnary)
 		{
 			_sqlOpToken = sqlOpToken;
-			_isNot = isNot;
+			_isUnary = isUnary;
 		}
 
 		#region ISQLFunction Members
@@ -63,11 +84,11 @@ namespace NHibernate.Dialect
 
 			var sqlBuffer = new SqlStringBuilder();
 
-			if (!_isNot)
+			if (!_isUnary)
 				AddToBuffer(args[0], sqlBuffer);
 
 			sqlBuffer.Add(" ").Add(_sqlOpToken).Add(" ");
-			for (var i = _isNot ? 0 : 1; i < args.Count; i++)
+			for (var i = _isUnary ? 0 : 1; i < args.Count; i++)
 			{
 				AddToBuffer(args[i], sqlBuffer);
 			}

--- a/src/NHibernate/Dialect/HanaDialectBase.cs
+++ b/src/NHibernate/Dialect/HanaDialectBase.cs
@@ -384,10 +384,10 @@ namespace NHibernate.Dialect
 
 		protected virtual void RegisterNHibernateFunctions()
 		{
-			RegisterFunction("band", new BitwiseFunctionOperation("bitand"));
-			RegisterFunction("bor", new BitwiseFunctionOperation("bitor"));
-			RegisterFunction("bxor", new BitwiseFunctionOperation("bitxor"));
-			RegisterFunction("bnot", new BitwiseFunctionOperation("bitnot"));
+			RegisterFunction("band", new Function.BitwiseFunctionOperation("bitand"));
+			RegisterFunction("bor", new Function.BitwiseFunctionOperation("bitor"));
+			RegisterFunction("bxor", new Function.BitwiseFunctionOperation("bitxor"));
+			RegisterFunction("bnot", new Function.BitwiseFunctionOperation("bitnot"));
 			RegisterFunction("bit_length", new SQLFunctionTemplate(NHibernateUtil.Int32, "length(to_binary(?1))*8"));
 			RegisterFunction("ceiling", new StandardSQLFunction("ceil"));
 			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.AnsiChar));

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -303,7 +303,7 @@ namespace NHibernate.Dialect
 
 			RegisterFunction("iif", new SQLFunctionTemplate(null, "case when ?1 then ?2 else ?3 end"));
 
-			RegisterFunction("band", new BitwiseFunctionOperation("bitand"));
+			RegisterFunction("band", new Function.BitwiseFunctionOperation("bitand"));
 			RegisterFunction("bor", new SQLFunctionTemplate(null, "?1 + ?2 - BITAND(?1, ?2)"));
 			RegisterFunction("bxor", new SQLFunctionTemplate(null, "?1 + ?2 - BITAND(?1, ?2) * 2"));
 			RegisterFunction("bnot", new SQLFunctionTemplate(null, "(-1 - ?1)"));

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -84,7 +84,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("atan2", new StandardSQLFunction("atan2", NHibernateUtil.Double));
 
 			RegisterFunction("power", new StandardSQLFunction("power", NHibernateUtil.Double));
-			RegisterFunction("bxor", new BitwiseNativeOperation("#"));
+			RegisterFunction("bxor", new Function.BitwiseNativeOperation("#"));
 
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
 			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -88,6 +88,10 @@ namespace NHibernate.Dialect
 
 			RegisterFunction("round", new StandardSQLFunction("round"));
 
+			// SQLite has no built-in support of bitwise xor, but can emulate it.
+			// http://sqlite.1065341.n5.nabble.com/XOR-operator-td98004.html
+			RegisterFunction("bxor", new SQLFunctionTemplate(null, "((?1 | ?2) - (?1 & ?2))"));
+
 			// NH-3787: SQLite requires the cast in SQL too for not defaulting to string.
 			RegisterFunction("transparentcast", new CastFunction());
 		}


### PR DESCRIPTION
Enable tests for PostgreSQL (follow-up to #1673).
Enable bitwise xor support with SQLite (fixes #1690).
Move the bitwise functions to the `NHibernate.Dialect.Function` namespace.