### PR TITLE
Release 5.2.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.2.0.{build}
+version: 5.2.1.{build}
 image: Visual Studio 2017
 environment:
   matrix:

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">2</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -13,8 +13,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.2.0" overwrite="false" />
-	<property name="project.version.numeric" value="5.2.0" overwrite="false" />
+	<property name="project.version" value="5.2.1" overwrite="false" />
+	<property name="project.version.numeric" value="5.2.1" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,7 +1,21 @@
+
 Build 5.2.1
 =============================
 
 Release notes - NHibernate - Version 5.2.1
+
+5 issues were resolved in this release.
+
+** Bug
+
+   * #1928 JoinAlias on JoinQueryOver fails
+   * #1920 ISession.Get may fail with a null exception
+   * #1918 Property-ref on many-to-one with composite id fails
+
+** Task
+
+   * #1932 Release 5.2.1
+   * #1927 Add missing possible breaking change
 
 As part of releasing 5.2.1, a missing 5.2.0 possible breaking change has been added about duplicated columns
 in mapping. See 5.2.0 possible breaking changes.


### PR DESCRIPTION
One PR remains open in the milestone, for including a missing possible breaking change of 5.2.0.

#1927