### PR TITLE
Remove dependency on System.Security.Permissions package for .NET Standard and .NET Core

### DIFF
--- a/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
+++ b/src/NHibernate/Bytecode/Lightweight/ReflectionOptimizer.cs
@@ -101,11 +101,20 @@ namespace NHibernate.Bytecode.Lightweight
 
 		protected DynamicMethod CreateDynamicMethod(System.Type returnType, System.Type[] argumentTypes)
 		{
-			System.Type owner = mappedType.IsInterface ? typeof (object) : mappedType;
-#pragma warning disable 612,618
-			bool canSkipChecks = SecurityManager.IsGranted(new ReflectionPermission(ReflectionPermissionFlag.MemberAccess));
-#pragma warning restore 612,618
+			var owner = mappedType.IsInterface ? typeof (object) : mappedType;
+			var canSkipChecks = CanSkipVisibilityChecks();
 			return new DynamicMethod(string.Empty, returnType, argumentTypes, owner, canSkipChecks);
+		}
+
+		private static bool CanSkipVisibilityChecks()
+		{
+#if NETFX
+			var permissionSet = new PermissionSet(PermissionState.None);
+			permissionSet.AddPermission(new ReflectionPermission(ReflectionPermissionFlag.MemberAccess));
+			return permissionSet.IsSubsetOf(AppDomain.CurrentDomain.PermissionSet);
+#else
+			return false;
+#endif
 		}
 
 		private static void EmitCastToReference(ILGenerator il, System.Type type)

--- a/src/NHibernate/Driver/OdbcDriver.cs
+++ b/src/NHibernate/Driver/OdbcDriver.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.Odbc;
 using NHibernate.SqlTypes;
 using NHibernate.Util;
 using Environment = NHibernate.Cfg.Environment;
@@ -47,12 +46,12 @@ namespace NHibernate.Driver
 #else
 		public override DbConnection CreateConnection()
 		{
-			return new OdbcConnection();
+			return new System.Data.Odbc.OdbcConnection();
 		}
 
 		public override DbCommand CreateCommand()
 		{
-			return new OdbcCommand();
+			return new System.Data.Odbc.OdbcCommand();
 		}
 #endif
 

--- a/src/NHibernate/Driver/OleDbDriver.cs
+++ b/src/NHibernate/Driver/OleDbDriver.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Data.Common;
-using System.Data.OleDb;
 
 namespace NHibernate.Driver
 {
@@ -26,12 +25,12 @@ namespace NHibernate.Driver
 #else
 		public override DbConnection CreateConnection()
 		{
-			return new OleDbConnection();
+			return new System.Data.OleDb.OleDbConnection();
 		}
 
 		public override DbCommand CreateCommand()
 		{
-			return new OleDbCommand();
+			return new System.Data.OleDb.OleDbCommand();
 		}
 #endif
 

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -53,12 +53,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
-    <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
-    <PackageReference Include="System.Security.Permissions" Version="4.4.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
System.Security.Permissions package is used to check that `ReflectionPermission` is granted to perform a small optimization for `DynamicMethod`, however in .NET Standard and .NET Core permissions are not really supported and `SecurityManager.IsGranted` always returns `false`.

Also for .NET Framework the obsoleted `SecurityManager.IsGranted` was replaced with a preferred method of checking permissions.