### PR TITLE
Single place to specify TargetFrameworks

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -11,7 +11,7 @@
     <FileVersion>$(VersionPrefix).0</FileVersion>
 
     <NhAppTargetFrameworks>net461;netcoreapp2.0</NhAppTargetFrameworks>
-    <NhLibTargetFrameworks>net461;netcoreapp2.0;netstandard2.0;</NhLibTargetFrameworks>
+    <NhLibTargetFrameworks>net461;netcoreapp2.0;netstandard2.0</NhLibTargetFrameworks>
 
     <Product>NHibernate</Product>
     <Company>NHibernate.info</Company>

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -10,6 +10,9 @@
     <AssemblyVersion>$(VersionMajor).$(VersionMinor).0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
 
+    <NhAppTargetFrameworks>net461;netcoreapp2.0</NhAppTargetFrameworks>
+    <NhLibTargetFrameworks>net461;netcoreapp2.0;netstandard2.0;</NhLibTargetFrameworks>
+
     <Product>NHibernate</Product>
     <Company>NHibernate.info</Company>
     <Copyright>Licensed under LGPL.</Copyright>

--- a/src/NHibernate.DomainModel/NHibernate.DomainModel.csproj
+++ b/src/NHibernate.DomainModel/NHibernate.DomainModel.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../build-common/NHibernate.props" />
   <PropertyGroup>
     <Description>The Domain Model used by the Unit Tests.</Description>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(NhLibTargetFrameworks)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);3001;3002;3003;3005</NoWarn>
   </PropertyGroup>

--- a/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
+++ b/src/NHibernate.Test.VisualBasic/NHibernate.Test.VisualBasic.vbproj
@@ -2,7 +2,7 @@
   <Import Project="../../build-common/NHibernate.props" />
   <PropertyGroup>
     <Description>The Visual Basic Unit Tests for NHibernate.</Description>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(NhAppTargetFrameworks)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);3001;3002;3003;3005</NoWarn>
     <OptionExplicit>On</OptionExplicit>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../build-common/NHibernate.props" />
   <PropertyGroup>
     <Description>The Unit Tests for NHibernate.</Description>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(NhAppTargetFrameworks)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);3001;3002;3003;3005</NoWarn>
   </PropertyGroup>

--- a/src/NHibernate.TestDatabaseSetup/NHibernate.TestDatabaseSetup.csproj
+++ b/src/NHibernate.TestDatabaseSetup/NHibernate.TestDatabaseSetup.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Title>NHibernate.TestDatabaseSetup</Title>
     <Description>Test Database Setup for NHibernate.</Description>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(NhAppTargetFrameworks)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);3001;3002;3003;3005</NoWarn>
   </PropertyGroup>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>An object persistence library for relational databases.</Description>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(NhLibTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3001;3002;3003;3005;1591;419</NoWarn>
     <SignAssembly>True</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>


### PR DESCRIPTION
It's better to have single place for build configuration;

But my main reason:
When you are on some shitty ultrabook and want to quickly disable other targets to make compilation less painful :)
