### PR TITLE
Fix DbType.Binary registration in DB2Dialect

### DIFF
--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -32,6 +32,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.AnsiString, "VARCHAR(254)");
 			RegisterColumnType(DbType.AnsiString, 8000, "VARCHAR($l)");
 			RegisterColumnType(DbType.AnsiString, 2147483647, "CLOB");
+			RegisterColumnType(DbType.Binary, "BLOB");
 			RegisterColumnType(DbType.Binary, 2147483647, "BLOB");
 			RegisterColumnType(DbType.Boolean, "SMALLINT");
 			RegisterColumnType(DbType.Byte, "SMALLINT");


### PR DESCRIPTION
Was throwing:
```
System.ArgumentException : Dialect does not support DbType.Binary
Parameter name: typecode
   at NHibernate.Dialect.TypeNames.Get(DbType typecode)
   at NHibernate.Dialect.Dialect.GetTypeName(SqlType sqlType)
   at NHibernate.Mapping.Column.GetDialectTypeName(Dialect dialect, IMapping mapping)
   at NHibernate.Mapping.Column.GetSqlType(Dialect dialect, IMapping mapping)
   at NHibernate.Mapping.Table.SqlCreateString(Dialect dialect, IMapping p, String defaultCatalog, String defaultSchema)
   at NHibernate.Cfg.Configuration.GenerateSchemaCreationScript(Dialect dialect)
   at NHibernate.Tool.hbm2ddl.SchemaExport.Initialize()
   at NHibernate.Tool.hbm2ddl.SchemaExport.Execute(Action`1 scriptAction, Boolean execute, Boolean justDrop, TextWriter exportOutput)
   at NHibernate.Tool.hbm2ddl.SchemaExport.Execute(Action`1 scriptAction, Boolean execute, Boolean justDrop)
   at NHibernate.Tool.hbm2ddl.SchemaExport.Execute(Boolean useStdOut, Boolean execute, Boolean justDrop)
   at NHibernate.Tool.hbm2ddl.SchemaExport.Create(Boolean useStdOut, Boolean execute)
```