### PR TITLE
Make obsolete abstract virtual

### DIFF
--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -1649,15 +1649,24 @@ namespace NHibernate.Persister.Collection
 		// 6.0 TODO: Remove (Replace with ISupportSelectModeJoinable.SelectFragment)
 		// Since v5.2
 		[Obsolete("Use overload taking includeLazyProperties parameter")]
-		public abstract string SelectFragment(IJoinable rhs, string rhsAlias, string lhsAlias, string currentEntitySuffix,
-											  string currentCollectionSuffix, bool includeCollectionColumns);
-		
+		public virtual string SelectFragment(
+			IJoinable rhs,
+			string rhsAlias,
+			string lhsAlias,
+			string currentEntitySuffix,
+			string currentCollectionSuffix,
+			bool includeCollectionColumns)
+		{
+			return SelectFragment(
+				rhs, rhsAlias, lhsAlias, currentEntitySuffix, currentCollectionSuffix, includeCollectionColumns, false);
+		}
+
 		// 6.0 TODO: Make abstract
 		public virtual string SelectFragment(
 			IJoinable rhs, string rhsAlias, string lhsAlias, string entitySuffix, string collectionSuffix,
 			bool includeCollectionColumns, bool includeLazyProperties)
 		{
-			throw new NotImplementedException("Fetching lazy properties is not implemented by " + GetType().FullName);
+			throw new NotImplementedException("SelectFragment with fetching lazy properties option is not implemented by " + GetType().FullName);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Persister/Collection/BasicCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/BasicCollectionPersister.cs
@@ -263,14 +263,6 @@ namespace NHibernate.Persister.Collection
 			return includeCollectionColumns ? SelectFragment(lhsAlias, collectionSuffix) : string.Empty;
 		}
 
-		// Since v5.2
-		[Obsolete("Use overload taking includeLazyProperties parameter")]
-		public override string SelectFragment(IJoinable rhs, string rhsAlias, string lhsAlias,
-			string entitySuffix, string collectionSuffix, bool includeCollectionColumns)
-		{
-			return SelectFragment(rhs, rhsAlias, lhsAlias, entitySuffix, collectionSuffix, includeCollectionColumns, false);
-		}
-
 		private string ManyToManySelectFragment(IJoinable rhs, string rhsAlias, string lhsAlias, string collectionSuffix)
 		{
 			SelectFragment frag = GenerateSelectFragment(lhsAlias, collectionSuffix);

--- a/src/NHibernate/Persister/Collection/OneToManyPersister.cs
+++ b/src/NHibernate/Persister/Collection/OneToManyPersister.cs
@@ -303,13 +303,6 @@ namespace NHibernate.Persister.Collection
 			}
 		}
 
-		// Since v5.2
-		[Obsolete("Use overload taking includeLazyProperties parameter")]
-		public override string SelectFragment(IJoinable rhs, string rhsAlias, string lhsAlias, string entitySuffix, string collectionSuffix, bool includeCollectionColumns)
-		{
-			return SelectFragment(rhs, rhsAlias, lhsAlias, entitySuffix, collectionSuffix, includeCollectionColumns, false);
-		}
-
 		public override string SelectFragment(IJoinable rhs, string rhsAlias, string lhsAlias, string entitySuffix, string collectionSuffix, bool includeCollectionColumns, bool fetchLazyProperties)
 		{
 			var buf = new StringBuilder();


### PR DESCRIPTION
I have realized than obsoleting an abstract member is not very nice to implementors: it forces them to override an obsolete member. Once dropped, their code will no more compile, while the purpose of `Obsolete` is to allow consumers to make required changes for next version and avoid errors due to upgrading.

Instead, we should switch such abstract member to virtual.

This is a kind of follow-up to #1599, since the only obsoleted abstract I have found was introduced there. (I have thought of this subject because I was starting to obsolete abstract members for another subject.)

There is somewhat a similar trouble with obsoleted interface members, but there is nothing we can do for them, and furthermore the implementor can implements them in a way that will not break compilation once they are dropped, contrary to abstract members.