### PR TITLE
Version steps System.ServiceModel.Primitives avoiding known vulnerability

### DIFF
--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -52,13 +52,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />


### PR DESCRIPTION
See issue #1839

Modifies NHibernate to use  System.ServiceModel.Primitives >=4.4.3

NHibernate, for both .NETCoreApp 2.0 and .NETStandard 2.0, presently have a dependency on System.ServiceModel.Primitives >= 4.4.0

System.ServiceModel.Primitives 4.4.0 - 4.4.2 have known vulnerabilities. 

The Microsoft advisories are available at:
 - [CVE-2018-0764](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-0764)
 - [CVE-2018-0786](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-0786)

[Microsoft .NET Flaws Let Remote Users Deny Service and Bypass Certificate Security Restrictions
](http://www.securitytracker.com/id/1040152)