### PR TITLE
Remove obsoleted hibernate configuration prefix

### DIFF
--- a/doc/reference/modules/toolset_guide.xml
+++ b/doc/reference/modules/toolset_guide.xml
@@ -66,7 +66,7 @@
         
         <para>
             You <emphasis>must</emphasis> specify a SQL <literal>Dialect</literal> via the 
-            <literal>hibernate.dialect</literal> property when using this tool.
+            <literal>dialect</literal> configuration property when using this tool.
         </para>
 
         <sect2 id="toolsetguide-s1-2" revision="1">
@@ -262,23 +262,23 @@ new SchemaExport(cfg).Create(false, true);]]></programlisting>
                     </thead>
                     <tbody>
                     <row>
-                        <entry><literal>hibernate.connection.driver_class</literal></entry>
+                        <entry><literal>connection.driver_class</literal></entry>
                         <entry>jdbc driver class</entry>
                     </row>
                     <row>
-                        <entry><literal>hibernate.connection.url</literal></entry>
+                        <entry><literal>connection.url</literal></entry>
                         <entry>jdbc url</entry>
                     </row>
                     <row>
-                        <entry><literal>hibernate.connection.username</literal></entry>
+                        <entry><literal>connection.username</literal></entry>
                         <entry>database user</entry>
                     </row>
                     <row>
-                        <entry><literal>hibernate.connection.password</literal></entry>
+                        <entry><literal>connection.password</literal></entry>
                         <entry>user password</entry>
                     </row>
                     <row>
-                        <entry><literal>hibernate.dialect</literal></entry>
+                        <entry><literal>dialect</literal></entry>
                         <entry>dialect</entry>
                     </row>
                     </tbody>

--- a/src/NHibernate/CacheMode.cs
+++ b/src/NHibernate/CacheMode.cs
@@ -33,7 +33,7 @@ namespace NHibernate
 		/// <summary> 
 		/// The session will never read items from the cache, but will add items
 		/// to the cache as it reads them from the database. In this mode, the
-		/// effect of <tt>hibernate.cache.use_minimal_puts</tt> is bypassed, in
+		/// effect of <c>cache.use_minimal_puts</c> is bypassed, in
 		/// order to <em>force</em> a cache refresh
 		/// </summary>
 		Refresh = Put | 4 // NH: include Put but have a different value


### PR DESCRIPTION
The documentation was still prefixing some configuration properties
with the "hibernate." prefix, which has been removed since NH 2.0.0.GA.