### PR TITLE
Allow setting dynamic component templates from dictionary in ByCode

### DIFF
--- a/src/NHibernate/Mapping/ByCode/IPlainPropertyContainerMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IPlainPropertyContainerMapper.cs
@@ -42,10 +42,29 @@ namespace NHibernate.Mapping.ByCode
 	{
 		void Component<TComponent>(Expression<Func<TContainer, TComponent>> property, Action<IComponentMapper<TComponent>> mapping);
 		void Component<TComponent>(Expression<Func<TContainer, TComponent>> property);
+		/// <summary>
+		/// Maps a non-generic dictionary property as a dynamic component.
+		/// </summary>
+		/// <param name="property">The property to map.</param>
+		/// <param name="dynamicComponentTemplate">The template for the component. It should either be a (usually
+		/// anonymous) type having the same properties than the component, or an
+		/// <c>IDictionary&lt;string, System.Type&gt;</c> of property names with their type.</param>
+		/// <param name="mapping">The mapping of the component.</param>
+		/// <typeparam name="TComponent">The type of the template.</typeparam>
 		void Component<TComponent>(Expression<Func<TContainer, IDictionary>> property, TComponent dynamicComponentTemplate, Action<IDynamicComponentMapper<TComponent>> mapping);
 
 		void Component<TComponent>(string notVisiblePropertyOrFieldName, Action<IComponentMapper<TComponent>> mapping);
 		void Component<TComponent>(string notVisiblePropertyOrFieldName);
+		/// <summary>
+		/// Maps a property or field as a dynamic component. The property can be a C# <c>dynamic</c> or a dictionary of
+		/// property names to their value.
+		/// </summary>
+		/// <param name="notVisiblePropertyOrFieldName">The property or field name to map.</param>
+		/// <param name="dynamicComponentTemplate">The template for the component. It should either be a (usually
+		/// anonymous) type having the same properties than the component, or an
+		/// <c>IDictionary&lt;string, System.Type&gt;</c> of property names with their type.</param>
+		/// <param name="mapping">The mapping of the component.</param>
+		/// <typeparam name="TComponent">The type of the template.</typeparam>
 		void Component<TComponent>(string notVisiblePropertyOrFieldName, TComponent dynamicComponentTemplate, Action<IDynamicComponentMapper<TComponent>> mapping);
 
 		void Any<TProperty>(Expression<Func<TContainer, TProperty>> property, System.Type idTypeOfMetaType, Action<IAnyMapper> mapping) where TProperty : class;
@@ -61,6 +80,17 @@ namespace NHibernate.Mapping.ByCode
 	public static class BasePlainPropertyContainerMapperExtensions
 	{
 		//6.0 TODO: Merge into IBasePlainPropertyContainerMapper<> interface
+		/// <summary>
+		/// Maps a generic <c>IDictionary&lt;string, object&gt;</c> property as a dynamic component.
+		/// </summary>
+		/// <param name="mapper">The mapper.</param>
+		/// <param name="property">The property to map.</param>
+		/// <param name="dynamicComponentTemplate">The template for the component. It should either be a (usually
+		/// anonymous) type having the same properties than the component, or an
+		/// <c>IDictionary&lt;string, System.Type&gt;</c> of property names with their type.</param>
+		/// <param name="mapping">The mapping of the component.</param>
+		/// <typeparam name="TContainer">The type of the mapped class.</typeparam>
+		/// <typeparam name="TComponent">The type of the template.</typeparam>
 		public static void Component<TContainer, TComponent>(
 			this IBasePlainPropertyContainerMapper<TContainer> mapper,
 			Expression<Func<TContainer, IDictionary<string, object>>> property,

--- a/src/NHibernate/Mapping/ByCode/Impl/CustomizersImpl/ComponentCustomizer.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/CustomizersImpl/ComponentCustomizer.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Mapping.ByCode.Impl.CustomizersImpl
 
 		public void Parent(string notVisiblePropertyOrFieldName, Action<IComponentParentMapper> parentMapping)
 		{
-			MemberInfo member = GetPropertyOrFieldMatchingNameOrThrow(notVisiblePropertyOrFieldName);
+			MemberInfo member = GetRequiredPropertyOrFieldByName(notVisiblePropertyOrFieldName);
 			AddCustomizer(m => m.Parent(member, parentMapping));
 		}
 


### PR DESCRIPTION
Fixes #913 - NH-3704

Replaces #341. It is a rebase of it, with fixes required due to changes in NHibernate.

The original PR repository being deleted, I do not see any way to work with it other than opening a new PR.

The original PR was put in the 6.0 milestone, but it does not have breaking changes. It can be put in the 5.3 milestone.

There was a discussion about the implementation relying on dynamically building a type matching the component. It allows to re-use the existing By-Code logic working on anonymous types, rather than coding a whole new code path for mapping dynamic components by code. It is a bit runtime heavy way of doing things, but it seems doing it another way will require a bit to much changes in By-Code.

If approved, it should be manually squashed before merging, in order to keep Ricardo as the main author.