### PR TITLE
Support mixed formulas and columns in By Code

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1759/ColumnsAndFormulasFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1759/ColumnsAndFormulasFixture.cs
@@ -182,7 +182,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1759
 			}
 		}
 
-		[Test, Ignore("Needs an unrelated additional simple fix in OneToManyPersister")]
+		[Test]
 		public async Task CheckMapKeyAsync()
 		{
 			using (var session = OpenSession())

--- a/src/NHibernate.Test/MappingByCode/MappersTests/ManyToManyMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/ManyToManyMapperTest.cs
@@ -1,25 +1,14 @@
 using System.Linq;
-using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
+using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode.Impl;
 using NUnit.Framework;
 
 namespace NHibernate.Test.MappingByCode.MappersTests
 {
 	[TestFixture]
-	public class ElementMapperTest
+	public class ManyToManyMapperTest
 	{
-		[Test]
-		public void WhenSetTypeByICompositeUserTypeThenSetTypeName()
-		{
-			var mapping = new HbmElement();
-			var mapper = new ElementMapper(typeof(object), mapping);
-
-			Assert.That(() => mapper.Type<MyCompoType>(), Throws.Nothing);
-			Assert.That(mapping.Type.name, Does.Contain(nameof(MyCompoType)));
-			Assert.That(mapping.type, Is.Null);
-		}
-
 		private class Element
 		{
 		}
@@ -27,8 +16,9 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		[Test]
 		public void CanSetColumnsAndFormulas()
 		{
-			var mapping = new HbmElement();
-			IElementMapper mapper = new ElementMapper(typeof(Element), mapping);
+			var hbmMapping = new HbmMapping();
+			var mapping = new HbmManyToMany();
+			IManyToManyMapper mapper = new ManyToManyMapper(typeof(Element), mapping, hbmMapping);
 			mapper.ColumnsAndFormulas(x => x.Name("pizza"), x => x.Formula("risotto"), x => x.Name("pasta"));
 
 			Assert.That(mapping.Items, Has.Length.EqualTo(3));
@@ -45,8 +35,9 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		[Test]
 		public void CanSetMultipleFormulas()
 		{
-			var mapping = new HbmElement();
-			IElementMapper mapper = new ElementMapper(typeof(Element), mapping);
+			var hbmMapping = new HbmMapping();
+			var mapping = new HbmManyToMany();
+			IManyToManyMapper mapper = new ManyToManyMapper(typeof(Element), mapping, hbmMapping);
 			mapper.Formulas("formula1", "formula2", "formula3");
 
 			Assert.That(mapping.formula, Is.Null);

--- a/src/NHibernate.Test/MappingByCode/MappersTests/ManyToOneMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/ManyToOneMapperTest.cs
@@ -218,6 +218,42 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		}
 
 		[Test]
+		public void CanSetColumnsAndFormulas()
+		{
+			var hbmMapping = new HbmMapping();
+			var member = typeof(MyClass).GetProperty("Relation");
+			var mapping = new HbmManyToOne();
+			IManyToOneMapper mapper = new ManyToOneMapper(member, mapping, hbmMapping);
+			mapper.ColumnsAndFormulas(x => x.Name("pizza"), x => x.Formula("risotto"), x => x.Name("pasta"));
+
+			Assert.That(mapping.Items, Has.Length.EqualTo(3));
+			Assert.That(mapping.Items[0], Is.TypeOf<HbmColumn>(), "first");
+			Assert.That(mapping.Items[1], Is.TypeOf<HbmFormula>(), "second");
+			Assert.That(mapping.Items[2], Is.TypeOf<HbmColumn>(), "third");
+			Assert.That(((HbmColumn)mapping.Items[0]).name, Is.EqualTo("pizza"));
+			Assert.That(((HbmFormula)mapping.Items[1]).Text, Has.Length.EqualTo(1).And.One.EqualTo("risotto"));
+			Assert.That(((HbmColumn)mapping.Items[2]).name, Is.EqualTo("pasta"));
+			Assert.That(mapping.column, Is.Null, "column");
+			Assert.That(mapping.formula, Is.Null, "formula");
+		}
+
+		[Test]
+		public void CanSetMultipleFormulas()
+		{
+			var hbmMapping = new HbmMapping();
+			var member = typeof(MyClass).GetProperty("Relation");
+			var mapping = new HbmManyToOne();
+			IManyToOneMapper mapper = new ManyToOneMapper(member, mapping, hbmMapping);
+			mapper.Formulas("formula1", "formula2", "formula3");
+
+			Assert.That(mapping.formula, Is.Null);
+			Assert.That(mapping.Items, Has.Length.EqualTo(3));
+			Assert.That(
+				mapping.Items.Cast<HbmFormula>().Select(f => f.Text.Single()),
+				Is.EquivalentTo(new[] { "formula1", "formula2", "formula3" }));
+		}
+
+		[Test]
 		public void WhenSetFetchModeToJoinThenSetFetch()
 		{
 			var hbmMapping = new HbmMapping();

--- a/src/NHibernate.Test/MappingByCode/MappersTests/MapKeyManyToManyMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/MapKeyManyToManyMapperTest.cs
@@ -1,34 +1,19 @@
 using System.Linq;
-using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
+using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode.Impl;
 using NUnit.Framework;
 
 namespace NHibernate.Test.MappingByCode.MappersTests
 {
 	[TestFixture]
-	public class ElementMapperTest
+	public class MapKeyManyToManyMapperTest
 	{
-		[Test]
-		public void WhenSetTypeByICompositeUserTypeThenSetTypeName()
-		{
-			var mapping = new HbmElement();
-			var mapper = new ElementMapper(typeof(object), mapping);
-
-			Assert.That(() => mapper.Type<MyCompoType>(), Throws.Nothing);
-			Assert.That(mapping.Type.name, Does.Contain(nameof(MyCompoType)));
-			Assert.That(mapping.type, Is.Null);
-		}
-
-		private class Element
-		{
-		}
-
 		[Test]
 		public void CanSetColumnsAndFormulas()
 		{
-			var mapping = new HbmElement();
-			IElementMapper mapper = new ElementMapper(typeof(Element), mapping);
+			var mapping = new HbmMapKeyManyToMany();
+			IMapKeyManyToManyMapper mapper = new MapKeyManyToManyMapper(mapping);
 			mapper.ColumnsAndFormulas(x => x.Name("pizza"), x => x.Formula("risotto"), x => x.Name("pasta"));
 
 			Assert.That(mapping.Items, Has.Length.EqualTo(3));
@@ -45,8 +30,8 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		[Test]
 		public void CanSetMultipleFormulas()
 		{
-			var mapping = new HbmElement();
-			IElementMapper mapper = new ElementMapper(typeof(Element), mapping);
+			var mapping = new HbmMapKeyManyToMany();
+			IMapKeyManyToManyMapper mapper = new MapKeyManyToManyMapper(mapping);
 			mapper.Formulas("formula1", "formula2", "formula3");
 
 			Assert.That(mapping.formula, Is.Null);

--- a/src/NHibernate.Test/MappingByCode/MappersTests/MapKeyMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/MapKeyMapperTest.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using NHibernate.Cfg.MappingSchema;
+using NHibernate.Mapping.ByCode;
 using NHibernate.Mapping.ByCode.Impl;
 using NUnit.Framework;
 
@@ -15,6 +17,38 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 
 			Assert.That(() => mapper.Type<MyCompoType>(), Throws.Nothing);
 			Assert.That(mapping.Type.name, Does.Contain(nameof(MyCompoType)));
+		}
+
+		[Test]
+		public void CanSetColumnsAndFormulas()
+		{
+			var mapping = new HbmMapKey();
+			IMapKeyMapper mapper = new MapKeyMapper(mapping);
+			mapper.ColumnsAndFormulas(x => x.Name("pizza"), x => x.Formula("risotto"), x => x.Name("pasta"));
+
+			Assert.That(mapping.Items, Has.Length.EqualTo(3));
+			Assert.That(mapping.Items[0], Is.TypeOf<HbmColumn>(), "first");
+			Assert.That(mapping.Items[1], Is.TypeOf<HbmFormula>(), "second");
+			Assert.That(mapping.Items[2], Is.TypeOf<HbmColumn>(), "third");
+			Assert.That(((HbmColumn)mapping.Items[0]).name, Is.EqualTo("pizza"));
+			Assert.That(((HbmFormula)mapping.Items[1]).Text, Has.Length.EqualTo(1).And.One.EqualTo("risotto"));
+			Assert.That(((HbmColumn)mapping.Items[2]).name, Is.EqualTo("pasta"));
+			Assert.That(mapping.column, Is.Null, "column");
+			Assert.That(mapping.formula, Is.Null, "formula");
+		}
+
+		[Test]
+		public void CanSetMultipleFormulas()
+		{
+			var mapping = new HbmMapKey();
+			IMapKeyMapper mapper = new MapKeyMapper(mapping);
+			mapper.Formulas("formula1", "formula2", "formula3");
+
+			Assert.That(mapping.formula, Is.Null);
+			Assert.That(mapping.Items, Has.Length.EqualTo(3));
+			Assert.That(
+				mapping.Items.Cast<HbmFormula>().Select(f => f.Text.Single()),
+				Is.EquivalentTo(new[] { "formula1", "formula2", "formula3" }));
 		}
 	}
 }

--- a/src/NHibernate.Test/MappingByCode/MappersTests/OneToOneMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/OneToOneMapperTest.cs
@@ -123,6 +123,21 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		}
 
 		[Test]
+		public void CanSetMultipleFormulas()
+		{
+			var member = For<MyClass>.Property(c => c.Relation);
+			var mapping = new HbmOneToOne();
+			var mapper = new OneToOneMapper(member, mapping);
+
+			mapper.Formulas("formula1", "formula2", "formula3");
+			Assert.That(mapping.formula1, Is.Null);
+			Assert.That(mapping.formula, Has.Length.EqualTo(3));
+			Assert.That(
+				mapping.formula.Select(f => f.Text.Single()),
+				Is.EquivalentTo(new[] { "formula1", "formula2", "formula3" }));
+		}
+
+		[Test]
 		public void WhenSetFormulaWithNullThenSetFormulaWithNull()
 		{
 			var member = For<MyClass>.Property(c => c.Relation);

--- a/src/NHibernate.Test/MappingByCode/MappersTests/PropertyMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/PropertyMapperTest.cs
@@ -285,6 +285,40 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		}
 
 		[Test]
+		public void CanSetColumnsAndFormulas()
+		{
+			var member = typeof(MyClass).GetProperty("Autoproperty");
+			var mapping = new HbmProperty();
+			IPropertyMapper mapper = new PropertyMapper(member, mapping);
+			mapper.ColumnsAndFormulas(x => x.Name("pizza"), x => x.Formula("risotto"), x => x.Name("pasta"));
+
+			Assert.That(mapping.Items, Has.Length.EqualTo(3));
+			Assert.That(mapping.Items[0], Is.TypeOf<HbmColumn>(), "first");
+			Assert.That(mapping.Items[1], Is.TypeOf<HbmFormula>(), "second");
+			Assert.That(mapping.Items[2], Is.TypeOf<HbmColumn>(), "third");
+			Assert.That(((HbmColumn)mapping.Items[0]).name, Is.EqualTo("pizza"));
+			Assert.That(((HbmFormula)mapping.Items[1]).Text, Has.Length.EqualTo(1).And.One.EqualTo("risotto"));
+			Assert.That(((HbmColumn)mapping.Items[2]).name, Is.EqualTo("pasta"));
+			Assert.That(mapping.column, Is.Null, "column");
+			Assert.That(mapping.formula, Is.Null, "formula");
+		}
+
+		[Test]
+		public void CanSetMultipleFormulas()
+		{
+			var member = typeof(MyClass).GetProperty("Autoproperty");
+			var mapping = new HbmProperty();
+			IPropertyMapper mapper = new PropertyMapper(member, mapping);
+			mapper.Formulas("formula1", "formula2", "formula3");
+
+			Assert.That(mapping.formula, Is.Null);
+			Assert.That(mapping.Items, Has.Length.EqualTo(3));
+			Assert.That(
+				mapping.Items.Cast<HbmFormula>().Select(f => f.Text.Single()),
+				Is.EquivalentTo(new[] { "formula1", "formula2", "formula3" }));
+		}
+
+		[Test]
 		public void WhenSetUpdateThenSetAttributes()
 		{
 			var member = For<MyClass>.Property(x => x.ReadOnly);

--- a/src/NHibernate.Test/NHSpecificTest/GH1759/ColumnsAndFormulasFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1759/ColumnsAndFormulasFixture.cs
@@ -170,7 +170,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1759
 			}
 		}
 
-		[Test, Ignore("Needs an unrelated additional simple fix in OneToManyPersister")]
+		[Test]
 		public void CheckMapKey()
 		{
 			using (var session = OpenSession())

--- a/src/NHibernate.Test/NHSpecificTest/GH1759/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/GH1759/Mappings.hbm.xml
@@ -64,8 +64,7 @@
       </element>
     </set>
 
-    <!-- This forbids hiring two persons on the same day, but well, that is just for testing. 
-         Disabled for now, needs an unrelated simple fix in OneToManyPersister
+    <!-- This forbids hiring two persons on the same day, but well, that is just for testing. -->
     <map name="UsersByHiring" inverse="true">
       <key>
         <column name="MainGroupName"/>
@@ -77,7 +76,6 @@
       </map-key>
       <one-to-many class="User"/>
     </map>
-    -->
 
     <!-- This is functionaly quite broken as the primary key does not include the map-key, which forbids
          to add the same comment for two distinct users. A fix would be to map the element as a composite

--- a/src/NHibernate/Mapping/ByCode/IColumnOrFormulaMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IColumnOrFormulaMapper.cs
@@ -1,0 +1,12 @@
+namespace NHibernate.Mapping.ByCode
+{
+	public interface IColumnOrFormulaMapper : IColumnMapper
+	{
+		/// <summary>
+		/// Maps a formula.
+		/// </summary>
+		/// <param name="formula">The formula to map.</param>
+		/// <remarks>Replaces any previously mapped column attribute.</remarks>
+		void Formula(string formula);
+	}
+}

--- a/src/NHibernate/Mapping/ByCode/IColumnsAndFormulasMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IColumnsAndFormulasMapper.cs
@@ -1,0 +1,198 @@
+using System;
+using NHibernate.Util;
+
+namespace NHibernate.Mapping.ByCode
+{
+	/// <summary>
+	/// A mapper for mapping mixed list of columns and formulas.
+	/// </summary>
+	public interface IColumnsAndFormulasMapper : IColumnsMapper
+	{
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		void ColumnsAndFormulas(params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper);
+
+		/// <summary>
+		/// Maps a formula.
+		/// </summary>
+		/// <param name="formula">The formula to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula, unless <see langword="null"/>.</remarks>
+		void Formula(string formula);
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		void Formulas(params string[] formulas);
+	}
+
+	// 6.0 TODO: remove once the extended interfaces inherit IColumnOrFormulaMapper
+	public static class ColumnsAndFormulasMapperExtensions
+	{
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void ColumnsAndFormulas(
+			this IElementMapper mapper,
+			params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			CallColumnsAndFormulas(mapper, columnOrFormulaMapper);
+		}
+
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void ColumnsAndFormulas(
+			this IManyToManyMapper mapper,
+			params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			CallColumnsAndFormulas(mapper, columnOrFormulaMapper);
+		}
+
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void ColumnsAndFormulas(
+			this IManyToOneMapper mapper,
+			params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			CallColumnsAndFormulas(mapper, columnOrFormulaMapper);
+		}
+
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void ColumnsAndFormulas(
+			this IMapKeyManyToManyMapper mapper,
+			params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			CallColumnsAndFormulas(mapper, columnOrFormulaMapper);
+		}
+
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void ColumnsAndFormulas(
+			this IMapKeyMapper mapper,
+			params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			CallColumnsAndFormulas(mapper, columnOrFormulaMapper);
+		}
+
+		/// <summary>
+		/// Maps a mixed list of columns and formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="columnOrFormulaMapper">The mappers for each column or formula.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void ColumnsAndFormulas(
+			this IPropertyMapper mapper,
+			params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			CallColumnsAndFormulas(mapper, columnOrFormulaMapper);
+		}
+
+		private static void CallColumnsAndFormulas(
+			object mapper,
+			Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			var colsOrForMapper = ReflectHelper.CastOrThrow<IColumnsAndFormulasMapper>(
+				mapper,
+				nameof(IColumnsAndFormulasMapper.ColumnsAndFormulas));
+			colsOrForMapper.ColumnsAndFormulas(columnOrFormulaMapper);
+		}
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void Formulas(this IElementMapper mapper, params string[] formulas)
+		{
+			CallFormulas(mapper, formulas);
+		}
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void Formulas(this IManyToManyMapper mapper, params string[] formulas)
+		{
+			CallFormulas(mapper, formulas);
+		}
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void Formulas(this IManyToOneMapper mapper, params string[] formulas)
+		{
+			CallFormulas(mapper, formulas);
+		}
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void Formulas(this IMapKeyManyToManyMapper mapper, params string[] formulas)
+		{
+			CallFormulas(mapper, formulas);
+		}
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void Formulas(this IMapKeyMapper mapper, params string[] formulas)
+		{
+			CallFormulas(mapper, formulas);
+		}
+
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		/// <remarks>Replaces any previously mapped column or formula.</remarks>
+		public static void Formulas(this IPropertyMapper mapper, params string[] formulas)
+		{
+			CallFormulas(mapper, formulas);
+		}
+
+		private static void CallFormulas(object mapper, string[] formulas)
+		{
+			var colsOrForMapper = ReflectHelper.CastOrThrow<IColumnsAndFormulasMapper>(
+				mapper,
+				"Setting many formula");
+			colsOrForMapper.Formulas(formulas);
+		}
+	}
+}

--- a/src/NHibernate/Mapping/ByCode/IElementMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IElementMapper.cs
@@ -2,6 +2,7 @@ using NHibernate.Type;
 
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: inherit from IColumnsAndFormulasMapper
 	public interface IElementMapper : IColumnsMapper
 	{
 		void Type(IType persistentType);
@@ -13,6 +14,7 @@ namespace NHibernate.Mapping.ByCode
 		void Scale(short scale);
 		void NotNullable(bool notnull);
 		void Unique(bool unique);
+		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
 		void Formula(string formula);
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IElementMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IElementMapper.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Mapping.ByCode
 		void Scale(short scale);
 		void NotNullable(bool notnull);
 		void Unique(bool unique);
-		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
+		// 6.0 TODO: remove once inherited from IColumnsAndFormulasMapper
 		void Formula(string formula);
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IManyToManyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IManyToManyMapper.cs
@@ -1,10 +1,12 @@
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: inherit from IColumnsAndFormulasMapper
 	public interface IManyToManyMapper : IColumnsMapper
 	{
 		void Class(System.Type entityType);
 		void EntityName(string entityName);
 		void NotFound(NotFoundMode mode);
+		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
 		void Formula(string formula);
 		void Lazy(LazyRelation lazyRelation);
 		void ForeignKey(string foreignKeyName);

--- a/src/NHibernate/Mapping/ByCode/IManyToManyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IManyToManyMapper.cs
@@ -6,7 +6,7 @@ namespace NHibernate.Mapping.ByCode
 		void Class(System.Type entityType);
 		void EntityName(string entityName);
 		void NotFound(NotFoundMode mode);
-		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
+		// 6.0 TODO: remove once inherited from IColumnsAndFormulasMapper
 		void Formula(string formula);
 		void Lazy(LazyRelation lazyRelation);
 		void ForeignKey(string foreignKeyName);

--- a/src/NHibernate/Mapping/ByCode/IManyToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IManyToOneMapper.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Mapping.ByCode
 		void UniqueKey(string uniquekeyName);
 		void Index(string indexName);
 		void Fetch(FetchKind fetchMode);
-		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
+		// 6.0 TODO: remove once inherited from IColumnsAndFormulasMapper
 		void Formula(string formula);
 		void Lazy(LazyRelation lazyRelation);
 		void Update(bool consideredInUpdateQuery);

--- a/src/NHibernate/Mapping/ByCode/IManyToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IManyToOneMapper.cs
@@ -3,6 +3,7 @@ using NHibernate.Mapping.ByCode.Impl;
 
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: inherit from IColumnsAndFormulasMapper
 	public interface IManyToOneMapper : IEntityPropertyMapper, IColumnsMapper
 	{
 		/// <summary>
@@ -19,6 +20,7 @@ namespace NHibernate.Mapping.ByCode
 		void UniqueKey(string uniquekeyName);
 		void Index(string indexName);
 		void Fetch(FetchKind fetchMode);
+		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
 		void Formula(string formula);
 		void Lazy(LazyRelation lazyRelation);
 		void Update(bool consideredInUpdateQuery);

--- a/src/NHibernate/Mapping/ByCode/IMapKeyManyToManyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IMapKeyManyToManyMapper.cs
@@ -1,8 +1,10 @@
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: inherit from IColumnsAndFormulasMapper
 	public interface IMapKeyManyToManyMapper : IColumnsMapper
 	{
 		void ForeignKey(string foreignKeyName);
+		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
 		void Formula(string formula);
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IMapKeyManyToManyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IMapKeyManyToManyMapper.cs
@@ -4,7 +4,7 @@ namespace NHibernate.Mapping.ByCode
 	public interface IMapKeyManyToManyMapper : IColumnsMapper
 	{
 		void ForeignKey(string foreignKeyName);
-		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
+		// 6.0 TODO: remove once inherited from IColumnsAndFormulasMapper
 		void Formula(string formula);
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IMapKeyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IMapKeyMapper.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Mapping.ByCode
 		void Type<TPersistentType>();
 		void Type(System.Type persistentType);
 		void Length(int length);
-		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
+		// 6.0 TODO: remove once inherited from IColumnsAndFormulasMapper
 		void Formula(string formula);
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IMapKeyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IMapKeyMapper.cs
@@ -2,12 +2,14 @@
 
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: inherit from IColumnsAndFormulasMapper
 	public interface IMapKeyMapper : IColumnsMapper
 	{
 		void Type(IType persistentType);
 		void Type<TPersistentType>();
 		void Type(System.Type persistentType);
 		void Length(int length);
+		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
 		void Formula(string formula);
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IOneToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IOneToOneMapper.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using NHibernate.Mapping.ByCode.Impl;
+using NHibernate.Util;
 
 namespace NHibernate.Mapping.ByCode
 {
@@ -18,5 +20,20 @@ namespace NHibernate.Mapping.ByCode
 	public interface IOneToOneMapper<T> : IOneToOneMapper
 	{
 		void PropertyReference<TProperty>(Expression<Func<T, TProperty>> reference);
+	}
+
+	// 6.0 TODO: move method into IOneToOneMapper
+	public static class OneToOneMapperExtensions
+	{
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		public static void Formulas(this IOneToOneMapper mapper, params string[] formulas)
+		{
+			var o2oMapper = ReflectHelper.CastOrThrow<OneToOneMapper>(mapper, "Setting many formula");
+			o2oMapper.Formulas(formulas);
+		}
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/IPropertyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IPropertyMapper.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Mapping.ByCode
 		void Unique(bool unique);
 		void UniqueKey(string uniquekeyName);
 		void Index(string indexName);
-		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
+		// 6.0 TODO: remove once inherited from IColumnsAndFormulasMapper
 		void Formula(string formula);
 		void Update(bool consideredInUpdateQuery);
 		void Insert(bool consideredInInsertQuery);

--- a/src/NHibernate/Mapping/ByCode/IPropertyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IPropertyMapper.cs
@@ -2,6 +2,7 @@ using NHibernate.Type;
 
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: inherit from IColumnsAndFormulasMapper
 	public interface IPropertyMapper : IEntityPropertyMapper, IColumnsMapper
 	{
 		void Type(IType persistentType);
@@ -15,6 +16,7 @@ namespace NHibernate.Mapping.ByCode
 		void Unique(bool unique);
 		void UniqueKey(string uniquekeyName);
 		void Index(string indexName);
+		// 6.0 TODO: remove once inhertied from IColumnsAndFormulasMapper
 		void Formula(string formula);
 		void Update(bool consideredInUpdateQuery);
 		void Insert(bool consideredInInsertQuery);

--- a/src/NHibernate/Mapping/ByCode/Impl/ColumnOrFormulaMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/ColumnOrFormulaMapper.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using NHibernate.Cfg.MappingSchema;
+using NHibernate.Util;
+
+namespace NHibernate.Mapping.ByCode.Impl
+{
+	public class ColumnOrFormulaMapper : ColumnMapper, IColumnOrFormulaMapper
+	{
+		private readonly HbmFormula _formulaMapping;
+
+		public ColumnOrFormulaMapper(HbmColumn columnMapping, string memberName, HbmFormula formulaMapping) :
+			base(columnMapping, memberName)
+		{
+			_formulaMapping = formulaMapping ?? throw new ArgumentNullException(nameof(formulaMapping));
+		}
+
+		public void Formula(string formula)
+		{
+			_formulaMapping.Text = formula?.Split(StringHelper.LineSeparators, StringSplitOptions.None);
+		}
+
+		public static object[] GetItemsFor(Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper, string baseDefaultColumnName)
+		{
+			if (columnOrFormulaMapper == null)
+				throw new ArgumentNullException(nameof(columnOrFormulaMapper));
+
+			var i = 1;
+			var columnsOrFormulas = new List<object>(columnOrFormulaMapper.Length);
+			foreach (var action in columnOrFormulaMapper)
+			{
+				var hbmCol = new HbmColumn();
+				var hbmFormula = new HbmFormula();
+				var defaultColumnName = baseDefaultColumnName + i++;
+				action(new ColumnOrFormulaMapper(hbmCol, defaultColumnName, hbmFormula));
+				if (hbmFormula.Text != null)
+				{
+					columnsOrFormulas.Add(hbmFormula);
+				}
+				else
+				{
+					columnsOrFormulas.Add(hbmCol);
+				}
+			}
+			return columnsOrFormulas.ToArray();
+		}
+	}
+}

--- a/src/NHibernate/Mapping/ByCode/Impl/ElementMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/ElementMapper.cs
@@ -8,7 +8,8 @@ using NHibernate.Util;
 
 namespace NHibernate.Mapping.ByCode.Impl
 {
-	public class ElementMapper : IElementMapper
+	// 6.0 TODO: remove IColumnsAndFormulasMapper once IElementMapper inherits it.
+	public class ElementMapper : IElementMapper, IColumnsAndFormulasMapper
 	{
 		private const string DefaultColumnName = "element";
 		private readonly HbmElement elementMapping;
@@ -35,7 +36,7 @@ namespace NHibernate.Mapping.ByCode.Impl
 		{
 			if (elementMapping.Columns.Count() > 1)
 			{
-				throw new MappingException("Multi-columns property can't be mapped through singlr-column API.");
+				throw new MappingException("Multi-columns property can't be mapped through single-column API.");
 			}
 			elementMapping.formula = null;
 			HbmColumn hbm = elementMapping.Columns.SingleOrDefault();
@@ -102,6 +103,53 @@ namespace NHibernate.Mapping.ByCode.Impl
 			elementMapping.notnull = false;
 			elementMapping.unique = false;
 			elementMapping.formula = null;
+		}
+
+		#endregion
+
+		#region Implementation of IColumnsAndFormulasMapper
+
+		/// <inheritdoc />
+		public void ColumnsAndFormulas(params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			ResetColumnPlainValues();
+
+			elementMapping.Items = ColumnOrFormulaMapper.GetItemsFor(columnOrFormulaMapper, DefaultColumnName);
+		}
+
+		/// <inheritdoc cref="IColumnsAndFormulasMapper.Formula" />
+		public void Formula(string formula)
+		{
+			if (formula == null)
+			{
+				return;
+			}
+
+			ResetColumnPlainValues();
+			elementMapping.Items = null;
+			string[] formulaLines = formula.Split(StringHelper.LineSeparators, StringSplitOptions.None);
+			if (formulaLines.Length > 1)
+			{
+				elementMapping.Items = new object[] {new HbmFormula {Text = formulaLines}};
+			}
+			else
+			{
+				elementMapping.formula = formula;
+			}
+		}
+
+		/// <inheritdoc />
+		public void Formulas(params string[] formulas)
+		{
+			if (formulas == null)
+				throw new ArgumentNullException(nameof(formulas));
+
+			ResetColumnPlainValues();
+			elementMapping.Items =
+				formulas
+					.Select(
+						f => (object) new HbmFormula { Text = f.Split(StringHelper.LineSeparators, StringSplitOptions.None) })
+					.ToArray();
 		}
 
 		#endregion
@@ -188,26 +236,6 @@ namespace NHibernate.Mapping.ByCode.Impl
 		public void Unique(bool unique)
 		{
 			Column(x => x.Unique(unique));
-		}
-
-		public void Formula(string formula)
-		{
-			if (formula == null)
-			{
-				return;
-			}
-
-			ResetColumnPlainValues();
-			elementMapping.Items = null;
-			string[] formulaLines = formula.Split(StringHelper.LineSeparators, StringSplitOptions.None);
-			if (formulaLines.Length > 1)
-			{
-				elementMapping.Items = new[] {new HbmFormula {Text = formulaLines}};
-			}
-			else
-			{
-				elementMapping.formula = formula;
-			}
 		}
 
 		#endregion

--- a/src/NHibernate/Mapping/ByCode/Impl/ManyToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/ManyToOneMapper.cs
@@ -7,7 +7,8 @@ using NHibernate.Util;
 
 namespace NHibernate.Mapping.ByCode.Impl
 {
-	public class ManyToOneMapper : IManyToOneMapper
+	// 6.0 TODO: remove IColumnsAndFormulasMapper once IManyToOneMapper inherits it.
+	public class ManyToOneMapper : IManyToOneMapper, IColumnsAndFormulasMapper
 	{
 		private readonly IAccessorPropertyMapper _entityPropertyMapper;
 		private readonly HbmManyToOne _manyToOne;
@@ -79,26 +80,6 @@ namespace NHibernate.Mapping.ByCode.Impl
 			_manyToOne.fetchSpecified = _manyToOne.fetch == HbmFetchMode.Join;
 		}
 
-		public void Formula(string formula)
-		{
-			if (formula == null)
-			{
-				return;
-			}
-
-			ResetColumnPlainValues();
-			_manyToOne.Items = null;
-			string[] formulaLines = formula.Split(StringHelper.LineSeparators, StringSplitOptions.None);
-			if (formulaLines.Length > 1)
-			{
-				_manyToOne.Items = new[] { new HbmFormula { Text = formulaLines } };
-			}
-			else
-			{
-				_manyToOne.formula = formula;
-			}
-		}
-
 		public void Lazy(LazyRelation lazyRelation)
 		{
 			_manyToOne.lazy = lazyRelation.ToHbm();
@@ -147,6 +128,55 @@ namespace NHibernate.Mapping.ByCode.Impl
 		public void OptimisticLock(bool takeInConsiderationForOptimisticLock)
 		{
 			_manyToOne.optimisticlock = takeInConsiderationForOptimisticLock;
+		}
+
+		#endregion
+		
+		#region Implementation of IColumnsAndFormulasMapper
+
+		/// <inheritdoc />
+		public void ColumnsAndFormulas(params Action<IColumnOrFormulaMapper>[] columnOrFormulaMapper)
+		{
+			ResetColumnPlainValues();
+
+			_manyToOne.Items = ColumnOrFormulaMapper.GetItemsFor(
+				columnOrFormulaMapper,
+				_member != null ? _member.Name : "unnamedcolumn");
+		}
+
+		/// <inheritdoc cref="IColumnsAndFormulasMapper.Formula" />
+		public void Formula(string formula)
+		{
+			if (formula == null)
+			{
+				return;
+			}
+
+			ResetColumnPlainValues();
+			_manyToOne.Items = null;
+			string[] formulaLines = formula.Split(StringHelper.LineSeparators, StringSplitOptions.None);
+			if (formulaLines.Length > 1)
+			{
+				_manyToOne.Items = new object[] { new HbmFormula { Text = formulaLines } };
+			}
+			else
+			{
+				_manyToOne.formula = formula;
+			}
+		}
+
+		/// <inheritdoc />
+		public void Formulas(params string[] formulas)
+		{
+			if (formulas == null)
+				throw new ArgumentNullException(nameof(formulas));
+
+			ResetColumnPlainValues();
+			_manyToOne.Items =
+				formulas
+					.Select(
+						f => (object) new HbmFormula { Text = f.Split(StringHelper.LineSeparators, StringSplitOptions.None) })
+					.ToArray();
 		}
 
 		#endregion

--- a/src/NHibernate/Mapping/ByCode/Impl/OneToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/OneToOneMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Cfg.MappingSchema;
@@ -113,6 +114,19 @@ namespace NHibernate.Mapping.ByCode.Impl
 				_oneToOne.formula1 = formula;
 				_oneToOne.formula = null;
 			}
+		}
+
+		public void Formulas(params string[] formulas)
+		{
+			if (formulas == null)
+				throw new ArgumentNullException(nameof(formulas));
+
+			_oneToOne.formula1 = null;
+			_oneToOne.formula =
+				formulas
+					.Select(
+						f => new HbmFormula { Text = f.Split(StringHelper.LineSeparators, StringSplitOptions.None) })
+					.ToArray();
 		}
 
 		public void ForeignKey(string foreignKeyName)


### PR DESCRIPTION
Many mapping elements allow to define their columns or formulas by nested elements, but most of them were not supporting having both nested columns and formulas.

Follow up to #1808, which has added this support for hbm mappings.

Fixes #1278 by the way.