### PR TITLE
Obsolete a forgotten dynamic proxy class

### DIFF
--- a/src/NHibernate/Proxy/Poco/BasicLazyInitializer.cs
+++ b/src/NHibernate/Proxy/Poco/BasicLazyInitializer.cs
@@ -8,8 +8,10 @@ using NHibernate.Util;
 
 namespace NHibernate.Proxy.Poco
 {
+	// Obsolete since v5.2
 	/// <summary> Lazy initializer for POCOs</summary>
 	[Serializable]
+	[Obsolete("DynamicProxy has been obsoleted, use static proxies instead (see StaticProxyFactory)")]
 	public abstract class BasicLazyInitializer : AbstractLazyInitializer
 	{
 		private static readonly IEqualityComparer IdentityEqualityComparer = new IdentityEqualityComparer();


### PR DESCRIPTION
`BasicLazyInitializer` is used only by the dynamic proxy, and should also be obsoleted.

Follow up to #1709 

Similarly to #1816, typed fix for not being in release notes, as it already covered by #1709 which is not yet released.