### PR TITLE
Mark proxy assembly with IgnoresAccessChecksToAttribute to allow implementing non public interfaces

### DIFF
--- a/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
+++ b/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
@@ -75,8 +75,17 @@ namespace NHibernate.Proxy
 				interfaces.Add(baseType);
 			}
 
+#if NETFX || NETCOREAPP2_0
+			var assemblyNamesToIgnoreAccessCheck =
+				interfaces.Where(i => !i.IsVisible)
+				          .Select(i => i.Assembly.GetName().Name)
+				          .Distinct();
+			foreach (var a in assemblyNamesToIgnoreAccessCheck)
+				ProxyBuilderHelper.GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, a);
+#else
 			interfaces.RemoveWhere(i => !i.IsVisible);
-
+#endif
+			
 			var typeBuilder = moduleBuilder.DefineType(typeName, typeAttributes, parentType, interfaces.ToArray());
 
 			var lazyInitializerField = typeBuilder.DefineField("__lazyInitializer", LazyInitializerType, FieldAttributes.Private);

--- a/src/NHibernate/Proxy/ProxyBuilderHelper.cs
+++ b/src/NHibernate/Proxy/ProxyBuilderHelper.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Security;
 using NHibernate.Util;
@@ -21,6 +22,7 @@ namespace NHibernate.Proxy
 	{
 		private static readonly ConstructorInfo ObjectConstructor = typeof(object).GetConstructor(System.Type.EmptyTypes);
 		private static readonly ConstructorInfo SecurityCriticalAttributeConstructor = typeof(SecurityCriticalAttribute).GetConstructor(System.Type.EmptyTypes);
+		private static readonly ConstructorInfo IgnoresAccessChecksToAttributeConstructor = typeof(IgnoresAccessChecksToAttribute).GetConstructor(new[] {typeof(string)});
 
 		internal static readonly MethodInfo SerializableGetObjectDataMethod = typeof(ISerializable).GetMethod(nameof(ISerializable.GetObjectData));
 		internal static readonly MethodInfo SerializationInfoSetTypeMethod = ReflectHelper.GetMethod<SerializationInfo>(si => si.SetType(null));
@@ -179,6 +181,18 @@ namespace NHibernate.Proxy
 			}
 
 			return methodBuilder;
+		}
+
+		internal static void GenerateInstanceOfIgnoresAccessChecksToAttribute(
+			AssemblyBuilder assemblyBuilder,
+			string assemblyName)
+		{
+			// [assembly: System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute(assemblyName)]
+			var customAttributeBuilder = new CustomAttributeBuilder(
+				IgnoresAccessChecksToAttributeConstructor,
+				new object[] {assemblyName});
+
+			assemblyBuilder.SetCustomAttribute(customAttributeBuilder);
 		}
 
 		private static System.Type ResolveTypeConstraint(MethodInfo method, System.Type typeConstraint)

--- a/src/NHibernate/Util/IgnoresAccessChecksToAttribute.cs
+++ b/src/NHibernate/Util/IgnoresAccessChecksToAttribute.cs
@@ -1,0 +1,14 @@
+﻿// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public class IgnoresAccessChecksToAttribute : Attribute
+	{
+		public string AssemblyName { get; }
+
+		public IgnoresAccessChecksToAttribute(string assemblyName)
+		{
+			AssemblyName = assemblyName;
+		}
+	}
+}


### PR DESCRIPTION
Some serious black magic here. This is supported at least in .NET 4.6+ and .NET Core 2.0. In .NET Standard fallback to the old method.

No new tests are needed. `VerifyProxyForClassWithInternalInterface` and `VerifyFieldInterceptorProxy` of `StaticProxyFactoryFixture` already check this.