### PR TITLE
Entity Projection: Fixed AsEntity() for root entity

### DIFF
--- a/src/NHibernate.Test/Async/Criteria/EntityProjectionsTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/EntityProjectionsTest.cs
@@ -228,6 +228,26 @@ namespace NHibernate.Test.Criteria
 				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
 			}
 		}
+		
+		[Test]
+		public async Task EntityProjectionAsSelectExpressionForArgumentAliasAsync()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntitySimpleChild child1 = null;
+				var complex = await (session
+					.QueryOver<EntityComplex>()
+					.JoinAlias(ep => ep.Child1, () => child1)
+					.Select(ec => ec.AsEntity())
+					.Take(1).SingleOrDefaultAsync());
+
+				Assert.That(complex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(complex), Is.True, "Object must be initialized");
+				Assert.That(NHibernateUtil.IsInitialized(complex.Child1), Is.False, "Object must be lazy");
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
 
 		[Test]
 		public async Task EntityProjectionLockModeAsync()

--- a/src/NHibernate.Test/Criteria/EntityProjectionsTest.cs
+++ b/src/NHibernate.Test/Criteria/EntityProjectionsTest.cs
@@ -217,6 +217,26 @@ namespace NHibernate.Test.Criteria
 				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
 			}
 		}
+		
+		[Test]
+		public void EntityProjectionAsSelectExpressionForArgumentAlias()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntitySimpleChild child1 = null;
+				var complex = session
+					.QueryOver<EntityComplex>()
+					.JoinAlias(ep => ep.Child1, () => child1)
+					.Select(ec => ec.AsEntity())
+					.Take(1).SingleOrDefault();
+
+				Assert.That(complex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(complex), Is.True, "Object must be initialized");
+				Assert.That(NHibernateUtil.IsInitialized(complex.Child1), Is.False, "Object must be lazy");
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
 
 		[Test]
 		public void EntityProjectionLockMode()

--- a/src/NHibernate/Criterion/ProjectionsExtensions.cs
+++ b/src/NHibernate/Criterion/ProjectionsExtensions.cs
@@ -347,7 +347,10 @@ namespace NHibernate.Criterion
 		{
 			var expression = methodCallExpression.Arguments[0];
 			var aliasName = ExpressionProcessor.FindMemberExpression(expression);
-			return Projections.Entity(expression.Type, aliasName);
+			return
+				string.IsNullOrEmpty(aliasName)
+					? Projections.RootEntity()
+					: Projections.Entity(expression.Type, aliasName);
 		}
 	}
 }


### PR DESCRIPTION
When instead of actual alias func argument is used:
```C#
var list = session.QueryOver<Entity>()
.Select(e => e.AsEntity())
.List();
```
exception is thrown:
`Criteria\QueryOver alias '' for entity projection is not found.`
