### PR TITLE
Fix a null-ref exception with no-proxy one-to-one

### DIFF
--- a/src/NHibernate/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/AdoNet/AbstractBatcher.cs
@@ -316,6 +316,8 @@ namespace NHibernate.AdoNet
 
 		private void CloseCommand(DbCommand cmd)
 		{
+			if (cmd == null)
+				return;
 			try
 			{
 				// no equiv to the java code in here


### PR DESCRIPTION
This null reference exception was swallowed and was only bloating logs.

The call with a `null` command originates from here:
https://github.com/nhibernate/nhibernate-core/blob/ee91396495a5e0874704f22c24ccde7412dafea0/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs#L1279-L1307

As `CloseReader` already does a silent early exit in case of `null`, I have chosen to fix this similarly in `CloseCommand`.