### PR TITLE
Move discovery of executedSpaces to RegisterCleanupActions

### DIFF
--- a/src/NHibernate.Test/Async/SecondLevelCacheTest/InvalidationTests.cs
+++ b/src/NHibernate.Test/Async/SecondLevelCacheTest/InvalidationTests.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Impl;
+using NHibernate.Linq;
 using NHibernate.Test.SecondLevelCacheTests;
 using NSubstitute;
 using NUnit.Framework;
@@ -59,6 +60,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 
 			using (var session = OpenSession())
 			{
+				//Add Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -70,6 +72,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 					await (tx.CommitAsync());
 				}
 
+				//Update Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -81,6 +84,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 					await (tx.CommitAsync());
 				}
 
+				//Delete Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -91,13 +95,44 @@ namespace NHibernate.Test.SecondLevelCacheTest
 
 					await (tx.CommitAsync());
 				}
+
+				//Update Item using HQL
+				using (var tx = session.BeginTransaction())
+				{
+					await (session.CreateQuery("UPDATE Item SET Name='Test'").ExecuteUpdateAsync());
+
+					await (tx.CommitAsync());
+				}
+
+
+				//Update Item using LINQ
+				using (var tx = session.BeginTransaction())
+				{
+					await (session.Query<Item>()
+					       .UpdateBuilder()
+					       .Set(x => x.Name, "Test")
+					       .UpdateAsync(CancellationToken.None));
+
+					await (tx.CommitAsync());
+				}
+
+				//Update Item using SQL
+				using (var tx = session.BeginTransaction())
+				{
+					await (session.CreateSQLQuery("UPDATE Item SET Name='Test'")
+					       .AddSynchronizedQuerySpace("Item")
+					       .ExecuteUpdateAsync());
+
+					await (tx.CommitAsync());
+				}
 			}
 
-			//Should receive one preinvalidation and one invalidation per commit
+			//Should receive one preinvalidation per non-DML commit
 			Assert.That(preInvalidations, Has.Count.EqualTo(3));
 			Assert.That(preInvalidations, Has.All.Count.EqualTo(1).And.Contains("Item"));
 
-			Assert.That(invalidations, Has.Count.EqualTo(3));
+			///...and one invalidation per commit
+			Assert.That(invalidations, Has.Count.EqualTo(6));
 			Assert.That(invalidations, Has.All.Count.EqualTo(1).And.Contains("Item"));
 		}
 

--- a/src/NHibernate.Test/SecondLevelCacheTest/InvalidationTests.cs
+++ b/src/NHibernate.Test/SecondLevelCacheTest/InvalidationTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Impl;
+using NHibernate.Linq;
 using NHibernate.Test.SecondLevelCacheTests;
 using NSubstitute;
 using NUnit.Framework;
@@ -47,6 +48,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 
 			using (var session = OpenSession())
 			{
+				//Add Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -58,6 +60,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 					tx.Commit();
 				}
 
+				//Update Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -69,6 +72,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 					tx.Commit();
 				}
 
+				//Delete Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -79,13 +83,44 @@ namespace NHibernate.Test.SecondLevelCacheTest
 
 					tx.Commit();
 				}
+
+				//Update Item using HQL
+				using (var tx = session.BeginTransaction())
+				{
+					session.CreateQuery("UPDATE Item SET Name='Test'").ExecuteUpdate();
+
+					tx.Commit();
+				}
+
+
+				//Update Item using LINQ
+				using (var tx = session.BeginTransaction())
+				{
+					session.Query<Item>()
+					       .UpdateBuilder()
+					       .Set(x => x.Name, "Test")
+					       .Update();
+
+					tx.Commit();
+				}
+
+				//Update Item using SQL
+				using (var tx = session.BeginTransaction())
+				{
+					session.CreateSQLQuery("UPDATE Item SET Name='Test'")
+					       .AddSynchronizedQuerySpace("Item")
+					       .ExecuteUpdate();
+
+					tx.Commit();
+				}
 			}
 
-			//Should receive one preinvalidation and one invalidation per commit
+			//Should receive one preinvalidation per non-DML commit
 			Assert.That(preInvalidations, Has.Count.EqualTo(3));
 			Assert.That(preInvalidations, Has.All.Count.EqualTo(1).And.Contains("Item"));
 
-			Assert.That(invalidations, Has.Count.EqualTo(3));
+			///...and one invalidation per commit
+			Assert.That(invalidations, Has.Count.EqualTo(6));
 			Assert.That(invalidations, Has.All.Count.EqualTo(1).And.Contains("Item"));
 		}
 

--- a/src/NHibernate/Async/Engine/ActionQueue.cs
+++ b/src/NHibernate/Async/Engine/ActionQueue.cs
@@ -82,10 +82,6 @@ namespace NHibernate.Engine
 			}
 			finally
 			{
-				if (executable.PropertySpaces != null)
-				{
-					executedSpaces.UnionWith(executable.PropertySpaces);
-				}
 				RegisterCleanupActions(executable);
 			}
 		}

--- a/src/NHibernate/Engine/ActionQueue.cs
+++ b/src/NHibernate/Engine/ActionQueue.cs
@@ -199,10 +199,6 @@ namespace NHibernate.Engine
 			}
 			finally
 			{
-				if (executable.PropertySpaces != null)
-				{
-					executedSpaces.UnionWith(executable.PropertySpaces);
-				}
 				RegisterCleanupActions(executable);
 			}
 		}
@@ -220,6 +216,10 @@ namespace NHibernate.Engine
 				RegisterProcess(executable.BeforeTransactionCompletionProcess);
 				RegisterProcess(executable.AfterTransactionCompletionProcess);
 #pragma warning restore 618,619
+			}
+			if (executable.PropertySpaces != null)
+			{
+				executedSpaces.UnionWith(executable.PropertySpaces);
 			}
 		}
 


### PR DESCRIPTION
Since BulkOperationCleanupAction isn't added among the regular executables, its queryspaces are ignored. The original implementation had AddSpacesToInvalidate on AfterTransactionCompletionProcessQueue, but we managed to simplify that away.

This fix doesn't readd that, but instead just moves the "discovery" to RegisterCleanupActions.

Fixes #1953