### PR TITLE
Generate stable sql objects names

### DIFF
--- a/src/NHibernate.Test/MappingTest/TableFixture.cs
+++ b/src/NHibernate.Test/MappingTest/TableFixture.cs
@@ -66,7 +66,7 @@ namespace NHibernate.Test.MappingTest
 			var tbl = new Table { Name = "name" };
 			Assert.That(
 				Constraint.GenerateName("FK_", tbl, null, new[] {new Column("col1"), new Column("col2")}),
-				Is.EqualTo("FK_IHNJ2ONUQL23X2DYGJ2YBBV3F7A"));
+				Is.EqualTo("FK_3B355A0C"));
 		}
 	}
 }

--- a/src/NHibernate.Test/MappingTest/TableFixture.cs
+++ b/src/NHibernate.Test/MappingTest/TableFixture.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Threading;
 using NHibernate.Dialect;
 using NHibernate.Mapping;
 using NUnit.Framework;
@@ -60,6 +58,15 @@ namespace NHibernate.Test.MappingTest
 			Dialect.Dialect dialect = new MsSql2000Dialect();
 
 			Assert.AreEqual("[schema].name", tbl.GetQualifiedName(dialect));
+		}
+
+		[Test]
+		public void NameIsStable()
+		{
+			var tbl = new Table { Name = "name" };
+			Assert.That(
+				Constraint.GenerateName("FK_", tbl, null, new[] {new Column("col1"), new Column("col2")}),
+				Is.EqualTo("FK_IHNJ2ONUQL23X2DYGJ2YBBV3F7A"));
 		}
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH1399/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1399/Fixture.cs
@@ -1,9 +1,10 @@
+using System;
 using NHibernate.Mapping;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH1399
 {
-	[TestFixture]
+	[TestFixture, Obsolete]
 	public class Fixture
 	{
 		[Test]

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -1191,6 +1190,13 @@ namespace NHibernate.Cfg
 						try
 						{
 							fk.AddReferencedTable(referencedClass);
+
+							if (string.IsNullOrEmpty(fk.Name))
+							{
+								fk.Name = Constraint.GenerateName(
+									fk.GeneratedConstraintNamePrefix, table, fk.ReferencedTable, fk.Columns);
+							}
+
 							fk.AlignColumns();
 						}
 						catch (MappingException me)

--- a/src/NHibernate/Mapping/Constraint.cs
+++ b/src/NHibernate/Mapping/Constraint.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.Util;
@@ -61,14 +62,9 @@ namespace NHibernate.Mapping
 
 			// Ensure a consistent ordering of columns, regardless of the order
 			// they were bound.
-			// Clone the list, as sometimes a set of order-dependent Column
-			// bindings are given.
-			var alphabeticalColumns = new List<Column>(columns);
-			alphabeticalColumns.Sort(ColumnComparator.Instance);
-			foreach (var column in alphabeticalColumns)
+			foreach (var column in columns.OrderBy(c => c.CanonicalName))
 			{
-				var columnName = column == null ? "" : column.Name;
-				sb.Append("column`").Append(columnName).Append("`");
+				sb.Append("column`").Append(column.CanonicalName).Append("`");
 			}
 			// Hash the generated name for avoiding collisions with user choosen names.
 			// This is not 100% reliable, as hashing may still have a chance of generating
@@ -78,15 +74,6 @@ namespace NHibernate.Mapping
 			var name = prefix + Hasher.HashToString(sb.ToString());
 
 			return name;
-		}
-
-		private class ColumnComparator : IComparer<Column>
-		{
-			public static readonly ColumnComparator Instance = new ColumnComparator();
-
-			public int Compare(Column col1, Column col2) {
-				return StringComparer.Ordinal.Compare(col1?.Name, col2?.Name);
-			}
 		}
 
 		/// <summary>

--- a/src/NHibernate/Mapping/Constraint.cs
+++ b/src/NHibernate/Mapping/Constraint.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.Util;
@@ -37,6 +38,142 @@ namespace NHibernate.Mapping
 		{
 			get { return columns; }
 		}
+
+		/// <summary>
+		/// Generate a name hopefully unique using the table and column names.
+		/// Static so the name can be generated prior to creating the Constraint.
+		/// They're cached, keyed by name, in multiple locations.
+		/// </summary>
+		/// <param name="prefix">A name prefix for the generated name.</param>
+		/// <param name="table">The table for which the name is generated.</param>
+		/// <param name="referencedTable">The referenced table, if any.</param>
+		/// <param name="columns">The columns for which the name is generated.</param>
+		/// <returns>The generated name.</returns>
+		/// <remarks>Hybrid of Hibernate <c>Constraint.generateName</c> and
+		/// <c>NamingHelper.generateHashedFkName</c>.</remarks>
+		public static string GenerateName(
+			string prefix, Table table, Table referencedTable, IEnumerable<Column> columns)
+		{
+			// Use a concatenation that guarantees uniqueness, even if identical names
+			// exist between all table and column identifiers.
+			var sb = new StringBuilder("table`" + table.Name + "`");
+			if (referencedTable != null)
+				sb.Append("references`" + referencedTable.Name + "`");
+
+			// Ensure a consistent ordering of columns, regardless of the order
+			// they were bound.
+			// Clone the list, as sometimes a set of order-dependent Column
+			// bindings are given.
+			var alphabeticalColumns = new List<Column>(columns);
+			alphabeticalColumns.Sort(ColumnComparator.Instance);
+			foreach (var column in alphabeticalColumns)
+			{
+				var columnName = column == null ? "" : column.Name;
+				sb.Append("column`").Append(columnName).Append("`");
+			}
+			// Hash the generated name for avoiding collisions with user choosen names.
+			// This is not 100% reliable, as hashing may still have a chance of generating
+			// collisions.
+			var name = prefix + HashName(sb.ToString());
+
+			// Hibernate uses an algorithm yielding names shorter than 30 characters. But we cannot
+			// use it (see HashName). And also we have DB limited to even less (Informix)...
+			if (name.Length > 30)
+			{
+				// This, of course, increases the collision risk.
+				name = name.Substring(0, 30);
+			}
+
+			return name;
+		}
+
+		#region Name generation support methods
+
+		/// <summary>
+		/// Hash a constraint name. Convert the hash digest to base 32
+		/// (full alphanumeric) for shortening the hash string representation
+		/// while keeping it suitable for db names.
+		/// </summary>
+		/// <param name="name">The name to be hashed.</param>
+		/// <returns>The hased name.</returns>
+		private static string HashName(string name)
+		{
+			// Hibernate uses MD5, but with .Net this would throw on FIPS enabled machine.
+			// As a consequence generated names will be quite longer.
+			using (var hasher = SHA256.Create())
+			{
+				var hash = hasher.ComputeHash(Encoding.UTF8.GetBytes(name));
+				// Converting to base 32 for shortening the name.
+				// Hibernate uses base 35, but we do not have a native implementation
+				// in .Net, and base 32 is easier to implement.
+				return ToBase32String(hash);
+			}
+		}
+
+		// Adapted from https://stackoverflow.com/a/7135008/1178314
+		// Changed for not padding with "="
+		private static string ToBase32String(byte[] input)
+		{
+			if (input == null || input.Length == 0)
+			{
+				throw new ArgumentNullException(nameof(input));
+			}
+
+			var charCount = (int) Math.Ceiling(input.Length / 5d) * 8;
+			var result = new StringBuilder(charCount);
+
+			byte nextChar = 0, bitsRemaining = 5;
+
+			foreach (var b in input)
+			{
+				nextChar = (byte)(nextChar | (b >> (8 - bitsRemaining)));
+				result.Append(ValueToChar(nextChar));
+
+				if (bitsRemaining < 4)
+				{
+					nextChar = (byte)((b >> (3 - bitsRemaining)) & 31);
+					result.Append(ValueToChar(nextChar));
+					bitsRemaining += 5;
+				}
+
+				bitsRemaining -= 3;
+				nextChar = (byte)((b << bitsRemaining) & 31);
+			}
+
+			// If we didn't end with a full char
+			if (result.Length != charCount)
+			{
+				result.Append(ValueToChar(nextChar));
+			}
+
+			return result.ToString();
+		}
+
+		private static char ValueToChar(byte b)
+		{
+			if (b < 26)
+			{
+				return (char)(b + 65);
+			}
+
+			if (b < 32)
+			{
+				return (char)(b + 24);
+			}
+
+			throw new ArgumentException("Byte is not a value Base32 value.", "b");
+		}
+
+		private class ColumnComparator : IComparer<Column>
+		{
+			public static readonly ColumnComparator Instance = new ColumnComparator();
+
+			public int Compare(Column col1, Column col2) {
+				return StringComparer.Ordinal.Compare(col1?.Name, col2?.Name);
+			}
+		}
+
+		#endregion
 
 		/// <summary>
 		/// Adds the <see cref="Column"/> to the <see cref="ICollection"/> of 

--- a/src/NHibernate/Mapping/Constraint.cs
+++ b/src/NHibernate/Mapping/Constraint.cs
@@ -55,9 +55,9 @@ namespace NHibernate.Mapping
 		{
 			// Use a concatenation that guarantees uniqueness, even if identical names
 			// exist between all table and column identifiers.
-			var sb = new StringBuilder("table`" + table.Name + "`");
+			var sb = new StringBuilder("table`").Append(table.Name).Append("`");
 			if (referencedTable != null)
-				sb.Append("references`" + referencedTable.Name + "`");
+				sb.Append("references`").Append(referencedTable.Name).Append("`");
 
 			// Ensure a consistent ordering of columns, regardless of the order
 			// they were bound.

--- a/src/NHibernate/Mapping/Constraint.cs
+++ b/src/NHibernate/Mapping/Constraint.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.Util;
@@ -74,94 +73,11 @@ namespace NHibernate.Mapping
 			// Hash the generated name for avoiding collisions with user choosen names.
 			// This is not 100% reliable, as hashing may still have a chance of generating
 			// collisions.
-			var name = prefix + HashName(sb.ToString());
-
-			// Hibernate uses an algorithm yielding names shorter than 30 characters. But we cannot
-			// use it (see HashName). And also we have DB limited to even less (Informix)...
-			if (name.Length > 30)
-			{
-				// This, of course, increases the collision risk.
-				name = name.Substring(0, 30);
-			}
+			// Hibernate uses MD5 here, which .Net standrad implementation is rejected by
+			// FIPS enabled machine. Better use a non-cryptographic hash.
+			var name = prefix + Hasher.HashToString(sb.ToString());
 
 			return name;
-		}
-
-		#region Name generation support methods
-
-		/// <summary>
-		/// Hash a constraint name. Convert the hash digest to base 32
-		/// (full alphanumeric) for shortening the hash string representation
-		/// while keeping it suitable for db names.
-		/// </summary>
-		/// <param name="name">The name to be hashed.</param>
-		/// <returns>The hased name.</returns>
-		private static string HashName(string name)
-		{
-			// Hibernate uses MD5, but with .Net this would throw on FIPS enabled machine.
-			// As a consequence generated names will be quite longer.
-			using (var hasher = SHA256.Create())
-			{
-				var hash = hasher.ComputeHash(Encoding.UTF8.GetBytes(name));
-				// Converting to base 32 for shortening the name.
-				// Hibernate uses base 35, but we do not have a native implementation
-				// in .Net, and base 32 is easier to implement.
-				return ToBase32String(hash);
-			}
-		}
-
-		// Adapted from https://stackoverflow.com/a/7135008/1178314
-		// Changed for not padding with "="
-		private static string ToBase32String(byte[] input)
-		{
-			if (input == null || input.Length == 0)
-			{
-				throw new ArgumentNullException(nameof(input));
-			}
-
-			var charCount = (int) Math.Ceiling(input.Length / 5d) * 8;
-			var result = new StringBuilder(charCount);
-
-			byte nextChar = 0, bitsRemaining = 5;
-
-			foreach (var b in input)
-			{
-				nextChar = (byte)(nextChar | (b >> (8 - bitsRemaining)));
-				result.Append(ValueToChar(nextChar));
-
-				if (bitsRemaining < 4)
-				{
-					nextChar = (byte)((b >> (3 - bitsRemaining)) & 31);
-					result.Append(ValueToChar(nextChar));
-					bitsRemaining += 5;
-				}
-
-				bitsRemaining -= 3;
-				nextChar = (byte)((b << bitsRemaining) & 31);
-			}
-
-			// If we didn't end with a full char
-			if (result.Length != charCount)
-			{
-				result.Append(ValueToChar(nextChar));
-			}
-
-			return result.ToString();
-		}
-
-		private static char ValueToChar(byte b)
-		{
-			if (b < 26)
-			{
-				return (char)(b + 65);
-			}
-
-			if (b < 32)
-			{
-				return (char)(b + 24);
-			}
-
-			throw new ArgumentException("Byte is not a value Base32 value.", "b");
 		}
 
 		private class ColumnComparator : IComparer<Column>
@@ -172,8 +88,6 @@ namespace NHibernate.Mapping
 				return StringComparer.Ordinal.Compare(col1?.Name, col2?.Name);
 			}
 		}
-
-		#endregion
 
 		/// <summary>
 		/// Adds the <see cref="Column"/> to the <see cref="ICollection"/> of 

--- a/src/NHibernate/Mapping/DenormalizedTable.cs
+++ b/src/NHibernate/Mapping/DenormalizedTable.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections;
 using NHibernate.Util;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Mapping
 {
@@ -56,19 +56,17 @@ namespace NHibernate.Mapping
 		public override void CreateForeignKeys()
 		{
 			includedTable.CreateForeignKeys();
-			IEnumerable includedFks = includedTable.ForeignKeyIterator;
-			foreach (ForeignKey fk in includedFks)
+			var includedFks = includedTable.ForeignKeyIterator;
+			foreach (var fk in includedFks)
 			{
-				// NH Different behaviour (fk name)
-				CreateForeignKey(GetForeignKeyName(fk), fk.Columns, fk.ReferencedEntityName);
+				CreateForeignKey(
+					Constraint.GenerateName(
+						fk.GeneratedConstraintNamePrefix,
+						this,
+						null,
+						fk.Columns),
+					fk.Columns, fk.ReferencedEntityName);
 			}
-		}
-
-		private string GetForeignKeyName(ForeignKey fk)
-		{
-			// (the FKName length, of H3.2 implementation, may be too long for some RDBMS so we implement something different) 
-			int hash = fk.Name.GetHashCode() ^ Name.GetHashCode();
-			return string.Format("KF{0}", hash.ToString("X"));
 		}
 
 		public override Column GetColumn(Column column)

--- a/src/NHibernate/Mapping/ForeignKey.cs
+++ b/src/NHibernate/Mapping/ForeignKey.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using NHibernate.Util;
@@ -233,5 +232,7 @@ namespace NHibernate.Mapping
 		{
 			get { return referencedColumns.Count == 0; }
 		}
+
+		public string GeneratedConstraintNamePrefix => "FK_";
 	}
 }

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -808,15 +808,9 @@ namespace NHibernate.Mapping
 			if (fk == null)
 			{
 				fk = new ForeignKey();
-				if (!string.IsNullOrEmpty(keyName))
-				{
-					fk.Name = keyName;
-				}
-				else
-				{
-					fk.Name = "FK" + UniqueColumnString(kCols, referencedEntityName);
-					//TODO: add referencedClass to disambiguate to FKs on the same columns, pointing to different tables
-				}
+				// NOTE : if the name is null, we will generate an implicit name during second pass processing
+				// after we know the referenced table name (which might not be resolved yet).
+				fk.Name = keyName;
 				fk.Table = this;
 				foreignKeys.Add(key, fk);
 				fk.ReferencedEntityName = referencedEntityName;
@@ -837,8 +831,8 @@ namespace NHibernate.Mapping
 
 		public virtual UniqueKey CreateUniqueKey(IList<Column> keyColumns)
 		{
-			string keyName = "UK" + UniqueColumnString(keyColumns);
-			UniqueKey uk = GetOrCreateUniqueKey(keyName);
+			var keyName = Constraint.GenerateName( "UK_", this, null, keyColumns);
+			var uk = GetOrCreateUniqueKey(keyName);
 			uk.AddColumns(keyColumns);
 			return uk;
 		}
@@ -851,11 +845,15 @@ namespace NHibernate.Mapping
 		/// <returns>
 		/// An unique string for the <see cref="Column"/> objects.
 		/// </returns>
+		// Since v5.2
+		[Obsolete("Use Constraint.GenerateName instead.")]
 		public string UniqueColumnString(IEnumerable uniqueColumns)
 		{
 			return UniqueColumnString(uniqueColumns, null);
 		}
 
+		// Since v5.2
+		[Obsolete("Use Constraint.GenerateName instead.")]
 		public string UniqueColumnString(IEnumerable iterator, string referencedEntityName)
 		{
 			// NH Different implementation (NH-1399)

--- a/src/NHibernate/Util/Hasher.cs
+++ b/src/NHibernate/Util/Hasher.cs
@@ -1,0 +1,117 @@
+/*
+ * Derived from MurmurHash2Simple,
+ * http://landman-code.blogspot.com/2009/02/c-superfasthash-and-murmurhash2.html
+ */
+
+/***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is HashTableHashing.MurmurHash2.
+ *
+ * The Initial Developer of the Original Code is
+ * Davy Landman.
+ * Portions created by the Initial Developer are Copyright (C) 2009
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+using System;
+using System.Text;
+
+namespace NHibernate.Util
+{
+	/// <summary>A stable hasher using MurmurHash2 algorithm.</summary>
+	internal static class Hasher
+	{
+		internal static string HashToString(string input)
+		{
+			var hash = Hash(input);
+			return hash.ToString("X");
+		}
+
+		internal static uint Hash(string input)
+		{
+			return Hash(Encoding.UTF8.GetBytes(input));
+		}
+
+		internal static uint Hash(byte[] data)
+		{
+			return Hash(data, 0xc58f1a7b);
+		}
+
+		private const uint _m = 0x5bd1e995;
+		private const int _r = 24;
+
+		internal static uint Hash(byte[] data, uint seed)
+		{
+			var length = data.Length;
+			if (length == 0)
+				return 0;
+			var h = seed ^ (uint) length;
+			var currentIndex = 0;
+			while (length >= 4)
+			{
+				var k = BitConverter.ToUInt32(data, currentIndex);
+				k *= _m;
+				k ^= k >> _r;
+				k *= _m;
+
+				h *= _m;
+				h ^= k;
+				currentIndex += 4;
+				length -= 4;
+			}
+
+			switch (length)
+			{
+				case 3:
+					h ^= BitConverter.ToUInt16(data, currentIndex);
+					h ^= (uint) data[currentIndex + 2] << 16;
+					h *= _m;
+					break;
+				case 2:
+					h ^= BitConverter.ToUInt16(data, currentIndex);
+					h *= _m;
+					break;
+				case 1:
+					h ^= data[currentIndex];
+					h *= _m;
+					break;
+			}
+
+			// Do a few final mixes of the hash to ensure the last few
+			// bytes are well-incorporated.
+
+			h ^= h >> 13;
+			h *= _m;
+			h ^= h >> 15;
+
+			return h;
+		}
+	}
+}


### PR DESCRIPTION
Fix #1769.

Possible breaking change:

- Auto-generated constraint names will not be the same than the ones generated with previous NHibernate versions under .Net Framework. (Under .Net Core those names were anyway changing at each run.)