### PR TITLE
Rationalize DateTimeOffset read and write

### DIFF
--- a/src/NHibernate/Type/DateTimeOffSetType.cs
+++ b/src/NHibernate/Type/DateTimeOffSetType.cs
@@ -58,21 +58,18 @@ namespace NHibernate.Type
 
 		public override void Set(DbCommand st, object value, int index, ISessionImplementor session)
 		{
-			var dateValue = (DateTimeOffset) value;
-			st.Parameters[index].Value =
-				new DateTimeOffset(dateValue.Ticks, dateValue.Offset);
+			st.Parameters[index].Value = value;
 		}
 
 		public override object Get(DbDataReader rs, int index, ISessionImplementor session)
 		{
 			try
 			{
-				var dbValue = (DateTimeOffset) rs[index];
-				return new DateTimeOffset(dbValue.Ticks, dbValue.Offset);
+				return (DateTimeOffset) rs[index];
 			}
 			catch (Exception ex)
 			{
-				throw new FormatException(string.Format("Input string '{0}' was not in the correct format.", rs[index]), ex);
+				throw new FormatException(string.Format("Input '{0}' was not in the correct format.", rs[index]), ex);
 			}
 		}
 


### PR DESCRIPTION
Some old unneeded code was lingering in the `DateTimeOffsetType` implementation.
It has initially be implemented by duplicating the old `DateTimeType` (the one cutting fractional seconds), leading to [NH-2358](https://nhibernate.jira.com/browse/NH-2358): it was duplicating the value while dropping fractional seconds.

This was fixed with 18bd45c in part as proposed in that ticket, by still duplicating the value but without dropping the fractional seconds. But there is no reasons for still duplicating the value.