### PR TITLE
Updated BasicLoader PostInstantiate QueryException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ NHibernate.dll
 TestResult.xml
 .vscode
 .DS_Store
-/.vs/VSWorkspaceState.json
-/.vs/slnx.sqlite
-/.vs/nhibernate/v15/.suo

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ NHibernate.dll
 TestResult.xml
 .vscode
 .DS_Store
+/.vs/VSWorkspaceState.json
+/.vs/slnx.sqlite
+/.vs/nhibernate/v15/.suo

--- a/src/NHibernate/Loader/BasicLoader.cs
+++ b/src/NHibernate/Loader/BasicLoader.cs
@@ -62,7 +62,7 @@ namespace NHibernate.Loader
 			// so be careful about how you formulate your queries in this case
 			if (bagCount > 1)
 			{
-				throw new QueryException($"Cannot simultaneously fetch multiple bags: {persisters[0].EntityName}");
+				throw new QueryException($"Cannot simultaneously fetch multiple bags: {this}");
 			}
 		}
 

--- a/src/NHibernate/Loader/BasicLoader.cs
+++ b/src/NHibernate/Loader/BasicLoader.cs
@@ -62,7 +62,7 @@ namespace NHibernate.Loader
 			// so be careful about how you formulate your queries in this case
 			if (bagCount > 1)
 			{
-				throw new QueryException("Cannot simultaneously fetch multiple bags.");
+				throw new QueryException($"Cannot simultaneously fetch multiple bags: {persisters[0].EntityName}");
 			}
 		}
 


### PR DESCRIPTION
I found it difficult when updating an older application using an older version of NHibernate, to track down what entity relationship was causing the QueryException "Cannot simultaneously fetch multiple bags.". When I updated the exception to return the entityName I found it extremely easy to identify the entity that needed changing.