### PR TITLE
Fix the <any/> handling without meta-values

### DIFF
--- a/doc/reference/modules/basic_mapping.xml
+++ b/doc/reference/modules/basic_mapping.xml
@@ -3364,8 +3364,8 @@
                 database column values to persistent classes that have identifier properties of the type specified by
                 <literal>id-type</literal>. If the meta-type is <literal>class</literal>, nothing else is required.
                 The class full name will be persisted in the database as the type of the associated entity.
-                On the other hand, if it is a basic type like <literal>string</literal> or
-                <literal>char</literal>, you must specify the mapping from values to classes.
+                On the other hand, if it is a basic type like <literal>int</literal> or <literal>char</literal>, you
+                must specify the mapping from values to classes. Here is an example with <literal>string</literal>.
             </para>
 
             <programlisting><![CDATA[<any name="being" id-type="long" meta-type="string">
@@ -3375,6 +3375,11 @@
     <column name="type"/>
     <column name="id"/>
 </any>]]></programlisting>
+
+            <para>
+                String types are a special case: they can be used without meta-values, in which case they will behave
+                much like the <literal>class</literal> meta-type.
+            </para>
 
             <programlistingco>
                 <areaspec>

--- a/src/NHibernate.Test/Async/CacheTest/SerializationFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/SerializationFixture.cs
@@ -199,7 +199,7 @@ namespace NHibernate.Test.CacheTest
 				{NHibernateUtil.TrueFalse, false},
 				{NHibernateUtil.YesNo, true},
 				{NHibernateUtil.Class, typeof(IType)},
-				{NHibernateUtil.ClassMetaType, entityName},
+				{NHibernateUtil.MetaType, entityName},
 				{NHibernateUtil.Serializable, new MyEntity {Id = 1}},
 				{NHibernateUtil.Object, new MyEntity {Id = 10}},
 				{NHibernateUtil.AnsiChar, 'a'},

--- a/src/NHibernate.Test/Async/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Async/Legacy/FooBarTest.cs
@@ -5180,8 +5180,13 @@ namespace NHibernate.Test.Legacy
 			s.Close();
 
 			s = OpenSession();
-			IList list = await (s.CreateQuery("from Bar bar where bar.Object.id = ? and bar.Object.class = ?")
-				.SetParameter(0, oid, NHibernateUtil.Int64).SetParameter(1, typeof(One).FullName, NHibernateUtil.ClassMetaType).ListAsync());
+			var list = await (s.CreateQuery("from Bar bar where bar.Object.id = ? and bar.Object.class = ?")
+#pragma warning disable 618
+			              .SetParameter(0, oid, NHibernateUtil.Int64).SetParameter(1, typeof(One).FullName, NHibernateUtil.ClassMetaType).ListAsync());
+#pragma warning restore 618
+			Assert.AreEqual(1, list.Count);
+			list = await (s.CreateQuery("from Bar bar where bar.Object.id = ? and bar.Object.class = ?")
+				.SetParameter(0, oid, NHibernateUtil.Int64).SetParameter(1, typeof(One).FullName, NHibernateUtil.MetaType).ListAsync());
 			Assert.AreEqual(1, list.Count);
 
 			// this is a little different from h2.0.3 because the full type is stored, not

--- a/src/NHibernate.Test/CacheTest/SerializationFixture.cs
+++ b/src/NHibernate.Test/CacheTest/SerializationFixture.cs
@@ -188,7 +188,7 @@ namespace NHibernate.Test.CacheTest
 				{NHibernateUtil.TrueFalse, false},
 				{NHibernateUtil.YesNo, true},
 				{NHibernateUtil.Class, typeof(IType)},
-				{NHibernateUtil.ClassMetaType, entityName},
+				{NHibernateUtil.MetaType, entityName},
 				{NHibernateUtil.Serializable, new MyEntity {Id = 1}},
 				{NHibernateUtil.Object, new MyEntity {Id = 10}},
 				{NHibernateUtil.AnsiChar, 'a'},

--- a/src/NHibernate.Test/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Legacy/FooBarTest.cs
@@ -5168,8 +5168,13 @@ namespace NHibernate.Test.Legacy
 			s.Close();
 
 			s = OpenSession();
-			IList list = s.CreateQuery("from Bar bar where bar.Object.id = ? and bar.Object.class = ?")
-				.SetParameter(0, oid, NHibernateUtil.Int64).SetParameter(1, typeof(One).FullName, NHibernateUtil.ClassMetaType).List();
+			var list = s.CreateQuery("from Bar bar where bar.Object.id = ? and bar.Object.class = ?")
+#pragma warning disable 618
+			              .SetParameter(0, oid, NHibernateUtil.Int64).SetParameter(1, typeof(One).FullName, NHibernateUtil.ClassMetaType).List();
+#pragma warning restore 618
+			Assert.AreEqual(1, list.Count);
+			list = s.CreateQuery("from Bar bar where bar.Object.id = ? and bar.Object.class = ?")
+				.SetParameter(0, oid, NHibernateUtil.Int64).SetParameter(1, typeof(One).FullName, NHibernateUtil.MetaType).List();
 			Assert.AreEqual(1, list.Count);
 
 			// this is a little different from h2.0.3 because the full type is stored, not

--- a/src/NHibernate.Test/NHSpecificTest/GH1774/Implicit/ImplicitMetaTypeFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1774/Implicit/ImplicitMetaTypeFixture.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.GH1774.Implicit
 {
-	[TestFixture, Ignore("Not fixed yet")]
+	[TestFixture]
 	public class ImplicitMetaTypeFixture : FixtureBase
 	{
 	}

--- a/src/NHibernate/Async/Type/ClassMetaType.cs
+++ b/src/NHibernate/Async/Type/ClassMetaType.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Type
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class ClassMetaType : AbstractType, IMetaType
+	public partial class ClassMetaType : AbstractType
 	{
 
 		public override Task<object> NullSafeGetAsync(DbDataReader rs, string[] names, ISessionImplementor session, object owner, CancellationToken cancellationToken)

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
@@ -276,19 +276,19 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				return;
 			}
 
-			if (rhsNode is IdentNode && lhsNode.DataType is IMetaType lhsNodeMetaType)
+			if (rhsNode is IdentNode && lhsNode.DataType is MetaType lhsNodeMetaType)
 			{
 				EvaluateType(rhsNode, lhsNodeMetaType);
 				return;
 			}
 
-			if (lhsNode is IdentNode && rhsNode.DataType is IMetaType rhsNodeMetaType)
+			if (lhsNode is IdentNode && rhsNode.DataType is MetaType rhsNodeMetaType)
 			{
 				EvaluateType(lhsNode, rhsNodeMetaType);
 			}
 		}
 
-		private void EvaluateType(SqlNode node, IMetaType metaType)
+		private void EvaluateType(SqlNode node, MetaType metaType)
 		{
 			var sessionFactory = SessionFactoryHelper.Factory;
 

--- a/src/NHibernate/Mapping/Any.cs
+++ b/src/NHibernate/Mapping/Any.cs
@@ -19,6 +19,7 @@ namespace NHibernate.Mapping
 
 		public Any(Table table) : base(table)
 		{
+			_type = GetLazyType();
 		}
 
 		/// <summary>
@@ -30,29 +31,45 @@ namespace NHibernate.Mapping
 			set { identifierTypeName = value; }
 		}
 
-		private IType type;
-		public override IType Type
+		private Lazy<IType> GetLazyType()
 		{
-			get
-			{
-				if (type == null)
+			return new Lazy<IType>(
+				() =>
 				{
-					type =
-						new AnyType(
-							metaValues == null
-							? ("class".Equals(metaTypeName) ? new ClassMetaType(): TypeFactory.HeuristicType(metaTypeName))
-								: new MetaType(metaValues, TypeFactory.HeuristicType(metaTypeName)),
-							TypeFactory.HeuristicType(identifierTypeName));
-				}
-				return type;
-			}
+					var identifierType = TypeFactory.HeuristicType(identifierTypeName);
+					if (identifierType == null)
+						throw new MappingException($"Identifier type '{identifierTypeName}' is invalid");
+
+					var hasMetaValues = metaValues != null && metaValues.Count > 0;
+
+					var metaType = !hasMetaValues && "class" == metaTypeName
+						? NHibernateUtil.String
+						: TypeFactory.HeuristicType(metaTypeName);
+
+					if (metaType == null)
+						throw new MappingException($"Meta type '{metaTypeName}' is invalid");
+
+					if (!hasMetaValues && metaType.ReturnedClass != typeof(string))
+						throw new MappingException(
+							$"Using a non-string meta type ('{metaTypeName}') without providing meta values is invalid");
+
+					return new AnyType(
+						new MetaType(metaValues, metaType),
+						identifierType);
+				});
 		}
+
+		// Types may be used by many threads, we must use a thread safe lazy initialization.
+		// (Or we should build this class in another way, but this would likely be a breaking change.)
+		private Lazy<IType> _type;
+
+		public override IType Type => _type.Value;
 
 		public void ResetCachedType()
 		{
 			// this is required if the user is programatically modifying the Any instance
 			// and need to reset the cached type instance;
-			type = null;
+			_type = GetLazyType();
 		}
 
 		public override void SetTypeUsingReflection(string className, string propertyName, string access)

--- a/src/NHibernate/NHibernateUtil.cs
+++ b/src/NHibernate/NHibernateUtil.cs
@@ -268,7 +268,14 @@ namespace NHibernate
 		/// NHibernate class meta type for association of kind <code>any</code>.
 		/// </summary>
 		/// <seealso cref="AnyType"/>
+		[Obsolete("Use MetaType without meta-values instead.")]
 		public static readonly ClassMetaType ClassMetaType = new ClassMetaType();
+
+		/// <summary>
+		/// NHibernate meta type for association of kind <code>any</code> without meta-values.
+		/// </summary>
+		/// <seealso cref="AnyType"/>
+		public static readonly MetaType MetaType = new MetaType(null, String);
 
 		/// <summary>
 		/// NHibernate serializable type

--- a/src/NHibernate/Type/AnyType.cs
+++ b/src/NHibernate/Type/AnyType.cs
@@ -46,20 +46,22 @@ namespace NHibernate.Type
 		private readonly IType identifierType;
 		private readonly IType metaType;
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="metaType"></param>
-		/// <param name="identifierType"></param>
+		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(AnyType));
+
 		internal AnyType(IType metaType, IType identifierType)
 		{
-			this.identifierType = identifierType;
-			this.metaType = metaType;
+			this.identifierType = identifierType ?? throw new ArgumentNullException(nameof(identifierType));
+			this.metaType = metaType ?? throw new ArgumentNullException(nameof(metaType));
+
+			if (!(metaType is MetaType))
+			{
+				Log.Warn("Using AnyType with a meta type which is not a MetaType is obsolete and may cause" +
+				         "querying issues.");
+			}
 		}
 
-		/// <summary></summary>
 		internal AnyType()
-			: this(NHibernateUtil.String, NHibernateUtil.Serializable)
+			: this(NHibernateUtil.MetaType, NHibernateUtil.Serializable)
 		{
 		}
 

--- a/src/NHibernate/Type/ClassMetaType.cs
+++ b/src/NHibernate/Type/ClassMetaType.cs
@@ -12,7 +12,8 @@ namespace NHibernate.Type
 	/// It work like a MetaType where the key is the entity-name it self
 	/// </remarks>
 	[Serializable]
-	public partial class ClassMetaType : AbstractType, IMetaType
+	[Obsolete("Use MetaType without meta-values instead.")]
+	public partial class ClassMetaType : AbstractType
 	{
 		public override SqlType[] SqlTypes(IMapping mapping)
 		{
@@ -99,11 +100,6 @@ namespace NHibernate.Type
 		public override bool[] ToColumnNullness(object value, IMapping mapping)
 		{
 			return NHibernateUtil.String.ToColumnNullness(value, mapping);
-		}
-
-		string IMetaType.GetMetaValue(string className, Dialect.Dialect dialect)
-		{
-			return NHibernateUtil.String.ObjectToSQLString(className, dialect);
 		}
 	}
 }

--- a/src/NHibernate/Type/IMetaType.cs
+++ b/src/NHibernate/Type/IMetaType.cs
@@ -1,7 +1,0 @@
-﻿namespace NHibernate.Type
-{
-	interface IMetaType
-	{
-		string GetMetaValue(string className, Dialect.Dialect dialect);
-	}
-}

--- a/src/NHibernate/Type/MetaType.cs
+++ b/src/NHibernate/Type/MetaType.cs
@@ -3,36 +3,51 @@ using System.Collections.Generic;
 using System.Data.Common;
 using NHibernate.Engine;
 using NHibernate.SqlTypes;
-using NHibernate.Util;
 
 namespace NHibernate.Type
 {
 	[Serializable]
-	public partial class MetaType : AbstractType, IMetaType
+	public partial class MetaType : AbstractType
 	{
-		private readonly IDictionary<object, string> values;
-		private readonly IDictionary<string, object> keys;
-		private readonly IType baseType;
+		private readonly IDictionary<object, string> _values;
+		private readonly IDictionary<string, object> _keys;
+		private readonly IType _baseType;
+		private readonly ILiteralType _baseLiteralType;
 
 		public MetaType(IDictionary<object, string> values, IType baseType)
 		{
-			this.baseType = baseType;
-			this.values = values;
-			keys = new Dictionary<string, object>();
-			foreach (KeyValuePair<object, string> me in values)
+			_baseType = baseType ?? throw new ArgumentNullException(nameof(baseType));
+			_baseLiteralType = baseType as ILiteralType;
+			_values = values;
+
+			if (_values == null)
 			{
-				keys[me.Value] = me.Key;
+				if (baseType.ReturnedClass != typeof(string))
+					throw new ArgumentException(
+						$"Meta type base type {baseType} does not yield string but {baseType.ReturnedClass}, while no " +
+						"meta-value mapping has been provided",
+						nameof(baseType));
+				if (_baseLiteralType == null)
+					_baseLiteralType = NHibernateUtil.String;
+			}
+			else
+			{
+				_keys = new Dictionary<string, object>();
+				foreach (var me in values)
+				{
+					_keys[me.Value] = me.Key;
+				}
 			}
 		}
 
 		public override SqlType[] SqlTypes(IMapping mapping)
 		{
-			return baseType.SqlTypes(mapping);
+			return _baseType.SqlTypes(mapping);
 		}
 
 		public override int GetColumnSpan(IMapping mapping)
 		{
-			return baseType.GetColumnSpan(mapping);
+			return _baseType.GetColumnSpan(mapping);
 		}
 
 		public override System.Type ReturnedClass
@@ -42,14 +57,20 @@ namespace NHibernate.Type
 
 		public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner)
 		{
-			object key = baseType.NullSafeGet(rs, names, session, owner);
-			return key == null ? null : values[key];
+			return GetValueForKey(_baseType.NullSafeGet(rs, names, session, owner));
 		}
 
-		public override object NullSafeGet(DbDataReader rs,string name,ISessionImplementor session,object owner)
+		public override object NullSafeGet(DbDataReader rs, string name, ISessionImplementor session, object owner)
 		{
-			object key = baseType.NullSafeGet(rs, name, session, owner);
-			return key == null ? null : values[key];
+			return GetValueForKey(_baseType.NullSafeGet(rs, name, session, owner));
+		}
+
+		private object GetValueForKey(object key)
+		{
+			// "_values?[key]" is valid code provided "_values[key]" can never yield null. It is the case because we
+			// use a dictionary interface which throws in case of missing key, and because a key associated to a null
+			// value would cause the building of the _keys dictionaries to fail.
+			return key == null ? null : _values?[key] ?? key;
 		}
 
 		public override void NullSafeSet(DbCommand st, object value, int index, bool[] settable, ISessionImplementor session)
@@ -57,9 +78,14 @@ namespace NHibernate.Type
 			if (settable[0]) NullSafeSet(st, value, index, session);
 		}
 
-		public override void NullSafeSet(DbCommand st,object value,int index,ISessionImplementor session)
+		public override void NullSafeSet(DbCommand st, object value, int index, ISessionImplementor session)
 		{
-			baseType.NullSafeSet(st, value == null ? null : keys[(string)value], index, session);
+			// "_keys?[(string) value]" is valid code provided "_keys[(string) value]" can never yield null. It is the
+			// case because we use a dictionary interface which throws in case of missing key, and because it is not
+			// possible to have a value associated to a null key since generic dictionaries do not support null keys.
+			var key = value == null ? null : _keys?[(string) value] ?? value;
+
+			_baseType.NullSafeSet(st, key, index, session);
 		}
 
 		public override string ToLoggableString(object value, ISessionFactoryImplementor factory)
@@ -69,7 +95,7 @@ namespace NHibernate.Type
 
 		public override string Name
 		{
-			get { return baseType.Name; } //TODO!
+			get { return _baseType.Name; } //TODO!
 		}
 
 		public override object DeepCopy(object value, ISessionFactoryImplementor factory)
@@ -94,15 +120,15 @@ namespace NHibernate.Type
 
 		public override bool[] ToColumnNullness(object value, IMapping mapping)
 		{
-			return baseType.ToColumnNullness(value, mapping);
+			return _baseType.ToColumnNullness(value, mapping);
 		}
 
-		string IMetaType.GetMetaValue(string className, Dialect.Dialect dialect)
+		internal string GetMetaValue(string className, Dialect.Dialect dialect)
 		{
-			var raw = keys[className];
-			if (baseType is ILiteralType literalType)
+			var raw = _keys?[className] ?? className;
+			if (_baseLiteralType != null)
 			{
-				return literalType.ObjectToSQLString(raw, dialect);
+				return _baseLiteralType.ObjectToSQLString(raw, dialect);
 			}
 
 			return raw?.ToString();


### PR DESCRIPTION
When not specifying meta-values, while not using meta-type `class`, the `<any/>` type mapping is directly using the mapped `meta-type` for handling reading and writing the meta-value.

This causes issues like #1774. Moreover, if the type is not string based, the `AnyType` will fail reading it and writing into it will very likely fail too (due to cast to/from string).

When mapping an `any` without meta-values, the class full name is directly used as the meta-value, which is indeed the behavior of `ClassMetaType`. ~~So the fix is to use `ClassMetaType` in that case too, but with the mapped meta-type instead of the default `StringType`.~~

As pointed by Alexander, there is no need for a separated `ClassMetaType`: it should be merged into `MetaType` instead, allowing it to behave like `ClassMetaType` when no value map is provided.