### PR TITLE
Obsolete StringHelper.Replace

### DIFF
--- a/src/NHibernate/Criterion/SQLProjection.cs
+++ b/src/NHibernate/Criterion/SQLProjection.cs
@@ -40,12 +40,12 @@ namespace NHibernate.Criterion
 			//SqlString result = new SqlString(criteriaQuery.GetSQLAlias(criteria));
 			//result.Replace(sql, "{alias}");
 			//return result;
-			return new SqlString(StringHelper.Replace(sql, "{alias}", criteriaQuery.GetSQLAlias(criteria)));
+			return new SqlString(sql?.Replace("{alias}", criteriaQuery.GetSQLAlias(criteria)));
 		}
 
 		public SqlString ToGroupSqlString(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
-			return new SqlString(StringHelper.Replace(groupBy, "{alias}", criteriaQuery.GetSQLAlias(criteria)));
+			return new SqlString(groupBy?.Replace("{alias}", criteriaQuery.GetSQLAlias(criteria)));
 		}
 
 		public override string ToString()

--- a/src/NHibernate/Driver/FirebirdClientDriver.cs
+++ b/src/NHibernate/Driver/FirebirdClientDriver.cs
@@ -103,7 +103,7 @@ namespace NHibernate.Driver
 
 						command.CommandText = Regex.Replace(
 							command.CommandText,
-							$@"{p.ParameterName}\b",
+							Regex.Escape(p.ParameterName) + @"\b",
 							$"cast({p.ParameterName} as {castType})");
 					}
 

--- a/src/NHibernate/Driver/FirebirdClientDriver.cs
+++ b/src/NHibernate/Driver/FirebirdClientDriver.cs
@@ -94,10 +94,19 @@ namespace NHibernate.Driver
 				var candidates = GetCastCandidates(expWithParams);
 
 				var index = 0;
+				
 				foreach (DbParameter p in command.Parameters)
 				{
 					if (candidates.Contains(p.ParameterName))
-						TypeCastParam(p, command, parameterTypes[index]);
+					{
+						var castType = GetFbTypeForParam(parameterTypes[index]);
+
+						command.CommandText = Regex.Replace(
+							command.CommandText,
+							$@"{p.ParameterName}\b",
+							$"cast({p.ParameterName} as {castType})");
+					}
+
 					index++;
 				}
 			}
@@ -118,14 +127,6 @@ namespace NHibernate.Driver
 					.Cast<Match>()
 					.Select(match => match.Value);
 			return new HashSet<string>(candidates);
-		}
-
-		private void TypeCastParam(DbParameter param, DbCommand command, SqlType sqlType)
-		{
-			var castType = GetFbTypeForParam(sqlType);
-			command.CommandText = command.CommandText.ReplaceWholeWord(
-				param.ParameterName,
-				$"cast({param.ParameterName} as {castType})");
 		}
 
 		private string GetFbTypeForParam(SqlType sqlType)

--- a/src/NHibernate/Hql/Ast/ANTLR/Util/SyntheticAndFactory.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Util/SyntheticAndFactory.cs
@@ -159,7 +159,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 
 			// Need to parse off the column qualifiers; this is assuming (which is true as of now)
 			// that this is only used from update and delete HQL statement parsing
-			whereFragment = StringHelper.Replace(whereFragment, persister.GenerateFilterConditionAlias(alias) + ".", "");
+			whereFragment = whereFragment.Replace(persister.GenerateFilterConditionAlias(alias) + ".", "");
 
 			// Note: this simply constructs a "raw" SQL_TOKEN representing the
 			// where fragment and injects this into the tree.  This "works";

--- a/src/NHibernate/Id/UUIDHexGenerator.cs
+++ b/src/NHibernate/Id/UUIDHexGenerator.cs
@@ -69,9 +69,9 @@ namespace NHibernate.Id
 		{
 			string guidString = GenerateNewGuid();
 
-			if (format != FormatWithDigitsOnly && sep != null)
+			if (format != FormatWithDigitsOnly && sep != null && guidString != null)
 			{
-				return StringHelper.Replace(guidString, "-", sep);
+				return guidString.Replace("-", sep);
 			}
 
 			return guidString;

--- a/src/NHibernate/Impl/AbstractQueryImpl.cs
+++ b/src/NHibernate/Impl/AbstractQueryImpl.cs
@@ -10,6 +10,7 @@ using NHibernate.Transform;
 using NHibernate.Type;
 using NHibernate.Util;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -265,7 +266,10 @@ namespace NHibernate.Impl
 
 			var paramPrefix = isJpaPositionalParam ? StringHelper.SqlParameter : ParserHelper.HqlVariablePrefix;
 
-			return StringHelper.Replace(query, paramPrefix + name, string.Join(StringHelper.CommaSpace, aliases), true);
+			return Regex.Replace(
+				query,
+				$@"{paramPrefix}{name}\b",
+				string.Join(StringHelper.CommaSpace, aliases));
 		}
 
 		#region Parameters

--- a/src/NHibernate/Impl/AbstractQueryImpl.cs
+++ b/src/NHibernate/Impl/AbstractQueryImpl.cs
@@ -268,7 +268,7 @@ namespace NHibernate.Impl
 
 			return Regex.Replace(
 				query,
-				$@"{paramPrefix}{name}\b",
+				Regex.Escape(paramPrefix + name) + @"\b",
 				string.Join(StringHelper.CommaSpace, aliases));
 		}
 

--- a/src/NHibernate/Mapping/SimpleAuxiliaryDatabaseObject.cs
+++ b/src/NHibernate/Mapping/SimpleAuxiliaryDatabaseObject.cs
@@ -45,9 +45,7 @@ namespace NHibernate.Mapping
 
 		private static string InjectCatalogAndSchema(string ddlString, string defaultCatalog, string defaultSchema)
 		{
-			string rtn = StringHelper.Replace(ddlString, "${catalog}", defaultCatalog);
-			rtn = StringHelper.Replace(rtn, "${schema}", defaultSchema);
-			return rtn;
+			return ddlString?.Replace("${catalog}", defaultCatalog).Replace("${schema}", defaultSchema);
 		}
 	}
 }

--- a/src/NHibernate/Mapping/UniqueKey.cs
+++ b/src/NHibernate/Mapping/UniqueKey.cs
@@ -62,10 +62,9 @@ namespace NHibernate.Mapping
 				buf.Append(column.GetQuotedName(dialect));
 			}
 
-			return
-				!nullable || dialect.SupportsNullInUnique
-					? StringHelper.Replace(buf.Append(StringHelper.ClosedParen).ToString(), "primary key", "unique")
-					: null;
+			return !nullable || dialect.SupportsNullInUnique
+				? buf.Append(StringHelper.ClosedParen).Replace("primary key", "unique").ToString()
+				: null;
 		}
 
 		public override string SqlCreateString(Dialect.Dialect dialect, IMapping p, string defaultCatalog, string defaultSchema)

--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -638,19 +638,19 @@ namespace NHibernate.Persister.Collection
 
 		public string GetSQLWhereString(string alias)
 		{
-			return StringHelper.Replace(sqlWhereStringTemplate, Template.Placeholder, alias);
+			return sqlWhereStringTemplate?.Replace(Template.Placeholder, alias);
 		}
 
 		public string GetSQLOrderByString(string alias)
 		{
-			return HasOrdering ? StringHelper.Replace(sqlOrderByStringTemplate, Template.Placeholder, alias) : string.Empty;
+			return HasOrdering ? sqlOrderByStringTemplate?.Replace(Template.Placeholder, alias) : string.Empty;
 		}
 
 		public string GetManyToManyOrderByString(string alias)
 		{
 			if (IsManyToMany && manyToManyOrderByString != null)
 			{
-				return StringHelper.Replace(manyToManyOrderByTemplate, Template.Placeholder, alias);
+				return manyToManyOrderByTemplate?.Replace(Template.Placeholder, alias);
 			}
 			else
 			{
@@ -1020,7 +1020,7 @@ namespace NHibernate.Persister.Collection
 			{
 				if (columnNames[i] == null)
 				{
-					result[i] = StringHelper.Replace(formulaTemplates[i], Template.Placeholder, alias);
+					result[i] = formulaTemplates[i]?.Replace(Template.Placeholder, alias);
 				}
 				else
 				{
@@ -1375,7 +1375,7 @@ namespace NHibernate.Persister.Collection
 
 			if (manyToManyWhereString != null)
 			{
-				buffer.Append(" and ").Append(StringHelper.Replace(manyToManyWhereTemplate, Template.Placeholder, alias));
+				buffer.Append(" and ").Append(manyToManyWhereTemplate?.Replace(Template.Placeholder, alias));
 			}
 
 			return buffer.ToString();

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1933,7 +1933,7 @@ namespace NHibernate.Persister.Entity
 			{
 				if (cols[j] == null)
 				{
-					result[j] = StringHelper.Replace(templates[j], Template.Placeholder, alias);
+					result[j] = templates[j]?.Replace(Template.Placeholder, alias);
 				}
 				else
 				{
@@ -2194,7 +2194,7 @@ namespace NHibernate.Persister.Entity
 
 		protected string GetSQLWhereString(string alias)
 		{
-			return StringHelper.Replace(sqlWhereStringTemplate, Template.Placeholder, alias);
+			return sqlWhereStringTemplate?.Replace(Template.Placeholder, alias);
 		}
 
 		protected bool HasWhere

--- a/src/NHibernate/Persister/Entity/AbstractPropertyMapping.cs
+++ b/src/NHibernate/Persister/Entity/AbstractPropertyMapping.cs
@@ -55,7 +55,7 @@ namespace NHibernate.Persister.Entity
 			for (int i = 0; i < columns.Length; i++)
 			{
 				if (columns[i] == null)
-					result[i] = StringHelper.Replace(templates[i], Template.Placeholder, alias);
+					result[i] = templates[i]?.Replace(Template.Placeholder, alias);
 				else
 					result[i] = StringHelper.Qualify(alias, columns[i]);
 			}
@@ -81,7 +81,7 @@ namespace NHibernate.Persister.Entity
 			for (int i = 0; i < columns.Length; i++)
 			{
 				if (columns[i] == null)
-					result[i] = StringHelper.Replace(templates[i], Template.Placeholder, string.Empty);
+					result[i] = templates[i]?.Replace(Template.Placeholder, string.Empty);
 				else
 					result[i] = columns[i];
 			}

--- a/src/NHibernate/SqlCommand/InFragment.cs
+++ b/src/NHibernate/SqlCommand/InFragment.cs
@@ -36,13 +36,13 @@ namespace NHibernate.SqlCommand
 		public InFragment SetColumn(string alias, string colName)
 		{
 			columnName = alias + StringHelper.Dot + colName;
-			return SetColumn(columnName);
+			return this;
 		}
 
 		public InFragment SetFormula(string alias, string formulaTemplate)
 		{
-			columnName = StringHelper.Replace(formulaTemplate, Template.Placeholder, alias);
-			return SetColumn(columnName);
+			columnName = formulaTemplate?.Replace(Template.Placeholder, alias);
+			return this;
 		}
 
 		public SqlString ToFragmentString()

--- a/src/NHibernate/SqlCommand/SelectFragment.cs
+++ b/src/NHibernate/SqlCommand/SelectFragment.cs
@@ -105,7 +105,7 @@ namespace NHibernate.SqlCommand
 		{
 			AddColumn(
 				null,
-				StringHelper.Replace(formula, Template.Placeholder, tableAlias),
+				formula?.Replace(Template.Placeholder, tableAlias),
 				formulaAlias);
 
 			return this;

--- a/src/NHibernate/Util/FilterHelper.cs
+++ b/src/NHibernate/Util/FilterHelper.cs
@@ -20,13 +20,12 @@ namespace NHibernate.Util
 			filterNames = new string[filterCount];
 			filterConditions = new string[filterCount];
 			filterCount = 0;
-			foreach (KeyValuePair<string, string> entry in filters)
+			foreach (var entry in filters)
 			{
 				filterNames[filterCount] = entry.Key;
 				filterConditions[filterCount] =
-					Template.RenderWhereStringTemplate(entry.Value, FilterImpl.MARKER, dialect, sqlFunctionRegistry);
-				filterConditions[filterCount] =
-					StringHelper.Replace(filterConditions[filterCount], ":", ":" + filterNames[filterCount] + ".");
+					Template.RenderWhereStringTemplate(entry.Value, FilterImpl.MARKER, dialect, sqlFunctionRegistry)?
+						.Replace(":", ":" + entry.Key + ".");
 				filterCount++;
 			}
 		}

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -83,7 +83,6 @@ namespace NHibernate.Util
 			return buf.ToString();
 		}
 
-		//TODO: Inline
 		public static string Replace(string template, string placeholder, string replacement)
 		{
 			// sometimes a null value will get passed in here -> SqlWhereStrings are a good example

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -83,6 +83,8 @@ namespace NHibernate.Util
 			return buf.ToString();
 		}
 
+		//Since v5.3
+		[Obsolete("Please use string.Replace or Regex.Replace instead.")]
 		public static string Replace(string template, string placeholder, string replacement)
 		{
 			// sometimes a null value will get passed in here -> SqlWhereStrings are a good example

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -83,11 +83,15 @@ namespace NHibernate.Util
 			return buf.ToString();
 		}
 
+		//TODO: Inline
 		public static string Replace(string template, string placeholder, string replacement)
 		{
-			return Replace(template, placeholder, replacement, false);
+			// sometimes a null value will get passed in here -> SqlWhereStrings are a good example
+			return template?.Replace(placeholder, replacement);
 		}
 
+		//Since v5.3
+		[Obsolete("Please use string.Replace or Regex.Replace instead.")]
 		public static string Replace(string template, string placeholder, string replacement, bool wholeWords)
 		{
 			Predicate<string> isWholeWord = c => WhiteSpace.Contains(c) || ClosedParen.Equals(c) || Comma.Equals(c);
@@ -129,6 +133,8 @@ namespace NHibernate.Util
 			}
 		}
 
+		//Since v5.3
+		[Obsolete("Please use string.Replace or Regex.Replace instead.")]
 		public static string ReplaceWholeWord(this string template, string placeholder, string replacement)
 		{
 			Predicate<string> isWholeWord = s => !Char.IsLetterOrDigit(s[0]);


### PR DESCRIPTION
`StringHelper.Replace*` methods are highly ineffective when the input string has many occurrences of a placeholder. 