### PR TITLE
Specify the precise version of dependencies to avoid compiler warning N…

### DIFF
--- a/src/NHibernate/NHibernate.nuspec.template
+++ b/src/NHibernate/NHibernate.nuspec.template
@@ -14,7 +14,7 @@
     <tags>ORM, DataBase, DAL, ObjectRelationalMapping</tags>
     <dependencies>
 	  <!-- Bet that if there is ever an Iesi.Collections 5.0, it would be incompatible. -->
-      <dependency id="Iesi.Collections" version="[4,5)" />
+      <dependency id="Iesi.Collections" version="[4.0.0.4000,5)" />
     </dependencies>
 	<projectUrl>
 		http://nhibernate.info


### PR DESCRIPTION
Explanation of why a package author should specify an existing lower bound version of a dependency: https://github.com/NuGet/Home/issues/5764

Currently a non existing version is indicated:
`      <dependency id="Iesi.Collections" version="[4,5)" />`

but it should be
`      <dependency id="Iesi.Collections" version="[4.0.0.4000,5)" />`
