### PR TITLE
Add in ByCode support of all type mappings on Id

### DIFF
--- a/src/NHibernate/Mapping/ByCode/IIdMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IIdMapper.cs
@@ -1,19 +1,44 @@
 using System;
+using NHibernate.Mapping.ByCode.Impl;
 using NHibernate.Type;
+using NHibernate.Util;
 
 namespace NHibernate.Mapping.ByCode
 {
+	// 6.0 TODO: move into IIdMapper,
+	// and probably add an ITypeMapper for mutualizing the four Type methods with IElementMapper and IPropertyMapper
+	// (Note that there is no IKeyPropertyMapper to be concerned with, the KeyPropertyMapper use IPropertyMapper
+	// directly instead.)
+	public static class IdMapperExtensions
+	{
+		public static void Type<TPersistentType>(this IIdMapper idMapper) where TPersistentType : IIdentifierType
+		{
+			ReflectHelper
+				.CastOrThrow<IdMapper>(idMapper, "generic Type method")
+				.Type<TPersistentType>();
+		}
+
+		public static void Type<TPersistentType>(this IIdMapper idMapper, object parameters) where TPersistentType : IIdentifierType
+		{
+			ReflectHelper
+				.CastOrThrow<IdMapper>(idMapper, "generic parameterized Type method")
+				.Type<TPersistentType>(parameters);
+		}
+
+		public static void Type(this IIdMapper idMapper, System.Type persistentType, object parameters)
+		{
+			ReflectHelper
+				.CastOrThrow<IdMapper>(idMapper, "parameterized Type method")
+				.Type(persistentType, parameters);
+		}
+	}
+	
 	public interface IIdMapper : IAccessorPropertyMapper, IColumnsMapper
 	{
 		void Generator(IGeneratorDef generator);
 		void Generator(IGeneratorDef generator, Action<IGeneratorMapper> generatorMapping);
 
 		void Type(IIdentifierType persistentType);
-		//void Type<TPersistentType>() where TPersistentType : IIdentifierType;
-		//void Type<TPersistentType>(object parameters) where TPersistentType : IIdentifierType;
-		//void Type(System.System.Type persistentType, object parameters);
-		//void Column(Action<IColumnMapper> columnMapper);
-		//void Columns(params Action<IColumnMapper>[] columnMapper);
 		void UnsavedValue(object value);
 		void Length(int length);
 	}

--- a/src/NHibernate/Mapping/ByCode/IIdMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IIdMapper.cs
@@ -5,34 +5,6 @@ using NHibernate.Util;
 
 namespace NHibernate.Mapping.ByCode
 {
-	// 6.0 TODO: move into IIdMapper,
-	// and probably add an ITypeMapper for mutualizing the four Type methods with IElementMapper and IPropertyMapper
-	// (Note that there is no IKeyPropertyMapper to be concerned with, the KeyPropertyMapper use IPropertyMapper
-	// directly instead.)
-	public static class IdMapperExtensions
-	{
-		public static void Type<TPersistentType>(this IIdMapper idMapper) where TPersistentType : IIdentifierType
-		{
-			ReflectHelper
-				.CastOrThrow<IdMapper>(idMapper, "generic Type method")
-				.Type<TPersistentType>();
-		}
-
-		public static void Type<TPersistentType>(this IIdMapper idMapper, object parameters) where TPersistentType : IIdentifierType
-		{
-			ReflectHelper
-				.CastOrThrow<IdMapper>(idMapper, "generic parameterized Type method")
-				.Type<TPersistentType>(parameters);
-		}
-
-		public static void Type(this IIdMapper idMapper, System.Type persistentType, object parameters)
-		{
-			ReflectHelper
-				.CastOrThrow<IdMapper>(idMapper, "parameterized Type method")
-				.Type(persistentType, parameters);
-		}
-	}
-	
 	public interface IIdMapper : IAccessorPropertyMapper, IColumnsMapper
 	{
 		void Generator(IGeneratorDef generator);
@@ -41,5 +13,29 @@ namespace NHibernate.Mapping.ByCode
 		void Type(IIdentifierType persistentType);
 		void UnsavedValue(object value);
 		void Length(int length);
+	}
+
+	public static class IdMapperExtensions
+	{
+		public static void Type<TPersistentType>(this IIdMapper idMapper)
+		{
+			Type<TPersistentType>(idMapper, null);
+		}
+
+		public static void Type<TPersistentType>(this IIdMapper idMapper, object parameters)
+		{
+			Type(idMapper, typeof (TPersistentType), parameters);
+		}
+
+		// 6.0 TODO: move into IIdMapper,
+		// and probably add an ITypeMapper for mutualizing it with IElementMapper and IPropertyMapper
+		// (Note that there is no IKeyPropertyMapper to be concerned with, the KeyPropertyMapper use IPropertyMapper
+		// directly instead.)
+		public static void Type(this IIdMapper idMapper, System.Type persistentType, object parameters)
+		{
+			ReflectHelper
+				.CastOrThrow<IdMapper>(idMapper, "Type method with a type argument")
+				.Type(persistentType, parameters);
+		}
 	}
 }

--- a/src/NHibernate/Mapping/ByCode/Impl/IdMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/IdMapper.cs
@@ -67,16 +67,6 @@ namespace NHibernate.Mapping.ByCode.Impl
 			}
 		}
 
-		public void Type<TPersistentType>()
-		{
-			Type(typeof (TPersistentType), null);
-		}
-
-		public void Type<TPersistentType>(object parameters)
-		{
-			Type(typeof (TPersistentType), parameters);
-		}
-
 		public void Type(System.Type persistentType, object parameters)
 		{
 			if (persistentType == null)

--- a/src/NHibernate/Mapping/ByCode/Impl/IdMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/IdMapper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Type;
+using NHibernate.UserTypes;
 
 namespace NHibernate.Mapping.ByCode.Impl
 {
@@ -62,6 +63,48 @@ namespace NHibernate.Mapping.ByCode.Impl
 			if (persistentType != null)
 			{
 				hbmId.type1 = persistentType.Name;
+				hbmId.type = null;
+			}
+		}
+
+		public void Type<TPersistentType>()
+		{
+			Type(typeof (TPersistentType), null);
+		}
+
+		public void Type<TPersistentType>(object parameters)
+		{
+			Type(typeof (TPersistentType), parameters);
+		}
+
+		public void Type(System.Type persistentType, object parameters)
+		{
+			if (persistentType == null)
+			{
+				throw new ArgumentNullException(nameof(persistentType));
+			}
+			if (!typeof (IUserType).IsAssignableFrom(persistentType) && !typeof (IType).IsAssignableFrom(persistentType) && !typeof (ICompositeUserType).IsAssignableFrom(persistentType))
+			{
+				throw new ArgumentOutOfRangeException(nameof(persistentType), "Expected type implementing IUserType, ICompositeUserType or IType.");
+			}
+			if (parameters != null)
+			{
+				hbmId.type1 = null;
+				var hbmType = new HbmType
+				{
+					name = persistentType.AssemblyQualifiedName,
+					param = (from pi in parameters.GetType().GetProperties()
+					         let pname = pi.Name
+					         let pvalue = pi.GetValue(parameters, null)
+					         select
+						         new HbmParam {name = pname, Text = new[] {ReferenceEquals(pvalue, null) ? "null" : pvalue.ToString()}})
+						.ToArray()
+				};
+				hbmId.type = hbmType;
+			}
+			else
+			{
+				hbmId.type1 = persistentType.AssemblyQualifiedName;
 				hbmId.type = null;
 			}
 		}


### PR DESCRIPTION
Mapping by code does not currently allow to set a parameterized type on ids.
This is an undue limitation, which may cause issues to users of custom types, and may also hinder usage of #1844 with mapping by code.

Having checked the xsd, this was the only case lacking full type specification possibilities in by-code. The `type` element is used on `element`, `property`, `key-property` and `id`. By code was already allowing to define parameters on the three former.