### PR TITLE
Modified field interceptor to skip initialization of lazy properties when setting one

### DIFF
--- a/src/NHibernate.Test/Async/GhostProperty/GhostPropertyFixture.cs
+++ b/src/NHibernate.Test/Async/GhostProperty/GhostPropertyFixture.cs
@@ -167,6 +167,21 @@ namespace NHibernate.Test.GhostProperty
 				}
 				Assert.That(NHibernateUtil.IsPropertyInitialized(order, "ALazyProperty"), Is.True);
 			}
-		} 
+		}
+
+		[Test]
+		public async Task AcceptPropertySetWithTransientObjectAsync()
+		{
+			Order order;
+			using (var s = OpenSession())
+			{
+				order = await (s.GetAsync<Order>(1));
+			}
+
+			var newPayment = new WireTransfer();
+			order.Payment = newPayment;
+
+			Assert.That(order.Payment, Is.EqualTo(newPayment));
+		}
 	}
 }

--- a/src/NHibernate.Test/Async/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/Async/LazyProperty/LazyPropertyFixture.cs
@@ -10,14 +10,17 @@
 
 using System.Collections;
 using System.Linq;
+using NHibernate.Cfg;
 using NHibernate.Intercept;
 using NHibernate.Tuple.Entity;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using NHibernate.Linq;
 
 namespace NHibernate.Test.LazyProperty
 {
 	using System.Threading.Tasks;
+	using System.Threading;
 	[TestFixture]
 	public class LazyPropertyFixtureAsync : TestCase
 	{
@@ -43,6 +46,11 @@ namespace NHibernate.Test.LazyProperty
 			}
 		}
 
+		protected override void Configure(Configuration configuration)
+		{
+			configuration.SetProperty(Environment.GenerateStatistics, "true");
+		}
+
 		protected override void OnSetUp()
 		{
 			Assert.That(
@@ -58,6 +66,7 @@ namespace NHibernate.Test.LazyProperty
 					Name = "some name",
 					Id = 1,
 					ALotOfText = "a lot of text ...",
+					Image = new byte[10],
 					FieldInterceptor = "Why not that name?"
 				});
 				tx.Commit();
@@ -120,6 +129,94 @@ namespace NHibernate.Test.LazyProperty
 				Assert.That(book.ALotOfText, Is.EqualTo("a lot of text ..."));
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
 			}
+		}
+
+		[Test]
+		public async Task CanSetValueForLazyPropertyAsync()
+		{
+			Book book;
+			using (ISession s = OpenSession())
+			{
+				book = await (s.GetAsync<Book>(1));
+			}
+
+			book.ALotOfText = "text";
+
+			Assert.That(book.ALotOfText, Is.EqualTo("text"));
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task CanUpdateValueForLazyPropertyAsync(bool initializeAfterSet, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			Book book;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				book = await (s.GetAsync<Book>(1, cancellationToken));
+				book.ALotOfText = "update-text";
+				if (initializeAfterSet)
+				{
+					var image = book.Image;
+				}
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			using (var s = OpenSession())
+			{
+				book = await (s.GetAsync<Book>(1, cancellationToken));
+				var text = book.ALotOfText;
+			}
+
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Image"), Is.True);
+			Assert.That(book.ALotOfText, Is.EqualTo("update-text"));
+			Assert.That(book.Image, Has.Length.EqualTo(10));
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task UpdateValueForLazyPropertyToSameValueAsync(bool initializeAfterSet, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			Book book;
+			string text;
+
+			using (var s = OpenSession())
+			{
+				book = await (s.GetAsync<Book>(1, cancellationToken));
+				text = book.ALotOfText;
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				book = await (s.GetAsync<Book>(1, cancellationToken));
+				book.ALotOfText = text;
+				if (initializeAfterSet)
+				{
+					var image = book.Image;
+				}
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(initializeAfterSet ? 0 : 1));
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Image"), initializeAfterSet ? (Constraint) Is.True : Is.False);
+			Assert.That(book.ALotOfText, Is.EqualTo(text));
+
+			using (var s = OpenSession())
+			{
+				book = await (s.GetAsync<Book>(1, cancellationToken));
+				text = book.ALotOfText;
+			}
+
+			Assert.That(book.Image, Has.Length.EqualTo(10));
+			Assert.That(book.ALotOfText, Is.EqualTo(text));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/GhostProperty/GhostPropertyFixture.cs
+++ b/src/NHibernate.Test/GhostProperty/GhostPropertyFixture.cs
@@ -162,6 +162,21 @@ namespace NHibernate.Test.GhostProperty
 				}
 				Assert.That(NHibernateUtil.IsPropertyInitialized(order, "ALazyProperty"), Is.True);
 			}
-		} 
+		}
+
+		[Test]
+		public void AcceptPropertySetWithTransientObject()
+		{
+			Order order;
+			using (var s = OpenSession())
+			{
+				order = s.Get<Order>(1);
+			}
+
+			var newPayment = new WireTransfer();
+			order.Payment = newPayment;
+
+			Assert.That(order.Payment, Is.EqualTo(newPayment));
+		}
 	}
 }

--- a/src/NHibernate.Test/LazyProperty/Book.cs
+++ b/src/NHibernate.Test/LazyProperty/Book.cs
@@ -13,6 +13,8 @@
 			set { _aLotOfText = value; }
 		}
 
+		public virtual byte[] Image { get; set; }
+
 		public virtual string FieldInterceptor { get; set; }
 	}
 }

--- a/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections;
 using System.Linq;
+using NHibernate.Cfg;
 using NHibernate.Intercept;
 using NHibernate.Tuple.Entity;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace NHibernate.Test.LazyProperty
 {
@@ -31,6 +33,11 @@ namespace NHibernate.Test.LazyProperty
 			}
 		}
 
+		protected override void Configure(Configuration configuration)
+		{
+			configuration.SetProperty(Environment.GenerateStatistics, "true");
+		}
+
 		protected override void OnSetUp()
 		{
 			Assert.That(
@@ -46,6 +53,7 @@ namespace NHibernate.Test.LazyProperty
 					Name = "some name",
 					Id = 1,
 					ALotOfText = "a lot of text ...",
+					Image = new byte[10],
 					FieldInterceptor = "Why not that name?"
 				});
 				tx.Commit();
@@ -114,6 +122,94 @@ namespace NHibernate.Test.LazyProperty
 				Assert.That(book.ALotOfText, Is.EqualTo("a lot of text ..."));
 				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
 			}
+		}
+
+		[Test]
+		public void CanSetValueForLazyProperty()
+		{
+			Book book;
+			using (ISession s = OpenSession())
+			{
+				book = s.Get<Book>(1);
+			}
+
+			book.ALotOfText = "text";
+
+			Assert.That(book.ALotOfText, Is.EqualTo("text"));
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public void CanUpdateValueForLazyProperty(bool initializeAfterSet)
+		{
+			Book book;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				book = s.Get<Book>(1);
+				book.ALotOfText = "update-text";
+				if (initializeAfterSet)
+				{
+					var image = book.Image;
+				}
+
+				tx.Commit();
+			}
+
+			using (var s = OpenSession())
+			{
+				book = s.Get<Book>(1);
+				var text = book.ALotOfText;
+			}
+
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Image"), Is.True);
+			Assert.That(book.ALotOfText, Is.EqualTo("update-text"));
+			Assert.That(book.Image, Has.Length.EqualTo(10));
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public void UpdateValueForLazyPropertyToSameValue(bool initializeAfterSet)
+		{
+			Book book;
+			string text;
+
+			using (var s = OpenSession())
+			{
+				book = s.Get<Book>(1);
+				text = book.ALotOfText;
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				book = s.Get<Book>(1);
+				book.ALotOfText = text;
+				if (initializeAfterSet)
+				{
+					var image = book.Image;
+				}
+
+				tx.Commit();
+			}
+
+			Assert.That(Sfi.Statistics.EntityUpdateCount, Is.EqualTo(initializeAfterSet ? 0 : 1));
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "ALotOfText"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(book, "Image"), initializeAfterSet ? (Constraint) Is.True : Is.False);
+			Assert.That(book.ALotOfText, Is.EqualTo(text));
+
+			using (var s = OpenSession())
+			{
+				book = s.Get<Book>(1);
+				text = book.ALotOfText;
+			}
+
+			Assert.That(book.Image, Has.Length.EqualTo(10));
+			Assert.That(book.ALotOfText, Is.EqualTo(text));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
+++ b/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
@@ -9,6 +9,7 @@
 		</id>
 		<property name="Name" />
 		<property name="ALotOfText" lazy="true" />
+		<property name="Image" lazy="true" />
 		<property name="FieldInterceptor" />
 	</class>
 

--- a/src/NHibernate/Async/Engine/Cascade.cs
+++ b/src/NHibernate/Async/Engine/Cascade.cs
@@ -60,12 +60,12 @@ namespace NHibernate.Engine
 
 				IType[] types = persister.PropertyTypes;
 				CascadeStyle[] cascadeStyles = persister.PropertyCascadeStyles;
-				ISet<string> uninitializedLazyProperties = persister.GetUninitializedLazyProperties(parent);
+				var uninitializedLazyProperties = persister.GetUninitializedLazyProperties(parent);
 				for (int i = 0; i < types.Length; i++)
 				{
 					CascadeStyle style = cascadeStyles[i];
 					string propertyName = persister.PropertyNames[i];
-					if (uninitializedLazyProperties.Contains(persister.PropertyNames[i]) && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
+					if (uninitializedLazyProperties.Contains(propertyName) && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
 					{
 						//do nothing to avoid a lazy property initialization
 						continue;

--- a/src/NHibernate/Async/Engine/Cascade.cs
+++ b/src/NHibernate/Async/Engine/Cascade.cs
@@ -60,12 +60,12 @@ namespace NHibernate.Engine
 
 				IType[] types = persister.PropertyTypes;
 				CascadeStyle[] cascadeStyles = persister.PropertyCascadeStyles;
-				bool hasUninitializedLazyProperties = persister.HasUninitializedLazyProperties(parent);
+				ISet<string> uninitializedLazyProperties = persister.GetUninitializedLazyProperties(parent);
 				for (int i = 0; i < types.Length; i++)
 				{
 					CascadeStyle style = cascadeStyles[i];
 					string propertyName = persister.PropertyNames[i];
-					if (hasUninitializedLazyProperties && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
+					if (uninitializedLazyProperties.Contains(persister.PropertyNames[i]) && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
 					{
 						//do nothing to avoid a lazy property initialization
 						continue;

--- a/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
@@ -877,10 +877,7 @@ namespace NHibernate.Persister.Entity
 			if (entry == null && !IsMutable)
 				throw new InvalidOperationException("Updating immutable entity that is not in session yet!");
 
-			if ((entityMetamodel.IsDynamicUpdate && dirtyFields != null) ||
-				// When having a dirty lazy property and the entity is not yet initialized we have to use a dynamic update for it even if
-				// it is disabled in order to have it updated.
-				(GetUninitializedLazyProperties(obj).Count > 0 && dirtyFields?.Count(o => PropertyLaziness[o]) > 0))
+			if (dirtyFields != null && (entityMetamodel.IsDynamicUpdate || HasDirtyLazyProperties(dirtyFields, obj)))
 			{
 				// For the case of dynamic-update="true", we need to generate the UPDATE SQL
 				propsToUpdate = GetPropertiesToUpdate(dirtyFields, hasDirtyCollection);

--- a/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
@@ -876,8 +876,11 @@ namespace NHibernate.Persister.Entity
 			// in the process of being deleted.
 			if (entry == null && !IsMutable)
 				throw new InvalidOperationException("Updating immutable entity that is not in session yet!");
-			
-			if (entityMetamodel.IsDynamicUpdate && dirtyFields != null)
+
+			if ((entityMetamodel.IsDynamicUpdate && dirtyFields != null) ||
+				// When having a dirty lazy property and the entity is not yet initialized we have to use a dynamic update for it even if
+				// it is disabled in order to have it updated.
+				(GetUninitializedLazyProperties(obj).Count > 0 && dirtyFields?.Count(o => PropertyLaziness[o]) > 0))
 			{
 				// For the case of dynamic-update="true", we need to generate the UPDATE SQL
 				propsToUpdate = GetPropertiesToUpdate(dirtyFields, hasDirtyCollection);

--- a/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using NHibernate.Cache;
 using NHibernate.Cache.Entry;
 using NHibernate.Engine;
@@ -16,6 +17,7 @@ using NHibernate.Metadata;
 using NHibernate.Tuple.Entity;
 using NHibernate.Type;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace NHibernate.Persister.Entity
 {

--- a/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
@@ -18,6 +18,8 @@ using NHibernate.Tuple.Entity;
 using NHibernate.Type;
 using System.Collections;
 using System.Collections.Generic;
+using NHibernate.Intercept;
+using NHibernate.Util;
 
 namespace NHibernate.Persister.Entity
 {

--- a/src/NHibernate/Engine/Cascade.cs
+++ b/src/NHibernate/Engine/Cascade.cs
@@ -113,12 +113,12 @@ namespace NHibernate.Engine
 
 				IType[] types = persister.PropertyTypes;
 				CascadeStyle[] cascadeStyles = persister.PropertyCascadeStyles;
-				ISet<string> uninitializedLazyProperties = persister.GetUninitializedLazyProperties(parent);
+				var uninitializedLazyProperties = persister.GetUninitializedLazyProperties(parent);
 				for (int i = 0; i < types.Length; i++)
 				{
 					CascadeStyle style = cascadeStyles[i];
 					string propertyName = persister.PropertyNames[i];
-					if (uninitializedLazyProperties.Contains(persister.PropertyNames[i]) && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
+					if (uninitializedLazyProperties.Contains(propertyName) && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
 					{
 						//do nothing to avoid a lazy property initialization
 						continue;

--- a/src/NHibernate/Engine/Cascade.cs
+++ b/src/NHibernate/Engine/Cascade.cs
@@ -113,12 +113,12 @@ namespace NHibernate.Engine
 
 				IType[] types = persister.PropertyTypes;
 				CascadeStyle[] cascadeStyles = persister.PropertyCascadeStyles;
-				bool hasUninitializedLazyProperties = persister.HasUninitializedLazyProperties(parent);
+				ISet<string> uninitializedLazyProperties = persister.GetUninitializedLazyProperties(parent);
 				for (int i = 0; i < types.Length; i++)
 				{
 					CascadeStyle style = cascadeStyles[i];
 					string propertyName = persister.PropertyNames[i];
-					if (hasUninitializedLazyProperties && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
+					if (uninitializedLazyProperties.Contains(persister.PropertyNames[i]) && persister.PropertyLaziness[i] && !action.PerformOnLazyProperty)
 					{
 						//do nothing to avoid a lazy property initialization
 						continue;

--- a/src/NHibernate/Intercept/AbstractFieldInterceptor.cs
+++ b/src/NHibernate/Intercept/AbstractFieldInterceptor.cs
@@ -81,7 +81,7 @@ namespace NHibernate.Intercept
 		#endregion
 
 		// Since v5.3
-		[Obsolete("This method has no more usages and will be removed in a future version")]
+		[Obsolete("Please use GetUninitializedFields extension method instead")]
 		public ISet<string> UninitializedFields
 		{
 			get { return uninitializedFields; }
@@ -193,7 +193,7 @@ namespace NHibernate.Intercept
 			return result;
 		}
 
-		public ISet<string> GetUninitializedLazyProperties()
+		public ISet<string> GetUninitializedFields()
 		{
 			return uninitializedFieldsReadOnly ?? CollectionHelper.EmptySet<string>();
 		}

--- a/src/NHibernate/Intercept/IFieldInterceptor.cs
+++ b/src/NHibernate/Intercept/IFieldInterceptor.cs
@@ -44,11 +44,11 @@ namespace NHibernate.Intercept
 	public static class FieldInterceptorExtensions
 	{
 		// 6.0 TODO: merge into IFieldInterceptor
-		internal static ISet<string> GetUninitializedLazyProperties(this IFieldInterceptor interceptor)
+		internal static ISet<string> GetUninitializedFields(this IFieldInterceptor interceptor)
 		{
 			if (interceptor is AbstractFieldInterceptor fieldInterceptor)
 			{
-				return fieldInterceptor.GetUninitializedLazyProperties();
+				return fieldInterceptor.GetUninitializedFields();
 			}
 
 			if (interceptor.IsInitialized)
@@ -56,7 +56,7 @@ namespace NHibernate.Intercept
 				return CollectionHelper.EmptySet<string>();
 			}
 
-			return null; // The called should use all lazy properties as the result
+			return null; // The caller should use all lazy properties as the result
 		}
 
 		// 6.0 TODO: merge into IFieldInterceptor

--- a/src/NHibernate/Intercept/IFieldInterceptor.cs
+++ b/src/NHibernate/Intercept/IFieldInterceptor.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using NHibernate.Engine;
 
 namespace NHibernate.Intercept
@@ -27,6 +29,8 @@ namespace NHibernate.Intercept
 		void ClearDirty();
 
 		/// <summary> Intercept field set/get </summary>
+		// Since v5.3
+		[Obsolete("This method has no more usages and will be removed in a future version")]
 		object Intercept(object target, string fieldName, object value);
 
 		/// <summary> Get the entity-name of the field DeclaringType.</summary>
@@ -34,5 +38,29 @@ namespace NHibernate.Intercept
 
 		/// <summary> Get the MappedClass (field container).</summary>
 		System.Type MappedClass { get; }
+	}
+
+	public static class FieldInterceptorExtensions
+	{
+		internal static ISet<string> GetUninitializedLazyProperties(this IFieldInterceptor interceptor)
+		{
+			if (interceptor is AbstractFieldInterceptor fieldInterceptor)
+			{
+				return fieldInterceptor.GetUninitializedLazyProperties();
+			}
+
+			throw new NotSupportedException("GetUninitializedLazyProperties method is not supported.");
+		}
+
+		public static object Intercept(this IFieldInterceptor interceptor, object target, string fieldName, object value, bool setter)
+		{
+			if (interceptor is AbstractFieldInterceptor fieldInterceptor)
+			{
+				return fieldInterceptor.Intercept(target, fieldName, value, setter);
+			}
+#pragma warning disable 618
+			return interceptor.Intercept(target, fieldName, value);
+#pragma warning restore 618
+		}
 	}
 }

--- a/src/NHibernate/Intercept/IFieldInterceptor.cs
+++ b/src/NHibernate/Intercept/IFieldInterceptor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NHibernate.Engine;
+using NHibernate.Util;
 
 namespace NHibernate.Intercept
 {
@@ -30,7 +31,7 @@ namespace NHibernate.Intercept
 
 		/// <summary> Intercept field set/get </summary>
 		// Since v5.3
-		[Obsolete("This method has no more usages and will be removed in a future version")]
+		[Obsolete("Please use 'Intercept(object target, string fieldName, object value, bool setter)' extension method instead")]
 		object Intercept(object target, string fieldName, object value);
 
 		/// <summary> Get the entity-name of the field DeclaringType.</summary>
@@ -42,6 +43,7 @@ namespace NHibernate.Intercept
 
 	public static class FieldInterceptorExtensions
 	{
+		// 6.0 TODO: merge into IFieldInterceptor
 		internal static ISet<string> GetUninitializedLazyProperties(this IFieldInterceptor interceptor)
 		{
 			if (interceptor is AbstractFieldInterceptor fieldInterceptor)
@@ -49,9 +51,15 @@ namespace NHibernate.Intercept
 				return fieldInterceptor.GetUninitializedLazyProperties();
 			}
 
-			throw new NotSupportedException("GetUninitializedLazyProperties method is not supported.");
+			if (interceptor.IsInitialized)
+			{
+				return CollectionHelper.EmptySet<string>();
+			}
+
+			return null; // The called should use all lazy properties as the result
 		}
 
+		// 6.0 TODO: merge into IFieldInterceptor
 		public static object Intercept(this IFieldInterceptor interceptor, object target, string fieldName, object value, bool setter)
 		{
 			if (interceptor is AbstractFieldInterceptor fieldInterceptor)

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -4105,7 +4105,7 @@ namespace NHibernate.Persister.Entity
 
 		internal ISet<string> GetUninitializedLazyProperties(object entity)
 		{
-			return EntityTuplizer.GetUninitializedLazyProperties(entity);
+			return EntityTuplizer.GetUninitializedLazyProperties(entity) ?? new HashSet<string>(lazyPropertyNames);
 		}
 
 		internal ISet<string> GetUninitializedLazyProperties(object[] state)

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1281,6 +1281,7 @@ namespace NHibernate.Persister.Entity
 					fieldName);
 			}
 
+			var uninitializedLazyProperties = GetUninitializedLazyProperties(entity);
 			if (HasCache && session.CacheMode.HasFlag(CacheMode.Get))
 			{
 				CacheKey cacheKey = session.GenerateCacheKey(id, IdentifierType, EntityName);
@@ -1291,15 +1292,16 @@ namespace NHibernate.Persister.Entity
 					if (!cacheEntry.AreLazyPropertiesUnfetched)
 					{
 						//note early exit here:
-						return InitializeLazyPropertiesFromCache(fieldName, entity, session, entry, cacheEntry);
+						return InitializeLazyPropertiesFromCache(fieldName, entity, session, entry, cacheEntry, uninitializedLazyProperties);
 					}
 				}
 			}
 
-			return InitializeLazyPropertiesFromDatastore(fieldName, entity, session, id, entry);
+			return InitializeLazyPropertiesFromDatastore(fieldName, entity, session, id, entry, uninitializedLazyProperties);
 		}
 
-		private object InitializeLazyPropertiesFromDatastore(string fieldName, object entity, ISessionImplementor session, object id, EntityEntry entry)
+		private object InitializeLazyPropertiesFromDatastore(string fieldName, object entity, ISessionImplementor session, object id, EntityEntry entry,
+															ISet<string> uninitializedLazyProperties)
 		{
 			if (!HasLazyProperties)
 				throw new AssertionFailure("no lazy properties");
@@ -1329,7 +1331,7 @@ namespace NHibernate.Persister.Entity
 					for (int j = 0; j < lazyPropertyNames.Length; j++)
 					{
 						object propValue = lazyPropertyTypes[j].NullSafeGet(rs, lazyPropertyColumnAliases[j], session, entity);
-						if (InitializeLazyProperty(fieldName, entity, session, snapshot, j, propValue))
+						if (InitializeLazyProperty(fieldName, entity, session, snapshot, j, propValue, uninitializedLazyProperties))
 						{
 							result = propValue;
 						}
@@ -1359,7 +1361,8 @@ namespace NHibernate.Persister.Entity
 			}
 		}
 
-		private object InitializeLazyPropertiesFromCache(string fieldName, object entity, ISessionImplementor session, EntityEntry entry, CacheEntry cacheEntry)
+		private object InitializeLazyPropertiesFromCache(string fieldName, object entity, ISessionImplementor session, EntityEntry entry, CacheEntry cacheEntry,
+														ISet<string> uninitializedLazyProperties)
 		{
 			log.Debug("initializing lazy properties from second-level cache");
 
@@ -1369,7 +1372,7 @@ namespace NHibernate.Persister.Entity
 			for (int j = 0; j < lazyPropertyNames.Length; j++)
 			{
 				object propValue = lazyPropertyTypes[j].Assemble(disassembledValues[lazyPropertyNumbers[j]], session, entity);
-				if (InitializeLazyProperty(fieldName, entity, session, snapshot, j, propValue))
+				if (InitializeLazyProperty(fieldName, entity, session, snapshot, j, propValue, uninitializedLazyProperties))
 				{
 					result = propValue;
 				}
@@ -1380,9 +1383,14 @@ namespace NHibernate.Persister.Entity
 			return result;
 		}
 
-		private bool InitializeLazyProperty(string fieldName, object entity, ISessionImplementor session, object[] snapshot, int j, object propValue)
+		private bool InitializeLazyProperty(string fieldName, object entity, ISessionImplementor session, object[] snapshot, int j, object propValue,
+											ISet<string> uninitializedLazyProperties)
 		{
-			SetPropertyValue(entity, lazyPropertyNumbers[j], propValue);
+			if (uninitializedLazyProperties.Contains(lazyPropertyNames[j]))
+			{
+				SetPropertyValue(entity, lazyPropertyNumbers[j], propValue);
+			}
+
 			if (snapshot != null)
 			{
 				// object have been loaded with setReadOnly(true); HHH-2236
@@ -3158,8 +3166,11 @@ namespace NHibernate.Persister.Entity
 			// in the process of being deleted.
 			if (entry == null && !IsMutable)
 				throw new InvalidOperationException("Updating immutable entity that is not in session yet!");
-			
-			if (entityMetamodel.IsDynamicUpdate && dirtyFields != null)
+
+			if ((entityMetamodel.IsDynamicUpdate && dirtyFields != null) ||
+				// When having a dirty lazy property and the entity is not yet initialized we have to use a dynamic update for it even if
+				// it is disabled in order to have it updated.
+				(GetUninitializedLazyProperties(obj).Count > 0 && dirtyFields?.Count(o => PropertyLaziness[o]) > 0))
 			{
 				// For the case of dynamic-update="true", we need to generate the UPDATE SQL
 				propsToUpdate = GetPropertiesToUpdate(dirtyFields, hasDirtyCollection);
@@ -4090,6 +4101,30 @@ namespace NHibernate.Persister.Entity
 		public void AfterInitialize(object entity, bool lazyPropertiesAreUnfetched, ISessionImplementor session)
 		{
 			EntityTuplizer.AfterInitialize(entity, lazyPropertiesAreUnfetched, session);
+		}
+
+		internal ISet<string> GetUninitializedLazyProperties(object entity)
+		{
+			return EntityTuplizer.GetUninitializedLazyProperties(entity);
+		}
+
+		internal ISet<string> GetUninitializedLazyProperties(object[] state)
+		{
+			if (!HasLazyProperties)
+			{
+				return CollectionHelper.EmptySet<string>();
+			}
+
+			var uninitializedProperties = new HashSet<string>();
+			for (var j = 0; j < lazyPropertyNames.Length; j++)
+			{
+				if (state[lazyPropertyNumbers[j]] == LazyPropertyInitializer.UnfetchedProperty)
+				{
+					uninitializedProperties.Add(lazyPropertyNames[j]);
+				}
+			}
+
+			return uninitializedProperties;
 		}
 
 		public virtual bool[] PropertyUpdateability

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -3167,10 +3167,7 @@ namespace NHibernate.Persister.Entity
 			if (entry == null && !IsMutable)
 				throw new InvalidOperationException("Updating immutable entity that is not in session yet!");
 
-			if ((entityMetamodel.IsDynamicUpdate && dirtyFields != null) ||
-				// When having a dirty lazy property and the entity is not yet initialized we have to use a dynamic update for it even if
-				// it is disabled in order to have it updated.
-				(GetUninitializedLazyProperties(obj).Count > 0 && dirtyFields?.Count(o => PropertyLaziness[o]) > 0))
+			if (dirtyFields != null && (entityMetamodel.IsDynamicUpdate || HasDirtyLazyProperties(dirtyFields, obj)))
 			{
 				// For the case of dynamic-update="true", we need to generate the UPDATE SQL
 				propsToUpdate = GetPropertiesToUpdate(dirtyFields, hasDirtyCollection);
@@ -3217,6 +3214,13 @@ namespace NHibernate.Persister.Entity
 					UpdateOrInsert(id, fields, oldFields, j == 0 ? rowId : null, propsToUpdate, j, oldVersion, obj, updateStrings[j], session);
 				}
 			}
+		}
+
+		private bool HasDirtyLazyProperties(int[] dirtyFields, object obj)
+		{
+			// When having a dirty lazy property and the entity is not yet initialized we have to use a dynamic update for
+			// it even if it is disabled in order to have it updated.
+			return GetUninitializedLazyProperties(obj).Count > 0 && dirtyFields.Any(i => PropertyLaziness[i]);
 		}
 
 		public object Insert(object[] fields, object obj, ISessionImplementor session)

--- a/src/NHibernate/Persister/Entity/IEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/IEntityPersister.cs
@@ -1,3 +1,4 @@
+using System;
 using NHibernate.Cache;
 using NHibernate.Cache.Entry;
 using NHibernate.Engine;
@@ -6,6 +7,7 @@ using NHibernate.Metadata;
 using NHibernate.Tuple.Entity;
 using NHibernate.Type;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace NHibernate.Persister.Entity
 {
@@ -618,6 +620,31 @@ namespace NHibernate.Persister.Entity
 				.Warn("Entity persister of {0} type is not supported, returning 1 as a batch size.", persister?.GetType());
 
 			return 1;
+		}
+
+		//6.0 TODO: Merge into IEntityPersister
+		internal static ISet<string> GetUninitializedLazyProperties(this IEntityPersister persister, object entity)
+		{
+			if (persister is AbstractEntityPersister abstractEntityPersister)
+			{
+				return abstractEntityPersister.GetUninitializedLazyProperties(entity);
+			}
+
+			throw new InvalidOperationException($"{persister?.GetType()} does not support GetUninitializedLazyProperties method.");
+		}
+
+		/// <summary>
+		/// Get uninitialized lazy properties from one row of a result set
+		/// </summary>
+		//6.0 TODO: Merge into IEntityPersister
+		public static ISet<string> GetUninitializedLazyProperties(this IEntityPersister persister, object[] state)
+		{
+			if (persister is AbstractEntityPersister abstractEntityPersister)
+			{
+				return abstractEntityPersister.GetUninitializedLazyProperties(state);
+			}
+
+			throw new InvalidOperationException($"{persister?.GetType()} does not support GetUninitializedProperties method.");
 		}
 	}
 }

--- a/src/NHibernate/Proxy/FieldInterceptorProxyBuilder.cs
+++ b/src/NHibernate/Proxy/FieldInterceptorProxyBuilder.cs
@@ -16,8 +16,10 @@ namespace NHibernate.Proxy
 		private static readonly PropertyInfo AccessorTypeFieldInterceptorProperty =
 			FieldInterceptorAccessorType.GetProperty(nameof(IFieldInterceptorAccessor.FieldInterceptor));
 		private static readonly System.Type FieldInterceptorType = typeof(IFieldInterceptor);
+		private static readonly System.Type FieldInterceptorExtensionsType = typeof(FieldInterceptorExtensions);
 		private static readonly MethodInfo FieldInterceptorInterceptMethod = FieldInterceptorType.GetMethod(nameof(IFieldInterceptor.Intercept));
 		private static readonly MethodInfo FieldInterceptorMarkDirtyMethod = FieldInterceptorType.GetMethod(nameof(IFieldInterceptor.MarkDirty));
+		private static readonly MethodInfo FieldInterceptorInterceptExtensionMethod = FieldInterceptorExtensionsType.GetMethod(nameof(FieldInterceptorExtensions.Intercept));
 		private static readonly System.Type AbstractFieldInterceptorType = typeof(AbstractFieldInterceptor);
 		private static readonly FieldInfo AbstractFieldInterceptorInvokeImplementationField =
 			AbstractFieldInterceptorType.GetField(nameof(AbstractFieldInterceptor.InvokeImplementation));
@@ -367,7 +369,7 @@ namespace NHibernate.Proxy
 				if (this.__fieldInterceptor != null)
 				{
 					this.__fieldInterceptor.MarkDirty();
-					this.__fieldInterceptor.Intercept(this, <ReflectHelper.GetPropertyName(setter)>, value);
+					this.__fieldInterceptor.Intercept(this, <ReflectHelper.GetPropertyName(setter)>, value, true);
 				}
 				base.<setter>(value);
 			 */
@@ -387,7 +389,7 @@ namespace NHibernate.Proxy
 			IL.Emit(OpCodes.Ldfld, fieldInterceptorField);
 			IL.Emit(OpCodes.Callvirt, FieldInterceptorMarkDirtyMethod);
 
-			// this.__fieldInterceptor.Intercept(this, <ReflectHelper.GetPropertyName(setter)>, propValue);
+			// this.__fieldInterceptor.Intercept(this, <ReflectHelper.GetPropertyName(setter)>, propValue, true);
 			IL.Emit(OpCodes.Ldarg_0);
 			IL.Emit(OpCodes.Ldfld, fieldInterceptorField);
 			IL.Emit(OpCodes.Ldarg_0);
@@ -396,7 +398,8 @@ namespace NHibernate.Proxy
 			var propertyType = setter.GetParameters()[0].ParameterType;
 			if (propertyType.IsValueType)
 				IL.Emit(OpCodes.Box, propertyType);
-			IL.Emit(OpCodes.Callvirt, FieldInterceptorInterceptMethod);
+			IL.Emit(OpCodes.Ldc_I4_1);
+			IL.EmitCall(OpCodes.Call, FieldInterceptorInterceptExtensionMethod, null);
 			IL.Emit(OpCodes.Pop);
 
 			// end if (this.__fieldInterceptor != null)

--- a/src/NHibernate/Tuple/Entity/AbstractEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/AbstractEntityTuplizer.cs
@@ -8,6 +8,7 @@ using NHibernate.Mapping;
 using NHibernate.Properties;
 using NHibernate.Proxy;
 using NHibernate.Type;
+using NHibernate.Util;
 
 namespace NHibernate.Tuple.Entity
 {
@@ -242,6 +243,11 @@ namespace NHibernate.Tuple.Entity
 			return false;
 		}
 
+		internal virtual ISet<string> GetUninitializedLazyProperties(object entity)
+		{
+			return CollectionHelper.EmptySet<string>();
+		}
+
 		#endregion
 
 		#region ITuplizer Members
@@ -250,14 +256,14 @@ namespace NHibernate.Tuple.Entity
 
 		public virtual object[] GetPropertyValues(object entity)
 		{
-			bool getAll = ShouldGetAllProperties(entity);
+			var uninitializedPropNames = GetUninitializedLazyProperties(entity);
 			int span = entityMetamodel.PropertySpan;
 			object[] result = new object[span];
 
 			for (int j = 0; j < span; j++)
 			{
 				StandardProperty property = entityMetamodel.Properties[j];
-				if (getAll || !property.IsLazy)
+				if (!uninitializedPropNames.Contains(property.Name) || !property.IsLazy)
 				{
 					result[j] = getters[j].Get(entity);
 				}

--- a/src/NHibernate/Tuple/Entity/IEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/IEntityTuplizer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Engine;
+using NHibernate.Util;
 
 namespace NHibernate.Tuple.Entity
 {
@@ -119,7 +120,7 @@ namespace NHibernate.Tuple.Entity
 		bool HasUninitializedLazyProperties(object entity);
 	}
 
-	internal static class EntityPersisterExtensions
+	internal static class EntityTuplizerExtensions
 	{
 		//6.0 TODO: Merge into IEntityTuplizer
 		internal static ISet<string> GetUninitializedLazyProperties(this IEntityTuplizer entityTuplizer, object entity)
@@ -128,8 +129,13 @@ namespace NHibernate.Tuple.Entity
 			{
 				return abstractEntityTuplizer.GetUninitializedLazyProperties(entity);
 			}
-			throw new NotSupportedException("GetUninitializedLazyProperties method is not supported.");
 
+			if (!entityTuplizer.HasUninitializedLazyProperties(entity))
+			{
+				return CollectionHelper.EmptySet<string>();
+			}
+
+			return null; // The called should use all lazy properties as the result
 		}
 	}
 }

--- a/src/NHibernate/Tuple/Entity/IEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/IEntityTuplizer.cs
@@ -135,7 +135,7 @@ namespace NHibernate.Tuple.Entity
 				return CollectionHelper.EmptySet<string>();
 			}
 
-			return null; // The called should use all lazy properties as the result
+			return null; // The caller should use all lazy properties as the result
 		}
 	}
 }

--- a/src/NHibernate/Tuple/Entity/IEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/IEntityTuplizer.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using NHibernate.Engine;
 
 namespace NHibernate.Tuple.Entity
@@ -115,5 +117,19 @@ namespace NHibernate.Tuple.Entity
 		/// <param name="entity">The entity to be check for uninitialized lazy properties. </param>
 		/// <returns> True if uninitialized lazy properties were found; false otherwise. </returns>
 		bool HasUninitializedLazyProperties(object entity);
+	}
+
+	internal static class EntityPersisterExtensions
+	{
+		//6.0 TODO: Merge into IEntityTuplizer
+		internal static ISet<string> GetUninitializedLazyProperties(this IEntityTuplizer entityTuplizer, object entity)
+		{
+			if (entityTuplizer is AbstractEntityTuplizer abstractEntityTuplizer)
+			{
+				return abstractEntityTuplizer.GetUninitializedLazyProperties(entity);
+			}
+			throw new NotSupportedException("GetUninitializedLazyProperties method is not supported.");
+
+		}
 	}
 }

--- a/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
@@ -286,7 +286,12 @@ namespace NHibernate.Tuple.Entity
 			}
 
 			var interceptor = FieldInterceptionHelper.ExtractFieldInterceptor(entity);
-			return interceptor?.GetUninitializedLazyProperties() ?? CollectionHelper.EmptySet<string>();
+			if (interceptor == null)
+			{
+				return CollectionHelper.EmptySet<string>();
+			}
+
+			return interceptor.GetUninitializedLazyProperties() ?? lazyPropertyNames;
 		}
 
 		public override bool IsLifecycleImplementor

--- a/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
@@ -231,9 +231,7 @@ namespace NHibernate.Tuple.Entity
 		{
 			if (IsInstrumented && (EntityMetamodel.HasLazyProperties || EntityMetamodel.HasUnwrapProxyForProperties))
 			{
-				HashSet<string> lazyProps = lazyPropertiesAreUnfetched && EntityMetamodel.HasLazyProperties ? lazyPropertyNames : null;
-				//TODO: if we support multiple fetch groups, we would need
-				//      to clone the set of lazy properties!
+				HashSet<string> lazyProps = lazyPropertiesAreUnfetched && EntityMetamodel.HasLazyProperties ? new HashSet<string>(lazyPropertyNames) : null;
 				FieldInterceptionHelper.InjectFieldInterceptor(entity, EntityName, this.MappedClass ,lazyProps, unwrapProxyPropertyNames, session);
 			}
 		}
@@ -278,6 +276,17 @@ namespace NHibernate.Tuple.Entity
 			{
 				return false;
 			}
+		}
+
+		internal override ISet<string> GetUninitializedLazyProperties(object entity)
+		{
+			if (!EntityMetamodel.HasLazyProperties)
+			{
+				return CollectionHelper.EmptySet<string>();
+			}
+
+			var interceptor = FieldInterceptionHelper.ExtractFieldInterceptor(entity);
+			return interceptor?.GetUninitializedLazyProperties() ?? CollectionHelper.EmptySet<string>();
 		}
 
 		public override bool IsLifecycleImplementor

--- a/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
@@ -291,7 +291,7 @@ namespace NHibernate.Tuple.Entity
 				return CollectionHelper.EmptySet<string>();
 			}
 
-			return interceptor.GetUninitializedLazyProperties() ?? lazyPropertyNames;
+			return interceptor.GetUninitializedFields() ?? lazyPropertyNames;
 		}
 
 		public override bool IsLifecycleImplementor

--- a/src/NHibernate/Util/CollectionHelper.cs
+++ b/src/NHibernate/Util/CollectionHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Iesi.Collections.Generic;
 
 namespace NHibernate.Util
 {
@@ -219,6 +220,8 @@ namespace NHibernate.Util
 		{
 			return EmptyMapClass<TKey, TValue>.Instance;
 		}
+
+		internal static ISet<T> EmptySet<T>() => EmptyReadOnlySet<T>.Instance;
 
 		public static readonly ICollection EmptyCollection = EmptyMap;
 		// Since v5
@@ -460,6 +463,12 @@ namespace NHibernate.Util
 			}
 
 			#endregion
+		}
+
+		[Serializable]
+		private class EmptyReadOnlySet<T>
+		{
+			public static readonly ISet<T> Instance = new ReadOnlySet<T>(new HashSet<T>());
 		}
 
 		/// <summary>


### PR DESCRIPTION
The aim of this PR is to have the ability to update uninitialized lazy properties without triggering their initialization, which is required by #1922 in order to update the fetched lazy properties.

This PR also modifies the behavior for properties mapped as lazy="no-proxy" to not be initialized when set, which solves the issue where a `LazyInitializationException` occurred when setting the property value while the session is disconnected (#1267 first point).