### PR TITLE
Fix registration of current_date for some dialects

### DIFF
--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -1048,6 +1048,53 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public void Current_Date()
+		{
+			AssumeFunctionSupported("current_date");
+			using (var s = OpenSession())
+			{
+				var a1 = new Animal("abcdef", 1.3f);
+				s.Save(a1);
+				s.Flush();
+			}
+			using (var s = OpenSession())
+			{
+				var hql = "select current_date() from Animal";
+				s.CreateQuery(hql).List();
+			}
+		}
+
+		[Test]
+		public void Current_Date_IsLowestTimeOfDay()
+		{
+			AssumeFunctionSupported("current_date");
+			if (!TestDialect.SupportsNonDataBoundCondition)
+				Assert.Ignore("Test is not supported by the target database");
+			var now = DateTime.Now;
+			if (now.TimeOfDay < TimeSpan.FromMinutes(5) || now.TimeOfDay > TimeSpan.Parse("23:55"))
+				Assert.Ignore("Test is unreliable around midnight");
+
+			var lowTimeDate = now.Date.AddSeconds(1);
+
+			using (var s = OpenSession())
+			{
+				var a1 = new Animal("abcdef", 1.3f);
+				s.Save(a1);
+				s.Flush();
+			}
+			using (var s = OpenSession())
+			{
+				var hql = "from Animal where current_date() < :lowTimeDate";
+				var result =
+					s
+						.CreateQuery(hql)
+						.SetDateTime("lowTimeDate", lowTimeDate)
+						.List();
+				Assert.That(result, Has.Count.GreaterThan(0));
+			}
+		}
+
+		[Test]
 		public void Extract()
 		{
 			AssumeFunctionSupported("extract");

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -250,7 +250,9 @@ namespace NHibernate.Dialect
 			RegisterFunction("to_char", new StandardSQLFunction("to_char", NHibernateUtil.String));
 			RegisterFunction("to_date", new StandardSQLFunction("to_date", NHibernateUtil.DateTime));
 
-			RegisterFunction("current_date", new NoArgSQLFunction("current_date", NHibernateUtil.Date, false));
+			// In Oracle, date includes a time, just with fractional seconds dropped. For actually only having
+			// the date, it must be truncated. Otherwise comparisons may yield unexpected results.
+			RegisterFunction("current_date", new SQLFunctionTemplate(NHibernateUtil.Date, "trunc(current_date)"));
 			RegisterFunction("current_time", new NoArgSQLFunction("current_timestamp", NHibernateUtil.Time, false));
 			RegisterFunction("current_timestamp", new CurrentTimeStamp());
 

--- a/src/NHibernate/Dialect/SybaseASE15Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASE15Dialect.cs
@@ -68,8 +68,8 @@ namespace NHibernate.Dialect
 			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(","+",")"));
 			RegisterFunction("cos", new StandardSQLFunction("cos", NHibernateUtil.Double));
 			RegisterFunction("cot", new StandardSQLFunction("cot", NHibernateUtil.Double));
-			RegisterFunction("current_date", new NoArgSQLFunction("getdate", NHibernateUtil.Date));
-			RegisterFunction("current_time", new NoArgSQLFunction("getdate", NHibernateUtil.Time));
+			RegisterFunction("current_date", new NoArgSQLFunction("current_date", NHibernateUtil.Date));
+			RegisterFunction("current_time", new NoArgSQLFunction("current_time", NHibernateUtil.Time));
 			RegisterFunction("current_timestamp", new NoArgSQLFunction("getdate", NHibernateUtil.DateTime));
 			RegisterFunction("datename", new StandardSQLFunction("datename", NHibernateUtil.String));
 			RegisterFunction("day", new StandardSQLFunction("day", NHibernateUtil.Int32));

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -232,7 +232,7 @@ namespace NHibernate.Dialect
 			// compatibility functions
 			RegisterFunction("current_timestamp", new NoArgSQLFunction("getdate", NHibernateUtil.DateTime, true));
 			RegisterFunction("current_time", new NoArgSQLFunction("getdate", NHibernateUtil.Time, true));
-			RegisterFunction("current_date", new NoArgSQLFunction("getdate", NHibernateUtil.Date, true));
+			RegisterFunction("current_date", new SQLFunctionTemplate(NHibernateUtil.Date, "date(getdate())"));
 		}
 
 		protected virtual void RegisterStringFunctions()


### PR DESCRIPTION
Also fix `current_time` for ASE 15 which looks like a bad copy-paste, since this database has the exact matching function.

`current_date`, when registered, is always registered as a NHibernate `DateType` function, so a date without time part. But some dialects were registering it with SQL code yielding a time part.
On reads (from a `select current_date()` by example), the time part is anyway dropped by `DateType`. But on comparisons (or ddl inserts/updates of a column able of storing the time part), the time part was staying and could lead to unexpected results.

There is also the case of `sysdate`, but this one is a bit muddier: it is registered in the base `Dialect` class as a `DateTimeType` function. But some dialects override it to `DateType`, including Oracle although it uses the Oracle `sysdate` function which yields a time part. I have left it untouched.

This fix of `current_date` is done for having a consistent behavior of `DateTime.Today` in Linq queries, in case it is translated as SQL instead of being sent as a parameter value. (I am preparing another PR for #959.)