### PR TITLE
Add support for caching fetched relations with linq query provider

### DIFF
--- a/src/AsyncGenerator.yml
+++ b/src/AsyncGenerator.yml
@@ -104,9 +104,6 @@
     - conversion: Ignore
       name: GetEnumerator
       containingTypeName: IFutureEnumerable
-    # 6.0 TODO: Remove QueryCacheResultBuilder from ignore
-    - conversion: Ignore
-      containingTypeName: QueryCacheResultBuilder
     - conversion: ToAsync
       name: ExecuteReader
       containingTypeName: IBatcher

--- a/src/AsyncGenerator.yml
+++ b/src/AsyncGenerator.yml
@@ -104,6 +104,9 @@
     - conversion: Ignore
       name: GetEnumerator
       containingTypeName: IFutureEnumerable
+    # 6.0 TODO: Remove QueryCacheResultBuilder from ignore
+    - conversion: Ignore
+      containingTypeName: QueryCacheResultBuilder
     - conversion: ToAsync
       name: ExecuteReader
       containingTypeName: IBatcher

--- a/src/NHibernate.Test/Async/Linq/QueryCacheableTests.cs
+++ b/src/NHibernate.Test/Async/Linq/QueryCacheableTests.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using NHibernate.Cfg;
+using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Linq;
 using NUnit.Framework;
 
@@ -280,6 +281,141 @@ namespace NHibernate.Test.Linq
 			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(5), "Unexpected execution count");
 			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(5), "Unexpected cache put count");
 			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1), "Unexpected cache hit count");
+		}
+
+		[Test]
+		public async Task FetchIsCachableAsync()
+		{
+			Sfi.Statistics.Clear();
+			await (Sfi.EvictQueriesAsync());
+
+			Order order;
+
+			using (var s = Sfi.OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				order = (await (s.Query<Order>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .Fetch(x => x.Customer)
+				         .FetchMany(x => x.OrderLines)
+				         .ThenFetch(x => x.Product)
+				         .ThenFetchMany(x => x.OrderLines)
+				         .Where(x => x.OrderId == 10248)
+				         .ToListAsync()))
+				         .First();
+
+				await (t.CommitAsync());
+			}
+
+			AssertFetchedOrder(order);
+
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(1), "Unexpected cache miss count");
+
+			Sfi.Statistics.Clear();
+
+			using (var s = Sfi.OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				order = (await (s.Query<Order>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .Fetch(x => x.Customer)
+				         .FetchMany(x => x.OrderLines)
+				         .ThenFetch(x => x.Product)
+				         .ThenFetchMany(x => x.OrderLines)
+				         .Where(x => x.OrderId == 10248)
+				         .ToListAsync()))
+				         .First();
+				await (t.CommitAsync());
+			}
+
+			AssertFetchedOrder(order);
+
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1), "Unexpected cache hit count");
+
+		}
+
+		[Test]
+		public async Task FutureFetchIsCachableAsync()
+		{
+			Sfi.Statistics.Clear();
+			await (Sfi.EvictQueriesAsync());
+			var multiQueries = Sfi.ConnectionProvider.Driver.SupportsMultipleQueries;
+
+			Order order;
+
+			using (var s = Sfi.OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Query<Order>()
+				 .WithOptions(o => o.SetCacheable(true))
+				 .Fetch(x => x.Customer)
+				 .Where(x => x.OrderId == 10248)
+				 .ToFuture();
+
+				order = s.Query<Order>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .FetchMany(x => x.OrderLines)
+				         .ThenFetch(x => x.Product)
+				         .ThenFetchMany(x => x.OrderLines)
+				         .Where(x => x.OrderId == 10248)
+				         .ToFuture()
+				         .ToList()
+				         .First();
+
+				await (t.CommitAsync());
+			}
+
+			AssertFetchedOrder(order);
+
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(multiQueries ? 1 : 2), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(2), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(2), "Unexpected cache miss count");
+
+			Sfi.Statistics.Clear();
+
+			using (var s = Sfi.OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Query<Order>()
+				 .WithOptions(o => o.SetCacheable(true))
+				 .Fetch(x => x.Customer)
+				 .Where(x => x.OrderId == 10248)
+				 .ToFuture();
+
+				order = s.Query<Order>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .FetchMany(x => x.OrderLines)
+				         .ThenFetch(x => x.Product)
+				         .ThenFetchMany(x => x.OrderLines)
+				         .Where(x => x.OrderId == 10248)
+				         .ToFuture()
+				         .ToList()
+				         .First();
+
+				await (t.CommitAsync());
+			}
+
+			AssertFetchedOrder(order);
+
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(2), "Unexpected cache hit count");
+		}
+
+		private static void AssertFetchedOrder(Order order)
+		{
+			Assert.That(NHibernateUtil.IsInitialized(order.Customer), Is.True, "Expected the fetched Customer to be initialized");
+			Assert.That(NHibernateUtil.IsInitialized(order.OrderLines), Is.True, "Expected the fetched  OrderLines to be initialized");
+			Assert.That(order.OrderLines, Has.Count.EqualTo(3), "Expected the fetched OrderLines to have 3 items");
+			var orderLine = order.OrderLines.First();
+			Assert.That(NHibernateUtil.IsInitialized(orderLine.Product), Is.True, "Expected the fetched Product to be initialized");
+			Assert.That(NHibernateUtil.IsInitialized(orderLine.Product.OrderLines), Is.True, "Expected the fetched OrderLines to be initialized");
 		}
 	}
 }

--- a/src/NHibernate/Async/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Async/Cache/StandardQueryCache.cs
@@ -296,39 +296,27 @@ namespace NHibernate.Cache
 					var returnType = returnTypes[0];
 
 					// Skip first element, it is the timestamp
-					var rows = new List<object>(cacheable.Count - 1);
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						rows.Add(cacheable[i]);
+						await (returnType.BeforeAssembleAsync(cacheable[i], session, cancellationToken)).ConfigureAwait(false);
 					}
 
-					foreach (var row in rows)
+					for (var i = 1; i < cacheable.Count; i++)
 					{
-						await (returnType.BeforeAssembleAsync(row, session, cancellationToken)).ConfigureAwait(false);
-					}
-
-					foreach (var row in rows)
-					{
-						result.Add(await (returnType.AssembleAsync(row, session, null, cancellationToken)).ConfigureAwait(false));
+						result.Add(await (returnType.AssembleAsync(cacheable[i], session, null, cancellationToken)).ConfigureAwait(false));
 					}
 				}
 				else
 				{
 					// Skip first element, it is the timestamp
-					var rows = new List<object[]>(cacheable.Count - 1);
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						rows.Add((object[]) cacheable[i]);
+						await (TypeHelper.BeforeAssembleAsync((object[]) cacheable[i], returnTypes, session, cancellationToken)).ConfigureAwait(false);
 					}
 
-					foreach (var row in rows)
+					for (var i = 1; i < cacheable.Count; i++)
 					{
-						await (TypeHelper.BeforeAssembleAsync(row, returnTypes, session, cancellationToken)).ConfigureAwait(false);
-					}
-
-					foreach (var row in rows)
-					{
-						result.Add(await (TypeHelper.AssembleAsync(row, returnTypes, session, null, cancellationToken)).ConfigureAwait(false));
+						result.Add(await (TypeHelper.AssembleAsync((object[]) cacheable[i], returnTypes, session, null, cancellationToken)).ConfigureAwait(false));
 					}
 				}
 

--- a/src/NHibernate/Async/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Async/Cache/StandardQueryCache.cs
@@ -338,7 +338,7 @@ namespace NHibernate.Cache
 					// have to initialize them.
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						await (TypeHelper.InitializeCollectionsAsync((object[]) cacheable[i], collectionTypes, session, cancellationToken)).ConfigureAwait(false);
+						await (TypeHelper.InitializeCollectionsAsync((object[]) cacheable[i], (object[]) result[i - 1], collectionTypes, session, cancellationToken)).ConfigureAwait(false);
 					}
 				}
 

--- a/src/NHibernate/Async/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Async/Cache/StandardQueryCache.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cfg;
 using NHibernate.Engine;
+using NHibernate.Persister.Collection;
 using NHibernate.Type;
 using NHibernate.Util;
 
@@ -308,13 +309,13 @@ namespace NHibernate.Cache
 				}
 				else
 				{
-					var collectionTypes = new Dictionary<int, CollectionType>();
+					var collectionIndexes = new Dictionary<int, ICollectionPersister>();
 					var nonCollectionTypeIndexes = new List<int>();
 					for (var i = 0; i < returnTypes.Length; i++)
 					{
 						if (returnTypes[i] is CollectionType collectionType)
 						{
-							collectionTypes.Add(i, collectionType);
+							collectionIndexes.Add(i, session.Factory.GetCollectionPersister(collectionType.Role));
 						}
 						else
 						{
@@ -336,9 +337,12 @@ namespace NHibernate.Cache
 					// Initialization of the fetched collection must be done at the end in order to be able to batch fetch them
 					// from the cache or database. The collections were already created in the previous for statement so we only
 					// have to initialize them.
-					for (var i = 1; i < cacheable.Count; i++)
+					if (collectionIndexes.Count > 0)
 					{
-						await (TypeHelper.InitializeCollectionsAsync((object[]) cacheable[i], (object[]) result[i - 1], collectionTypes, session, cancellationToken)).ConfigureAwait(false);
+						for (var i = 1; i < cacheable.Count; i++)
+						{
+							await (TypeHelper.InitializeCollectionsAsync((object[]) cacheable[i], (object[]) result[i - 1], collectionIndexes, session, cancellationToken)).ConfigureAwait(false);
+						}
 					}
 				}
 

--- a/src/NHibernate/Async/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Async/Cache/StandardQueryCache.cs
@@ -308,6 +308,20 @@ namespace NHibernate.Cache
 				}
 				else
 				{
+					var collectionTypes = new Dictionary<int, CollectionType>();
+					var nonCollectionTypeIndexes = new List<int>();
+					for (var i = 0; i < returnTypes.Length; i++)
+					{
+						if (returnTypes[i] is CollectionType collectionType)
+						{
+							collectionTypes.Add(i, collectionType);
+						}
+						else
+						{
+							nonCollectionTypeIndexes.Add(i);
+						}
+					}
+
 					// Skip first element, it is the timestamp
 					for (var i = 1; i < cacheable.Count; i++)
 					{
@@ -316,7 +330,15 @@ namespace NHibernate.Cache
 
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						result.Add(await (TypeHelper.AssembleAsync((object[]) cacheable[i], returnTypes, session, null, cancellationToken)).ConfigureAwait(false));
+						result.Add(await (TypeHelper.AssembleAsync((object[]) cacheable[i], returnTypes, nonCollectionTypeIndexes, session, cancellationToken)).ConfigureAwait(false));
+					}
+
+					// Initialization of the fetched collection must be done at the end in order to be able to batch fetch them
+					// from the cache or database. The collections were already created in the previous for statement so we only
+					// have to initialize them.
+					for (var i = 1; i < cacheable.Count; i++)
+					{
+						await (TypeHelper.InitializeCollectionsAsync((object[]) cacheable[i], collectionTypes, session, cancellationToken)).ConfigureAwait(false);
 					}
 				}
 

--- a/src/NHibernate/Async/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Async/Impl/MultiCriteriaImpl.cs
@@ -185,8 +185,8 @@ namespace NHibernate.Impl
 
 							object o =
 								await (loader.GetRowFromResultSetAsync(reader, session, queryParameters, loader.GetLockModes(queryParameters.LockModes),
-																					 null, hydratedObjects[i], keys, true,
-																					(persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
+								                           null, hydratedObjects[i], keys, true, null, null,
+								                           (persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
 							if (createSubselects[i])
 							{
 								subselectResultKeys[i].Add(keys);

--- a/src/NHibernate/Async/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/MultiQueryImpl.cs
@@ -143,7 +143,7 @@ namespace NHibernate.Impl
 
 							rowCount++;
 							object result = await (translator.Loader.GetRowFromResultSetAsync(
-								reader, session, parameter, lockModeArray, optionalObjectKey, hydratedObjects[i], keys, true,
+								reader, session, parameter, lockModeArray, optionalObjectKey, hydratedObjects[i], keys, true, null, null,
 								(persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
 							tempResults.Add(result);
 

--- a/src/NHibernate/Async/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Async/Loader/Hql/QueryLoader.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.Event;
 using NHibernate.Hql.Ast.ANTLR;

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -56,11 +56,13 @@ namespace NHibernate.Loader
 			{
 				return Task.FromCanceled<IList>(cancellationToken);
 			}
-			return DoQueryAndInitializeNonLazyCollectionsAsync(session, queryParameters, returnProxies, null, cancellationToken);
+			return DoQueryAndInitializeNonLazyCollectionsAsync(session, queryParameters, returnProxies, null, null, cancellationToken);
 		}
 
 
-		private async Task<IList> DoQueryAndInitializeNonLazyCollectionsAsync(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, IResultTransformer forcedResultTransformer, CancellationToken cancellationToken)
+		private async Task<IList> DoQueryAndInitializeNonLazyCollectionsAsync(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, 
+		                                                     IResultTransformer forcedResultTransformer,
+		                                                     QueryCacheResultBuilder queryCacheResultBuilder, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			IPersistenceContext persistenceContext = session.PersistenceContext;
@@ -77,7 +79,7 @@ namespace NHibernate.Loader
 			{
 				try
 				{
-					result = await (DoQueryAsync(session, queryParameters, returnProxies, forcedResultTransformer, cancellationToken)).ConfigureAwait(false);
+					result = await (DoQueryAsync(session, queryParameters, returnProxies, forcedResultTransformer, queryCacheResultBuilder, cancellationToken)).ConfigureAwait(false);
 				}
 				finally
 				{
@@ -139,6 +141,8 @@ namespace NHibernate.Loader
 			return result;
 		}
 
+		// Since 5.3
+		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
 		internal Task<object> GetRowFromResultSetAsync(DbDataReader resultSet, ISessionImplementor session,
 											QueryParameters queryParameters, LockMode[] lockModeArray,
 											EntityKey optionalObjectKey, IList hydratedObjects, EntityKey[] keys,
@@ -149,14 +153,15 @@ namespace NHibernate.Loader
 				return Task.FromCanceled<object>(cancellationToken);
 			}
 			return GetRowFromResultSetAsync(resultSet, session, queryParameters, lockModeArray, optionalObjectKey, hydratedObjects,
-									   keys, returnProxies, null, cacheBatchingHandler, cancellationToken);
+									   keys, returnProxies, null, null, cacheBatchingHandler, cancellationToken);
 		}
 
 		internal async Task<object> GetRowFromResultSetAsync(DbDataReader resultSet, ISessionImplementor session,
 											QueryParameters queryParameters, LockMode[] lockModeArray,
 											EntityKey optionalObjectKey, IList hydratedObjects, EntityKey[] keys,
 											bool returnProxies, IResultTransformer forcedResultTransformer,
-											Action<IEntityPersister, CachePutData> cacheBatchingHandler, CancellationToken cancellationToken)
+											QueryCacheResultBuilder queryCacheResultBuilder,
+		                                    Action<IEntityPersister, CachePutData> cacheBatchingHandler, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			ILoadable[] persisters = EntityPersisters;
@@ -176,7 +181,7 @@ namespace NHibernate.Loader
 				await (GetRowAsync(resultSet, persisters, keys, queryParameters.OptionalObject, optionalObjectKey, lockModeArray,
 					   hydratedObjects, session, !returnProxies, cacheBatchingHandler, cancellationToken)).ConfigureAwait(false);
 
-			await (ReadCollectionElementsAsync(row, resultSet, session, cancellationToken)).ConfigureAwait(false);
+			var collectionKeys = await (ReadCollectionElementsAsync(row, resultSet, session, cancellationToken)).ConfigureAwait(false);
 
 			if (returnProxies)
 			{
@@ -205,16 +210,20 @@ namespace NHibernate.Loader
 				}
 			}
 
-			return forcedResultTransformer == null
+			var result = forcedResultTransformer == null
 					   ? await (GetResultColumnOrRowAsync(row, queryParameters.ResultTransformer, resultSet, session, cancellationToken)).ConfigureAwait(false)
 					   : forcedResultTransformer.TransformTuple(await (GetResultRowAsync(row, resultSet, session, cancellationToken)).ConfigureAwait(false),
 																ResultRowAliases);
+
+			queryCacheResultBuilder?.AddRow(result, row, collectionKeys);
+
+			return result;
 		}
 
 		/// <summary>
 		/// Read any collection elements contained in a single row of the result set
 		/// </summary>
-		private async Task ReadCollectionElementsAsync(object[] row, DbDataReader resultSet, ISessionImplementor session, CancellationToken cancellationToken)
+		private async Task<object[]> ReadCollectionElementsAsync(object[] row, DbDataReader resultSet, ISessionImplementor session, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			//TODO: make this handle multiple collection roles!
@@ -223,6 +232,7 @@ namespace NHibernate.Loader
 
 			if (collectionPersisters != null)
 			{
+				var result = new object[collectionPersisters.Length];
 				ICollectionAliases[] descriptors = CollectionAliases;
 				int[] collectionOwners = CollectionOwners;
 
@@ -249,12 +259,17 @@ namespace NHibernate.Loader
 						//keys[collectionOwner].getIdentifier()
 					}
 
-					await (ReadCollectionElementAsync(owner, key, collectionPersister, descriptors[i], resultSet, session, cancellationToken)).ConfigureAwait(false);
+					result[i] = await (ReadCollectionElementAsync(owner, key, collectionPersister, descriptors[i], resultSet, session, cancellationToken)).ConfigureAwait(false);
 				}
+
+				return result;
 			}
+
+			return null;
 		}
 
-		private async Task<IList> DoQueryAsync(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, IResultTransformer forcedResultTransformer, CancellationToken cancellationToken)
+		private async Task<IList> DoQueryAsync(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, 
+		                      IResultTransformer forcedResultTransformer, QueryCacheResultBuilder queryCacheResultBuilder, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			using (session.BeginProcess())
@@ -302,8 +317,8 @@ namespace NHibernate.Loader
 
 						object result = await (GetRowFromResultSetAsync(rs, session, queryParameters, lockModeArray, optionalObjectKey,
 															hydratedObjects,
-															keys, returnProxies, forcedResultTransformer,
-															(persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
+															keys, returnProxies, forcedResultTransformer, queryCacheResultBuilder,
+						                                    (persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
 						results.Add(result);
 
 						if (createSubselects)
@@ -476,7 +491,7 @@ namespace NHibernate.Loader
 		/// <summary>
 		/// Read one collection element from the current row of the ADO.NET result set
 		/// </summary>
-		private static async Task ReadCollectionElementAsync(object optionalOwner, object optionalKey, ICollectionPersister persister,
+		private static async Task<object> ReadCollectionElementAsync(object optionalOwner, object optionalKey, ICollectionPersister persister,
 												  ICollectionAliases descriptor, DbDataReader rs, ISessionImplementor session, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -513,6 +528,8 @@ namespace NHibernate.Loader
 				{
 					await (rowCollection.ReadFromAsync(rs, persister, descriptor, owner, cancellationToken)).ConfigureAwait(false);
 				}
+
+				return collectionRowKey;
 			}
 			else if (optionalKey != null)
 			{
@@ -526,9 +543,11 @@ namespace NHibernate.Loader
 				}
 				persistenceContext.LoadContexts.GetCollectionLoadContext(rs).GetLoadingCollection(persister, optionalKey);
 				// handle empty collection
+				return optionalKey;
 			}
 
 			// else no collection element, but also no owner
+			return null;
 		}
 
 		/// <summary>
@@ -1361,13 +1380,18 @@ namespace NHibernate.Loader
 			IQueryCache queryCache = _factory.GetQueryCache(queryParameters.CacheRegion);
 
 			QueryKey key = GenerateQueryKey(session, queryParameters);
+			var queryCacheBuilder = new QueryCacheResultBuilder(this, session);
 
 			IList result = await (GetResultFromQueryCacheAsync(session, queryParameters, querySpaces, queryCache, key, cancellationToken)).ConfigureAwait(false);
 
 			if (result == null)
 			{
-				result = await (DoListAsync(session, queryParameters, key.ResultTransformer, cancellationToken)).ConfigureAwait(false);
-				await (PutResultInQueryCacheAsync(session, queryParameters, queryCache, key, result, cancellationToken)).ConfigureAwait(false);
+				result = await (DoListAsync(session, queryParameters, key.ResultTransformer, queryCacheBuilder, cancellationToken)).ConfigureAwait(false);
+				await (PutResultInQueryCacheAsync(session, queryParameters, queryCache, key, queryCacheBuilder.Result, cancellationToken)).ConfigureAwait(false);
+			}
+			else
+			{
+				result = queryCacheBuilder.GetResultList(result);
 			}
 
 			result = TransformCacheableResults(queryParameters, key.ResultTransformer, result);
@@ -1387,7 +1411,7 @@ namespace NHibernate.Loader
 				key, queryParameters, 
 				queryParameters.HasAutoDiscoverScalarTypes
 					? null
-					: key.ResultTransformer.GetCachedResultTypes(ResultTypes),
+					: key.ResultTransformer.GetCachedResultTypes(CacheTypes),
 				querySpaces, session, cancellationToken)).ConfigureAwait(false);
 
 			if (_factory.Statistics.IsStatisticsEnabled)
@@ -1414,7 +1438,7 @@ namespace NHibernate.Loader
 
 			var put = await (queryCache.PutAsync(
 				key, queryParameters,
-				key.ResultTransformer.GetCachedResultTypes(ResultTypes),
+				key.ResultTransformer.GetCachedResultTypes(CacheTypes),
 				result, session, cancellationToken)).ConfigureAwait(false);
 
 			if (put && _factory.Statistics.IsStatisticsEnabled)
@@ -1436,10 +1460,22 @@ namespace NHibernate.Loader
 			{
 				return Task.FromCanceled<IList>(cancellationToken);
 			}
-			return DoListAsync(session, queryParameters, null, cancellationToken);
+			return DoListAsync(session, queryParameters, null, null, cancellationToken);
 		}
 
-		protected async Task<IList> DoListAsync(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer, CancellationToken cancellationToken)
+		// Since 5.3
+		[Obsolete("Use the overload with queryCacheResultBuilder parameter")]
+		protected Task<IList> DoListAsync(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer, CancellationToken cancellationToken)
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromCanceled<IList>(cancellationToken);
+			}
+			return DoListAsync(session, queryParameters, forcedResultTransformer, null, cancellationToken);
+		}
+
+		protected async Task<IList> DoListAsync(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer,
+		                       QueryCacheResultBuilder queryCacheResultBuilder, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			bool statsEnabled = Factory.Statistics.IsStatisticsEnabled;
@@ -1452,7 +1488,7 @@ namespace NHibernate.Loader
 			IList result;
 			try
 			{
-				result = await (DoQueryAndInitializeNonLazyCollectionsAsync(session, queryParameters, true, forcedResultTransformer, cancellationToken)).ConfigureAwait(false);
+				result = await (DoQueryAndInitializeNonLazyCollectionsAsync(session, queryParameters, true, forcedResultTransformer, queryCacheResultBuilder, cancellationToken)).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException) { throw; }
 			catch (HibernateException)

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -121,7 +121,8 @@ namespace NHibernate.Loader
 			{
 				result =
 					await (GetRowFromResultSetAsync(resultSet, session, queryParameters, GetLockModes(queryParameters.LockModes), null,
-										hydratedObjects, new EntityKey[entitySpan], returnProxies, (persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
+					                    hydratedObjects, new EntityKey[entitySpan], returnProxies, null, null,
+					                    (persister, data) => cacheBatcher.AddToBatch(persister, data), cancellationToken)).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException) { throw; }
 			catch (HibernateException)
@@ -139,21 +140,6 @@ namespace NHibernate.Loader
 			await (cacheBatcher.ExecuteBatchAsync(cancellationToken)).ConfigureAwait(false);
 			await (session.PersistenceContext.InitializeNonLazyCollectionsAsync(cancellationToken)).ConfigureAwait(false);
 			return result;
-		}
-
-		// Since 5.3
-		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
-		internal Task<object> GetRowFromResultSetAsync(DbDataReader resultSet, ISessionImplementor session,
-											QueryParameters queryParameters, LockMode[] lockModeArray,
-											EntityKey optionalObjectKey, IList hydratedObjects, EntityKey[] keys,
-											bool returnProxies, Action<IEntityPersister, CachePutData> cacheBatchingHandler, CancellationToken cancellationToken)
-		{
-			if (cancellationToken.IsCancellationRequested)
-			{
-				return Task.FromCanceled<object>(cancellationToken);
-			}
-			return GetRowFromResultSetAsync(resultSet, session, queryParameters, lockModeArray, optionalObjectKey, hydratedObjects,
-									   keys, returnProxies, null, null, cacheBatchingHandler, cancellationToken);
 		}
 
 		internal async Task<object> GetRowFromResultSetAsync(DbDataReader resultSet, ISessionImplementor session,

--- a/src/NHibernate/Async/Multi/QueryBatch.cs
+++ b/src/NHibernate/Async/Multi/QueryBatch.cs
@@ -184,9 +184,14 @@ namespace NHibernate.Multi
 					resultSetsCommand.Sql);
 			}
 
-			if (statsEnabled)
+			if (!statsEnabled)
 			{
-				stopWatch.Stop();
+				return;
+			}
+
+			stopWatch.Stop();
+			if (resultSetsCommand.HasQueries)
+			{
 				Session.Factory.StatisticsImplementor.QueryExecuted(
 					resultSetsCommand.Sql.ToString(),
 					rowCount,
@@ -214,7 +219,7 @@ namespace NHibernate.Multi
 					parameters[i] = queryInfo.Parameters;
 					returnTypes[i] = queryInfo.Parameters.HasAutoDiscoverScalarTypes
 						? null
-						: queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.ResultTypes);
+						: queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.GetCacheTypes());
 					spaces[i] = queryInfo.QuerySpaces;
 				}
 
@@ -222,11 +227,12 @@ namespace NHibernate.Multi
 
 				for (var i = 0; i < queryInfos.Length; i++)
 				{
-					queryInfos[i].SetCachedResult(results[i]);
+					var queryInfo = queryInfos[i];
+					queryInfo.SetCachedResult(results[i]);
 
 					if (statisticsEnabled)
 					{
-						var queryIdentifier = queryInfos[i].QueryIdentifier;
+						var queryIdentifier = queryInfo.QueryIdentifier;
 						if (results[i] == null)
 						{
 							Session.Factory.StatisticsImplementor.QueryCacheMiss(queryIdentifier, cache.RegionName);
@@ -258,7 +264,7 @@ namespace NHibernate.Multi
 					var queryInfo = queryInfos[i];
 					keys[i] = queryInfo.CacheKey;
 					parameters[i] = queryInfo.Parameters;
-					returnTypes[i] = queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.ResultTypes);
+					returnTypes[i] = queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.GetCacheTypes());
 					results[i] = queryInfo.ResultToCache;
 				}
 

--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -75,6 +75,7 @@ namespace NHibernate.Multi
 					var lockModeArray = loader.GetLockModes(queryParameters.LockModes);
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
+					var queryCacheBuilder = new QueryCacheResultBuilder(loader, Session);
 					var cacheBatcher = queryInfo.CacheBatcher;
 					var ownCacheBatcher = cacheBatcher == null;
 					if (ownCacheBatcher)
@@ -95,6 +96,7 @@ namespace NHibernate.Multi
 								keys,
 								true,
 								forcedResultTransformer,
+								queryCacheBuilder,
 								(persister, data) => cacheBatcher.AddToBatch(persister, data)
 , cancellationToken							)).ConfigureAwait(false);
 						if (loader.IsSubselectLoadingEnabled)
@@ -108,7 +110,7 @@ namespace NHibernate.Multi
 
 					queryInfo.Result = tmpResults;
 					if (queryInfo.CanPutToCache)
-						queryInfo.ResultToCache = tmpResults;
+						queryInfo.ResultToCache = queryCacheBuilder.Result;
 
 					if (ownCacheBatcher)
 						await (cacheBatcher.ExecuteBatchAsync(cancellationToken)).ConfigureAwait(false);

--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -75,7 +75,7 @@ namespace NHibernate.Multi
 					var lockModeArray = loader.GetLockModes(queryParameters.LockModes);
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
-					var queryCacheBuilder = new QueryCacheResultBuilder(loader, Session);
+					var queryCacheBuilder = new QueryCacheResultBuilder(loader);
 					var cacheBatcher = queryInfo.CacheBatcher;
 					var ownCacheBatcher = cacheBatcher == null;
 					if (ownCacheBatcher)

--- a/src/NHibernate/Cache/QueryCacheResultBuilder.cs
+++ b/src/NHibernate/Cache/QueryCacheResultBuilder.cs
@@ -27,20 +27,19 @@ namespace NHibernate.Cache
 			_resultTypes = loader.ResultTypes;
 			_cacheTypes = loader.CacheTypes;
 
-			if (loader.EntityFetches == null)
+			if (loader.EntityFetches != null)
 			{
-				return;
-			}
-
-			for (var i = 0; i < loader.EntityFetches.Length; i++)
-			{
-				if (loader.EntityFetches[i])
+				for (var i = 0; i < loader.EntityFetches.Length; i++)
 				{
-					_entityFetchIndexes.Add(i);
+					if (loader.EntityFetches[i])
+					{
+						_entityFetchIndexes.Add(i);
+					}
 				}
+
+				_hasFetches = _entityFetchIndexes.Count > 0;
 			}
 
-			_hasFetches = _entityFetchIndexes.Count > 0;
 			if (loader.CollectionFetches == null)
 			{
 				return;

--- a/src/NHibernate/Cache/QueryCacheResultBuilder.cs
+++ b/src/NHibernate/Cache/QueryCacheResultBuilder.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NHibernate.Engine;
+using NHibernate.Persister.Collection;
+using NHibernate.Type;
+
+namespace NHibernate.Cache
+{
+	/// <summary>
+	/// A builder that builds a list from a query that can be passed to <see cref="IBatchableQueryCache"/>.
+	/// </summary>
+	public sealed class QueryCacheResultBuilder
+	{
+		private readonly IType[] _resultTypes;
+		private readonly IType[] _cacheTypes;
+		private readonly ICollectionPersister[] _collectionPersisters;
+		private readonly List<int> _entityFetchIndexes = new List<int>();
+		private readonly List<int> _collectionFetchIndexes = new List<int>();
+		private readonly bool _hasFetches;
+		private readonly bool _hasCollectionFetches;
+		private readonly ISessionImplementor _session;
+
+		internal QueryCacheResultBuilder(Loader.Loader loader, ISessionImplementor session)
+		{
+			_resultTypes = loader.ResultTypes;
+			_cacheTypes = loader.CacheTypes;
+			_collectionPersisters = loader.GetCollectionPersisters();
+			_session = session;
+
+			if (loader.EntityFetches == null)
+			{
+				return;
+			}
+
+			for (var i = 0; i < loader.EntityFetches.Length; i++)
+			{
+				if (loader.EntityFetches[i])
+				{
+					_entityFetchIndexes.Add(i);
+				}
+			}
+
+			_hasFetches = _entityFetchIndexes.Count > 0;
+			if (loader.CollectionFetches == null)
+			{
+				return;
+			}
+
+			for (var i = 0; i < loader.CollectionFetches.Length; i++)
+			{
+				if (loader.CollectionFetches[i])
+				{
+					_collectionFetchIndexes.Add(i);
+				}
+			}
+
+			_hasCollectionFetches = _collectionFetchIndexes.Count > 0;
+		}
+
+		internal IList Result { get; } = new List<object>();
+
+		internal void AddRow(object result, object[] entities, object[] collectionKeys)
+		{
+			if (!_hasFetches)
+			{
+				Result.Add(result);
+				return;
+			}
+
+			var row = new object[_cacheTypes.Length];
+			if (_resultTypes.Length == 1)
+			{
+				row[0] = result;
+			}
+			else
+			{
+				Array.Copy((object[]) result, 0, row, 0, _resultTypes.Length);
+			}
+
+			var i = _resultTypes.Length;
+			foreach (var index in _entityFetchIndexes)
+			{
+				row[i++] = entities[index];
+			}
+
+			foreach (var index in _collectionFetchIndexes)
+			{
+				row[i++] = collectionKeys[index];
+			}
+
+			Result.Add(row);
+		}
+
+		internal IList GetResultList(IList cacheList)
+		{
+			if (!_hasFetches)
+			{
+				return cacheList;
+			}
+
+			var result = new List<object>();
+
+			foreach (object[] cacheRow in cacheList)
+			{
+				if (_resultTypes.Length == 1)
+				{
+					result.Add(cacheRow[0]);
+				}
+				else
+				{
+					var row = new object[_resultTypes.Length];
+					Array.Copy(cacheRow, 0, row, 0, _resultTypes.Length);
+					result.Add(row);
+				}
+
+				if (!_hasCollectionFetches)
+				{
+					continue;
+				}
+
+				var i = _cacheTypes.Length - _collectionFetchIndexes.Count;
+				foreach (var index in _collectionFetchIndexes)
+				{
+					var persister = _collectionPersisters[index];
+					var key = cacheRow[i];
+					var collection = _session.PersistenceContext.GetCollection(new CollectionKey(persister, key));
+					collection.ForceInitialization();
+					i++;
+				}
+			}
+
+			return result;
+		}
+	}
+}

--- a/src/NHibernate/Cache/QueryCacheResultBuilder.cs
+++ b/src/NHibernate/Cache/QueryCacheResultBuilder.cs
@@ -53,6 +53,8 @@ namespace NHibernate.Cache
 					_collectionFetchIndexes.Add(i);
 				}
 			}
+
+			_hasFetches = _hasFetches || _collectionFetchIndexes.Count > 0;
 		}
 
 		internal IList Result { get; } = new List<object>();

--- a/src/NHibernate/Cache/QueryCacheResultBuilder.cs
+++ b/src/NHibernate/Cache/QueryCacheResultBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NHibernate.Collection;
 using NHibernate.Engine;
 using NHibernate.Persister.Collection;
 using NHibernate.Type;
@@ -17,19 +18,14 @@ namespace NHibernate.Cache
 	{
 		private readonly IType[] _resultTypes;
 		private readonly IType[] _cacheTypes;
-		private readonly ICollectionPersister[] _collectionPersisters;
 		private readonly List<int> _entityFetchIndexes = new List<int>();
 		private readonly List<int> _collectionFetchIndexes = new List<int>();
 		private readonly bool _hasFetches;
-		private readonly bool _hasCollectionFetches;
-		private readonly ISessionImplementor _session;
 
-		internal QueryCacheResultBuilder(Loader.Loader loader, ISessionImplementor session)
+		internal QueryCacheResultBuilder(Loader.Loader loader)
 		{
 			_resultTypes = loader.ResultTypes;
 			_cacheTypes = loader.CacheTypes;
-			_collectionPersisters = loader.GetCollectionPersisters();
-			_session = session;
 
 			if (loader.EntityFetches == null)
 			{
@@ -57,13 +53,11 @@ namespace NHibernate.Cache
 					_collectionFetchIndexes.Add(i);
 				}
 			}
-
-			_hasCollectionFetches = _collectionFetchIndexes.Count > 0;
 		}
 
 		internal IList Result { get; } = new List<object>();
 
-		internal void AddRow(object result, object[] entities, object[] collectionKeys)
+		internal void AddRow(object result, object[] entities, IPersistentCollection[] collections)
 		{
 			if (!_hasFetches)
 			{
@@ -89,7 +83,7 @@ namespace NHibernate.Cache
 
 			foreach (var index in _collectionFetchIndexes)
 			{
-				row[i++] = collectionKeys[index];
+				row[i++] = collections[index];
 			}
 
 			Result.Add(row);
@@ -115,21 +109,6 @@ namespace NHibernate.Cache
 					var row = new object[_resultTypes.Length];
 					Array.Copy(cacheRow, 0, row, 0, _resultTypes.Length);
 					result.Add(row);
-				}
-
-				if (!_hasCollectionFetches)
-				{
-					continue;
-				}
-
-				var i = _cacheTypes.Length - _collectionFetchIndexes.Count;
-				foreach (var index in _collectionFetchIndexes)
-				{
-					var persister = _collectionPersisters[index];
-					var key = cacheRow[i];
-					var collection = _session.PersistenceContext.GetCollection(new CollectionKey(persister, key));
-					collection.ForceInitialization();
-					i++;
 				}
 			}
 

--- a/src/NHibernate/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Cache/StandardQueryCache.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cfg;
 using NHibernate.Engine;
+using NHibernate.Persister.Collection;
 using NHibernate.Type;
 using NHibernate.Util;
 
@@ -342,13 +343,13 @@ namespace NHibernate.Cache
 				}
 				else
 				{
-					var collectionTypes = new Dictionary<int, CollectionType>();
+					var collectionIndexes = new Dictionary<int, ICollectionPersister>();
 					var nonCollectionTypeIndexes = new List<int>();
 					for (var i = 0; i < returnTypes.Length; i++)
 					{
 						if (returnTypes[i] is CollectionType collectionType)
 						{
-							collectionTypes.Add(i, collectionType);
+							collectionIndexes.Add(i, session.Factory.GetCollectionPersister(collectionType.Role));
 						}
 						else
 						{
@@ -370,9 +371,12 @@ namespace NHibernate.Cache
 					// Initialization of the fetched collection must be done at the end in order to be able to batch fetch them
 					// from the cache or database. The collections were already created in the previous for statement so we only
 					// have to initialize them.
-					for (var i = 1; i < cacheable.Count; i++)
+					if (collectionIndexes.Count > 0)
 					{
-						TypeHelper.InitializeCollections((object[]) cacheable[i], (object[]) result[i - 1], collectionTypes, session);
+						for (var i = 1; i < cacheable.Count; i++)
+						{
+							TypeHelper.InitializeCollections((object[]) cacheable[i], (object[]) result[i - 1], collectionIndexes, session);
+						}
 					}
 				}
 

--- a/src/NHibernate/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Cache/StandardQueryCache.cs
@@ -330,39 +330,27 @@ namespace NHibernate.Cache
 					var returnType = returnTypes[0];
 
 					// Skip first element, it is the timestamp
-					var rows = new List<object>(cacheable.Count - 1);
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						rows.Add(cacheable[i]);
+						returnType.BeforeAssemble(cacheable[i], session);
 					}
 
-					foreach (var row in rows)
+					for (var i = 1; i < cacheable.Count; i++)
 					{
-						returnType.BeforeAssemble(row, session);
-					}
-
-					foreach (var row in rows)
-					{
-						result.Add(returnType.Assemble(row, session, null));
+						result.Add(returnType.Assemble(cacheable[i], session, null));
 					}
 				}
 				else
 				{
 					// Skip first element, it is the timestamp
-					var rows = new List<object[]>(cacheable.Count - 1);
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						rows.Add((object[]) cacheable[i]);
+						TypeHelper.BeforeAssemble((object[]) cacheable[i], returnTypes, session);
 					}
 
-					foreach (var row in rows)
+					for (var i = 1; i < cacheable.Count; i++)
 					{
-						TypeHelper.BeforeAssemble(row, returnTypes, session);
-					}
-
-					foreach (var row in rows)
-					{
-						result.Add(TypeHelper.Assemble(row, returnTypes, session, null));
+						result.Add(TypeHelper.Assemble((object[]) cacheable[i], returnTypes, session, null));
 					}
 				}
 

--- a/src/NHibernate/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Cache/StandardQueryCache.cs
@@ -372,7 +372,7 @@ namespace NHibernate.Cache
 					// have to initialize them.
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						TypeHelper.InitializeCollections((object[]) cacheable[i], collectionTypes, session);
+						TypeHelper.InitializeCollections((object[]) cacheable[i], (object[]) result[i - 1], collectionTypes, session);
 					}
 				}
 

--- a/src/NHibernate/Impl/MultiCriteriaImpl.cs
+++ b/src/NHibernate/Impl/MultiCriteriaImpl.cs
@@ -258,8 +258,8 @@ namespace NHibernate.Impl
 
 							object o =
 								loader.GetRowFromResultSet(reader, session, queryParameters, loader.GetLockModes(queryParameters.LockModes),
-																					 null, hydratedObjects[i], keys, true,
-																					(persister, data) => cacheBatcher.AddToBatch(persister, data));
+								                           null, hydratedObjects[i], keys, true, null, null,
+								                           (persister, data) => cacheBatcher.AddToBatch(persister, data));
 							if (createSubselects[i])
 							{
 								subselectResultKeys[i].Add(keys);

--- a/src/NHibernate/Impl/MultiQueryImpl.cs
+++ b/src/NHibernate/Impl/MultiQueryImpl.cs
@@ -587,7 +587,7 @@ namespace NHibernate.Impl
 
 							rowCount++;
 							object result = translator.Loader.GetRowFromResultSet(
-								reader, session, parameter, lockModeArray, optionalObjectKey, hydratedObjects[i], keys, true,
+								reader, session, parameter, lockModeArray, optionalObjectKey, hydratedObjects[i], keys, true, null, null,
 								(persister, data) => cacheBatcher.AddToBatch(persister, data));
 							tempResults.Add(result);
 

--- a/src/NHibernate/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Loader/Hql/QueryLoader.cs
@@ -303,7 +303,7 @@ namespace NHibernate.Loader.Hql
 
 			if (_collectionPersisters != null)
 			{
-				cacheTypes.AddRange(_collectionPersisters.Where((t, i) => CollectionFetches[i]).Select(t => t.KeyType));
+				cacheTypes.AddRange(_collectionPersisters.Where((t, i) => CollectionFetches[i]).Select(t => t.CollectionType));
 			}
 
 			_cacheTypes = cacheTypes.ToArray();

--- a/src/NHibernate/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Loader/Hql/QueryLoader.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.Event;
 using NHibernate.Hql.Ast.ANTLR;
@@ -43,6 +44,7 @@ namespace NHibernate.Loader.Hql
 		private readonly NullableDictionary<string, string> _sqlAliasByEntityAlias = new NullableDictionary<string, string>();
 		private int _selectLength;
 		private LockMode[] _defaultLockModes;
+		private IType[] _cacheTypes;
 		private ISet<ICollectionPersister> _uncacheableCollectionPersisters;
 
 		public QueryLoader(QueryTranslatorImpl queryTranslator, ISessionFactoryImplementor factory, SelectClause selectClause)
@@ -201,6 +203,8 @@ namespace NHibernate.Loader.Hql
 			get { return _collectionPersisters; }
 		}
 
+		public override IType[] CacheTypes => _cacheTypes;
+
 		private void Initialize(SelectClause selectClause)
 		{
 			IList<FromElement> fromElementList = selectClause.FromElementsForLoad;
@@ -220,6 +224,7 @@ namespace NHibernate.Loader.Hql
 				_collectionPersisters = new IQueryableCollection[length];
 				_collectionOwners = new int[length];
 				_collectionSuffixes = new string[length];
+				CollectionFetches = new bool[length];
 
 				for (int i = 0; i < length; i++)
 				{
@@ -229,6 +234,7 @@ namespace NHibernate.Loader.Hql
 					//				collectionSuffixes[i] = collectionFromElement.getColumnAliasSuffix();
 					//				collectionSuffixes[i] = Integer.toString( i ) + "_";
 					_collectionSuffixes[i] = collectionFromElement.CollectionSuffix;
+					CollectionFetches[i] = collectionFromElement.IsFetch;
 				}
 			}
 
@@ -242,6 +248,8 @@ namespace NHibernate.Loader.Hql
 			_includeInSelect = new bool[size];
 			_owners = new int[size];
 			_ownerAssociationTypes = new EntityType[size];
+			EntityFetches = new bool[size];
+			var cacheTypes = new List<IType>(ResultTypes);
 
 			for (int i = 0; i < size; i++)
 			{
@@ -264,6 +272,11 @@ namespace NHibernate.Loader.Hql
 				_sqlAliasSuffixes[i] = (size == 1) ? "" : i + "_";
 				//			sqlAliasSuffixes[i] = element.getColumnAliasSuffix();
 				_includeInSelect[i] = !element.IsFetch;
+				EntityFetches[i] = element.IsFetch;
+				if (element.IsFetch)
+				{
+					cacheTypes.Add(_entityPersisters[i].Type);
+				}
 				if (_includeInSelect[i])
 				{
 					_selectLength++;
@@ -287,6 +300,13 @@ namespace NHibernate.Loader.Hql
 					}
 				}
 			}
+
+			if (_collectionPersisters != null)
+			{
+				cacheTypes.AddRange(_collectionPersisters.Where((t, i) => CollectionFetches[i]).Select(t => t.KeyType));
+			}
+
+			_cacheTypes = cacheTypes.ToArray();
 
 			//NONE, because its the requested lock mode, not the actual! 
 			_defaultLockModes = ArrayHelper.Fill(LockMode.None, size);

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -156,6 +156,12 @@ namespace NHibernate.Loader
 		/// </summary>
 		public IType[] ResultTypes { get; protected set; }
 
+		public bool[] EntityFetches { get; protected set; }
+
+		public bool[] CollectionFetches { get; protected set; }
+
+		public virtual IType[] CacheTypes => ResultTypes;
+
 		public ISessionFactoryImplementor Factory
 		{
 			get { return _factory; }
@@ -180,6 +186,7 @@ namespace NHibernate.Loader
 		/// An (optional) persister for a collection to be initialized; only collection loaders
 		/// return a non-null value
 		/// </summary>
+		// 6.0 TODO: Make it public
 		protected virtual ICollectionPersister[] CollectionPersisters
 		{
 			get { return null; }
@@ -233,6 +240,12 @@ namespace NHibernate.Loader
 			return Factory.Settings.IsCommentsEnabled ? PrependComment(sql, parameters) : sql;
 		}
 
+		// 6.0 TODO: Remove and replace its usages with CollectionPersisters property
+		internal ICollectionPersister[] GetCollectionPersisters()
+		{
+			return CollectionPersisters;
+		}
+
 		private static SqlString PrependComment(SqlString sql, QueryParameters parameters)
 		{
 			string comment = parameters.Comment;
@@ -254,11 +267,13 @@ namespace NHibernate.Loader
 		private IList DoQueryAndInitializeNonLazyCollections(ISessionImplementor session, QueryParameters queryParameters,
 															 bool returnProxies)
 		{
-			return DoQueryAndInitializeNonLazyCollections(session, queryParameters, returnProxies, null);
+			return DoQueryAndInitializeNonLazyCollections(session, queryParameters, returnProxies, null, null);
 		}
 
 
-		private IList DoQueryAndInitializeNonLazyCollections(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, IResultTransformer forcedResultTransformer)
+		private IList DoQueryAndInitializeNonLazyCollections(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, 
+		                                                     IResultTransformer forcedResultTransformer,
+		                                                     QueryCacheResultBuilder queryCacheResultBuilder)
 		{
 			IPersistenceContext persistenceContext = session.PersistenceContext;
 			bool defaultReadOnlyOrig = persistenceContext.DefaultReadOnly;
@@ -274,7 +289,7 @@ namespace NHibernate.Loader
 			{
 				try
 				{
-					result = DoQuery(session, queryParameters, returnProxies, forcedResultTransformer);
+					result = DoQuery(session, queryParameters, returnProxies, forcedResultTransformer, queryCacheResultBuilder);
 				}
 				finally
 				{
@@ -351,20 +366,23 @@ namespace NHibernate.Loader
 			}
 		}
 
+		// Since 5.3
+		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
 		internal object GetRowFromResultSet(DbDataReader resultSet, ISessionImplementor session,
 											QueryParameters queryParameters, LockMode[] lockModeArray,
 											EntityKey optionalObjectKey, IList hydratedObjects, EntityKey[] keys,
 											bool returnProxies, Action<IEntityPersister, CachePutData> cacheBatchingHandler)
 		{
 			return GetRowFromResultSet(resultSet, session, queryParameters, lockModeArray, optionalObjectKey, hydratedObjects,
-									   keys, returnProxies, null, cacheBatchingHandler);
+									   keys, returnProxies, null, null, cacheBatchingHandler);
 		}
 
 		internal object GetRowFromResultSet(DbDataReader resultSet, ISessionImplementor session,
 											QueryParameters queryParameters, LockMode[] lockModeArray,
 											EntityKey optionalObjectKey, IList hydratedObjects, EntityKey[] keys,
 											bool returnProxies, IResultTransformer forcedResultTransformer,
-											Action<IEntityPersister, CachePutData> cacheBatchingHandler)
+											QueryCacheResultBuilder queryCacheResultBuilder,
+		                                    Action<IEntityPersister, CachePutData> cacheBatchingHandler)
 		{
 			ILoadable[] persisters = EntityPersisters;
 			int entitySpan = persisters.Length;
@@ -383,7 +401,7 @@ namespace NHibernate.Loader
 				GetRow(resultSet, persisters, keys, queryParameters.OptionalObject, optionalObjectKey, lockModeArray,
 					   hydratedObjects, session, !returnProxies, cacheBatchingHandler);
 
-			ReadCollectionElements(row, resultSet, session);
+			var collectionKeys = ReadCollectionElements(row, resultSet, session);
 
 			if (returnProxies)
 			{
@@ -412,16 +430,20 @@ namespace NHibernate.Loader
 				}
 			}
 
-			return forcedResultTransformer == null
+			var result = forcedResultTransformer == null
 					   ? GetResultColumnOrRow(row, queryParameters.ResultTransformer, resultSet, session)
 					   : forcedResultTransformer.TransformTuple(GetResultRow(row, resultSet, session),
 																ResultRowAliases);
+
+			queryCacheResultBuilder?.AddRow(result, row, collectionKeys);
+
+			return result;
 		}
 
 		/// <summary>
 		/// Read any collection elements contained in a single row of the result set
 		/// </summary>
-		private void ReadCollectionElements(object[] row, DbDataReader resultSet, ISessionImplementor session)
+		private object[] ReadCollectionElements(object[] row, DbDataReader resultSet, ISessionImplementor session)
 		{
 			//TODO: make this handle multiple collection roles!
 
@@ -429,6 +451,7 @@ namespace NHibernate.Loader
 
 			if (collectionPersisters != null)
 			{
+				var result = new object[collectionPersisters.Length];
 				ICollectionAliases[] descriptors = CollectionAliases;
 				int[] collectionOwners = CollectionOwners;
 
@@ -455,12 +478,17 @@ namespace NHibernate.Loader
 						//keys[collectionOwner].getIdentifier()
 					}
 
-					ReadCollectionElement(owner, key, collectionPersister, descriptors[i], resultSet, session);
+					result[i] = ReadCollectionElement(owner, key, collectionPersister, descriptors[i], resultSet, session);
 				}
+
+				return result;
 			}
+
+			return null;
 		}
 
-		private IList DoQuery(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, IResultTransformer forcedResultTransformer)
+		private IList DoQuery(ISessionImplementor session, QueryParameters queryParameters, bool returnProxies, 
+		                      IResultTransformer forcedResultTransformer, QueryCacheResultBuilder queryCacheResultBuilder)
 		{
 			using (session.BeginProcess())
 			{
@@ -507,8 +535,8 @@ namespace NHibernate.Loader
 
 						object result = GetRowFromResultSet(rs, session, queryParameters, lockModeArray, optionalObjectKey,
 															hydratedObjects,
-															keys, returnProxies, forcedResultTransformer,
-															(persister, data) => cacheBatcher.AddToBatch(persister, data));
+															keys, returnProxies, forcedResultTransformer, queryCacheResultBuilder,
+						                                    (persister, data) => cacheBatcher.AddToBatch(persister, data));
 						results.Add(result);
 
 						if (createSubselects)
@@ -794,7 +822,7 @@ namespace NHibernate.Loader
 		/// <summary>
 		/// Read one collection element from the current row of the ADO.NET result set
 		/// </summary>
-		private static void ReadCollectionElement(object optionalOwner, object optionalKey, ICollectionPersister persister,
+		private static object ReadCollectionElement(object optionalOwner, object optionalKey, ICollectionPersister persister,
 												  ICollectionAliases descriptor, DbDataReader rs, ISessionImplementor session)
 		{
 			IPersistenceContext persistenceContext = session.PersistenceContext;
@@ -830,6 +858,8 @@ namespace NHibernate.Loader
 				{
 					rowCollection.ReadFrom(rs, persister, descriptor, owner);
 				}
+
+				return collectionRowKey;
 			}
 			else if (optionalKey != null)
 			{
@@ -843,9 +873,11 @@ namespace NHibernate.Loader
 				}
 				persistenceContext.LoadContexts.GetCollectionLoadContext(rs).GetLoadingCollection(persister, optionalKey);
 				// handle empty collection
+				return optionalKey;
 			}
 
 			// else no collection element, but also no owner
+			return null;
 		}
 
 		/// <summary>
@@ -1811,13 +1843,18 @@ namespace NHibernate.Loader
 			IQueryCache queryCache = _factory.GetQueryCache(queryParameters.CacheRegion);
 
 			QueryKey key = GenerateQueryKey(session, queryParameters);
+			var queryCacheBuilder = new QueryCacheResultBuilder(this, session);
 
 			IList result = GetResultFromQueryCache(session, queryParameters, querySpaces, queryCache, key);
 
 			if (result == null)
 			{
-				result = DoList(session, queryParameters, key.ResultTransformer);
-				PutResultInQueryCache(session, queryParameters, queryCache, key, result);
+				result = DoList(session, queryParameters, key.ResultTransformer, queryCacheBuilder);
+				PutResultInQueryCache(session, queryParameters, queryCache, key, queryCacheBuilder.Result);
+			}
+			else
+			{
+				result = queryCacheBuilder.GetResultList(result);
 			}
 
 			result = TransformCacheableResults(queryParameters, key.ResultTransformer, result);
@@ -1866,7 +1903,7 @@ namespace NHibernate.Loader
 				key, queryParameters, 
 				queryParameters.HasAutoDiscoverScalarTypes
 					? null
-					: key.ResultTransformer.GetCachedResultTypes(ResultTypes),
+					: key.ResultTransformer.GetCachedResultTypes(CacheTypes),
 				querySpaces, session);
 
 			if (_factory.Statistics.IsStatisticsEnabled)
@@ -1892,7 +1929,7 @@ namespace NHibernate.Loader
 
 			var put = queryCache.Put(
 				key, queryParameters,
-				key.ResultTransformer.GetCachedResultTypes(ResultTypes),
+				key.ResultTransformer.GetCachedResultTypes(CacheTypes),
 				result, session);
 
 			if (put && _factory.Statistics.IsStatisticsEnabled)
@@ -1909,10 +1946,18 @@ namespace NHibernate.Loader
 		/// <returns></returns>
 		protected IList DoList(ISessionImplementor session, QueryParameters queryParameters)
 		{
-			return DoList(session, queryParameters, null);
+			return DoList(session, queryParameters, null, null);
 		}
 
+		// Since 5.3
+		[Obsolete("Use the overload with queryCacheResultBuilder parameter")]
 		protected IList DoList(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer)
+		{
+			return DoList(session, queryParameters, forcedResultTransformer, null);
+		}
+
+		protected IList DoList(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer,
+		                       QueryCacheResultBuilder queryCacheResultBuilder)
 		{
 			bool statsEnabled = Factory.Statistics.IsStatisticsEnabled;
 			var stopWatch = new Stopwatch();
@@ -1924,7 +1969,7 @@ namespace NHibernate.Loader
 			IList result;
 			try
 			{
-				result = DoQueryAndInitializeNonLazyCollections(session, queryParameters, true, forcedResultTransformer);
+				result = DoQueryAndInitializeNonLazyCollections(session, queryParameters, true, forcedResultTransformer, queryCacheResultBuilder);
 			}
 			catch (HibernateException)
 			{

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -322,7 +322,8 @@ namespace NHibernate.Loader
 			{
 				result =
 					GetRowFromResultSet(resultSet, session, queryParameters, GetLockModes(queryParameters.LockModes), null,
-										hydratedObjects, new EntityKey[entitySpan], returnProxies, (persister, data) => cacheBatcher.AddToBatch(persister, data));
+					                    hydratedObjects, new EntityKey[entitySpan], returnProxies, null, null,
+					                    (persister, data) => cacheBatcher.AddToBatch(persister, data));
 			}
 			catch (HibernateException)
 			{
@@ -357,17 +358,6 @@ namespace NHibernate.Loader
 			{
 				return null;
 			}
-		}
-
-		// Since 5.3
-		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
-		internal object GetRowFromResultSet(DbDataReader resultSet, ISessionImplementor session,
-											QueryParameters queryParameters, LockMode[] lockModeArray,
-											EntityKey optionalObjectKey, IList hydratedObjects, EntityKey[] keys,
-											bool returnProxies, Action<IEntityPersister, CachePutData> cacheBatchingHandler)
-		{
-			return GetRowFromResultSet(resultSet, session, queryParameters, lockModeArray, optionalObjectKey, hydratedObjects,
-									   keys, returnProxies, null, null, cacheBatchingHandler);
 		}
 
 		internal object GetRowFromResultSet(DbDataReader resultSet, ISessionImplementor session,

--- a/src/NHibernate/Multi/ICachingInformation.cs
+++ b/src/NHibernate/Multi/ICachingInformation.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using NHibernate.Cache;
 using NHibernate.Engine;
 using NHibernate.Type;
+using NHibernate.Util;
 
 namespace NHibernate.Multi
 {
@@ -44,6 +48,8 @@ namespace NHibernate.Multi
 		/// <summary>
 		/// The query result types.
 		/// </summary>
+		// Since 5.3
+		[Obsolete("This property is not used and will be removed in a future version.")]
 		IType[] ResultTypes { get; }
 
 		/// <summary>
@@ -67,5 +73,22 @@ namespace NHibernate.Multi
 		/// </summary>
 		/// <param name="cacheBatcher">A cache batcher.</param>
 		void SetCacheBatcher(CacheBatcher cacheBatcher);
+	}
+
+	internal static class CachingInformationExtensions
+	{
+		// 6.0 TODO: Move to ICachingInformation as a Property
+		public static IType[] GetCacheTypes(this ICachingInformation cachingInformation)
+		{
+			var loaderProperty = cachingInformation.GetType().GetProperty("Loader");
+			if (loaderProperty?.GetValue(cachingInformation) is Loader.Loader loader)
+			{
+				return loader.CacheTypes;
+			}
+
+#pragma warning disable 618
+			return cachingInformation.ResultTypes;
+#pragma warning restore 618
+		}
 	}
 }

--- a/src/NHibernate/Multi/ICachingInformation.cs
+++ b/src/NHibernate/Multi/ICachingInformation.cs
@@ -77,13 +77,12 @@ namespace NHibernate.Multi
 
 	internal static class CachingInformationExtensions
 	{
-		// 6.0 TODO: Move to ICachingInformation as a Property
+		// 6.0 TODO: Remove and use CacheTypes instead.
 		public static IType[] GetCacheTypes(this ICachingInformation cachingInformation)
 		{
-			var loaderProperty = cachingInformation.GetType().GetProperty("Loader");
-			if (loaderProperty?.GetValue(cachingInformation) is Loader.Loader loader)
+			if (cachingInformation is ICachingInformationWithFetches cachingInformationWithFetches)
 			{
-				return loader.CacheTypes;
+				return cachingInformationWithFetches.CacheTypes;
 			}
 
 #pragma warning disable 618

--- a/src/NHibernate/Multi/ICachingInformationWithFetches.cs
+++ b/src/NHibernate/Multi/ICachingInformationWithFetches.cs
@@ -1,0 +1,13 @@
+﻿using NHibernate.Type;
+
+namespace NHibernate.Multi
+{
+	// 6.0 TODO: merge into 'ICachingInformation'.
+	internal interface ICachingInformationWithFetches
+	{
+		/// <summary>
+		/// The query cache types.
+		/// </summary>
+		IType[] CacheTypes { get; }
+	}
+}

--- a/src/NHibernate/Multi/QueryBatch.cs
+++ b/src/NHibernate/Multi/QueryBatch.cs
@@ -195,9 +195,14 @@ namespace NHibernate.Multi
 					resultSetsCommand.Sql);
 			}
 
-			if (statsEnabled)
+			if (!statsEnabled)
 			{
-				stopWatch.Stop();
+				return;
+			}
+
+			stopWatch.Stop();
+			if (resultSetsCommand.HasQueries)
+			{
 				Session.Factory.StatisticsImplementor.QueryExecuted(
 					resultSetsCommand.Sql.ToString(),
 					rowCount,
@@ -224,7 +229,7 @@ namespace NHibernate.Multi
 					parameters[i] = queryInfo.Parameters;
 					returnTypes[i] = queryInfo.Parameters.HasAutoDiscoverScalarTypes
 						? null
-						: queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.ResultTypes);
+						: queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.GetCacheTypes());
 					spaces[i] = queryInfo.QuerySpaces;
 				}
 
@@ -232,11 +237,12 @@ namespace NHibernate.Multi
 
 				for (var i = 0; i < queryInfos.Length; i++)
 				{
-					queryInfos[i].SetCachedResult(results[i]);
+					var queryInfo = queryInfos[i];
+					queryInfo.SetCachedResult(results[i]);
 
 					if (statisticsEnabled)
 					{
-						var queryIdentifier = queryInfos[i].QueryIdentifier;
+						var queryIdentifier = queryInfo.QueryIdentifier;
 						if (results[i] == null)
 						{
 							Session.Factory.StatisticsImplementor.QueryCacheMiss(queryIdentifier, cache.RegionName);
@@ -276,7 +282,7 @@ namespace NHibernate.Multi
 					var queryInfo = queryInfos[i];
 					keys[i] = queryInfo.CacheKey;
 					parameters[i] = queryInfo.Parameters;
-					returnTypes[i] = queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.ResultTypes);
+					returnTypes[i] = queryInfo.CacheKey.ResultTransformer.GetCachedResultTypes(queryInfo.GetCacheTypes());
 					results[i] = queryInfo.ResultToCache;
 				}
 

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Multi
 		private CacheMode? _cacheMode;
 		private IList<TResult> _finalResults;
 
-		protected class QueryInfo : ICachingInformation
+		protected class QueryInfo : ICachingInformation, ICachingInformationWithFetches
 		{
 			/// <summary>
 			/// The query loader.
@@ -55,6 +55,9 @@ namespace NHibernate.Multi
 			// is enabled).
 			/// <inheritdoc />
 			public IType[] ResultTypes => Loader.ResultTypes;
+
+			/// <inheritdoc />
+			public IType[] CacheTypes => Loader.CacheTypes;
 
 			/// <inheritdoc />
 			public string QueryIdentifier => Loader.QueryIdentifier;

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -214,7 +214,7 @@ namespace NHibernate.Multi
 					var lockModeArray = loader.GetLockModes(queryParameters.LockModes);
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
-					var queryCacheBuilder = new QueryCacheResultBuilder(loader, Session);
+					var queryCacheBuilder = new QueryCacheResultBuilder(loader);
 					var cacheBatcher = queryInfo.CacheBatcher;
 					var ownCacheBatcher = cacheBatcher == null;
 					if (ownCacheBatcher)
@@ -280,7 +280,7 @@ namespace NHibernate.Multi
 				{
 					if (queryInfo.IsResultFromCache)
 					{
-						var queryCacheBuilder = new QueryCacheResultBuilder(queryInfo.Loader, Session);
+						var queryCacheBuilder = new QueryCacheResultBuilder(queryInfo.Loader);
 						queryInfo.Result = queryCacheBuilder.GetResultList(queryInfo.Result);
 					}
 

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -214,6 +214,7 @@ namespace NHibernate.Multi
 					var lockModeArray = loader.GetLockModes(queryParameters.LockModes);
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
+					var queryCacheBuilder = new QueryCacheResultBuilder(loader, Session);
 					var cacheBatcher = queryInfo.CacheBatcher;
 					var ownCacheBatcher = cacheBatcher == null;
 					if (ownCacheBatcher)
@@ -234,6 +235,7 @@ namespace NHibernate.Multi
 								keys,
 								true,
 								forcedResultTransformer,
+								queryCacheBuilder,
 								(persister, data) => cacheBatcher.AddToBatch(persister, data)
 							);
 						if (loader.IsSubselectLoadingEnabled)
@@ -247,7 +249,7 @@ namespace NHibernate.Multi
 
 					queryInfo.Result = tmpResults;
 					if (queryInfo.CanPutToCache)
-						queryInfo.ResultToCache = tmpResults;
+						queryInfo.ResultToCache = queryCacheBuilder.Result;
 
 					if (ownCacheBatcher)
 						cacheBatcher.ExecuteBatch();
@@ -276,6 +278,12 @@ namespace NHibernate.Multi
 
 				if (queryInfo.IsCacheable)
 				{
+					if (queryInfo.IsResultFromCache)
+					{
+						var queryCacheBuilder = new QueryCacheResultBuilder(queryInfo.Loader, Session);
+						queryInfo.Result = queryCacheBuilder.GetResultList(queryInfo.Result);
+					}
+
 					// This transformation must not be applied to ResultToCache.
 					queryInfo.Result =
 						queryInfo.Loader.TransformCacheableResults(

--- a/src/NHibernate/Type/TypeHelper.cs
+++ b/src/NHibernate/Type/TypeHelper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using NHibernate.Collection;
 using NHibernate.Engine;
 using NHibernate.Intercept;
+using NHibernate.Persister.Collection;
 using NHibernate.Properties;
 using NHibernate.Tuple;
 
@@ -116,15 +117,15 @@ namespace NHibernate.Type
 		/// </summary>
 		/// <param name="cacheRow">The cached values.</param>
 		/// <param name="assembleRow">The assembled values to update.</param>
-		/// <param name="types">The dictionary containing collection types and their indexes in the <paramref name="cacheRow"/> parameter as key.</param>
+		/// <param name="collectionIndexes">The dictionary containing collection persisters and their indexes in the <paramref name="cacheRow"/> parameter as key.</param>
 		/// <param name="session">The originating session.</param>
 		internal static void InitializeCollections(
 			object[] cacheRow,
 			object[] assembleRow,
-			IDictionary<int, CollectionType> types,
+			IDictionary<int, ICollectionPersister> collectionIndexes,
 			ISessionImplementor session)
 		{
-			foreach (var pair in types)
+			foreach (var pair in collectionIndexes)
 			{
 				var value = cacheRow[pair.Key];
 				if (value == null)
@@ -132,8 +133,7 @@ namespace NHibernate.Type
 					continue;
 				}
 
-				var persister = session.Factory.GetCollectionPersister(pair.Value.Role);
-				var collection = session.PersistenceContext.GetCollection(new CollectionKey(persister, value));
+				var collection = session.PersistenceContext.GetCollection(new CollectionKey(pair.Value, value));
 				collection.ForceInitialization();
 				assembleRow[pair.Key] = collection;
 			}


### PR DESCRIPTION
This PR fixes #1195 as it adds the ability to cache all fetched relations (many-to-one/one-to-many). The solution uses a special query cache result builder that appends extra values when creating the cache list that is then passed to the `IBatchableQueryCache.(Put\PutMany)` method. When fetching a many-to-one relation an additional value is added to the row of the cache list which is the id of the fetched relation. When fetching a one-to-many relation two values are added, the first is the id of the fetched element and the second is the collection id, which is the id of the entity that contains that collection. When the cached list is retrieved form the cache, the query cache will assembly and initialize all objects from the cached query and afterwards a special method is called that will remove the extra values that were added by the result builder.