### PR TITLE
Move WcfOperationSessionContext into a separate project

### DIFF
--- a/src/NHibernate.Everything.sln
+++ b/src/NHibernate.Everything.sln
@@ -74,6 +74,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHibernate.Example.Web", "N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHibernate.TestDatabaseSetup", "NHibernate.TestDatabaseSetup\NHibernate.TestDatabaseSetup.csproj", "{783DB85E-2EED-4377-8EF4-8D6EFE042007}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHibernate.Wcf", "NHibernate.Wcf\NHibernate.Wcf.csproj", "{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|.NET = Debug|.NET
@@ -157,6 +159,18 @@ Global
 		{783DB85E-2EED-4377-8EF4-8D6EFE042007}.Release|Any CPU.Build.0 = Release|Any CPU
 		{783DB85E-2EED-4377-8EF4-8D6EFE042007}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{783DB85E-2EED-4377-8EF4-8D6EFE042007}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Debug|.NET.ActiveCfg = Debug|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Debug|.NET.Build.0 = Debug|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Release|.NET.ActiveCfg = Release|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Release|.NET.Build.0 = Release|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -173,6 +187,7 @@ Global
 		{446E148D-A9D5-4D7D-A706-BEDD45B2BC7D} = {92509065-DAEA-4457-8300-C7B64CD0E9F4}
 		{7C2EF610-BCA0-4D1F-898A-DE9908E4970C} = {094F74CD-2DD7-496F-BC48-A6D357BF33FD}
 		{783DB85E-2EED-4377-8EF4-8D6EFE042007} = {094F74CD-2DD7-496F-BC48-A6D357BF33FD}
+		{B225A2A6-8CDE-4578-A1E7-72466EDEA0C0} = {094F74CD-2DD7-496F-BC48-A6D357BF33FD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A41913C2-EDEB-440A-BBDE-0AEB56C1CBA6}

--- a/src/NHibernate.Wcf/Context/WcfOperationSessionContext.cs
+++ b/src/NHibernate.Wcf/Context/WcfOperationSessionContext.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.ServiceModel;
 

--- a/src/NHibernate.Wcf/Context/WcfOperationSessionContext.cs
+++ b/src/NHibernate.Wcf/Context/WcfOperationSessionContext.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using System.ServiceModel;
 
 using NHibernate.Engine;
@@ -9,6 +10,7 @@ namespace NHibernate.Context
 	/// Provides a <see cref="ISessionFactory.GetCurrentSession()">current session</see>
 	/// for the current OperationContext in WCF. Works only during the lifetime of a WCF operation.
 	/// </summary>
+	[TypeForwardedFrom("NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4")]
 	public class WcfOperationSessionContext : MapBasedSessionContext
 	{
 		public WcfOperationSessionContext(ISessionFactoryImplementor factory) : base(factory) {}

--- a/src/NHibernate.Wcf/NHibernate.Wcf.csproj
+++ b/src/NHibernate.Wcf/NHibernate.Wcf.csproj
@@ -1,0 +1,53 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../build-common/NHibernate.props" />
+
+  <PropertyGroup>
+    <RootNamespace>NHibernate</RootNamespace>
+    <Description>WCF session context support for NHibernate.</Description>
+    <TargetFrameworks>$(NhLibTargetFrameworks)</TargetFrameworks>
+    <NoWarn>$(NoWarn);3001;3002;3003;3005;1591;419</NoWarn>
+    <SignAssembly>True</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyOriginatorKeyFile>..\NHibernate.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <PackageDescription>NHibernate is a mature, open source object-relational mapper for the .NET framework. It is actively developed, fully featured and used in thousands of successful projects.</PackageDescription>
+    <PackageTags>ORM; O/RM; DataBase; DAL; ObjectRelationalMapping; NHibernate; ADO.Net; Core; WCF</PackageTags>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+    <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\NHibernate.snk" Link="NHibernate.snk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NHibernate\NHibernate.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <Reference Include="System.ServiceModel" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="../../releasenotes.txt">
+      <PackagePath>./NHibernate.releasenotes.txt</PackagePath>
+    </Content>
+    <Content Include="../../README.md">
+      <PackagePath>./NHibernate.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.license.txt</PackagePath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/NHibernate.sln
+++ b/src/NHibernate.sln
@@ -1,17 +1,18 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{593DCEA7-C933-46F3-939F-D8172399AB05}"
 	ProjectSection(SolutionItems) = preProject
+		..\appveyor.yml = ..\appveyor.yml
 		AsyncGenerator.yml = AsyncGenerator.yml
+		..\build-common\common.xml = ..\build-common\common.xml
 		..\default.build = ..\default.build
 		..\build-common\NHibernate.props = ..\build-common\NHibernate.props
 		..\releasenotes.txt = ..\releasenotes.txt
-		..\teamcity.build = ..\teamcity.build
-		..\build-common\common.xml = ..\build-common\common.xml
-		..\appveyor.yml = ..\appveyor.yml
 		..\ReleaseProcedure.txt = ..\ReleaseProcedure.txt
+		..\teamcity.build = ..\teamcity.build
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHibernate", "NHibernate\NHibernate.csproj", "{5909BFE7-93CF-4E5F-BE22-6293368AF01D}"
@@ -23,6 +24,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHibernate.TestDatabaseSetup", "NHibernate.TestDatabaseSetup\NHibernate.TestDatabaseSetup.csproj", "{BEEC1564-6FB6-49F7-BBE5-8EBD2F0F6E8A}"
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "NHibernate.Test.VisualBasic", "NHibernate.Test.VisualBasic\NHibernate.Test.VisualBasic.vbproj", "{7C2EF610-BCA0-4D1F-898A-DE9908E4970C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHibernate.Wcf", "NHibernate.Wcf\NHibernate.Wcf.csproj", "{0FE89152-D42C-4162-8023-0A45857225B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +53,10 @@ Global
 		{7C2EF610-BCA0-4D1F-898A-DE9908E4970C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C2EF610-BCA0-4D1F-898A-DE9908E4970C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C2EF610-BCA0-4D1F-898A-DE9908E4970C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FE89152-D42C-4162-8023-0A45857225B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE89152-D42C-4162-8023-0A45857225B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FE89152-D42C-4162-8023-0A45857225B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FE89152-D42C-4162-8023-0A45857225B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1276,7 +1276,13 @@ namespace NHibernate.Impl
 				case "web":
 					return new WebSessionContext(this);
 				case "wcf_operation":
-					return new WcfOperationSessionContext(this);
+					// The WCF session context used to be included in this assembly,
+					// but now is in an optional external assembly, so to maintain
+					// compatibility we map the well-known name to a assembly qualified
+					// type name so it can be loaded via reflection below.
+					var assemblyName = typeof(SessionFactoryImpl).Assembly.FullName.Replace("NHibernate,", "NHibernate.Wcf,");
+					impl = "NHibernate.Context.WcfOperationSessionContext, " + assemblyName;
+					break;
 			}
 
 			try

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -46,19 +46,16 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />


### PR DESCRIPTION
NHibernate currently references the System.ServiceModel.Primitives package, which along with it's own dependencies, adds ~4 MB to a published .NET Core application. The reference is only used to provide WcfOperationSessionContext. This PR creates a new project and NuGet package, NHibernate.Wcf, and moves WcfOperationSessionContext and the System.ServiceModel.Primitives reference accordingly, allowing users to chose when to opt-in to the additional dependencies.