### PR TITLE
Merge two logs in one

### DIFF
--- a/src/NHibernate/Async/Tool/hbm2ddl/SchemaExport.cs
+++ b/src/NHibernate/Async/Tool/hbm2ddl/SchemaExport.cs
@@ -173,8 +173,7 @@ namespace NHibernate.Tool.hbm2ddl
 			catch (OperationCanceledException) { throw; }
 			catch (Exception e)
 			{
-				log.Warn("Unsuccessful: {0}", sql);
-				log.Warn(e, e.Message);
+				log.Warn(e, "Unsuccessful: {0}", sql);
 				if (throwOnError)
 				{
 					throw;

--- a/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs
+++ b/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs
@@ -190,8 +190,7 @@ namespace NHibernate.Tool.hbm2ddl
 			}
 			catch (Exception e)
 			{
-				log.Warn("Unsuccessful: {0}", sql);
-				log.Warn(e, e.Message);
+				log.Warn(e, "Unsuccessful: {0}", sql);
 				if (throwOnError)
 				{
 					throw;


### PR DESCRIPTION
There is no need for logging the exception separately. Moreover, some data providers (Sybase.AdoNet4.AseClient) sometimes fail when reading the exception message, causing this way of logging to fail the whole program.

This change is required for allowing `SchemaExport` to work with Sybase.AdoNet4.AseClient 16.0 SP3, and maybe other versions. The flaw is of course on the data provider side, but this change allows to dodge it.

(There is a number of other cases in NHibernate where the exception message is read, while, in my opinion, it should not. But all those other cases are less troublesome in case of `Message` property failure, because they are not swallowing cases, with the swallow being defeated by the `Message` exception.

This read is done for two main cases: providing a log message when logging an exception, and providing an exception message when encapsulating an exception.
The former should not do that at all in my opinion: it should not even log the exception since it re-throws it anyway in most cases. At least, it should do it with a message relevant to the method having failed, rather than duplicating the message in the log by logging both the complete exception and its message.
The later should not do that either in most cases. It should also provide its own message, relevant to the feature having failed, eventually hinting at checking the inner exception.)