### PR TITLE
Obsolete unused version related methods of SByteType

### DIFF
--- a/src/NHibernate/Type/SByteType.cs
+++ b/src/NHibernate/Type/SByteType.cs
@@ -73,16 +73,22 @@ namespace NHibernate.Type
 
 		#region IVersionType Members
 
+		// Since 5.2
+		[Obsolete("This member has no more usage and will be removed in a future version.")]
 		public virtual object Next(object current, ISessionImplementor session)
 		{
 			return (SByte)((SByte)current + 1);
 		}
 
+		// Since 5.2
+		[Obsolete("This member has no more usage and will be removed in a future version.")]
 		public virtual object Seed(ISessionImplementor session)
 		{
 			return (SByte)1;
 		}
 
+		// Since 5.2
+		[Obsolete("This member has no more usage and will be removed in a future version.")]
 		public IComparer Comparator
 		{
 			get { return Comparer<SByte>.Default; }


### PR DESCRIPTION
`SByteType` seems to have implemented `IVersionType` previously, but that is
no more the case.