### PR TITLE
Allow generic dictionaries for dynamic entities

### DIFF
--- a/doc/reference/modules/persistent_classes.xml
+++ b/doc/reference/modules/persistent_classes.xml
@@ -254,12 +254,12 @@ namespace Eg
         <para>
             Persistent entities don't necessarily have to be represented as POCO classes
             at runtime. NHibernate also supports dynamic models
-            (using <literal>Dictionaries</literal> of <literal>Dictionary</literal>s at runtime) . With this approach, you don't
+            (using <literal>Dictionaries</literal>). With this approach, you don't
             write persistent classes, only mapping files.
         </para>
 
         <para>
-            The following examples demonstrates the representation using <literal>Map</literal>s (Dictionary).
+            The following examples demonstrates the representation using <literal>Dictionaries</literal>.
             First, in the mapping file, an <literal>entity-name</literal> has to be declared
             instead of a class name:
         </para>
@@ -305,7 +305,7 @@ namespace Eg
         </para>
         
         <para>
-            At runtime we can work with <literal>Dictionaries</literal> of <literal>Dictionaries</literal>:
+            At runtime we can work with <literal>Dictionaries</literal>:
         </para>
         
         <programlisting><![CDATA[using(ISession s = OpenSession())
@@ -336,6 +336,20 @@ using(ITransaction tx = s.BeginTransaction())
             to the NHibernate mapping, the database schema can easily be normalized and sound,
             allowing to add a proper domain model implementation on top later on.
         </para>
+
+        <para>
+            A loaded dynamic entity can be manipulated as an <literal>IDictionary</literal> or
+            <literal>IDictionary&lt;string, object&gt;</literal>.
+        </para>
+
+        <programlisting><![CDATA[using(ISession s = OpenSession())
+using(ITransaction tx = s.BeginTransaction())
+{
+    var customers = s
+        .CreateQuery("from Customer")
+        .List<IDictionary<string, object>>();
+    ...
+}]]></programlisting>
     </sect1>
     
     <sect1 id="persistent-classes-tuplizers" revision="1">
@@ -357,9 +371,9 @@ using(ITransaction tx = s.BeginTransaction())
         </para>
         
         <para>
-            Users may also plug in their own tuplizers.  Perhaps you require that a <literal>System.Collections.IDictionary</literal>
-            implementation other than <literal>System.Collections.Hashtable</literal> be used while in the
-            dynamic-map entity-mode; or perhaps you need to define a different proxy generation strategy
+            Users may also plug in their own tuplizers.  Perhaps you require that a <literal>IDictionary</literal>
+            implementation other than <literal>System.Collections.Generic.Dictionary&lt;string, object&gt;</literal>
+            is used while in the dynamic-map entity-mode; or perhaps you need to define a different proxy generation strategy
             than the one used by default.  Both would be achieved by defining a custom tuplizer
             implementation.  Tuplizers definitions are attached to the entity or component mapping they
             are meant to manage.  Going back to the example of our customer entity:

--- a/src/NHibernate.Test/Async/EntityModeTest/Map/Basic/DynamicClassFixture.cs
+++ b/src/NHibernate.Test/Async/EntityModeTest/Map/Basic/DynamicClassFixture.cs
@@ -10,8 +10,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using NHibernate.Cfg;
-using NHibernate.Engine;
+using Antlr.Runtime.Misc;
 using NUnit.Framework;
 using NHibernate.Criterion;
 
@@ -29,7 +28,7 @@ namespace NHibernate.Test.EntityModeTest.Map.Basic
 
 		protected override IList Mappings
 		{
-			get { return new string[] {"EntityModeTest.Map.Basic.ProductLine.hbm.xml"}; }
+			get { return new[] {"EntityModeTest.Map.Basic.ProductLine.hbm.xml"}; }
 		}
 
 		public delegate IDictionary SingleCarQueryDelegate(ISession session);
@@ -108,6 +107,85 @@ namespace NHibernate.Test.EntityModeTest.Map.Basic
 				cars = singleCarQueryHandler(s);
 				await (s.DeleteAsync(cars, cancellationToken));
 				await (t.CommitAsync(cancellationToken));
+			}
+		}
+
+		[Test]
+		public async Task ShouldWorkWithHQLAndGenericsAsync()
+		{
+			await (TestLazyDynamicClassAsync(
+				s => s.CreateQuery("from ProductLine pl order by pl.Description").UniqueResult<IDictionary<string, object>>(),
+				s => s.CreateQuery("from Model m").List<IDictionary<string, object>>()));
+		}
+
+		[Test]
+		public async Task ShouldWorkWithCriteriaAndGenericsAsync()
+		{
+			await (TestLazyDynamicClassAsync(
+				s => s.CreateCriteria("ProductLine").AddOrder(Order.Asc("Description")).UniqueResult<IDictionary<string, object>>(),
+				s => s.CreateCriteria("Model").List<IDictionary<string, object>>()));
+		}
+
+		public async Task TestLazyDynamicClassAsync(
+			Func<ISession, IDictionary<string, object>> singleCarQueryHandler,
+			Func<ISession, IList<IDictionary<string, object>>> allModelQueryHandler, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var cars = new Dictionary<string, object> { ["Description"] = "Cars" };
+
+				var monaro = new Dictionary<string, object>
+				{
+					["ProductLine"] = cars,
+					["Name"] = "Monaro",
+					["Description"] = "Holden Monaro"
+				};
+
+				var hsv = new Dictionary<string, object>
+				{
+					["ProductLine"] = cars,
+					["Name"] = "hsv",
+					["Description"] = "Holden hsv"
+				};
+
+				var models = new List<IDictionary<string, object>> {monaro, hsv};
+
+				cars["Models"] = models;
+
+				await (s.SaveAsync("ProductLine", cars, cancellationToken));
+				await (t.CommitAsync(cancellationToken));
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var cars = singleCarQueryHandler(s);
+				var models = (IList<object>) cars["Models"];
+				Assert.That(NHibernateUtil.IsInitialized(models), Is.False);
+				Assert.That(models.Count, Is.EqualTo(2));
+				Assert.That(NHibernateUtil.IsInitialized(models), Is.True);
+				s.Clear();
+				var list = allModelQueryHandler(s);
+				foreach (var dic in list)
+				{
+					Assert.That(NHibernateUtil.IsInitialized(dic["ProductLine"]), Is.False);
+				}
+				var model = list[0];
+				Assert.That(((IList<object>) ((IDictionary<string, object>) model["ProductLine"])["Models"]).Contains(model), Is.True);
+				s.Clear();
+
+				await (t.CommitAsync(cancellationToken));
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from ProductLine");
+				t.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/EntityModeTest/Map/Basic/DynamicClassFixture.cs
+++ b/src/NHibernate.Test/EntityModeTest/Map/Basic/DynamicClassFixture.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using NHibernate.Cfg;
-using NHibernate.Engine;
+using Antlr.Runtime.Misc;
 using NUnit.Framework;
 using NHibernate.Criterion;
 
@@ -17,7 +16,7 @@ namespace NHibernate.Test.EntityModeTest.Map.Basic
 
 		protected override IList Mappings
 		{
-			get { return new string[] {"EntityModeTest.Map.Basic.ProductLine.hbm.xml"}; }
+			get { return new[] {"EntityModeTest.Map.Basic.ProductLine.hbm.xml"}; }
 		}
 
 		public delegate IDictionary SingleCarQueryDelegate(ISession session);
@@ -95,6 +94,85 @@ namespace NHibernate.Test.EntityModeTest.Map.Basic
 				t = s.BeginTransaction();
 				cars = singleCarQueryHandler(s);
 				s.Delete(cars);
+				t.Commit();
+			}
+		}
+
+		[Test]
+		public void ShouldWorkWithHQLAndGenerics()
+		{
+			TestLazyDynamicClass(
+				s => s.CreateQuery("from ProductLine pl order by pl.Description").UniqueResult<IDictionary<string, object>>(),
+				s => s.CreateQuery("from Model m").List<IDictionary<string, object>>());
+		}
+
+		[Test]
+		public void ShouldWorkWithCriteriaAndGenerics()
+		{
+			TestLazyDynamicClass(
+				s => s.CreateCriteria("ProductLine").AddOrder(Order.Asc("Description")).UniqueResult<IDictionary<string, object>>(),
+				s => s.CreateCriteria("Model").List<IDictionary<string, object>>());
+		}
+
+		public void TestLazyDynamicClass(
+			Func<ISession, IDictionary<string, object>> singleCarQueryHandler,
+			Func<ISession, IList<IDictionary<string, object>>> allModelQueryHandler)
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var cars = new Dictionary<string, object> { ["Description"] = "Cars" };
+
+				var monaro = new Dictionary<string, object>
+				{
+					["ProductLine"] = cars,
+					["Name"] = "Monaro",
+					["Description"] = "Holden Monaro"
+				};
+
+				var hsv = new Dictionary<string, object>
+				{
+					["ProductLine"] = cars,
+					["Name"] = "hsv",
+					["Description"] = "Holden hsv"
+				};
+
+				var models = new List<IDictionary<string, object>> {monaro, hsv};
+
+				cars["Models"] = models;
+
+				s.Save("ProductLine", cars);
+				t.Commit();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var cars = singleCarQueryHandler(s);
+				var models = (IList<object>) cars["Models"];
+				Assert.That(NHibernateUtil.IsInitialized(models), Is.False);
+				Assert.That(models.Count, Is.EqualTo(2));
+				Assert.That(NHibernateUtil.IsInitialized(models), Is.True);
+				s.Clear();
+				var list = allModelQueryHandler(s);
+				foreach (var dic in list)
+				{
+					Assert.That(NHibernateUtil.IsInitialized(dic["ProductLine"]), Is.False);
+				}
+				var model = list[0];
+				Assert.That(((IList<object>) ((IDictionary<string, object>) model["ProductLine"])["Models"]).Contains(model), Is.True);
+				s.Clear();
+
+				t.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from ProductLine");
 				t.Commit();
 			}
 		}

--- a/src/NHibernate/Proxy/Map/MapLazyInitializer.cs
+++ b/src/NHibernate/Proxy/Map/MapLazyInitializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NHibernate.Engine;
 
 namespace NHibernate.Proxy.Map
@@ -15,6 +16,8 @@ namespace NHibernate.Proxy.Map
 		{
 			get { return (IDictionary) GetImplementation(); }
 		}
+
+		public IDictionary<string, object> GenericMap => (IDictionary<string, object>) GetImplementation();
 
 		public override System.Type PersistentClass
 		{

--- a/src/NHibernate/Proxy/Map/MapProxy.cs
+++ b/src/NHibernate/Proxy/Map/MapProxy.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace NHibernate.Proxy.Map
 {
 	/// <summary> Proxy for "dynamic-map" entity representations. </summary>
 	[Serializable]
-	public class MapProxy : INHibernateProxy, IDictionary
+	public class MapProxy : INHibernateProxy, IDictionary, IDictionary<string, object>
 	{
 		private readonly MapLazyInitializer li;
 
@@ -111,6 +112,73 @@ namespace NHibernate.Proxy.Map
 		public IEnumerator GetEnumerator()
 		{
 			return li.Map.GetEnumerator();
+		}
+
+		#endregion
+
+		#region IDictionary<string, object> Members
+
+		bool IDictionary<string, object>.ContainsKey(string key)
+		{
+			return li.GenericMap.ContainsKey(key);
+		}
+
+		void IDictionary<string, object>.Add(string key, object value)
+		{
+			li.GenericMap.Add(key, value);
+		}
+
+		bool IDictionary<string, object>.Remove(string key)
+		{
+			return li.GenericMap.Remove(key);
+		}
+
+		bool IDictionary<string, object>.TryGetValue(string key, out object value)
+		{
+			return li.GenericMap.TryGetValue(key, out value);
+		}
+
+		object IDictionary<string, object>.this[string key]
+		{
+			get => li.GenericMap[key];
+			set => li.GenericMap[key] = value;
+		}
+
+		ICollection<object> IDictionary<string, object>.Values => li.GenericMap.Values;
+
+		ICollection<string> IDictionary<string, object>.Keys => li.GenericMap.Keys;
+
+		#endregion
+
+		#region ICollection<KeyValuePair<string, object>> Members
+
+		void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+		{
+			li.GenericMap.Add(item);
+		}
+
+		bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+		{
+			return li.GenericMap.Contains(item);
+		}
+
+		void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+		{
+			li.GenericMap.CopyTo(array, arrayIndex);
+		}
+
+		bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+		{
+			return li.GenericMap.Remove(item);
+		}
+
+		#endregion
+
+		#region IEnumerable<KeyValuePair<string, object>> Members
+
+		IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+		{
+			return li.GenericMap.GetEnumerator();
 		}
 
 		#endregion

--- a/src/NHibernate/Tuple/DynamicEntityInstantiator.cs
+++ b/src/NHibernate/Tuple/DynamicEntityInstantiator.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NHibernate.Mapping;
+
+namespace NHibernate.Tuple
+{
+	[Serializable]
+	public class DynamicEntityInstantiator : IInstantiator
+	{
+		public const string Key = "$type$";
+
+		private readonly string _entityName;
+		private readonly HashSet<string> _isInstanceEntityNames = new HashSet<string>();
+
+		public DynamicEntityInstantiator(PersistentClass mappingInfo)
+		{
+			_entityName = mappingInfo.EntityName;
+			_isInstanceEntityNames.Add(_entityName);
+			if (mappingInfo.HasSubclasses)
+			{
+				foreach (var subclassInfo in mappingInfo.SubclassClosureIterator)
+					_isInstanceEntityNames.Add(subclassInfo.EntityName);
+			}
+		}
+
+		protected virtual IDictionary<string, object> GenerateMap()
+		{
+			return new Dictionary<string, object>();
+		}
+
+		#region IInstantiator Members
+
+		public object Instantiate(object id)
+		{
+			return Instantiate();
+		}
+
+		public object Instantiate()
+		{
+			var map = GenerateMap();
+			if (_entityName != null)
+			{
+				map[Key] = _entityName;
+			}
+
+			return map;
+		}
+
+		public bool IsInstance(object obj)
+		{
+			if (!(obj is IDictionary<string, object> that))
+				return false;
+			if (_entityName == null)
+				return true;
+
+			var type = (string) that[Key];
+			return type == null || _isInstanceEntityNames.Contains(type);
+
+		}
+
+		#endregion
+	}
+}

--- a/src/NHibernate/Tuple/DynamicEntityInstantiator.cs
+++ b/src/NHibernate/Tuple/DynamicEntityInstantiator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Mapping;
 
@@ -39,10 +38,7 @@ namespace NHibernate.Tuple
 		public object Instantiate()
 		{
 			var map = GenerateMap();
-			if (_entityName != null)
-			{
-				map[Key] = _entityName;
-			}
+			map[Key] = _entityName;
 
 			return map;
 		}
@@ -51,12 +47,8 @@ namespace NHibernate.Tuple
 		{
 			if (!(obj is IDictionary<string, object> that))
 				return false;
-			if (_entityName == null)
-				return true;
 
-			var type = (string) that[Key];
-			return type == null || _isInstanceEntityNames.Contains(type);
-
+			return that.TryGetValue(Key, out var type) && _isInstanceEntityNames.Contains(type as string);
 		}
 
 		#endregion

--- a/src/NHibernate/Tuple/DynamicMapInstantiator.cs
+++ b/src/NHibernate/Tuple/DynamicMapInstantiator.cs
@@ -50,7 +50,7 @@ namespace NHibernate.Tuple
 
 		protected virtual IDictionary GenerateMap()
 		{
-			return new Hashtable();
+			return new Dictionary<string, object>();
 		}
 
 		public bool IsInstance(object obj)

--- a/src/NHibernate/Tuple/DynamicMapInstantiator.cs
+++ b/src/NHibernate/Tuple/DynamicMapInstantiator.cs
@@ -5,6 +5,8 @@ using NHibernate.Mapping;
 
 namespace NHibernate.Tuple
 {
+	//Since v5.2
+	[Obsolete("This class is not used and will be removed in a future version.")]
 	[Serializable]
 	public class DynamicMapInstantiator : IInstantiator
 	{
@@ -13,8 +15,6 @@ namespace NHibernate.Tuple
 		private readonly string entityName;
 		private readonly HashSet<string> isInstanceEntityNames = new HashSet<string>();
 
-		//Since v5.2
-		[Obsolete("This constructor is not used and will be removed in a future version.")]
 		public DynamicMapInstantiator()
 		{
 			entityName = null;
@@ -50,7 +50,7 @@ namespace NHibernate.Tuple
 
 		protected virtual IDictionary GenerateMap()
 		{
-			return new Dictionary<string, object>();
+			return new Hashtable();
 		}
 
 		public bool IsInstance(object obj)

--- a/src/NHibernate/Tuple/Entity/DynamicMapEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/DynamicMapEntityTuplizer.cs
@@ -57,7 +57,7 @@ namespace NHibernate.Tuple.Entity
 
 		protected override IInstantiator BuildInstantiator(PersistentClass mappingInfo)
 		{
-			return new DynamicMapInstantiator(mappingInfo);
+			return new DynamicEntityInstantiator(mappingInfo);
 		}
 
 		protected override IProxyFactory BuildProxyFactory(PersistentClass mappingInfo, IGetter idGetter,


### PR DESCRIPTION
Follow-up to #755 

Generic dictionaries could already be used for creating dynamic entities, but not for working with dynamic entities loaded from the database.

Possible breaking change: querying a dynamic entity as a `Hashtable` instead of an `IDictionary` is no more supported.