### PR TITLE
Avoid more cases releasing a connection from transaction completion

### DIFF
--- a/doc/reference/modules/transactions.xml
+++ b/doc/reference/modules/transactions.xml
@@ -676,8 +676,8 @@ finally
                 </para>
                 <para>
                     When using <literal>transaction.use_connection_on_system_prepare</literal>, if the session is
-                    disposed within the scope, the connection releasing will still occurs from transaction
-                    completion event.
+                    disposed within the scope, the connection releasing may still occurs from transaction
+                    completion event. (This depends on the target database.)
                 </para>
             </listitem>
             <listitem>

--- a/src/NHibernate.Test/NHSpecificTest/GH1547/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1547/Fixture.cs
@@ -222,6 +222,9 @@ namespace NHibernate.Test.NHSpecificTest.GH1547
 		bool IDriver.SupportsEnlistmentWhenAutoEnlistmentIsDisabled =>
 			_driverImplementation.SupportsEnlistmentWhenAutoEnlistmentIsDisabled;
 
+		bool IDriver.SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare =>
+			_driverImplementation.SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare;
+
 		bool IDriver.HasDelayedDistributedTransactionCompletion =>
 			_driverImplementation.HasDelayedDistributedTransactionCompletion;
 

--- a/src/NHibernate.Test/TypesTest/AbstractDateTimeTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/AbstractDateTimeTypeFixture.cs
@@ -648,6 +648,9 @@ namespace NHibernate.Test.TypesTest
 		bool IDriver.SupportsEnlistmentWhenAutoEnlistmentIsDisabled =>
 			_driverImplementation.SupportsEnlistmentWhenAutoEnlistmentIsDisabled;
 
+		bool IDriver.SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare =>
+			_driverImplementation.SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare;
+
 		bool IDriver.HasDelayedDistributedTransactionCompletion =>
 			_driverImplementation.HasDelayedDistributedTransactionCompletion;
 

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -484,6 +484,21 @@ namespace NHibernate.AdoNet
 			_connection.EnlistTransaction(transaction);
 		}
 
+		/// <summary>
+		/// If the connection may not be used by a system transaction completion, release it.
+		/// </summary>
+		public void ReleaseConnectionNotNeededForSystemTransaction()
+		{
+			// The current connection will not be used if the dialect supports concurrent writting connections
+			// in the same transaction and if the connection is not user supplied. In such case it uses a dedicated
+			// connection to perform the flush from. (See BeginProcessingFromSystemTransaction.)
+			if (_connection != null && _ownConnection &&
+				Factory.Dialect.SupportsConcurrentWritingConnectionsInSameTransaction)
+			{
+				CloseConnection();
+			}
+		}
+
 		public IDisposable BeginProcessingFromSystemTransaction(bool allowConnectionUsage)
 		{
 			var needSwapping = _ownConnection && allowConnectionUsage &&

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -493,7 +493,8 @@ namespace NHibernate.AdoNet
 			// in the same transaction and if the connection is not user supplied. In such case it uses a dedicated
 			// connection to perform the flush from. (See BeginProcessingFromSystemTransaction.)
 			if (_connection != null && _ownConnection &&
-				Factory.Dialect.SupportsConcurrentWritingConnectionsInSameTransaction)
+				Factory.Dialect.SupportsConcurrentWritingConnectionsInSameTransaction &&
+				Factory.ConnectionProvider.Driver.SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare)
 			{
 				CloseConnection();
 			}

--- a/src/NHibernate/Driver/DriverBase.cs
+++ b/src/NHibernate/Driver/DriverBase.cs
@@ -326,6 +326,9 @@ namespace NHibernate.Driver
 		/// <inheritdoc />
 		public virtual bool SupportsEnlistmentWhenAutoEnlistmentIsDisabled => true;
 
+		/// <inheritdoc />
+		public virtual bool SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare => true;
+
 		public virtual bool HasDelayedDistributedTransactionCompletion => false;
 
 		/// <inheritdoc />

--- a/src/NHibernate/Driver/IDriver.cs
+++ b/src/NHibernate/Driver/IDriver.cs
@@ -144,6 +144,12 @@ namespace NHibernate.Driver
 		bool SupportsEnlistmentWhenAutoEnlistmentIsDisabled { get; }
 
 		/// <summary>
+		/// Does this driver connections support being closed during a scope then re-acquired during prepare, including
+		/// in case of concurrent rollback?
+		/// </summary>
+		bool SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare { get; }
+
+		/// <summary>
 		/// Does sometimes this driver finish distributed transaction after end of scope disposal?
 		/// </summary>
 		/// <remarks>

--- a/src/NHibernate/Driver/SqlClientDriver.cs
+++ b/src/NHibernate/Driver/SqlClientDriver.cs
@@ -300,6 +300,14 @@ namespace NHibernate.Driver
 		public override bool HasDelayedDistributedTransactionCompletion => true;
 
 		/// <inheritdoc />
+		/// <remarks>
+		/// The connection gets corrupted in case of rollback of a concurrent resource manager while a prepare phase
+		/// was using it. Furthermore, subsequent usage of a connection with same transaction string freezes.
+		/// See #1750.
+		/// </remarks>
+		public override bool SupportsClosingConnectionInsideScopeWithEnlistDuringPrepare => false;
+
+		/// <inheritdoc />
 		public override DateTime MinDate => new DateTime(1753, 1, 1);
 	}
 }

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -1491,6 +1491,13 @@ namespace NHibernate.Impl
 				if (TransactionContext != null && TransactionContext.CanFlushOnSystemTransactionCompleted)
 				{
 					TransactionContext.ShouldCloseSessionOnSystemTransactionCompleted = true;
+					// If the current connection is not going to be used anymore (by another session or on the flush
+					// from transaction completion or because it is a supplied one), release it now to avoid issues with
+					// data providers not supporting well having them released from transaction completion.
+					if (!IsTransactionCoordinatorShared && Factory.Dialect.SupportsConcurrentWritingConnectionsInSameTransaction)
+					{
+						ConnectionManager.ReleaseConnectionNotNeededForSystemTransaction();
+					}
 					return;
 				}
 				Dispose(true);


### PR DESCRIPTION
This is a follow up to [NH-4011](https://nhibernate.jira.com/browse/NH-4011), about system transactions integration.
When a session is disposed inside a scope while not having disabled flush from system transaction completion (`transaction.use_connection_on_system_prepare`), its connection is not released until transaction completion. Releasing connection from there was determined as source of random crashes (mainly connection pool corruption), at least with SQL-Server. Thus the introduction of the setting.
It appears Npgsql may also have such troubles (see npgsql/npgsql#1985).

This change allows to remove most remaining cases of connection closing from transaction completion, by always closing it from the session disposal, provided it may not be used by the flush from transaction
completion.