### PR TITLE
Do not generate FK on non-generated unique constraint

### DIFF
--- a/src/NHibernate.Test/DialectTest/SchemaTests/DialectNotSupportingNullInUnique.cs
+++ b/src/NHibernate.Test/DialectTest/SchemaTests/DialectNotSupportingNullInUnique.cs
@@ -29,6 +29,7 @@ namespace NHibernate.Test.DialectTest.SchemaTests
 							m.UniqueKey("Test");
 						});
 					rc.Property(x => x.Name2, m => m.UniqueKey("Test"));
+					rc.ManyToOne(e => e.Parent, m => { m.PropertyRef("Name"); });
 				});
 
 			return mapper.CompileMappingForAllExplicitlyAddedEntities();
@@ -42,7 +43,8 @@ namespace NHibernate.Test.DialectTest.SchemaTests
 
 			var script = configuration.GenerateSchemaCreationScript(new DialectNotSupportingNullInUnique());
 
-			Assert.That(script, Has.None.Contains("unique"));
+			Assert.That(script, Has.None.Match(@".*\bunique\b.*").IgnoreCase);
+			Assert.That(script, Has.None.Match(@".*\bforeign key\b.*").IgnoreCase);
 		}
 	}
 }

--- a/src/NHibernate.Test/DialectTest/SchemaTests/Entity.cs
+++ b/src/NHibernate.Test/DialectTest/SchemaTests/Entity.cs
@@ -8,5 +8,6 @@ namespace NHibernate.Test.DialectTest.SchemaTests
 		public virtual string Name { get; set; }
 		public virtual string Name1 { get; set; }
 		public virtual string Name2 { get; set; }
+		public virtual Entity Parent { get; set; }
 	}
 }

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -851,7 +851,7 @@ namespace NHibernate.Cfg
 					{
 						foreach (var fk in table.ForeignKeyIterator)
 						{
-							if (fk.HasPhysicalConstraint && IncludeAction(fk.ReferencedTable.SchemaActions, SchemaAction.Drop))
+							if (fk.IsGenerated(dialect) && IncludeAction(fk.ReferencedTable.SchemaActions, SchemaAction.Drop))
 							{
 								script.Add(fk.SqlDropString(dialect, defaultCatalog, defaultSchema));
 							}
@@ -939,7 +939,7 @@ namespace NHibernate.Cfg
 					{
 						foreach (var fk in table.ForeignKeyIterator)
 						{
-							if (fk.HasPhysicalConstraint && IncludeAction(fk.ReferencedTable.SchemaActions, SchemaAction.Export))
+							if (fk.IsGenerated(dialect) && IncludeAction(fk.ReferencedTable.SchemaActions, SchemaAction.Export))
 							{
 								script.Add(fk.SqlCreateString(dialect, mapping, defaultCatalog, defaultSchema));
 							}
@@ -2344,7 +2344,7 @@ namespace NHibernate.Cfg
 					{
 						foreach (var fk in table.ForeignKeyIterator)
 						{
-							if (fk.HasPhysicalConstraint && IncludeAction(fk.ReferencedTable.SchemaActions, SchemaAction.Update))
+							if (fk.IsGenerated(dialect) && IncludeAction(fk.ReferencedTable.SchemaActions, SchemaAction.Update))
 							{
 								bool create = tableInfo == null
 											  ||

--- a/src/NHibernate/Mapping/ForeignKey.cs
+++ b/src/NHibernate/Mapping/ForeignKey.cs
@@ -234,5 +234,20 @@ namespace NHibernate.Mapping
 		}
 
 		public string GeneratedConstraintNamePrefix => "FK_";
+
+		public override bool IsGenerated(Dialect.Dialect dialect)
+		{
+			if (!HasPhysicalConstraint)
+				return false;
+			if (dialect.SupportsNullInUnique || IsReferenceToPrimaryKey)
+				return true;
+
+			foreach (var column in ReferencedColumns)
+			{
+				if (column.IsNullable)
+					return false;
+			}
+			return true;
+		}
 	}
 }

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -453,7 +453,7 @@ namespace NHibernate.Mapping
 			{
 				foreach (ForeignKey foreignKey in ForeignKeyIterator)
 				{
-					if (foreignKey.HasPhysicalConstraint)
+					if (foreignKey.IsGenerated(dialect))
 					{
 						buf.Append(",").Append(foreignKey.SqlConstraintString(dialect, foreignKey.Name, defaultCatalog, defaultSchema));
 					}


### PR DESCRIPTION
When an unique key is not generated due to the database not supporting a `null` value in an unique key, foreign keys on the unique key must not be generated either.

This is an old bug of the feature consisting in not generating unique constraints for nullable columns when the target database does not support null in unique. But as no dialects were enabling this feature, tests were not showcasing it.

#1854 enables a dialect with this feature, and its build fails due to FK being generated for non-generated unique constraints, see [here](https://teamcity.jetbrains.com/viewLog.html?buildId=1749931&buildTypeId=NHibernate_NHibernateSapSqlAnywhere).
