### PR TITLE
Allow disabling Firebird driver parameter casting

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -1011,6 +1011,28 @@ var session = sessions.OpenSession(conn);
                     </row>
                     <row>
                         <entry>
+                            <literal>firebird.disable_parameter_casting</literal>
+                        </entry>
+                        <entry>
+                            <para>
+                                Firebird with FirebirdSql.Data.FirebirdClient may be unable to determine the type
+                                of parameters in many circumstances, unless they are explicitly casted in the SQL
+                                query. To avoid this trouble, the NHibernate <literal>FirebirdClientDriver</literal> parses SQL
+                                commands for detecting parameters in them and adding an explicit SQL cast around
+                                parameters which may trigger the issue.
+                            </para>
+                            <para>
+                                Defaults to <literal>false</literal>.
+                                For disabling this behavior, set this setting to true.
+                            </para>
+                            <para>
+                                <emphasis role="strong">eg.</emphasis>
+                                <literal>true</literal> | <literal>false</literal>
+                            </para>
+                        </entry>
+                    </row>
+                    <row>
+                        <entry>
                             <literal>oracle.use_n_prefixed_types_for_unicode</literal>
                         </entry>
                         <entry>

--- a/src/NHibernate.Test/Async/DriverTest/FirebirdClientDriverFixture.cs
+++ b/src/NHibernate.Test/Async/DriverTest/FirebirdClientDriverFixture.cs
@@ -25,6 +25,7 @@ namespace NHibernate.Test.DriverTest
 	{
 		private string _connectionString;
 		private FirebirdClientDriver _driver;
+		private FirebirdClientDriver _driverWithoutCasting;
 
 		[OneTimeSetUp]
 		public void OneTimeSetup()
@@ -38,6 +39,10 @@ namespace NHibernate.Test.DriverTest
 			_driver = new FirebirdClientDriver();
 			_driver.Configure(cfg.Properties);
 			_connectionString = cfg.GetProperty("connection.connection_string");
+
+			_driverWithoutCasting = new FirebirdClientDriver();
+			cfg.SetProperty(Cfg.Environment.FirebirdDisableParameterCasting, "true");
+			_driverWithoutCasting.Configure(cfg.Properties);
 		}
 
 		[Test]

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -267,6 +267,20 @@ namespace NHibernate.Cfg
 		public const string OracleUseNPrefixedTypesForUnicode = "oracle.use_n_prefixed_types_for_unicode";
 
 		/// <summary>
+		/// <para>
+		/// Firebird with FirebirdSql.Data.FirebirdClient may be unable to determine the type
+		/// of parameters in many circumstances, unless they are explicitly casted in the SQL
+		/// query. To avoid this trouble, the NHibernate <c>FirebirdClientDriver</c> parses SQL
+		/// commands for detecting parameters in them and adding an explicit SQL cast around
+		/// parameters which may trigger the issue.
+		/// </para>
+		/// <para>
+		/// For disabling this behavior, set this setting to true.
+		/// </para>
+		/// </summary>
+		public const string FirebirdDisableParameterCasting = "firebird.disable_parameter_casting";
+
+		/// <summary>
 		/// <para>Set whether tracking the session id or not. When <see langword="true"/>, each session 
 		/// will have an unique <see cref="Guid"/> that can be retrieved by <see cref="ISessionImplementor.SessionId"/>,
 		/// otherwise <see cref="ISessionImplementor.SessionId"/> will always be <see cref="Guid.Empty"/>. Session id 

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -188,6 +188,18 @@
 												</xs:documentation>
 											</xs:annotation>
 										</xs:enumeration>
+										<xs:enumeration value="firebird.disable_parameter_casting">
+											<xs:annotation>
+												<xs:documentation>
+													Firebird with FirebirdSql.Data.FirebirdClient may be unable to determine the type
+													of parameters in many circumstances, unless they are explicitly casted in the SQL
+													query. To avoid this trouble, the NHibernate FirebirdClientDriver parses SQL
+													commands for detecting parameters in them and adding an explicit SQL cast around
+													parameters which may trigger the issue.
+													For disabling this behavior, set this setting to true.
+												</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
 										<xs:enumeration value="sql_types.keep_datetime">
 											<xs:annotation>
 												<xs:documentation>


### PR DESCRIPTION
The NHibernate Firebird driver does hack SQL commands for explicitly casting their parameters. This may cause issues in some cases, while, depending on the application, it may not be required. See #1886.