### PR TITLE
Handle DbDataReaders that do not support GetSchemaTable

### DIFF
--- a/src/NHibernate/Async/Driver/NDataReader.cs
+++ b/src/NHibernate/Async/Driver/NDataReader.cs
@@ -87,9 +87,11 @@ namespace NHibernate.Driver
 			internal static async Task<NResult> CreateAsync(DbDataReader reader, bool isMidstream, CancellationToken cancellationToken)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
+				var schemaTable = SafeGetSchemaTable(reader, out var exception);
 				var result = new NResult
 				{
-					schemaTable = reader.GetSchemaTable()
+					schemaTable = schemaTable,
+					schemaTableNotSupportedException = exception
 				};
 
 				List<object[]> recordsList = new List<object[]>();

--- a/src/NHibernate/Driver/NDataReader.cs
+++ b/src/NHibernate/Driver/NDataReader.cs
@@ -488,6 +488,7 @@ namespace NHibernate.Driver
 			private int colCount = 0;
 
 			private DataTable schemaTable;
+			private NotSupportedException schemaTableNotSupportedException;
 
 			// key = field name
 			// index = field index
@@ -508,9 +509,11 @@ namespace NHibernate.Driver
 			/// </param>
 			internal static NResult Create(DbDataReader reader, bool isMidstream)
 			{
+				var schemaTable = SafeGetSchemaTable(reader, out var exception);
 				var result = new NResult
 				{
-					schemaTable = reader.GetSchemaTable()
+					schemaTable = schemaTable,
+					schemaTableNotSupportedException = exception
 				};
 
 				List<object[]> recordsList = new List<object[]>();
@@ -547,6 +550,22 @@ namespace NHibernate.Driver
 
 				result.records = recordsList.ToArray();
 				return result;
+			}
+
+
+			private static DataTable SafeGetSchemaTable(IDataReader reader, out NotSupportedException exception)
+			{
+				exception = null;
+				try
+				{
+					return reader.GetSchemaTable();
+				}
+				catch (NotSupportedException e)
+				{
+					ReflectHelper.PreserveStackTrace(e);
+					exception = e;
+					return null;
+				}
 			}
 
 			/// <summary>
@@ -591,6 +610,8 @@ namespace NHibernate.Driver
 			/// <summary></summary>
 			public DataTable GetSchemaTable()
 			{
+				if (schemaTableNotSupportedException != null)
+					throw schemaTableNotSupportedException;
 				return schemaTable;
 			}
 

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1424,7 +1424,7 @@ namespace NHibernate.Loader
 			if (_columnNameCache == null)
 			{
 				Log.Debug("Building columnName->columnIndex cache");
-				_columnNameCache = new ColumnNameCache(rs.GetSchemaTable().Rows.Count);
+				_columnNameCache = new ColumnNameCache(rs.FieldCount);
 			}
 
 			return _columnNameCache;


### PR DESCRIPTION
Some ADO.NET providers do not support `DbDataReader.GetSchemaTable` method which makes these providers completely unusable with NHibernate. This issue is relevant to the ADO.NET providers which target .NET Standard prior 2.0.

These issues were found when I was testing IBM.Data.DB2.Core, but they are not exclusive to this provider. The problem lies in the fact that [`DbDataReader.GetSchemaTable`](https://referencesource.microsoft.com/#System.Data/System/Data/Common/DbDataReader.cs,c89b8cb58d0d8a5c) throws `NotSupportedException`. As I understand this method was not in .NET Standard <2.0, and was brought there. But because one is not allowed to add `abstract` methods they added a virtual which throws `NotSupportedException`.