### PR TITLE
Fix attempt of static proxies to call base method for abstract classes

### DIFF
--- a/src/NHibernate.Test/StaticProxyTest/StaticProxyFactoryFixture.cs
+++ b/src/NHibernate.Test/StaticProxyTest/StaticProxyFactoryFixture.cs
@@ -46,10 +46,10 @@ namespace NHibernate.Test.StaticProxyTest
 			public PublicInterfaceTestClass()
 			{
 				// Check access to properties from the default constructor do not fail once proxified
-				Assert.That(Id, Is.Zero);
-				Assert.That(Name, Is.Null);
 				Id = -1;
-				Name = string.Empty;
+				Assert.That(Id, Is.EqualTo(-1));
+				Name = "Unknown";
+				Assert.That(Name, Is.EqualTo("Unknown"));
 			}
 		}
 
@@ -63,10 +63,10 @@ namespace NHibernate.Test.StaticProxyTest
 			{
 				// Check access to properties from the default constructor do not fail once proxified
 				IPublic pub = this;
-				Assert.That(pub.Id, Is.Zero);
-				Assert.That(pub.Name, Is.Null);
 				pub.Id = -1;
-				pub.Name = string.Empty;
+				Assert.That(pub.Id, Is.EqualTo(-1));
+				pub.Name = "Unknown";
+				Assert.That(pub.Name, Is.EqualTo("Unknown"));
 			}
 		}
 
@@ -75,10 +75,10 @@ namespace NHibernate.Test.StaticProxyTest
 		{
 			protected AbstractTestClass()
 			{
-				Assert.That(Id, Is.Zero);
-				Assert.That(Name, Is.Null);
 				Id = -1;
+				Assert.That(Id, Is.Zero);
 				Name = "Unknown";
+				Assert.That(Name, Is.Null);
 			}
 
 			public abstract int Id { get; set; }

--- a/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
+++ b/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
@@ -428,7 +428,7 @@ namespace NHibernate.Proxy
 				/*
 				 * var mi = (MethodInfo)MethodBase.GetMethodFromHandle(<method>, <parentType>);
 				 * var delegate = (<delegateType>)mi.CreateDelegate(typeof(<delegateType>), this);
-				 * delegate.Invoke(...);
+				 * delegate.Invoke(args...);
 				 */
 				
 				var parameters = method.GetParameters();
@@ -458,7 +458,7 @@ namespace NHibernate.Proxy
 			else
 			{
 				/*
-				 * base.<method>(...);
+				 * base.<method>(args...);
 				 */
 				
 				IL.Emit(OpCodes.Ldarg_0);


### PR DESCRIPTION
Previously it was failing PEVerify similarly to #1728 but for abstract classes (this is possible in case of a polymorphic entities). Unlike interfaces the abstract base class can go into a situation when lazy initializer is not yet available, eg. code in a constructor.