### PR TITLE
Lazy SQL generation for SelectLockingStrategy

### DIFF
--- a/src/NHibernate/Async/Dialect/Lock/SelectLockingStrategy.cs
+++ b/src/NHibernate/Async/Dialect/Lock/SelectLockingStrategy.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Dialect.Lock
 			ISessionFactoryImplementor factory = session.Factory;
 			try
 			{
-				var st = await (session.Batcher.PrepareCommandAsync(CommandType.Text, sql, lockable.IdAndVersionSqlTypes, cancellationToken)).ConfigureAwait(false);
+				var st = await (session.Batcher.PrepareCommandAsync(CommandType.Text, Sql, lockable.IdAndVersionSqlTypes, cancellationToken)).ConfigureAwait(false);
 				DbDataReader rs = null;
 				try
 				{
@@ -76,7 +76,7 @@ namespace NHibernate.Dialect.Lock
 				                       	{
 				                       		SqlException = sqle,
 				                       		Message = "could not lock: " + MessageHelper.InfoString(lockable, id, factory),
-				                       		Sql = sql.ToString(),
+				                       		Sql = Sql.ToString(),
 				                       		EntityName = lockable.EntityName,
 				                       		EntityId = id
 				                       	};

--- a/src/NHibernate/Dialect/Lock/SelectLockingStrategy.cs
+++ b/src/NHibernate/Dialect/Lock/SelectLockingStrategy.cs
@@ -22,15 +22,16 @@ namespace NHibernate.Dialect.Lock
 	{
 		private readonly ILockable lockable;
 		private readonly LockMode lockMode;
-		private SqlString sql;
+		private readonly Lazy<SqlString> sql;
 
 		public SelectLockingStrategy(ILockable lockable, LockMode lockMode)
 		{
 			this.lockable = lockable;
 			this.lockMode = lockMode;
+			this.sql = new Lazy<SqlString>(GenerateLockString);
 		}
 
-		private SqlString Sql => sql ?? (sql = GenerateLockString());
+		private SqlString Sql => sql.Value;
 
 		private SqlString GenerateLockString()
 		{

--- a/src/NHibernate/Dialect/Lock/SelectLockingStrategy.cs
+++ b/src/NHibernate/Dialect/Lock/SelectLockingStrategy.cs
@@ -22,14 +22,15 @@ namespace NHibernate.Dialect.Lock
 	{
 		private readonly ILockable lockable;
 		private readonly LockMode lockMode;
-		private readonly SqlString sql;
+		private SqlString sql;
 
 		public SelectLockingStrategy(ILockable lockable, LockMode lockMode)
 		{
 			this.lockable = lockable;
 			this.lockMode = lockMode;
-			sql = GenerateLockString();
 		}
+
+		private SqlString Sql => sql ?? (sql = GenerateLockString());
 
 		private SqlString GenerateLockString()
 		{
@@ -57,7 +58,7 @@ namespace NHibernate.Dialect.Lock
 			ISessionFactoryImplementor factory = session.Factory;
 			try
 			{
-				var st = session.Batcher.PrepareCommand(CommandType.Text, sql, lockable.IdAndVersionSqlTypes);
+				var st = session.Batcher.PrepareCommand(CommandType.Text, Sql, lockable.IdAndVersionSqlTypes);
 				DbDataReader rs = null;
 				try
 				{
@@ -100,7 +101,7 @@ namespace NHibernate.Dialect.Lock
 				                       	{
 				                       		SqlException = sqle,
 				                       		Message = "could not lock: " + MessageHelper.InfoString(lockable, id, factory),
-				                       		Sql = sql.ToString(),
+				                       		Sql = Sql.ToString(),
 				                       		EntityName = lockable.EntityName,
 				                       		EntityId = id
 				                       	};


### PR DESCRIPTION
I believe most of those lock statements are never used in most apps but we generate them for each lock mode:
https://github.com/nhibernate/nhibernate-core/blob/13e9e19ceaa4105a7cdd0297ad9245fa8fac72fc/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs#L1743-L1749

 So let's not waste memory unless it's really requested.