### PR TITLE
Support multiple formulas on one-to-one

### DIFF
--- a/src/NHibernate.Test/MappingByCode/MappersTests/OneToOneMapperTest.cs
+++ b/src/NHibernate.Test/MappingByCode/MappersTests/OneToOneMapperTest.cs
@@ -123,6 +123,21 @@ namespace NHibernate.Test.MappingByCode.MappersTests
 		}
 
 		[Test]
+		public void CanSetMultipleFormulas()
+		{
+			var member = For<MyClass>.Property(c => c.Relation);
+			var mapping = new HbmOneToOne();
+			var mapper = new OneToOneMapper(member, mapping);
+
+			mapper.Formulas("formula1", "formula2", "formula3");
+			Assert.That(mapping.formula1, Is.Null);
+			Assert.That(mapping.formula, Has.Length.EqualTo(3));
+			Assert.That(
+				mapping.formula.Select(f => f.Text.Single()),
+				Is.EquivalentTo(new[] { "formula1", "formula2", "formula3" }));
+	}
+
+		[Test]
 		public void WhenSetFormulaWithNullThenSetFormulaWithNull()
 		{
 			var member = For<MyClass>.Property(c => c.Relation);

--- a/src/NHibernate/Mapping/ByCode/IOneToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IOneToOneMapper.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using NHibernate.Mapping.ByCode.Impl;
+using NHibernate.Util;
 
 namespace NHibernate.Mapping.ByCode
 {
@@ -18,5 +20,20 @@ namespace NHibernate.Mapping.ByCode
 	public interface IOneToOneMapper<T> : IOneToOneMapper
 	{
 		void PropertyReference<TProperty>(Expression<Func<T, TProperty>> reference);
+	}
+
+	// 6.0 TODO: move method into IOneToOneMapper
+	public static class OneToOneMapperExtension
+	{
+		/// <summary>
+		/// Maps many formulas.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="formulas">The formulas to map.</param>
+		public static void Formulas(this IOneToOneMapper mapper, params string[] formulas)
+		{
+			var o2oMapper = ReflectHelper.CastOrThrow<OneToOneMapper>(mapper, "Setting many formula");
+			o2oMapper.Formulas(formulas);
+		}
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/Impl/OneToOneMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/OneToOneMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Cfg.MappingSchema;
@@ -113,6 +114,19 @@ namespace NHibernate.Mapping.ByCode.Impl
 				_oneToOne.formula1 = formula;
 				_oneToOne.formula = null;
 			}
+		}
+
+		public void Formulas(params string[] formulas)
+		{
+			if (formulas == null)
+				throw new ArgumentNullException(nameof(formulas));
+
+			_oneToOne.formula1 = null;
+			_oneToOne.formula =
+				formulas
+					.Select(
+						f => new HbmFormula { Text = f.Split(StringHelper.LineSeparators, StringSplitOptions.None) })
+					.ToArray();
 		}
 
 		public void ForeignKey(string foreignKeyName)


### PR DESCRIPTION
Hbm supports multiple formulas on one-to-one, but mapping by code does not allow specifying them on one-to-one.
(It does neither on any other elements, but #1759 will fix that for the other elements by adding a `ColumnsAndFormulas` method.)