### PR TITLE
Process classes accordingly to inheritance path in mapping by code

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH2931/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2931/Fixture.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NHibernate.Mapping.ByCode;
+﻿using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
 using System.Linq;
 
@@ -12,9 +11,13 @@ namespace NHibernate.Test.NHSpecificTest.NH2931
 		public void CompiledMappings_ShouldNotDependOnAddedOrdering_AddedBy_AddMapping()
 		{
 			var mapper = new ModelMapper();
-			mapper.AddMapping<EntityMapping>();
-			mapper.AddMapping<DerivedClassMapping>();
-			mapper.AddMapping<BaseClassMapping>();
+			mapper.AddMapping<AMapping>();
+			mapper.AddMapping<BMapping>();
+			mapper.AddMapping<CMapping>();
+			mapper.AddMapping<DMapping>();
+			mapper.AddMapping<EMapping>();
+			mapper.AddMapping<FMapping>();
+			mapper.AddMapping<GMapping>();
 			var config = TestConfigurationHelper.GetDefaultConfiguration();
 			Assert.DoesNotThrow(() => config.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities()));
 		}
@@ -22,11 +25,14 @@ namespace NHibernate.Test.NHSpecificTest.NH2931
 		[Test]
 		public void CompiledMappings_ShouldNotDependOnAddedOrdering_AddedBy_AddMappings()
 		{
+			var mappings =
+				typeof(MappingByCodeTest)
+					.Assembly
+					.GetExportedTypes()
+					//only add our test entities/mappings
+					.Where(t => t.Namespace == typeof(MappingByCodeTest).Namespace && t.Name.EndsWith("Mapping"));
 			var mapper = new ModelMapper();
-			mapper.AddMappings(typeof(EntityMapping).Assembly
-				.GetExportedTypes()
-				//only add our test entities/mappings
-				.Where(t => t.Namespace == typeof(MappingByCodeTest).Namespace));
+			mapper.AddMappings(mappings);
 			var config = TestConfigurationHelper.GetDefaultConfiguration();
 			Assert.DoesNotThrow(() => config.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities()));
 		}

--- a/src/NHibernate.Test/NHSpecificTest/NH2931/Mappings.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2931/Mappings.cs
@@ -1,37 +1,18 @@
-﻿using NHibernate.Mapping.ByCode;
-using NHibernate.Mapping.ByCode.Conformist;
+﻿using NHibernate.Mapping.ByCode.Conformist;
 
 namespace NHibernate.Test.NHSpecificTest.NH2931
 {
-    public class EntityMapping : ClassMapping<Entity>
-    {
-        public EntityMapping()
-        {
-            Id(i => i.Id, m => m.Generator(Generators.GuidComb));
-        }
-    }
-    //NOTE: tests may work if the order of mappings is
-    // 1) BaseClassMapping
-    // 2) DerivedClassMapping
-    //but they always fail when
-    // 1) DerivedClassMapping
-    // 2) BaseClassMapping
-    //MappingByCodeTest.CompiledMappings_ShouldNotDependOnAddedOrdering_AddedBy_AddMapping
-    // explicitly forces the first ordering to occur, but the most common use is simply
-    // typeof(SomeEntity).Assembly.GetTypes() to register everything; as shown in 
-    //MappingByCodeTest.CompiledMappings_ShouldNotDependOnAddedOrdering_AddedBy_AddMappings
-    public class DerivedClassMapping : JoinedSubclassMapping<DerivedClass>
-    {
-        public DerivedClassMapping()
-        {
-            Property(p => p.DerivedProperty);
-        }
-    }
-    public class BaseClassMapping : JoinedSubclassMapping<BaseClass>
-    {
-        public BaseClassMapping()
-        {
-            Property(p => p.BaseProperty);
-        }
-    }
+	public class AMapping : JoinedSubclassMapping<A> {}
+
+	public class BMapping : ClassMapping<B> {}
+
+	public class CMapping : JoinedSubclassMapping<C> {}
+
+	public class DMapping : JoinedSubclassMapping<D> {}
+
+	public class EMapping : JoinedSubclassMapping<E> {}
+
+	public class FMapping : JoinedSubclassMapping<F> {}
+
+	public class GMapping : ClassMapping<G> {}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH2931/Models.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2931/Models.cs
@@ -1,17 +1,16 @@
-﻿using System;
-
-namespace NHibernate.Test.NHSpecificTest.NH2931
+﻿namespace NHibernate.Test.NHSpecificTest.NH2931
 {
-    public abstract class Entity
-    {
-        public Guid Id { get; private set; }
-    }
-    public class BaseClass : Entity
-    {
-        public string BaseProperty { get; set; }
-    }
-    public class DerivedClass : BaseClass
-    {
-        public string DerivedProperty { get; set; }
-    }
+	public class A : F{ }
+
+	public class B { }
+
+	public class C : B { }
+
+	public class D : B { }
+
+	public class E : F { }
+
+	public class F : G { }
+
+	public class G { }
 }


### PR DESCRIPTION
In some rare cases the old code did not work as it was intended because
comparison algorithm doesn't always compare the types directly, but
instead the comparison can be made through a 3rd type.

Adapt the sample provided by @rrutkows to demonstrate the issue.