### PR TITLE
Add an overridable ADO BeginTransaction method

### DIFF
--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using NHibernate.Driver;
 using NHibernate.Engine;
 using NHibernate.Impl;
 

--- a/src/NHibernate/Driver/DriverBase.cs
+++ b/src/NHibernate/Driver/DriverBase.cs
@@ -47,6 +47,21 @@ namespace NHibernate.Driver
 		public abstract DbCommand CreateCommand();
 
 		/// <summary>
+		/// Begin an ADO <see cref="DbTransaction" />.
+		/// </summary>
+		/// <param name="isolationLevel">The isolation level requested for the transaction.</param>
+		/// <param name="connection">The connection on which to start the transaction.</param>
+		/// <returns>The started <see cref="DbTransaction" />.</returns>
+		public virtual DbTransaction BeginTransaction(IsolationLevel isolationLevel, DbConnection connection)
+		{
+			if (isolationLevel == IsolationLevel.Unspecified)
+			{
+				return connection.BeginTransaction();
+			}
+			return connection.BeginTransaction(isolationLevel);
+		}
+
+		/// <summary>
 		/// Does this Driver require the use of a Named Prefix in the SQL statement.  
 		/// </summary>
 		/// <remarks>

--- a/src/NHibernate/Driver/DriverExtensions.cs
+++ b/src/NHibernate/Driver/DriverExtensions.cs
@@ -36,7 +36,7 @@ namespace NHibernate.Driver
 			var beginMethod = driver.GetType().GetMethod(
 				nameof(DriverBase.BeginTransaction),
 				new[] { typeof(IsolationLevel), typeof(DbConnection) });
-			if (beginMethod != null)
+			if (beginMethod != null && beginMethod.ReturnType == typeof(DbTransaction) && !beginMethod.IsStatic)
 			{
 				return (DbTransaction) beginMethod.Invoke(driver, new object[] { isolationLevel, connection });
 			}

--- a/src/NHibernate/Driver/DriverExtensions.cs
+++ b/src/NHibernate/Driver/DriverExtensions.cs
@@ -1,16 +1,63 @@
+using System.Data;
 using System.Data.Common;
 using NHibernate.AdoNet;
 using NHibernate.SqlTypes;
-using NHibernate.Type;
 
 namespace NHibernate.Driver
 {
-	internal static class DriverExtensions
+	public static class DriverExtensions
 	{
+		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(DriverExtensions));
+		// No threading protection on this member: we do not care, at worst it will cause some duplicated warning.
+		private static bool _hasWarnedForMissingBeginTransaction;
+
 		internal static void AdjustParameterForValue(this IDriver driver, DbParameter parameter, SqlType sqlType, object value)
 		{
 			var adjustingDriver = driver as IParameterAdjuster;
 			adjustingDriver?.AdjustParameterForValue(parameter, sqlType, value);
+		}
+
+		// 6.0 TODO: merge into IDriver
+		/// <summary>
+		/// Begin an ADO <see cref="DbTransaction" />.
+		/// </summary>
+		/// <param name="driver">The driver.</param>
+		/// <param name="isolationLevel">The isolation level requested for the transaction.</param>
+		/// <param name="connection">The connection on which to start the transaction.</param>
+		/// <returns>The started <see cref="DbTransaction" />.</returns>
+		public static DbTransaction BeginTransaction(this IDriver driver, IsolationLevel isolationLevel, DbConnection connection)
+		{
+			if (driver is DriverBase driverBase)
+			{
+				return driverBase.BeginTransaction(isolationLevel, connection);
+			}
+
+			// Use reflection for supporting custom drivers.
+			var beginMethod = driver.GetType().GetMethod(
+				nameof(DriverBase.BeginTransaction),
+				new[] { typeof(IsolationLevel), typeof(DbConnection) });
+			if (beginMethod != null)
+			{
+				return (DbTransaction) beginMethod.Invoke(driver, new object[] { isolationLevel, connection });
+			}
+
+			if (!_hasWarnedForMissingBeginTransaction)
+			{
+				// Ideally it should be a dictionary per driver class, but keep it simple. Drivers not deriving from
+				// DriverBase are already not common, so applications which would use two distinct such drivers are
+				// even less common.
+				_hasWarnedForMissingBeginTransaction = true;
+				Log.Warn(
+					"Driver {0} is obsolete. It should implement a 'public DbTransaction BeginTransaction(" +
+					"IsolationLevel, DbConnection) method.",
+					driver);
+			}
+
+			if (isolationLevel == IsolationLevel.Unspecified)
+			{
+				return connection.BeginTransaction();
+			}
+			return connection.BeginTransaction(isolationLevel);
 		}
 	}
 }

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using NHibernate.Driver;
 using NHibernate.Engine;
 using NHibernate.Impl;
 
@@ -146,14 +147,7 @@ namespace NHibernate.Transaction
 
 				try
 				{
-					if (isolationLevel == IsolationLevel.Unspecified)
-					{
-						trans = session.Connection.BeginTransaction();
-					}
-					else
-					{
-						trans = session.Connection.BeginTransaction(isolationLevel);
-					}
+					trans = session.Factory.ConnectionProvider.Driver.BeginTransaction(isolationLevel, session.Connection);
 				}
 				catch (HibernateException)
 				{


### PR DESCRIPTION
Fixes #1908 

I have done something else than @greenlight2k suggestion, because looking into it again, it appeared to me `BeginTransaction` should belong to the driver.