### PR TITLE
Remove WcfOperationSessionContext from .Net Core and .Net Standard

### DIFF
--- a/src/NHibernate/Context/WcfOperationSessionContext.cs
+++ b/src/NHibernate/Context/WcfOperationSessionContext.cs
@@ -2,7 +2,7 @@
 // a WCF OperationContext for it. Since it adds additional heavy dependencies, it has been
 // considered not desirable to provide it for .Net Standard. (It could be useful in case some
 // WCF server becames available in another frameworks or if a .Net Framework application
-// consumes the .Net standard distribution of NHibernate instead of the .Net Framework one)
+// consumes the .Net Standard distribution of NHibernate instead of the .Net Framework one.)
 // See https://github.com/dotnet/wcf/issues/1200 and #1842
 #if NETFX
 using System.Collections;
@@ -65,17 +65,17 @@ using NHibernate.Engine;
 namespace NHibernate.Context
 {
 	/// <summary>
-	/// Obsolete class not usable in the .Net Core and .Net Standard distributions of NHibernate. Use the
+	/// Obsolete class not usable with the current framework. Use the
 	/// .Net Framework distribution of NHibernate if you need it. See
 	/// https://github.com/nhibernate/nhibernate-core/issues/1842
 	/// </summary>
-	[Obsolete("Not supported in the .Net Core and .Net Standard distributions of NHibernate", true)]
+	[Obsolete("Not supported in this platform", true)]
 	public class WcfOperationSessionContext : MapBasedSessionContext
 	{
 		public WcfOperationSessionContext(ISessionFactoryImplementor factory) : base(factory)
 		{
-			throw new NotSupportedException(
-				"WcfOperationSessionContext is currently supported only by the .Net Framework distribution of NHibernate");
+			throw new PlatformNotSupportedException(
+				"WcfOperationSessionContext is not supported for the current framework");
 		}
 
 		protected override IDictionary GetMap()

--- a/src/NHibernate/Context/WcfOperationSessionContext.cs
+++ b/src/NHibernate/Context/WcfOperationSessionContext.cs
@@ -69,7 +69,7 @@ namespace NHibernate.Context
 	/// .Net Framework distribution of NHibernate if you need it. See
 	/// https://github.com/nhibernate/nhibernate-core/issues/1842
 	/// </summary>
-	[Obsolete("Not supported in the .Net Core and .Net Standard distributions of NHibernate")]
+	[Obsolete("Not supported in the .Net Core and .Net Standard distributions of NHibernate", true)]
 	public class WcfOperationSessionContext : MapBasedSessionContext
 	{
 		public WcfOperationSessionContext(ISessionFactoryImplementor factory) : base(factory)

--- a/src/NHibernate/Context/WcfOperationSessionContext.cs
+++ b/src/NHibernate/Context/WcfOperationSessionContext.cs
@@ -1,4 +1,10 @@
-using System;
+// There is no support of WCF Server under .Net Core, so it makes little sense to provide
+// a WCF OperationContext for it. Since it adds additional heavy dependencies, it has been
+// considered not desirable to provide it for .Net Standard. (It could be useful in case some
+// WCF server becames available in another frameworks or if a .Net Framework application
+// consumes the .Net standard distribution of NHibernate instead of the .Net Framework one)
+// See https://github.com/dotnet/wcf/issues/1200 and #1842
+#if NETFX
 using System.Collections;
 using System.ServiceModel;
 
@@ -50,3 +56,36 @@ namespace NHibernate.Context
 		public void Detach(OperationContext owner) { }
 	}
 }
+#else
+// 6.0 TODO: remove the whole #else
+using System;
+using System.Collections;
+using NHibernate.Engine;
+
+namespace NHibernate.Context
+{
+	/// <summary>
+	/// Obsolete class not usable in the .Net Core and .Net Standard distributions of NHibernate. Use the
+	/// .Net Framework distribution of NHibernate if you need it. See
+	/// https://github.com/nhibernate/nhibernate-core/issues/1842
+	/// </summary>
+	[Obsolete("Not supported in the .Net Core and .Net Standard distributions of NHibernate")]
+	public class WcfOperationSessionContext : MapBasedSessionContext
+	{
+		public WcfOperationSessionContext(ISessionFactoryImplementor factory) : base(factory)
+		{
+			throw new NotSupportedException(
+				"WcfOperationSessionContext is currently supported only by the .Net Framework distribution of NHibernate");
+		}
+
+		protected override IDictionary GetMap()
+		{
+			return null;
+		}
+
+		protected override void SetMap(IDictionary value)
+		{
+		}
+	}
+}
+#endif

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1283,10 +1283,10 @@ namespace NHibernate.Impl
 					// a WCF OperationContext for it. Since it adds additional heavy dependencies, it has been
 					// considered not desirable to provide it for .Net Standard. (It could be useful in case some
 					// WCF server becames available in another frameworks or if a .Net Framework application
-					// consumes the .Net standard distribution of NHibernate instead of the .Net Framework one)
+					// consumes the .Net Standard distribution of NHibernate instead of the .Net Framework one.)
 					// See https://github.com/dotnet/wcf/issues/1200 and #1842
-					throw new NotSupportedException(
-						"WcfOperationSessionContext is currently supported only by the .Net Framework distribution of NHibernate");
+					throw new PlatformNotSupportedException(
+						"WcfOperationSessionContext is not supported for the current framework");
 #endif
 			}
 

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1276,7 +1276,18 @@ namespace NHibernate.Impl
 				case "web":
 					return new WebSessionContext(this);
 				case "wcf_operation":
+#if NETFX
 					return new WcfOperationSessionContext(this);
+#else
+					// There is no support of WCF Server under .Net Core, so it makes little sense to provide
+					// a WCF OperationContext for it. Since it adds additional heavy dependencies, it has been
+					// considered not desirable to provide it for .Net Standard. (It could be useful in case some
+					// WCF server becames available in another frameworks or if a .Net Framework application
+					// consumes the .Net standard distribution of NHibernate instead of the .Net Framework one)
+					// See https://github.com/dotnet/wcf/issues/1200 and #1842
+					throw new NotSupportedException(
+						"WcfOperationSessionContext is currently supported only by the .Net Framework distribution of NHibernate");
+#endif
 			}
 
 			try

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -52,13 +52,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />


### PR DESCRIPTION
Currently, WCF Server support is a .Net Framework only feature.
On .Net Core, it does not seem it will be implemented any time soon, see dotnet/wcf#1200.

The `WcfOperationSessionContext` is meant to be used as a session context during server side calls, so providing it for .Net Core has currently no usages.

Moreover, providing it for .Net Core or .Net Standard requires additional dependencies under .Net Core and .Net Standard, which creates some concerns (see #1820 & #1839).

The .Net Standard use case for it seems very tiny, it could be currently useful only if a .Net Framework WCF server application was using the .Net Standard distribution of NHibernate instead of the .Net Framework one. So better not provide it for .Net Standard too.

Replaces #1820 and #1840 (unless, for the later, if this PR cannot be merged in 5.2).