### PR TITLE
Decouple configuration of IObjectsFactory from BytecodeProvider

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/GH1547/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1547/Fixture.cs
@@ -132,7 +132,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1547
 
 		public DriverForSubstitutedCommand()
 		{
-			_driverImplementation = (IDriver) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(DriverClass);
+			_driverImplementation = (IDriver) Cfg.Environment.ObjectsFactory.CreateInstance(DriverClass);
 		}
 
 		DbCommand IDriver.GenerateCommand(CommandType type, SqlString sqlString, SqlType[] parameterTypes)

--- a/src/NHibernate.Test/TypesTest/AbstractDateTimeTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/AbstractDateTimeTypeFixture.cs
@@ -533,7 +533,7 @@ namespace NHibernate.Test.TypesTest
 
 		public ClientDriverWithParamsStats()
 		{
-			_driverImplementation = (IDriver) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(DriverClass);
+			_driverImplementation = (IDriver) Cfg.Environment.ObjectsFactory.CreateInstance(DriverClass);
 		}
 
 		private static void Inc<T>(T type, IDictionary<T, int> dic)

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaExport.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaExport.cs
@@ -187,7 +187,7 @@ namespace NHibernate.Tool.hbm2ddl
 			cancellationToken.ThrowIfCancellationRequested();
 			if (dialect.SupportsSqlBatches)
 			{
-				var objFactory = Environment.BytecodeProvider.ObjectsFactory;
+				var objFactory = Environment.ObjectsFactory;
 				ScriptSplitter splitter = (ScriptSplitter)objFactory.CreateInstance(typeof(ScriptSplitter), sql);
 
 				foreach (string stmt in splitter)

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaUpdate.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaUpdate.cs
@@ -78,7 +78,7 @@ namespace NHibernate.Tool.hbm2ddl
 						{
 							cfg.SetNamingStrategy(
 								(INamingStrategy)
-								Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
+								Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
 						}
 					}
 					else

--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaValidator.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaValidator.cs
@@ -48,7 +48,7 @@ namespace NHibernate.Tool.hbm2ddl
 						{
 							cfg.SetNamingStrategy(
 								(INamingStrategy)
-								Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
+								Cfg.Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
 						}
 					}
 					else

--- a/src/NHibernate/Bytecode/AbstractBytecodeProvider.cs
+++ b/src/NHibernate/Bytecode/AbstractBytecodeProvider.cs
@@ -6,7 +6,6 @@ namespace NHibernate.Bytecode
 {
 	public abstract class AbstractBytecodeProvider : IBytecodeProvider, IInjectableProxyFactoryFactory, IInjectableCollectionTypeFactoryClass
 	{
-		private readonly IObjectsFactory objectsFactory = new ActivatorObjectsFactory();
 		protected System.Type proxyFactoryFactory;
 		private ICollectionTypeFactory collectionTypeFactory;
 		private System.Type collectionTypeFactoryClass = typeof(Type.DefaultCollectionTypeFactory);
@@ -21,7 +20,7 @@ namespace NHibernate.Bytecode
 				{
 					try
 					{
-						return (IProxyFactoryFactory) ObjectsFactory.CreateInstance(proxyFactoryFactory);
+						return (IProxyFactoryFactory) Cfg.Environment.ObjectsFactory.CreateInstance(proxyFactoryFactory);
 					}
 					catch (Exception e)
 					{
@@ -35,10 +34,9 @@ namespace NHibernate.Bytecode
 
 		public abstract IReflectionOptimizer GetReflectionOptimizer(System.Type clazz, IGetter[] getters, ISetter[] setters);
 
-		public virtual IObjectsFactory ObjectsFactory
-		{
-			get { return objectsFactory; }
-		}
+		// Since 5.2
+		[Obsolete("Please use NHibernate.Cfg.Environment.ObjectsFactory instead")]
+		public virtual IObjectsFactory ObjectsFactory => Cfg.Environment.ObjectsFactory;
 
 		public virtual ICollectionTypeFactory CollectionTypeFactory
 		{
@@ -49,7 +47,7 @@ namespace NHibernate.Bytecode
 					try
 					{
 						collectionTypeFactory =
-							(ICollectionTypeFactory) ObjectsFactory.CreateInstance(collectionTypeFactoryClass);
+							(ICollectionTypeFactory) Cfg.Environment.ObjectsFactory.CreateInstance(collectionTypeFactoryClass);
 					}
 					catch (Exception e)
 					{

--- a/src/NHibernate/Bytecode/IBytecodeProvider.cs
+++ b/src/NHibernate/Bytecode/IBytecodeProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using NHibernate.Properties;
 
 namespace NHibernate.Bytecode
@@ -26,6 +27,8 @@ namespace NHibernate.Bytecode
 		/// <remarks>
 		/// For entities <see cref="IReflectionOptimizer"/> and its implementations.
 		/// </remarks>
+		// Since 5.2
+		[Obsolete("Please use NHibernate.Cfg.Environment.ObjectsFactory instead")]
 		IObjectsFactory ObjectsFactory { get; }
 
 		/// <summary>

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -1902,7 +1902,7 @@ namespace NHibernate.Cfg
 				{
 					try
 					{
-						listeners[i] = Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(listenerClasses[i]));
+						listeners[i] = Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(listenerClasses[i]));
 					}
 					catch (Exception e)
 					{

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -382,6 +382,16 @@ namespace NHibernate.Cfg
 		}
 
 		/// <summary>
+		/// NHibernate's object instantiator.
+		/// </summary>
+		/// <remarks>
+		/// This should only be set before a configuration object
+		/// is created, otherwise the change may not take effect.
+		/// For entities see <see cref="IReflectionOptimizer"/> and its implementations.
+		/// </remarks>
+		public static IObjectsFactory ObjectsFactory { get; set; } = new ActivatorObjectsFactory();
+
+		/// <summary>
 		/// Whether to enable the use of reflection optimizer
 		/// </summary>
 		/// <remarks>

--- a/src/NHibernate/Cfg/SettingsFactory.cs
+++ b/src/NHibernate/Cfg/SettingsFactory.cs
@@ -217,7 +217,7 @@ namespace NHibernate.Cfg
 				{
 					settings.QueryCacheFactory =
 						(IQueryCacheFactory)
-						Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(queryCacheFactoryClassName));
+						Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(queryCacheFactoryClassName));
 				}
 				catch (Exception cnfe)
 				{
@@ -331,7 +331,7 @@ namespace NHibernate.Cfg
 			log.Info("Batcher factory: {0}", tBatcher.AssemblyQualifiedName);
 			try
 			{
-				return (IBatcherFactory) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(tBatcher);
+				return (IBatcherFactory) Environment.ObjectsFactory.CreateInstance(tBatcher);
 			}
 			catch (Exception cnfe)
 			{
@@ -352,7 +352,7 @@ namespace NHibernate.Cfg
 			{
 				return
 					(ICacheProvider)
-					Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(cacheClassName));
+					Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(cacheClassName));
 			}
 			catch (Exception e)
 			{
@@ -370,7 +370,7 @@ namespace NHibernate.Cfg
 			{
 				return
 					(IQueryTranslatorFactory)
-					Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(className));
+					Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(className));
 			}
 			catch (Exception cnfe)
 			{
@@ -403,7 +403,7 @@ namespace NHibernate.Cfg
 			{
 				var transactionFactory =
 					(ITransactionFactory)
-					Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(className));
+					Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(className));
 				transactionFactory.Configure(properties);
 				return transactionFactory;
 			}
@@ -426,7 +426,7 @@ namespace NHibernate.Cfg
 			{
 				return
 					(IQueryModelRewriterFactory)
-					Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(className));
+					Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(className));
 			}
 			catch (Exception cnfe)
 			{

--- a/src/NHibernate/Cfg/XmlHbmBinding/AuxiliaryDatabaseObjectFactory.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/AuxiliaryDatabaseObjectFactory.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 				System.Type customType = ReflectHelper.ClassForName(className);
 
 				IAuxiliaryDatabaseObject customObject =
-					(IAuxiliaryDatabaseObject) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(customType);
+					(IAuxiliaryDatabaseObject) Environment.ObjectsFactory.CreateInstance(customType);
 
 				foreach (string dialectName in databaseObjectSchema.FindDialectScopeNames())
 				{

--- a/src/NHibernate/Connection/ConnectionProvider.cs
+++ b/src/NHibernate/Connection/ConnectionProvider.cs
@@ -105,7 +105,7 @@ namespace NHibernate.Connection
 				try
 				{
 					driver =
-						(IDriver) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(driverClass));
+						(IDriver) Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(driverClass));
 					driver.Configure(settings);
 				}
 				catch (Exception e)

--- a/src/NHibernate/Connection/ConnectionProviderFactory.cs
+++ b/src/NHibernate/Connection/ConnectionProviderFactory.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Connection
 					log.Info("Initializing connection provider: {0}", providerClass);
 					connections =
 						(IConnectionProvider)
-						Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(providerClass));
+						Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(providerClass));
 				}
 				catch (Exception e)
 				{

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -184,7 +184,7 @@ namespace NHibernate.Dialect
 		{
 			try
 			{
-				var dialect = (Dialect)Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(dialectName));
+				var dialect = (Dialect)Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(dialectName));
 				dialect.Configure(props);
 				return dialect;
 			}

--- a/src/NHibernate/Driver/ReflectionDriveConnectionCommandProvider.cs
+++ b/src/NHibernate/Driver/ReflectionDriveConnectionCommandProvider.cs
@@ -27,12 +27,12 @@ namespace NHibernate.Driver
 
 		public DbConnection CreateConnection()
 		{
-			return (DbConnection) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(connectionType);
+			return (DbConnection) Environment.ObjectsFactory.CreateInstance(connectionType);
 		}
 
 		public DbCommand CreateCommand()
 		{
-			return (DbCommand) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(commandType);
+			return (DbCommand) Environment.ObjectsFactory.CreateInstance(commandType);
 		}
 
 		#endregion

--- a/src/NHibernate/Exceptions/SQLExceptionConverterFactory.cs
+++ b/src/NHibernate/Exceptions/SQLExceptionConverterFactory.cs
@@ -105,7 +105,7 @@ namespace NHibernate.Exceptions
 				}
 
 				// Otherwise, try to use the no-arg constructor
-				return (ISQLExceptionConverter) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(converterClass);
+				return (ISQLExceptionConverter) Cfg.Environment.ObjectsFactory.CreateInstance(converterClass);
 			}
 			catch (Exception t)
 			{

--- a/src/NHibernate/Id/IdentifierGeneratorFactory.cs
+++ b/src/NHibernate/Id/IdentifierGeneratorFactory.cs
@@ -203,7 +203,7 @@ namespace NHibernate.Id
 			try
 			{
 				System.Type clazz = GetIdentifierGeneratorClass(strategy, dialect);
-				var idgen = (IIdentifierGenerator) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(clazz);
+				var idgen = (IIdentifierGenerator) Cfg.Environment.ObjectsFactory.CreateInstance(clazz);
 				var conf = idgen as IConfigurable;
 				if (conf != null)
 				{

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1283,7 +1283,7 @@ namespace NHibernate.Impl
 			{
 				System.Type implClass = ReflectHelper.ClassForName(impl);
 				return
-					(ICurrentSessionContext)Environment.BytecodeProvider.ObjectsFactory.CreateInstance(implClass, new object[] { this });
+					(ICurrentSessionContext)Environment.ObjectsFactory.CreateInstance(implClass, new object[] { this });
 			}
 			catch (Exception e)
 			{

--- a/src/NHibernate/Linq/Functions/LinqToHqlGeneratorsRegistryFactory.cs
+++ b/src/NHibernate/Linq/Functions/LinqToHqlGeneratorsRegistryFactory.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Linq.Functions
 				try
 				{
 					log.Info("Initializing LinqToHqlGeneratorsRegistry: {0}", registry);
-					return (ILinqToHqlGeneratorsRegistry) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(registry));
+					return (ILinqToHqlGeneratorsRegistry) Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(registry));
 				}
 				catch (Exception e)
 				{

--- a/src/NHibernate/Mapping/Collection.cs
+++ b/src/NHibernate/Mapping/Collection.cs
@@ -152,7 +152,7 @@ namespace NHibernate.Mapping
 				{
 					try
 					{
-						comparer = Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(ComparerClassName));
+						comparer = Cfg.Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(ComparerClassName));
 					}
 					catch (Exception ex)
 					{

--- a/src/NHibernate/Properties/PropertyAccessorFactory.cs
+++ b/src/NHibernate/Properties/PropertyAccessorFactory.cs
@@ -260,7 +260,7 @@ namespace NHibernate.Properties
 
 			try
 			{
-				var result = (IPropertyAccessor) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(accessorClass);
+				var result = (IPropertyAccessor) Cfg.Environment.ObjectsFactory.CreateInstance(accessorClass);
 				accessors[accessorName] = result;
 				return result;
 			}

--- a/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs
+++ b/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs
@@ -203,7 +203,7 @@ namespace NHibernate.Tool.hbm2ddl
 		{
 			if (dialect.SupportsSqlBatches)
 			{
-				var objFactory = Environment.BytecodeProvider.ObjectsFactory;
+				var objFactory = Environment.ObjectsFactory;
 				ScriptSplitter splitter = (ScriptSplitter)objFactory.CreateInstance(typeof(ScriptSplitter), sql);
 
 				foreach (string stmt in splitter)

--- a/src/NHibernate/Tool/hbm2ddl/SchemaUpdate.cs
+++ b/src/NHibernate/Tool/hbm2ddl/SchemaUpdate.cs
@@ -105,7 +105,7 @@ namespace NHibernate.Tool.hbm2ddl
 						{
 							cfg.SetNamingStrategy(
 								(INamingStrategy)
-								Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
+								Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
 						}
 					}
 					else

--- a/src/NHibernate/Tool/hbm2ddl/SchemaValidator.cs
+++ b/src/NHibernate/Tool/hbm2ddl/SchemaValidator.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Tool.hbm2ddl
 						{
 							cfg.SetNamingStrategy(
 								(INamingStrategy)
-								Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
+								Cfg.Environment.ObjectsFactory.CreateInstance(ReflectHelper.ClassForName(args[i].Substring(9))));
 						}
 					}
 					else

--- a/src/NHibernate/Transform/AliasToBeanResultTransformer.cs
+++ b/src/NHibernate/Transform/AliasToBeanResultTransformer.cs
@@ -85,7 +85,7 @@ namespace NHibernate.Transform
 			{
 				result = _resultClass.IsClass
 							? _beanConstructor.Invoke(null)
-							: Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(_resultClass, true);
+							: Cfg.Environment.ObjectsFactory.CreateInstance(_resultClass, true);
 
 				for (int i = 0; i < aliases.Length; i++)
 				{

--- a/src/NHibernate/Tuple/PocoInstantiator.cs
+++ b/src/NHibernate/Tuple/PocoInstantiator.cs
@@ -103,7 +103,7 @@ namespace NHibernate.Tuple
 			}
 			if (mappedClass.IsValueType)
 			{
-				return Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(mappedClass, true);
+				return Cfg.Environment.ObjectsFactory.CreateInstance(mappedClass, true);
 			}
 			if (constructor == null)
 			{

--- a/src/NHibernate/Type/CompositeCustomType.cs
+++ b/src/NHibernate/Type/CompositeCustomType.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Type
 
 			try
 			{
-				userType = (ICompositeUserType) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(userTypeClass);
+				userType = (ICompositeUserType) Cfg.Environment.ObjectsFactory.CreateInstance(userTypeClass);
 			}
 			catch (MethodAccessException mae)
 			{

--- a/src/NHibernate/Type/CustomCollectionType.cs
+++ b/src/NHibernate/Type/CustomCollectionType.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Type
 
 			try
 			{
-				userType = (IUserCollectionType) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(userTypeClass);
+				userType = (IUserCollectionType) Cfg.Environment.ObjectsFactory.CreateInstance(userTypeClass);
 			}
 			catch (InstantiationException ie)
 			{

--- a/src/NHibernate/Type/CustomType.cs
+++ b/src/NHibernate/Type/CustomType.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Type
 
 			try
 			{
-				userType = (IUserType) Cfg.Environment.BytecodeProvider.ObjectsFactory.CreateInstance(userTypeClass);
+				userType = (IUserType) Cfg.Environment.ObjectsFactory.CreateInstance(userTypeClass);
 			}
 			catch (ArgumentNullException ane)
 			{

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -542,7 +542,7 @@ namespace NHibernate.Type
 			{
 				try
 				{
-					type = (IType) Environment.BytecodeProvider.ObjectsFactory.CreateInstance(typeClass);
+					type = (IType) Environment.ObjectsFactory.CreateInstance(typeClass);
 				}
 				catch (Exception e)
 				{


### PR DESCRIPTION
Here is a simple solution to configure `IObjectsFactory` separately from `IBytecodeProvider`, [related issue](https://github.com/nhibernate/nhibernate-core/issues/1671). I know that having it configured statically is not the best solution, but the problem is that today, `IObjectsFactory` is used by many static methods that are public. If we want this in `5.2`, this is the only possible solution that I see.
In addition, the `IObjectsFactory` has an overload with the `nonPublic` parameter which is not possible to implement with most of the IoC containers. The overload is currently used in only two places ([AliasToBeanResultTransformer](https://github.com/nhibernate/nhibernate-core/blob/bced0cd2389fe931d885327b630e1ee9fbed4b75/src/NHibernate/Transform/AliasToBeanResultTransformer.cs#L88) and [PocoInstantiator](https://github.com/nhibernate/nhibernate-core/blob/a058d38eee7d23488a377248b903e1b90ef2e554/src/NHibernate/Tuple/PocoInstantiator.cs#L106)) and all tests passes when the second argument is removed. Wouldn't it be better to obsolete that overload and let the implementor decide whether to use a non public constructor? 

Even the overload with the `ctorArgs` is not possible to implement with some IoC containers as it is [considered as a code smell](https://www.cuttingedge.it/blogs/steven/pivot/entry.php?id=99). This overload is also used only two times, one time in [SessionFactoryImpl](https://github.com/nhibernate/nhibernate-core/blob/1024b71aec3b5e75c80e0ad6515943d6aee4adba/src/NHibernate/Impl/SessionFactoryImpl.cs#L1286) which is not that easy to change because of the circular dependency between `ICurrentSessionContext` and `ISessionFactory` and the second in [SchemaExport](https://github.com/nhibernate/nhibernate-core/blob/f8b1bc46f92c7a8cd503d3450f73f6b33ad4e8fb/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs#L207) which is quite strange as the [ScriptSplitter](https://github.com/nhibernate/nhibernate-core/blob/ad4c2ef101cbf8ba798220973f4f78dd795e0896/src/NHibernate/Tool/hbm2ddl/ScriptSplitter.cs#L9) does not have any virtual members.