### PR TITLE
Replace an O(n) lookup in LINQ query parsing by an O(1) one

### DIFF
--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -1079,9 +1079,9 @@ namespace NHibernate.Test.Hql
 		public async Task Current_Date_IsLowestTimeOfDayAsync()
 		{
 			AssumeFunctionSupported("current_date");
-			var now = DateTime.Now;
 			if (!TestDialect.SupportsNonDataBoundCondition)
 				Assert.Ignore("Test is not supported by the target database");
+			var now = DateTime.Now;
 			if (now.TimeOfDay < TimeSpan.FromMinutes(5) || now.TimeOfDay > TimeSpan.Parse("23:55"))
 				Assert.Ignore("Test is unreliable around midnight");
 


### PR DESCRIPTION
The HQL generators registry already uses dictionaries to resolve generators for methods found in LINQ expression. But some generators do not declare statically their supported methods and instead have
to be queried with a loop on them for support of methods encountered in the LINQ query.

The result of this lookup can be cached for avoiding calling this loop again on the next query using the method.
If #1868 is merged, this change will compensate for #1868 causing up to three such lookups by method.