### PR TITLE
Fix possible InvalidCastException in ActionQueue

### DIFF
--- a/src/NHibernate/Action/AbstractEntityInsertAction.cs
+++ b/src/NHibernate/Action/AbstractEntityInsertAction.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NHibernate.Engine;
+using NHibernate.Persister.Entity;
+
+namespace NHibernate.Action
+{
+	[Serializable]
+	public abstract class AbstractEntityInsertAction : EntityAction
+	{
+		protected internal AbstractEntityInsertAction(
+			object id,
+			object[] state,
+			object instance,
+			IEntityPersister persister,
+			ISessionImplementor session)
+			: base(session, id, instance, persister)
+		{
+			State = state;
+		}
+
+		public object[] State { get; }
+	}
+}

--- a/src/NHibernate/Action/EntityInsertAction.cs
+++ b/src/NHibernate/Action/EntityInsertAction.cs
@@ -9,22 +9,15 @@ using NHibernate.Persister.Entity;
 namespace NHibernate.Action
 {
 	[Serializable]
-	public sealed partial class EntityInsertAction : EntityAction
+	public sealed partial class EntityInsertAction : AbstractEntityInsertAction
 	{
-		private readonly object[] state;
 		private object version;
 		private object cacheEntry;
 
 		public EntityInsertAction(object id, object[] state, object instance, object version, IEntityPersister persister, ISessionImplementor session)
-			: base(session, id, instance, persister)
+			: base(id, state, instance, persister, session)
 		{
-			this.state = state;
 			this.version = version;
-		}
-
-		public object[] State
-		{
-			get { return state; }
 		}
 
 		protected internal override bool HasPostCommitEventListeners
@@ -56,7 +49,7 @@ namespace NHibernate.Action
 			if (!veto)
 			{
 
-				persister.Insert(id, state, instance, Session);
+				persister.Insert(id, State, instance, Session);
 
 				EntityEntry entry = Session.PersistenceContext.GetEntry(instance);
 				if (entry == null)
@@ -68,12 +61,12 @@ namespace NHibernate.Action
 
 				if (persister.HasInsertGeneratedProperties)
 				{
-					persister.ProcessInsertGeneratedProperties(id, instance, state, Session);
+					persister.ProcessInsertGeneratedProperties(id, instance, State, Session);
 					if (persister.IsVersionPropertyGenerated)
 					{
-						version = Versioning.GetVersion(state, persister);
+						version = Versioning.GetVersion(State, persister);
 					}
-					entry.PostUpdate(instance, state, version);
+					entry.PostUpdate(instance, State, version);
 				}
 			}
 
@@ -81,7 +74,7 @@ namespace NHibernate.Action
 
 			if (IsCachePutEnabled(persister))
 			{
-				CacheEntry ce = new CacheEntry(state, persister, persister.HasUninitializedLazyProperties(instance), version, session, instance);
+				CacheEntry ce = new CacheEntry(State, persister, persister.HasUninitializedLazyProperties(instance), version, session, instance);
 				cacheEntry = persister.CacheEntryStructure.Structure(ce);
 
 				CacheKey ck = Session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
@@ -127,7 +120,7 @@ namespace NHibernate.Action
 			IPostInsertEventListener[] postListeners = Session.Listeners.PostInsertEventListeners;
 			if (postListeners.Length > 0)
 			{
-				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, state, Persister, (IEventSource)Session);
+				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, State, Persister, (IEventSource)Session);
 				foreach (IPostInsertEventListener listener in postListeners)
 				{
 					listener.OnPostInsert(postEvent);
@@ -140,7 +133,7 @@ namespace NHibernate.Action
 			IPostInsertEventListener[] postListeners = Session.Listeners.PostCommitInsertEventListeners;
 			if (postListeners.Length > 0)
 			{
-				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, state, Persister, (IEventSource)Session);
+				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, State, Persister, (IEventSource)Session);
 				foreach (IPostInsertEventListener listener in postListeners)
 				{
 					listener.OnPostInsert(postEvent);
@@ -154,7 +147,7 @@ namespace NHibernate.Action
 			bool veto = false;
 			if (preListeners.Length > 0)
 			{
-				var preEvent = new PreInsertEvent(Instance, Id, state, Persister, (IEventSource) Session);
+				var preEvent = new PreInsertEvent(Instance, Id, State, Persister, (IEventSource) Session);
 				foreach (IPreInsertEventListener listener in preListeners)
 				{
 					veto |= listener.OnPreInsert(preEvent);

--- a/src/NHibernate/Async/Action/EntityIdentityInsertAction.cs
+++ b/src/NHibernate/Async/Action/EntityIdentityInsertAction.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public sealed partial class EntityIdentityInsertAction : EntityAction
+	public sealed partial class EntityIdentityInsertAction : AbstractEntityInsertAction
 	{
 
 		public override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -41,10 +41,10 @@ namespace NHibernate.Action
 
 			if (!veto)
 			{
-				generatedId = await (persister.InsertAsync(state, instance, Session, cancellationToken)).ConfigureAwait(false);
+				generatedId = await (persister.InsertAsync(State, instance, Session, cancellationToken)).ConfigureAwait(false);
 				if (persister.HasInsertGeneratedProperties)
 				{
-					await (persister.ProcessInsertGeneratedPropertiesAsync(generatedId, instance, state, Session, cancellationToken)).ConfigureAwait(false);
+					await (persister.ProcessInsertGeneratedPropertiesAsync(generatedId, instance, State, Session, cancellationToken)).ConfigureAwait(false);
 				}
 				//need to do that here rather than in the save event listener to let
 				//the post insert events to have a id-filled entity when IDENTITY is used (EJB3)
@@ -77,7 +77,7 @@ namespace NHibernate.Action
 			IPostInsertEventListener[] postListeners = Session.Listeners.PostInsertEventListeners;
 			if (postListeners.Length > 0)
 			{
-				PostInsertEvent postEvent = new PostInsertEvent(Instance, generatedId, state, Persister, (IEventSource)Session);
+				PostInsertEvent postEvent = new PostInsertEvent(Instance, generatedId, State, Persister, (IEventSource)Session);
 				foreach (IPostInsertEventListener listener in postListeners)
 				{
 					await (listener.OnPostInsertAsync(postEvent, cancellationToken)).ConfigureAwait(false);
@@ -91,7 +91,7 @@ namespace NHibernate.Action
 			IPostInsertEventListener[] postListeners = Session.Listeners.PostCommitInsertEventListeners;
 			if (postListeners.Length > 0)
 			{
-				var postEvent = new PostInsertEvent(Instance, generatedId, state, Persister, (IEventSource) Session);
+				var postEvent = new PostInsertEvent(Instance, generatedId, State, Persister, (IEventSource) Session);
 				foreach (IPostInsertEventListener listener in postListeners)
 				{
 					await (listener.OnPostInsertAsync(postEvent, cancellationToken)).ConfigureAwait(false);
@@ -106,7 +106,7 @@ namespace NHibernate.Action
 			bool veto = false;
 			if (preListeners.Length > 0)
 			{
-				var preEvent = new PreInsertEvent(Instance, null, state, Persister, (IEventSource) Session);
+				var preEvent = new PreInsertEvent(Instance, null, State, Persister, (IEventSource) Session);
 				foreach (IPreInsertEventListener listener in preListeners)
 				{
 					veto |= await (listener.OnPreInsertAsync(preEvent, cancellationToken)).ConfigureAwait(false);

--- a/src/NHibernate/Async/Action/EntityInsertAction.cs
+++ b/src/NHibernate/Async/Action/EntityInsertAction.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Action
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public sealed partial class EntityInsertAction : EntityAction
+	public sealed partial class EntityInsertAction : AbstractEntityInsertAction
 	{
 
 		public override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -45,7 +45,7 @@ namespace NHibernate.Action
 			if (!veto)
 			{
 
-				await (persister.InsertAsync(id, state, instance, Session, cancellationToken)).ConfigureAwait(false);
+				await (persister.InsertAsync(id, State, instance, Session, cancellationToken)).ConfigureAwait(false);
 
 				EntityEntry entry = Session.PersistenceContext.GetEntry(instance);
 				if (entry == null)
@@ -57,12 +57,12 @@ namespace NHibernate.Action
 
 				if (persister.HasInsertGeneratedProperties)
 				{
-					await (persister.ProcessInsertGeneratedPropertiesAsync(id, instance, state, Session, cancellationToken)).ConfigureAwait(false);
+					await (persister.ProcessInsertGeneratedPropertiesAsync(id, instance, State, Session, cancellationToken)).ConfigureAwait(false);
 					if (persister.IsVersionPropertyGenerated)
 					{
-						version = Versioning.GetVersion(state, persister);
+						version = Versioning.GetVersion(State, persister);
 					}
-					entry.PostUpdate(instance, state, version);
+					entry.PostUpdate(instance, State, version);
 				}
 			}
 
@@ -70,7 +70,7 @@ namespace NHibernate.Action
 
 			if (IsCachePutEnabled(persister))
 			{
-				CacheEntry ce = new CacheEntry(state, persister, persister.HasUninitializedLazyProperties(instance), version, session, instance);
+				CacheEntry ce = new CacheEntry(State, persister, persister.HasUninitializedLazyProperties(instance), version, session, instance);
 				cacheEntry = persister.CacheEntryStructure.Structure(ce);
 
 				CacheKey ck = Session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
@@ -118,7 +118,7 @@ namespace NHibernate.Action
 			IPostInsertEventListener[] postListeners = Session.Listeners.PostInsertEventListeners;
 			if (postListeners.Length > 0)
 			{
-				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, state, Persister, (IEventSource)Session);
+				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, State, Persister, (IEventSource)Session);
 				foreach (IPostInsertEventListener listener in postListeners)
 				{
 					await (listener.OnPostInsertAsync(postEvent, cancellationToken)).ConfigureAwait(false);
@@ -132,7 +132,7 @@ namespace NHibernate.Action
 			IPostInsertEventListener[] postListeners = Session.Listeners.PostCommitInsertEventListeners;
 			if (postListeners.Length > 0)
 			{
-				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, state, Persister, (IEventSource)Session);
+				PostInsertEvent postEvent = new PostInsertEvent(Instance, Id, State, Persister, (IEventSource)Session);
 				foreach (IPostInsertEventListener listener in postListeners)
 				{
 					await (listener.OnPostInsertAsync(postEvent, cancellationToken)).ConfigureAwait(false);
@@ -147,7 +147,7 @@ namespace NHibernate.Action
 			bool veto = false;
 			if (preListeners.Length > 0)
 			{
-				var preEvent = new PreInsertEvent(Instance, Id, state, Persister, (IEventSource) Session);
+				var preEvent = new PreInsertEvent(Instance, Id, State, Persister, (IEventSource) Session);
 				foreach (IPreInsertEventListener listener in preListeners)
 				{
 					veto |= await (listener.OnPreInsertAsync(preEvent, cancellationToken)).ConfigureAwait(false);


### PR DESCRIPTION
This has found while I was reviewing #1414. In practice this never happens as the branch where `EntityIdentityInsertAction` is inserted into the action queue is never executed.