### PR TITLE
Document setting the logger factory programmatically

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -1136,6 +1136,10 @@ in the parameter binding.</programlisting>
                                 set in the <literal>hibernate.cfg.xml</literal> configuration file.
                             </para>
                             <para>
+                                Alternatively to using the setting, a logger factory can be programmatically supplied by using
+                                <literal>NHibernateLogger.SetLoggersFactory</literal>.
+                            </para>
+                            <para>
                                 <emphasis role="strong">eg.</emphasis>
                                 <literal>classname.of.LoggerFactory, assembly</literal>
                             </para>


### PR DESCRIPTION
In order to avoid issues like #1697, documents the alternate way to using `nhibernate-logger` setting.