### PR TITLE
IQueryCache constraint should be an IQueryCacheFactory constraint

### DIFF
--- a/src/NHibernate.Test/CfgTest/Loquacious/ConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/Loquacious/ConfigurationFixture.cs
@@ -29,7 +29,7 @@ namespace NHibernate.Test.CfgTest.Loquacious
 					.Through<HashtableCacheProvider>()
 					.PrefixingRegionsWith("xyz")
 					.Queries
-						.Through<StandardQueryCache>()
+						.Through<StandardQueryCacheFactory>()
 					.UsingMinimalPuts()
 					.WithDefaultExpiration(15)
 				.GeneratingCollections
@@ -69,7 +69,7 @@ namespace NHibernate.Test.CfgTest.Loquacious
 			Assert.That(cfg.Properties[Environment.SessionFactoryName], Is.EqualTo("SomeName"));
 			Assert.That(cfg.Properties[Environment.CacheProvider], Is.EqualTo(typeof(HashtableCacheProvider).AssemblyQualifiedName));
 			Assert.That(cfg.Properties[Environment.CacheRegionPrefix], Is.EqualTo("xyz"));
-			Assert.That(cfg.Properties[Environment.QueryCacheFactory], Is.EqualTo(typeof(StandardQueryCache).AssemblyQualifiedName));
+			Assert.That(cfg.Properties[Environment.QueryCacheFactory], Is.EqualTo(typeof(StandardQueryCacheFactory).AssemblyQualifiedName));
 			Assert.That(cfg.Properties[Environment.UseMinimalPuts], Is.EqualTo("true"));
 			Assert.That(cfg.Properties[Environment.CacheDefaultExpiration], Is.EqualTo("15"));
 			Assert.That(cfg.Properties[Environment.CollectionTypeFactoryClass], Is.EqualTo(typeof(DefaultCollectionTypeFactory).AssemblyQualifiedName));

--- a/src/NHibernate.Test/CfgTest/Loquacious/ConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/Loquacious/ConfigurationFixture.cs
@@ -97,6 +97,12 @@ namespace NHibernate.Test.CfgTest.Loquacious
 			Assert.That(cfg.Properties[Environment.MaxFetchDepth], Is.EqualTo("11"));
 			Assert.That(cfg.Properties[Environment.QuerySubstitutions], Is.EqualTo("true 1, false 0, yes 'Y', no 'N'"));
 			Assert.That(cfg.Properties[Environment.Hbm2ddlAuto], Is.EqualTo("validate"));
+
+			// Keywords import and auto-validation require a valid connection string, disable them before checking
+			// the session factory can be built.
+			cfg.SetProperty(Environment.Hbm2ddlKeyWords, "none");
+			cfg.SetProperty(Environment.Hbm2ddlAuto, null);
+			Assert.That(() => cfg.BuildSessionFactory().Dispose(), Throws.Nothing);
 		}
 
 		[Test]

--- a/src/NHibernate.Test/CfgTest/Loquacious/LambdaConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/Loquacious/LambdaConfigurationFixture.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.CfgTest.Loquacious
 													c.DefaultExpiration = 15;
 													c.RegionsPrefix = "xyz";
 													c.Provider<HashtableCacheProvider>();
-													c.QueryCache<StandardQueryCache>();
+													c.QueryCache<StandardQueryCacheFactory>();
 												});
 			configure.CollectionTypeFactory<DefaultCollectionTypeFactory>();
 			configure.HqlQueryTranslator<ASTQueryTranslatorFactory>();
@@ -69,7 +69,7 @@ namespace NHibernate.Test.CfgTest.Loquacious
 									Is.EqualTo(typeof(HashtableCacheProvider).AssemblyQualifiedName));
 			Assert.That(configure.Properties[Environment.CacheRegionPrefix], Is.EqualTo("xyz"));
 			Assert.That(configure.Properties[Environment.QueryCacheFactory],
-									Is.EqualTo(typeof(StandardQueryCache).AssemblyQualifiedName));
+									Is.EqualTo(typeof(StandardQueryCacheFactory).AssemblyQualifiedName));
 			Assert.That(configure.Properties[Environment.UseMinimalPuts], Is.EqualTo("true"));
 			Assert.That(configure.Properties[Environment.CacheDefaultExpiration], Is.EqualTo("15"));
 			Assert.That(configure.Properties[Environment.CollectionTypeFactoryClass],

--- a/src/NHibernate.Test/CfgTest/Loquacious/LambdaConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/Loquacious/LambdaConfigurationFixture.cs
@@ -3,6 +3,7 @@ using NHibernate.AdoNet;
 using NHibernate.Bytecode;
 using NHibernate.Cache;
 using NHibernate.Cfg;
+using NHibernate.Cfg.Loquacious;
 using NHibernate.Dialect;
 using NHibernate.Driver;
 using NHibernate.Hql.Ast.ANTLR;
@@ -27,7 +28,7 @@ namespace NHibernate.Test.CfgTest.Loquacious
 													c.DefaultExpiration = 15;
 													c.RegionsPrefix = "xyz";
 													c.Provider<HashtableCacheProvider>();
-													c.QueryCache<StandardQueryCacheFactory>();
+													c.QueryCacheFactory<StandardQueryCacheFactory>();
 												});
 			configure.CollectionTypeFactory<DefaultCollectionTypeFactory>();
 			configure.HqlQueryTranslator<ASTQueryTranslatorFactory>();
@@ -106,6 +107,12 @@ namespace NHibernate.Test.CfgTest.Loquacious
 			Assert.That(configure.Properties[Environment.QuerySubstitutions], Is.EqualTo("true 1, false 0, yes 'Y', no 'N'"));
 			Assert.That(configure.Properties[Environment.Hbm2ddlAuto], Is.EqualTo("validate"));
 			Assert.That(configure.Properties[Environment.LinqToHqlGeneratorsRegistry], Is.EqualTo(typeof(DefaultLinqToHqlGeneratorsRegistry).AssemblyQualifiedName));
+			
+			// Keywords import and auto-validation require a valid connection string, disable them before checking
+			// the session factory can be built.
+			configure.SetProperty(Environment.Hbm2ddlKeyWords, "none");
+			configure.SetProperty(Environment.Hbm2ddlAuto, null);
+			Assert.That(() => configure.BuildSessionFactory().Dispose(), Throws.Nothing);
 		}
 	}
 }

--- a/src/NHibernate/Cfg/Loquacious/CacheConfiguration.cs
+++ b/src/NHibernate/Cfg/Loquacious/CacheConfiguration.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Cfg.Loquacious
 			cfg.SetProperty(Environment.CacheProvider, typeof(TProvider).AssemblyQualifiedName);
 		}
 
-		public void QueryCache<TFactory>() where TFactory : IQueryCache
+		public void QueryCache<TFactory>() where TFactory : IQueryCacheFactory
 		{
 			UseSecondLevelCache = true;
 			UseQueryCache = true;
@@ -111,7 +111,7 @@ namespace NHibernate.Cfg.Loquacious
 
 		#region Implementation of IQueryCacheConfiguration
 
-		public ICacheConfiguration Through<TFactory>() where TFactory : IQueryCache
+		public ICacheConfiguration Through<TFactory>() where TFactory : IQueryCacheFactory
 		{
 			cc.Configuration.SetProperty(Environment.UseSecondLevelCache, "true");
 			cc.Configuration.SetProperty(Environment.UseQueryCache, "true");

--- a/src/NHibernate/Cfg/Loquacious/CacheConfiguration.cs
+++ b/src/NHibernate/Cfg/Loquacious/CacheConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using NHibernate.Cache;
 
 namespace NHibernate.Cfg.Loquacious
@@ -39,7 +40,13 @@ namespace NHibernate.Cfg.Loquacious
 			cfg.SetProperty(Environment.CacheProvider, typeof(TProvider).AssemblyQualifiedName);
 		}
 
-		public void QueryCache<TFactory>() where TFactory : IQueryCacheFactory
+		[Obsolete("This method is invalid and should not be used. Use QueryCacheFactory method instead.", true)]
+		public void QueryCache<TFactory>() where TFactory : IQueryCache
+		{
+			throw new InvalidOperationException("This method is invalid and should not be used. Use QueryCacheFactory method instead.");
+		}
+
+		public void QueryCacheFactory<TFactory>() where TFactory : IQueryCacheFactory
 		{
 			UseSecondLevelCache = true;
 			UseQueryCache = true;
@@ -111,8 +118,12 @@ namespace NHibernate.Cfg.Loquacious
 
 		#region Implementation of IQueryCacheConfiguration
 
-		public ICacheConfiguration Through<TFactory>() where TFactory : IQueryCacheFactory
+		// 6.0 TODO: enable constraint and remove runtime type check
+		public ICacheConfiguration Through<TFactory>() // where TFactory : IQueryCacheFactory
 		{
+			if (!typeof(IQueryCacheFactory).IsAssignableFrom(typeof(TFactory)))
+				throw new ArgumentException($"{nameof(TFactory)} must be an {nameof(IQueryCacheFactory)}", nameof(TFactory));
+
 			cc.Configuration.SetProperty(Environment.UseSecondLevelCache, "true");
 			cc.Configuration.SetProperty(Environment.UseQueryCache, "true");
 			cc.Configuration.SetProperty(Environment.QueryCacheFactory, typeof(TFactory).AssemblyQualifiedName);

--- a/src/NHibernate/Cfg/Loquacious/ICacheConfiguration.cs
+++ b/src/NHibernate/Cfg/Loquacious/ICacheConfiguration.cs
@@ -17,6 +17,6 @@ namespace NHibernate.Cfg.Loquacious
 		string RegionsPrefix { set; }
 		int DefaultExpiration { set; }
 		void Provider<TProvider>() where TProvider : ICacheProvider;
-		void QueryCache<TFactory>() where TFactory : IQueryCache;
+		void QueryCache<TFactory>() where TFactory : IQueryCacheFactory;
 	}
 }

--- a/src/NHibernate/Cfg/Loquacious/ICacheConfiguration.cs
+++ b/src/NHibernate/Cfg/Loquacious/ICacheConfiguration.cs
@@ -1,4 +1,7 @@
+using System;
 using NHibernate.Cache;
+using NHibernate.Util;
+
 namespace NHibernate.Cfg.Loquacious
 {
 	public interface ICacheConfiguration
@@ -17,6 +20,18 @@ namespace NHibernate.Cfg.Loquacious
 		string RegionsPrefix { set; }
 		int DefaultExpiration { set; }
 		void Provider<TProvider>() where TProvider : ICacheProvider;
-		void QueryCache<TFactory>() where TFactory : IQueryCacheFactory;
+		[Obsolete("This method is invalid and should not be used. Use the QueryCacheFactory extension method instead.", true)]
+		void QueryCache<TFactory>() where TFactory : IQueryCache;
+	}
+
+	// 6.0 TODO: merge into ICacheConfigurationProperties
+	public static class CacheConfigurationPropertiesExtensions
+	{
+		public static void QueryCacheFactory<TFactory>(this ICacheConfigurationProperties config) where TFactory : IQueryCacheFactory
+		{
+			ReflectHelper
+				.CastOrThrow<CacheConfigurationProperties>(config, "Setting the query cache factory with Loquacious")
+				.QueryCacheFactory<TFactory>();
+		}
 	}
 }

--- a/src/NHibernate/Cfg/Loquacious/IQueryCacheConfiguration.cs
+++ b/src/NHibernate/Cfg/Loquacious/IQueryCacheConfiguration.cs
@@ -4,6 +4,6 @@ namespace NHibernate.Cfg.Loquacious
 {
 	public interface IQueryCacheConfiguration
 	{
-		ICacheConfiguration Through<TFactory>() where TFactory : IQueryCache;
+		ICacheConfiguration Through<TFactory>() where TFactory : IQueryCacheFactory;
 	}
 }

--- a/src/NHibernate/Cfg/Loquacious/IQueryCacheConfiguration.cs
+++ b/src/NHibernate/Cfg/Loquacious/IQueryCacheConfiguration.cs
@@ -1,9 +1,8 @@
-using NHibernate.Cache;
-
 namespace NHibernate.Cfg.Loquacious
 {
 	public interface IQueryCacheConfiguration
 	{
-		ICacheConfiguration Through<TFactory>() where TFactory : IQueryCacheFactory;
+		// 6.0 TODO: enable constraint
+		ICacheConfiguration Through<TFactory>(); // where TFactory : IQueryCacheFactory;
 	}
 }


### PR DESCRIPTION
The configuration setting is used to create an instance of a factory, not of the query cache itself.