### PR TITLE
 Discriminate query plan caches by the assembly depending return type

### DIFF
--- a/src/NHibernate/Engine/Query/QueryPlanCache.cs
+++ b/src/NHibernate/Engine/Query/QueryPlanCache.cs
@@ -196,20 +196,23 @@ namespace NHibernate.Engine.Query
 			// hashcode may vary among processes, they cannot be stored and have to be re-computed after deserialization
 			[NonSerialized]
 			private int? _hashCode;
+
+			private readonly System.Type queryType;
 			private readonly System.Type queryTypeDiscriminator;
 
 			public HQLQueryPlanKey(string query, bool shallow, IDictionary<string, IFilter> enabledFilters)
-				: this(typeof(object), query, shallow, enabledFilters)
+				: this(typeof(object), typeof(object), query, shallow, enabledFilters)
 			{
 			}
 
 			public HQLQueryPlanKey(IQueryExpression queryExpression, bool shallow, IDictionary<string, IFilter> enabledFilters)
-				: this(queryExpression.GetType(), queryExpression.Key, shallow, enabledFilters)
+				: this(queryExpression.Type, queryExpression.GetType(), queryExpression.Key, shallow, enabledFilters)
 			{
 			}
 
-			protected HQLQueryPlanKey(System.Type queryTypeDiscriminator, string query, bool shallow, IDictionary<string, IFilter> enabledFilters)
+			protected HQLQueryPlanKey(System.Type queryType, System.Type queryTypeDiscriminator, string query, bool shallow, IDictionary<string, IFilter> enabledFilters)
 			{
+				this.queryType = queryType;
 				this.queryTypeDiscriminator = queryTypeDiscriminator;
 				this.query = query;
 				this.shallow = shallow;
@@ -255,6 +258,11 @@ namespace NHibernate.Engine.Query
 					return false;
 				}
 
+				if (queryType != that.queryType)
+				{
+					return false;
+				}
+
 				if (queryTypeDiscriminator != that.queryTypeDiscriminator)
 				{
 					return false;
@@ -285,6 +293,7 @@ namespace NHibernate.Engine.Query
 					var hash = query.GetHashCode();
 					hash = 29 * hash + (shallow ? 1 : 0);
 					hash = 29 * hash + CollectionHelper.GetHashCode(_filterNames);
+					hash = 29 * hash + queryType.GetHashCode();
 					hash = 29 * hash + queryTypeDiscriminator.GetHashCode();
 					return hash;
 				}


### PR DESCRIPTION
 When having multiple assemblies with the same type (this can happen when
 dynamically generating assemblies or loading assemblies multiple times),
 NHibernate used to return query plan cache entries with mismatching types.

 The query portion of the cache key contained the type, but not the
 assembly. Thus two types from different assemblies, but with the same
 name lead to returning plans with wrong return types.