### PR TITLE
Fix static proxy serialization

### DIFF
--- a/src/NHibernate.Test/StaticProxyTest/StaticProxyFactoryFixture.cs
+++ b/src/NHibernate.Test/StaticProxyTest/StaticProxyFactoryFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using NHibernate.Proxy;
 using NUnit.Framework;
 
@@ -16,6 +19,12 @@ namespace NHibernate.Test.StaticProxyTest
 			public virtual int Id { get; set; }
 		}
 
+		[Serializable]
+		public class SimpleTestClass
+		{
+			public virtual int Id { get; set; }
+		}
+
 		[Test]
 		public void CanCreateProxyForClassWithInternalInterface()
 		{
@@ -23,6 +32,62 @@ namespace NHibernate.Test.StaticProxyTest
 			factory.PostInstantiate(typeof(TestClass).FullName, typeof(TestClass), new HashSet<System.Type> {typeof(INHibernateProxy)}, null, null, null);
 			var proxy = factory.GetProxy(1, null);
 			Assert.That(proxy, Is.Not.Null);
+		}
+
+		[Test]
+		public void InitializedProxyStaysInitializedAfterDeserialization()
+		{
+			TestsContext.AssumeSystemTypeIsSerializable();
+
+			var factory = new StaticProxyFactory();
+			factory.PostInstantiate(typeof(SimpleTestClass).FullName, typeof(SimpleTestClass), new HashSet<System.Type> {typeof(INHibernateProxy)}, null, null, null);
+			var proxy = factory.GetProxy(2, null);
+			Assert.That(proxy, Is.Not.Null, "proxy");
+			Assert.That(NHibernateUtil.IsInitialized(proxy), Is.False, "proxy already initialized after creation");
+			Assert.That(proxy.HibernateLazyInitializer, Is.Not.Null, "HibernateLazyInitializer");
+
+			var impl = new SimpleTestClass { Id = 2 };
+			proxy.HibernateLazyInitializer.SetImplementation(impl);
+			Assert.That(NHibernateUtil.IsInitialized(proxy), Is.True, "proxy not initialized after setting implementation");
+
+			var serializer = new BinaryFormatter();
+			object deserialized;
+			using (var memoryStream = new MemoryStream())
+			{
+				serializer.Serialize(memoryStream, proxy);
+				memoryStream.Seek(0L, SeekOrigin.Begin);
+				deserialized = serializer.Deserialize(memoryStream);
+			}
+			Assert.That(deserialized, Is.Not.Null, "deserialized");
+			Assert.That(deserialized, Is.InstanceOf<INHibernateProxy>());
+			Assert.That(NHibernateUtil.IsInitialized(deserialized), Is.True, "proxy no more initialized after deserialization");
+			Assert.That(deserialized, Is.InstanceOf<SimpleTestClass>());
+			Assert.That(((SimpleTestClass) deserialized).Id, Is.EqualTo(2));
+		}
+
+		[Test]
+		public void NonInitializedProxyStaysNonInitializedAfterSerialization()
+		{
+			TestsContext.AssumeSystemTypeIsSerializable();
+
+			var factory = new StaticProxyFactory();
+			factory.PostInstantiate(typeof(SimpleTestClass).FullName, typeof(SimpleTestClass), new HashSet<System.Type> {typeof(INHibernateProxy)}, null, null, null);
+			var proxy = factory.GetProxy(2, null);
+			Assert.That(proxy, Is.Not.Null, "proxy");
+			Assert.That(NHibernateUtil.IsInitialized(proxy), Is.False, "proxy already initialized after creation");
+
+			var serializer = new BinaryFormatter();
+			object deserialized;
+			using (var memoryStream = new MemoryStream())
+			{
+				serializer.Serialize(memoryStream, proxy);
+				Assert.That(NHibernateUtil.IsInitialized(proxy), Is.False, "proxy initialized after serialization");
+				memoryStream.Seek(0L, SeekOrigin.Begin);
+				deserialized = serializer.Deserialize(memoryStream);
+			}
+			Assert.That(deserialized, Is.Not.Null, "deserialized");
+			Assert.That(deserialized, Is.InstanceOf<INHibernateProxy>());
+			Assert.That(NHibernateUtil.IsInitialized(deserialized), Is.False, "proxy initialized after deserialization");
 		}
 	}
 }

--- a/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
+++ b/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
@@ -24,6 +24,7 @@ namespace NHibernate.Proxy
 		private static readonly PropertyInfo LazyInitializerIdentifierProperty = LazyInitializerType.GetProperty(nameof(ILazyInitializer.Identifier));
 		private static readonly MethodInfo LazyInitializerInitializeMethod = LazyInitializerType.GetMethod(nameof(ILazyInitializer.Initialize));
 		private static readonly MethodInfo LazyInitializerGetImplementationMethod = LazyInitializerType.GetMethod(nameof(ILazyInitializer.GetImplementation), System.Type.EmptyTypes);
+		private static readonly PropertyInfo LazyInitializerIsUninitializedProperty = LazyInitializerType.GetProperty(nameof(ILazyInitializer.IsUninitialized));
 		private static readonly IProxyAssemblyBuilder ProxyAssemblyBuilder = new DefaultProxyAssemblyBuilder();
 
 		private static readonly ConstructorInfo SecurityCriticalAttributeConstructor = typeof(SecurityCriticalAttribute).GetConstructor(System.Type.EmptyTypes);
@@ -199,7 +200,12 @@ namespace NHibernate.Proxy
 			IL.Emit(OpCodes.Call, ReflectionCache.TypeMethods.GetTypeFromHandle);
 			IL.Emit(OpCodes.Callvirt, SerializationInfoSetTypeMethod);
 
-			// (new NHibernateProxyObjectReference(this.__proxyInfo, this.__lazyInitializer.Identifier)).GetObjectData(info, context);
+			// return
+			// 	(new NHibernateProxyObjectReference(
+			// 		this.__proxyInfo,
+			// 		this.__lazyInitializer.Identifier),
+			// 		this.__lazyInitializer.IsUninitialized ? null : this.__lazyInitializer.GetImplementation())
+			// 	.GetObjectData(info, context);
 			//this.__proxyInfo
 			IL.Emit(OpCodes.Ldarg_0);
 			IL.Emit(OpCodes.Ldfld, proxyInfoField);
@@ -209,11 +215,27 @@ namespace NHibernate.Proxy
 			IL.Emit(OpCodes.Ldfld, lazyInitializerField);
 			IL.Emit(OpCodes.Callvirt, LazyInitializerIdentifierProperty.GetMethod);
 
+			// this.__lazyInitializer.IsUninitialized ? null : this.__lazyInitializer.GetImplementation()
+			var isUnitialized = IL.DefineLabel();
+			var endIsUnitializedTernary = IL.DefineLabel();
+			IL.Emit(OpCodes.Ldarg_0);
+			IL.Emit(OpCodes.Ldfld, lazyInitializerField);
+			IL.Emit(OpCodes.Callvirt, LazyInitializerIsUninitializedProperty.GetMethod);
+			IL.Emit(OpCodes.Brtrue, isUnitialized);
+			IL.Emit(OpCodes.Ldarg_0);
+			IL.Emit(OpCodes.Ldfld, lazyInitializerField);
+			IL.Emit(OpCodes.Callvirt, LazyInitializerGetImplementationMethod);
+			IL.Emit(OpCodes.Br, endIsUnitializedTernary);
+			IL.MarkLabel(isUnitialized);
+			IL.Emit(OpCodes.Ldnull);
+			IL.MarkLabel(endIsUnitializedTernary);
+
 			var constructor = typeof(NHibernateProxyObjectReference).GetConstructor(
 				new[]
 				{
 					typeof(NHibernateProxyFactoryInfo),
 					typeof(object),
+					typeof(object)
 				});
 			IL.Emit(OpCodes.Newobj, constructor);
 


### PR DESCRIPTION
The static proxy serialization logic causes a regression compared to the previous dynamic proxy serialization: it loses the initialized state of the proxy, causing it to be always un-initialized after de-serialization.

This causes a performance loss for session serialization cases, since all proxies will lazily initialize if used, even if prior to serialization they were already initialized.

This causes a failure in case of direct serialization of an initialized proxy, since after deserialization, if used, it will attempt to lazily initialize and it will fail, being moreover no more connected to a session. Previously, it would have still been initialized and it would not have tried to lazily initialize on use.

Additionally, the static proxy deserialization constructor implementation always fails PeVerify. This implementation is not really used since deserialization is delegated to an object reference, but still, better generate assemblies not failing PeVerify whenever possible.