### PR TITLE
Start/Stop required db-service for TeamCity

### DIFF
--- a/teamcity.build
+++ b/teamcity.build
@@ -4,6 +4,7 @@
 	<property name="root.dir" value="." />
 	<property name="config.teamcity" value="default"/>
 	<property name="current-test-configuration.dir" value="${root.dir}/current-test-configuration" /> 
+	<property name="skip.db-service" value="true" overwrite="false" />
 
 	<include buildfile="${root.dir}/default.build" />
 
@@ -13,7 +14,15 @@
 
 	<property name="build.number" value="${CCNetLabel}" if="${property::exists('CCNetLabel')}" />
 
-	<target name="clean-configure-test" depends="cleanall init copy-teamcity-configuration binaries test verify-test-results binaries-zip" />
+	<target name="clean-configure-test" depends="cleanall init copy-teamcity-configuration binaries start-db-service test stop-db-service verify-test-results binaries-zip" />
+
+	<target name="start-db-service" unless="${skip.db-service or not property::exists('db-service')}">
+		<servicecontroller action="Start" service="${db-service}" timeout="120000" />
+	</target>
+
+	<target name="stop-db-service" unless="${skip.db-service or not property::exists('db-service')}">
+		<servicecontroller action="Stop" service="${db-service}" timeout="120000" />
+	</target>
 
 	<target name="copy-teamcity-configuration">
 		<copy file="build-common/teamcity-hibernate.cfg.xml" tofile="${current-test-configuration.dir}/hibernate.cfg.xml" />
@@ -33,10 +42,12 @@
 	</target>
 
 	<target name="setup-teamcity-default">
+		<property name="db-service" value="MSSQL$SQLEXPRESS" />
 		<!-- default (SQL Server) does not require any additional settings/binaries -->
 	</target>
 
 	<target name="setup-teamcity-sqlServerOdbc">
+		<property name="db-service" value="MSSQL$SQLEXPRESS" />
 		<property name="nhibernate.connection.driver_class" value="NHibernate.Driver.OdbcDriver" />
 		<property name="nhibernate.odbc.explicit_datetime_scale" value="3" />
 	<!-- We need to use a dialect that avoids mapping DbType.Time to TIME on MSSQL. On modern SQL Server
@@ -52,10 +63,12 @@
 	</target>
 
 	<target name="setup-teamcity-sqlServer-Sql2008ClientDriver">
+		<property name="db-service" value="MSSQL$SQLEXPRESS" />
 		<property name="nhibernate.connection.driver_class" value="NHibernate.Driver.Sql2008ClientDriver" />
 	</target>
 
 	<target name="setup-teamcity-sqlServer2012">
+		<property name="db-service" value="MSSQL$SQLEXPRESS" />
 		<property name="nhibernate.dialect" value="NHibernate.Dialect.MsSql2012Dialect" />
 	</target>
 
@@ -75,12 +88,14 @@
 	</target>
 
 	<target name="setup-teamcity-firebird32">
+		<property name="db-service" value="FirebirdServerDefaultInstance" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.FirebirdClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.FirebirdDialect" />
 		<property name="nhibernate.connection.connection_string"	value="DataSource=localhost;Database=nhibernate;User ID=SYSDBA;Password=masterkey;MaxPoolSize=200;charset=utf8;" />
 	</target>
 
 	<target name="setup-teamcity-firebird64">
+		<property name="db-service" value="FirebirdServerDefaultInstance" />
 		<property name="nunit-x64" value="true" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.FirebirdClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.FirebirdDialect" />
@@ -109,12 +124,14 @@
 	</target>
 
 	<target name="setup-teamcity-postgresql">
+		<property name="db-service" value="postgresql-x64-10" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.NpgsqlDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.PostgreSQL83Dialect" />
 		<property name="nhibernate.connection.connection_string"	value="Host=localhost;Port=5432;Database=nhibernate;Username=nhibernate;Password=nhibernate;Enlist=true" />
 	</target>
 
 	<target name="setup-teamcity-oracle">
+		<property name="db-service" value="OracleServiceXE" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Data Source=XE" />
@@ -123,6 +140,7 @@
 	</target>
 
 	<target name="setup-teamcity-oracle32">
+		<property name="db-service" value="OracleServiceXE" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
@@ -141,6 +159,7 @@
 	</target>
 
 	<target name="setup-teamcity-oracle64">
+		<property name="db-service" value="OracleServiceXE" />
 		<property name="nunit-x64" value="true" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
@@ -160,6 +179,7 @@
 	</target>
 
 	<target name="setup-teamcity-oracle-managed32">
+		<property name="db-service" value="OracleServiceXE" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleManagedDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
 		<property name="nhibernate.connection.connection_string"	value="User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XE)))" />
@@ -171,6 +191,7 @@
 	</target>
 
 	<target name="setup-teamcity-oracle-managed64">
+		<property name="db-service" value="OracleServiceXE" />
 		<property name="nunit-x64" value="true" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.OracleManagedDataClientDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.Oracle10gDialect" />
@@ -183,6 +204,7 @@
 	</target>
 
 	<target name="setup-teamcity-mysql">
+		<property name="db-service" value="MySQL57" />
 		<property name="nhibernate.connection.driver_class" value="NHibernate.Driver.MySqlDataDriver" />
 		<property name="nhibernate.dialect"	value="NHibernate.Dialect.MySQL5Dialect" />
 		<property name="nhibernate.connection.connection_string" value="Data Source=localhost;Database=nhibernate;User ID=nhibernate;Password=nhibernate;Protocol=memory;Old Guids=True;" />


### PR DESCRIPTION
Since the TeamCity build agent has occasional memory issues, mainly due to some database services taking more and more memory as they accumulate up-time (and run testes), I propose to start and stop the required database service for each build.

This change is not enabled by default in order to avoid disrupting other builds for now. It will be enabled by adding a `-D:skip.db-service=false` parameter to the Nant step on the build template.

If approved, I think it needs to be done in 5.1.x then merged to master, in order to not hinder any 5.1.x patch. It will have to be back-ported to previous branches if patches are required for them.