### PR TITLE
Upgrade to AsyncGenerator 0.8.2.7

### DIFF
--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -7,7 +7,7 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net461" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="CSharpAsyncGenerator.CommandLine" version="0.8.2.6" targetFramework="net461" />
+  <package id="CSharpAsyncGenerator.CommandLine" version="0.8.2.7" targetFramework="net461" />
   <package id="vswhere" version="2.1.4" targetFramework="net461" />
   <package id="gitreleasemanager" version="0.7.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Required for generating obsolete async methods for #1718 (https://github.com/nhibernate/nhibernate-core/pull/1718#discussion_r192739208)