### PR TITLE
Allow to provide dev specific properties in NHibernate.dev.props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ TestResult.xml
 
 .idea/
 .vs/
+/build-common/NHibernate.dev.props

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -1,5 +1,7 @@
 <Project>
   <Import Project="DotNetSdkMono.props" />
+  <Import Condition="Exists('NHibernate.dev.props')" Project="NHibernate.dev.props"/>
+
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">2</VersionMinor>
@@ -10,8 +12,8 @@
     <AssemblyVersion>$(VersionMajor).$(VersionMinor).0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
 
-    <NhAppTargetFrameworks>net461;netcoreapp2.0</NhAppTargetFrameworks>
-    <NhLibTargetFrameworks>net461;netcoreapp2.0;netstandard2.0</NhLibTargetFrameworks>
+    <NhAppTargetFrameworks Condition ="$(NhAppTargetFrameworks) == ''">net461;netcoreapp2.0</NhAppTargetFrameworks>
+    <NhLibTargetFrameworks Condition ="$(NhLibTargetFrameworks) == ''">net461;netcoreapp2.0;netstandard2.0</NhLibTargetFrameworks>
 
     <Product>NHibernate</Product>
     <Company>NHibernate.info</Company>


### PR DESCRIPTION
Follow up to #1700

Now you can change build targets on your machine without hanging pending changes by creating local NHibernate.dev.props.
Example of `NHibernate.dev.props` content:
```
<Project>
  <PropertyGroup>
    <NhAppTargetFrameworks>net461</NhAppTargetFrameworks>
    <NhLibTargetFrameworks>net461</NhLibTargetFrameworks>
  </PropertyGroup>
</Project>

```
