### PR TITLE
Fix a test on an feature obsoleted by #1707

### DIFF
--- a/src/NHibernate.Test/CollectionTest/WhereWithReadLockFixture.cs
+++ b/src/NHibernate.Test/CollectionTest/WhereWithReadLockFixture.cs
@@ -122,7 +122,7 @@ namespace NHibernate.Test.CollectionTest
 		[Test]
 		public void GenerateLockHintAtEndForSelectByUniqueKey()
 		{
-			var sql = ((IPostInsertIdentityPersister) _bagPersister).GetSelectByUniqueKeyString("blah");
+			var sql = ((ICompositeKeyPostInsertIdentityPersister) _bagPersister).GetSelectByUniqueKeyString(null, out _);
 			Assert.That(sql.ToString(), Does.EndWith(DialectWithReadLockHint.ReadOnlyLock));
 		}
 	}


### PR DESCRIPTION
#1707 has obsoleted a method which has got an additional test recently added by #1859, causing the test to no more compile. (This would have been avoided if I had rebased #1707 just in case.)

So I label this as a fix of #1707.