### PR TITLE
Avoid completing twice the same transaction

### DIFF
--- a/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
@@ -411,6 +411,10 @@ namespace NHibernate.Transaction
 			/// otherwise.</param>
 			protected virtual void CompleteTransaction(bool isCommitted)
 			{
+				// Some implementations (Mono) may "re-complete" the transaction on the cloned transaction disposal:
+				// do an early exit here in such case.
+				if (!IsInActiveTransaction)
+					return;
 				try
 				{
 					// Allow transaction completed actions to run while others stay blocked.


### PR DESCRIPTION
As seen in #1729, some implementation may "complete" many time the same transaction. NHibernate enlistment should detect this and complete a single time.

More specifically to the Mono case, this trouble could be avoided by ceasing using a transaction clone in NHibernate. But I am reluctant to do this more impacting change while it does not seem to be enough to get scope reliably working with Mono.