### PR TITLE
Optimize batchable cache calls for cached queries

### DIFF
--- a/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
@@ -41,6 +41,7 @@ namespace NHibernate.Test.CacheTest
 		{
 			configuration.SetProperty(Environment.UseSecondLevelCache, "true");
 			configuration.SetProperty(Environment.UseQueryCache, "true");
+			configuration.SetProperty(Environment.GenerateStatistics, "true");
 			configuration.SetProperty(Environment.CacheProvider, typeof(BatchableCacheProvider).AssemblyQualifiedName);
 		}
 
@@ -706,14 +707,7 @@ namespace NHibernate.Test.CacheTest
 			if (!Sfi.ConnectionProvider.Driver.SupportsMultipleQueries)
 				Assert.Ignore($"{Sfi.ConnectionProvider.Driver} does not support multiple queries");
 
-			var queryCache = Sfi.GetQueryCache(null);
-			var field = typeof(StandardQueryCache).GetField(
-				"_cache",
-				BindingFlags.NonPublic | BindingFlags.Instance);
-			Assert.That(field, Is.Not.Null, "Unable to find _cache field");
-			var cache = (BatchableCache) field.GetValue(queryCache);
-			Assert.That(cache, Is.Not.Null, "_cache is null");
-
+			var cache = GetDefaultQueryCache();
 			var timestamp = Sfi.UpdateTimestampsCache;
 			var tsField = typeof(UpdateTimestampsCache).GetField(
 				"_updateTimestamps",
@@ -870,6 +864,354 @@ namespace NHibernate.Test.CacheTest
 			}
 		}
 
+		[TestCase(true)]
+		[TestCase(false)]
+		public async Task QueryEntityBatchCacheTestAsync(bool clearEntityCacheAfterQuery, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var cache = (BatchableCache) persister.Cache.Cache;
+			var queryCache = GetDefaultQueryCache();
+
+			Sfi.Statistics.Clear();
+			await (Sfi.EvictQueriesAsync(cancellationToken));
+			cache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			List<ReadOnlyItem> items;
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				items = await (s.Query<ReadOnlyItem>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .ToListAsync(cancellationToken));
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(1), "Unexpected query cache PutCalls");
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(36), "Unexpected items count");
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(1), "Unexpected cache miss count");
+
+			cache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			if (clearEntityCacheAfterQuery)
+			{
+				await (cache.ClearAsync(cancellationToken));
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				items = await (s.Query<ReadOnlyItem>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .ToListAsync(cancellationToken));
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(0), "Unexpected query cache PutCalls");
+			// Ideally the PutMultipleCalls count should be 1 when clearing the cache after the first query, in order to achieve this
+			// the CacheBatcher would need to be on the session and executed once the query is processed
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 9 : 0), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(36));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1), "Unexpected cache hit count");
+		}
+
+		[TestCase(true, false)]
+		[TestCase(false, false)]
+		[TestCase(true, true)]
+		[TestCase(false, true)]
+		public async Task QueryFetchCollectionBatchCacheTestAsync(bool clearEntityCacheAfterQuery, bool future, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			if (future && !Sfi.ConnectionProvider.Driver.SupportsMultipleQueries)
+			{
+				Assert.Ignore($"{Sfi.ConnectionProvider.Driver} does not support multiple queries");
+			}
+
+			var persister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
+			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var collectionPersister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
+			var cache = (BatchableCache) persister.Cache.Cache;
+			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
+			var collectionCache = (BatchableCache) collectionPersister.Cache.Cache;
+			var queryCache = GetDefaultQueryCache();
+
+			int middleId;
+
+			using (var s = OpenSession())
+			{
+				var ids = await (s.Query<ReadOnly>().Select(o => o.Id).OrderBy(o => o).ToListAsync(cancellationToken));
+				middleId = ids[2];
+			}
+
+			Sfi.Statistics.Clear();
+			await (Sfi.EvictQueriesAsync(cancellationToken));
+			queryCache.ClearStatistics();
+			cache.ClearStatistics();
+			await (cache.ClearAsync(cancellationToken));
+			itemCache.ClearStatistics();
+			await (itemCache.ClearAsync(cancellationToken));
+			collectionCache.ClearStatistics();
+			await (collectionCache.ClearAsync(cancellationToken));
+
+			List<ReadOnly> items;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnly>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .FetchMany(o => o.Items)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .Where(o => o.Id <= middleId)
+					         .ToFuture()
+					         .ToList();
+				}
+				else
+				{
+					items = await (s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .ToListAsync(cancellationToken));
+				}
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetMultipleCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(collectionCache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected collection cache PutMultipleCalls");
+			Assert.That(collectionCache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected collection cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 3 : 6), "Unexpected items count");
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache miss count");
+
+			cache.ClearStatistics();
+			itemCache.ClearStatistics();
+			collectionCache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			if (clearEntityCacheAfterQuery)
+			{
+				await (cache.ClearAsync(cancellationToken));
+				await (collectionCache.ClearAsync(cancellationToken));
+				await (itemCache.ClearAsync(cancellationToken));
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnly>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .FetchMany(o => o.Items)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .Where(o => o.Id <= middleId)
+					         .ToFuture()
+					         .ToList();
+				}
+				else
+				{
+					items = await (s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .ToListAsync(cancellationToken));
+				}
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(0), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(collectionCache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected collection cache GetMultipleCalls");
+			Assert.That(collectionCache.GetMultipleCalls[0], Has.Length.EqualTo(6), "Unexpected collection cache GetMultipleCalls length");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(cache.GetMultipleCalls[0], Has.Length.EqualTo(6), "Unexpected entity cache GetMultipleCalls length");
+			Assert.That(itemCache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity item cache GetMultipleCalls");
+			Assert.That(itemCache.GetMultipleCalls[0], Has.Length.EqualTo(36), "Unexpected entity item cache GetMultipleCalls length");
+			// Ideally the PutMultipleCalls count should be 1 when clearing the cache after the first query, in order to achieve this
+			// the CacheBatcher would need to be on the session and executed once the batch fetch queries are processed
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 2 : 0), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(collectionCache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 2 : 0), "Unexpected collection cache PutMultipleCalls");
+			Assert.That(itemCache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 9 : 0), "Unexpected entity item cache PutMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 3 : 6));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache hit count");
+		}
+
+		[TestCase(true, false)]
+		[TestCase(false, false)]
+		[TestCase(true, true)]
+		[TestCase(false, true)]
+		public async Task QueryFetchEntityBatchCacheTestAsync(bool clearEntityCacheAfterQuery, bool future, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			if (future && !Sfi.ConnectionProvider.Driver.SupportsMultipleQueries)
+			{
+				Assert.Ignore($"{Sfi.ConnectionProvider.Driver} does not support multiple queries");
+			}
+
+			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var parentPersister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
+			var cache = (BatchableCache) persister.Cache.Cache;
+			var parentCache = (BatchableCache) parentPersister.Cache.Cache;
+			var queryCache = GetDefaultQueryCache();
+
+			int middleId;
+
+			using (var s = OpenSession())
+			{
+				var ids = await (s.Query<ReadOnlyItem>().Select(o => o.Id).OrderBy(o => o).ToListAsync(cancellationToken));
+				middleId = ids[17];
+			}
+
+			Sfi.Statistics.Clear();
+			await (Sfi.EvictQueriesAsync(cancellationToken));
+			queryCache.ClearStatistics();
+			cache.ClearStatistics();
+			await (cache.ClearAsync(cancellationToken));
+			parentCache.ClearStatistics();
+			await (parentCache.ClearAsync(cancellationToken));
+
+			List<ReadOnlyItem> items;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnlyItem>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .Fetch(o => o.Parent)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .Where(o => o.Id <= middleId)
+							 .ToFuture()
+							 .ToList();
+				}
+				else
+				{
+					items = await (s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .ToListAsync(cancellationToken));
+				}
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetMultipleCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(parentCache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected parent cache PutMultipleCalls");
+			Assert.That(parentCache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected parent cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 18 : 36), "Unexpected items count");
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache miss count");
+
+			cache.ClearStatistics();
+			parentCache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			if (clearEntityCacheAfterQuery)
+			{
+				await (cache.ClearAsync(cancellationToken));
+				await (parentCache.ClearAsync(cancellationToken));
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnlyItem>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .Fetch(o => o.Parent)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .Where(o => o.Id <= middleId)
+							 .ToFuture()
+							 .ToList();
+				}
+				else
+				{
+					items = await (s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .ToListAsync(cancellationToken));
+				}
+
+				await (tx.CommitAsync(cancellationToken));
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(0), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(parentCache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected parent cache GetMultipleCalls");
+			Assert.That(parentCache.GetMultipleCalls[0], Has.Length.EqualTo(6), "Unexpected parent cache GetMultipleCalls length");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(cache.GetMultipleCalls[0], Has.Length.EqualTo(36), "Unexpected entity cache GetMultipleCalls length");
+			// Ideally the PutMultipleCalls count should be 1 when clearing the cache after the first query, in order to achieve this
+			// the CacheBatcher would need to be on the session and executed once the batch fetch queries are processed
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 9 : 0), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(parentCache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 2 : 0), "Unexpected parent cache PutMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 18 : 36));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache hit count");
+		}
+
 		private async Task AssertMultipleCacheCallsAsync<TEntity>(IEnumerable<int> loadIds,  IReadOnlyList<int> getIds, int idIndex, 
 														int[][] fetchedIdIndexes, int[] putIdIndexes, Func<int, bool> cacheBeforeLoadFn = null, CancellationToken cancellationToken = default(CancellationToken))
 			where TEntity : CacheEntity
@@ -994,6 +1336,19 @@ namespace NHibernate.Test.CacheTest
 
 				await (tx.CommitAsync(cancellationToken));
 			}
+		}
+
+		private BatchableCache GetDefaultQueryCache()
+		{
+			var queryCache = Sfi.GetQueryCache(null);
+			var field = typeof(StandardQueryCache).GetField(
+				"_cache",
+				BindingFlags.NonPublic | BindingFlags.Instance);
+			Assert.That(field, Is.Not.Null, "Unable to find _cache field");
+			var cache = (BatchableCache) field.GetValue(queryCache);
+			Assert.That(cache, Is.Not.Null, "_cache is null");
+
+			return cache;
 		}
 
 	}

--- a/src/NHibernate.Test/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/BatchableCacheFixture.cs
@@ -29,6 +29,7 @@ namespace NHibernate.Test.CacheTest
 		{
 			configuration.SetProperty(Environment.UseSecondLevelCache, "true");
 			configuration.SetProperty(Environment.UseQueryCache, "true");
+			configuration.SetProperty(Environment.GenerateStatistics, "true");
 			configuration.SetProperty(Environment.CacheProvider, typeof(BatchableCacheProvider).AssemblyQualifiedName);
 		}
 
@@ -694,14 +695,7 @@ namespace NHibernate.Test.CacheTest
 			if (!Sfi.ConnectionProvider.Driver.SupportsMultipleQueries)
 				Assert.Ignore($"{Sfi.ConnectionProvider.Driver} does not support multiple queries");
 
-			var queryCache = Sfi.GetQueryCache(null);
-			var field = typeof(StandardQueryCache).GetField(
-				"_cache",
-				BindingFlags.NonPublic | BindingFlags.Instance);
-			Assert.That(field, Is.Not.Null, "Unable to find _cache field");
-			var cache = (BatchableCache) field.GetValue(queryCache);
-			Assert.That(cache, Is.Not.Null, "_cache is null");
-
+			var cache = GetDefaultQueryCache();
 			var timestamp = Sfi.UpdateTimestampsCache;
 			var tsField = typeof(UpdateTimestampsCache).GetField(
 				"_updateTimestamps",
@@ -858,6 +852,354 @@ namespace NHibernate.Test.CacheTest
 			}
 		}
 
+		[TestCase(true)]
+		[TestCase(false)]
+		public void QueryEntityBatchCacheTest(bool clearEntityCacheAfterQuery)
+		{
+			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var cache = (BatchableCache) persister.Cache.Cache;
+			var queryCache = GetDefaultQueryCache();
+
+			Sfi.Statistics.Clear();
+			Sfi.EvictQueries();
+			cache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			List<ReadOnlyItem> items;
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				items = s.Query<ReadOnlyItem>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .ToList();
+
+				tx.Commit();
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(1), "Unexpected query cache PutCalls");
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(36), "Unexpected items count");
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(1), "Unexpected cache miss count");
+
+			cache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			if (clearEntityCacheAfterQuery)
+			{
+				cache.Clear();
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				items = s.Query<ReadOnlyItem>()
+				         .WithOptions(o => o.SetCacheable(true))
+				         .ToList();
+
+				tx.Commit();
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(0), "Unexpected query cache PutCalls");
+			// Ideally the PutMultipleCalls count should be 1 when clearing the cache after the first query, in order to achieve this
+			// the CacheBatcher would need to be on the session and executed once the query is processed
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 9 : 0), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(36));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1), "Unexpected cache hit count");
+		}
+
+		[TestCase(true, false)]
+		[TestCase(false, false)]
+		[TestCase(true, true)]
+		[TestCase(false, true)]
+		public void QueryFetchCollectionBatchCacheTest(bool clearEntityCacheAfterQuery, bool future)
+		{
+			if (future && !Sfi.ConnectionProvider.Driver.SupportsMultipleQueries)
+			{
+				Assert.Ignore($"{Sfi.ConnectionProvider.Driver} does not support multiple queries");
+			}
+
+			var persister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
+			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var collectionPersister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
+			var cache = (BatchableCache) persister.Cache.Cache;
+			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
+			var collectionCache = (BatchableCache) collectionPersister.Cache.Cache;
+			var queryCache = GetDefaultQueryCache();
+
+			int middleId;
+
+			using (var s = OpenSession())
+			{
+				var ids = s.Query<ReadOnly>().Select(o => o.Id).OrderBy(o => o).ToList();
+				middleId = ids[2];
+			}
+
+			Sfi.Statistics.Clear();
+			Sfi.EvictQueries();
+			queryCache.ClearStatistics();
+			cache.ClearStatistics();
+			cache.Clear();
+			itemCache.ClearStatistics();
+			itemCache.Clear();
+			collectionCache.ClearStatistics();
+			collectionCache.Clear();
+
+			List<ReadOnly> items;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnly>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .FetchMany(o => o.Items)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .Where(o => o.Id <= middleId)
+					         .ToFuture()
+					         .ToList();
+				}
+				else
+				{
+					items = s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .ToList();
+				}
+
+				tx.Commit();
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetMultipleCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(collectionCache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected collection cache PutMultipleCalls");
+			Assert.That(collectionCache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected collection cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 3 : 6), "Unexpected items count");
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache miss count");
+
+			cache.ClearStatistics();
+			itemCache.ClearStatistics();
+			collectionCache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			if (clearEntityCacheAfterQuery)
+			{
+				cache.Clear();
+				collectionCache.Clear();
+				itemCache.Clear();
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnly>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .FetchMany(o => o.Items)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .Where(o => o.Id <= middleId)
+					         .ToFuture()
+					         .ToList();
+				}
+				else
+				{
+					items = s.Query<ReadOnly>()
+					         .WithOptions(o => o.SetCacheable(true))
+					         .FetchMany(o => o.Items)
+					         .ToList();
+				}
+
+				tx.Commit();
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(0), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(collectionCache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected collection cache GetMultipleCalls");
+			Assert.That(collectionCache.GetMultipleCalls[0], Has.Length.EqualTo(6), "Unexpected collection cache GetMultipleCalls length");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(cache.GetMultipleCalls[0], Has.Length.EqualTo(6), "Unexpected entity cache GetMultipleCalls length");
+			Assert.That(itemCache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity item cache GetMultipleCalls");
+			Assert.That(itemCache.GetMultipleCalls[0], Has.Length.EqualTo(36), "Unexpected entity item cache GetMultipleCalls length");
+			// Ideally the PutMultipleCalls count should be 1 when clearing the cache after the first query, in order to achieve this
+			// the CacheBatcher would need to be on the session and executed once the batch fetch queries are processed
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 2 : 0), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(collectionCache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 2 : 0), "Unexpected collection cache PutMultipleCalls");
+			Assert.That(itemCache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 9 : 0), "Unexpected entity item cache PutMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 3 : 6));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache hit count");
+		}
+
+		[TestCase(true, false)]
+		[TestCase(false, false)]
+		[TestCase(true, true)]
+		[TestCase(false, true)]
+		public void QueryFetchEntityBatchCacheTest(bool clearEntityCacheAfterQuery, bool future)
+		{
+			if (future && !Sfi.ConnectionProvider.Driver.SupportsMultipleQueries)
+			{
+				Assert.Ignore($"{Sfi.ConnectionProvider.Driver} does not support multiple queries");
+			}
+
+			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var parentPersister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
+			var cache = (BatchableCache) persister.Cache.Cache;
+			var parentCache = (BatchableCache) parentPersister.Cache.Cache;
+			var queryCache = GetDefaultQueryCache();
+
+			int middleId;
+
+			using (var s = OpenSession())
+			{
+				var ids = s.Query<ReadOnlyItem>().Select(o => o.Id).OrderBy(o => o).ToList();
+				middleId = ids[17];
+			}
+
+			Sfi.Statistics.Clear();
+			Sfi.EvictQueries();
+			queryCache.ClearStatistics();
+			cache.ClearStatistics();
+			cache.Clear();
+			parentCache.ClearStatistics();
+			parentCache.Clear();
+
+			List<ReadOnlyItem> items;
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnlyItem>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .Fetch(o => o.Parent)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .Where(o => o.Id <= middleId)
+							 .ToFuture()
+							 .ToList();
+				}
+				else
+				{
+					items = s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .ToList();
+				}
+
+				tx.Commit();
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetMultipleCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(parentCache.PutMultipleCalls, Has.Count.EqualTo(1), "Unexpected parent cache PutMultipleCalls");
+			Assert.That(parentCache.GetMultipleCalls, Has.Count.EqualTo(0), "Unexpected parent cache GetMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 18 : 36), "Unexpected items count");
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(1), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache miss count");
+
+			cache.ClearStatistics();
+			parentCache.ClearStatistics();
+			queryCache.ClearStatistics();
+
+			if (clearEntityCacheAfterQuery)
+			{
+				cache.Clear();
+				parentCache.Clear();
+			}
+
+			Sfi.Statistics.Clear();
+
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				if (future)
+				{
+					s.Query<ReadOnlyItem>()
+					 .WithOptions(o => o.SetCacheable(true))
+					 .Fetch(o => o.Parent)
+					 .Where(o => o.Id > middleId)
+					 .ToFuture();
+
+					items = s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .Where(o => o.Id <= middleId)
+							 .ToFuture()
+							 .ToList();
+				}
+				else
+				{
+					items = s.Query<ReadOnlyItem>()
+							 .WithOptions(o => o.SetCacheable(true))
+							 .Fetch(o => o.Parent)
+							 .ToList();
+				}
+
+				tx.Commit();
+			}
+
+			Assert.That(queryCache.GetCalls, Has.Count.EqualTo(future ? 0 : 1), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.GetMultipleCalls, Has.Count.EqualTo(future ? 1 : 0), "Unexpected query cache GetCalls");
+			Assert.That(queryCache.PutCalls, Has.Count.EqualTo(0), "Unexpected query cache PutCalls");
+			Assert.That(queryCache.PutMultipleCalls, Has.Count.EqualTo(0), "Unexpected query cache PutMultipleCalls");
+			Assert.That(parentCache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected parent cache GetMultipleCalls");
+			Assert.That(parentCache.GetMultipleCalls[0], Has.Length.EqualTo(6), "Unexpected parent cache GetMultipleCalls length");
+			Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(1), "Unexpected entity cache GetMultipleCalls");
+			Assert.That(cache.GetMultipleCalls[0], Has.Length.EqualTo(36), "Unexpected entity cache GetMultipleCalls length");
+			// Ideally the PutMultipleCalls count should be 1 when clearing the cache after the first query, in order to achieve this
+			// the CacheBatcher would need to be on the session and executed once the batch fetch queries are processed
+			Assert.That(cache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 9 : 0), "Unexpected entity cache PutMultipleCalls");
+			Assert.That(parentCache.PutMultipleCalls, Has.Count.EqualTo(clearEntityCacheAfterQuery ? 2 : 0), "Unexpected parent cache PutMultipleCalls");
+			Assert.That(items, Has.Count.EqualTo(future ? 18 : 36));
+			Assert.That(Sfi.Statistics.QueryExecutionCount, Is.EqualTo(0), "Unexpected execution count");
+			Assert.That(Sfi.Statistics.QueryCachePutCount, Is.EqualTo(0), "Unexpected cache put count");
+			Assert.That(Sfi.Statistics.QueryCacheMissCount, Is.EqualTo(0), "Unexpected cache miss count");
+			Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(future ? 2 : 1), "Unexpected cache hit count");
+		}
+
 		private void AssertMultipleCacheCalls<TEntity>(IEnumerable<int> loadIds,  IReadOnlyList<int> getIds, int idIndex, 
 														int[][] fetchedIdIndexes, int[] putIdIndexes, Func<int, bool> cacheBeforeLoadFn = null)
 			where TEntity : CacheEntity
@@ -982,6 +1324,19 @@ namespace NHibernate.Test.CacheTest
 
 				tx.Commit();
 			}
+		}
+
+		private BatchableCache GetDefaultQueryCache()
+		{
+			var queryCache = Sfi.GetQueryCache(null);
+			var field = typeof(StandardQueryCache).GetField(
+				"_cache",
+				BindingFlags.NonPublic | BindingFlags.Instance);
+			Assert.That(field, Is.Not.Null, "Unable to find _cache field");
+			var cache = (BatchableCache) field.GetValue(queryCache);
+			Assert.That(cache, Is.Not.Null, "_cache is null");
+
+			return cache;
 		}
 
 	}

--- a/src/NHibernate/Async/Cache/StandardQueryCache.cs
+++ b/src/NHibernate/Async/Cache/StandardQueryCache.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cfg;
+using NHibernate.Collection;
 using NHibernate.Engine;
 using NHibernate.Persister.Collection;
 using NHibernate.Type;
@@ -208,43 +209,85 @@ namespace NHibernate.Cache
 			var persistenceContext = session.PersistenceContext;
 			var defaultReadOnlyOrig = persistenceContext.DefaultReadOnly;
 			var results = new IList[keys.Length];
-			for (var i = 0; i < keys.Length; i++)
+			var finalReturnTypes = new ICacheAssembler[keys.Length][];
+			try
 			{
-				var cacheable = cacheables[i];
-				if (cacheable == null)
-					continue;
+				session.PersistenceContext.BatchFetchQueue.InitializeQueryCacheQueue();
 
-				var key = keys[i];
-				if (checkedSpacesIndexes.Contains(i) && !upToDates[upToDatesIndex++])
+				for (var i = 0; i < keys.Length; i++)
 				{
-					Log.Debug("cached query results were not up to date for: {0}", key);
-					continue;
+					var cacheable = cacheables[i];
+					if (cacheable == null)
+						continue;
+
+					var key = keys[i];
+					if (checkedSpacesIndexes.Contains(i) && !upToDates[upToDatesIndex++])
+					{
+						Log.Debug("cached query results were not up to date for: {0}", key);
+						continue;
+					}
+
+					var queryParams = queryParameters[i];
+					if (queryParams.IsReadOnlyInitialized)
+						persistenceContext.DefaultReadOnly = queryParams.ReadOnly;
+					else
+						queryParams.ReadOnly = persistenceContext.DefaultReadOnly;
+
+					Log.Debug("returning cached query results for: {0}", key);
+
+					finalReturnTypes[i] = GetReturnTypes(key, returnTypes[i], cacheable);
+					await (PerformBeforeAssembleAsync(finalReturnTypes[i], session, cacheable, cancellationToken)).ConfigureAwait(false);
 				}
 
-				var queryParams = queryParameters[i];
-				if (queryParams.IsReadOnlyInitialized)
-					persistenceContext.DefaultReadOnly = queryParams.ReadOnly;
-				else
-					queryParams.ReadOnly = persistenceContext.DefaultReadOnly;
-
-				// Adjust the session cache mode, as GetResultFromCacheable assemble types which may cause
-				// entity loads, which may interact with the cache.
-				using (session.SwitchCacheMode(queryParams.CacheMode))
+				for (var i = 0; i < keys.Length; i++)
 				{
-					try
+					if (finalReturnTypes[i] == null)
 					{
-						results[i] = await (GetResultFromCacheableAsync(
-							key,
-							returnTypes[i],
-							queryParams.NaturalKeyLookup,
-							session,
-							cacheable, cancellationToken)).ConfigureAwait(false);
+						continue;
 					}
-					finally
+
+					var queryParams = queryParameters[i];
+					// Adjust the session cache mode, as PerformAssemble assemble types which may cause
+					// entity loads, which may interact with the cache.
+					using (session.SwitchCacheMode(queryParams.CacheMode))
 					{
-						persistenceContext.DefaultReadOnly = defaultReadOnlyOrig;
+						try
+						{
+							results[i] = await (PerformAssembleAsync(keys[i], finalReturnTypes[i], queryParams.NaturalKeyLookup, session, cacheables[i], cancellationToken)).ConfigureAwait(false);
+						}
+						finally
+						{
+							persistenceContext.DefaultReadOnly = defaultReadOnlyOrig;
+						}
 					}
 				}
+
+				for (var i = 0; i < keys.Length; i++)
+				{
+					if (finalReturnTypes[i] == null)
+					{
+						continue;
+					}
+
+					var queryParams = queryParameters[i];
+					// Adjust the session cache mode, as InitializeCollections will initialize collections,
+					// which may interact with the cache.
+					using (session.SwitchCacheMode(queryParams.CacheMode))
+					{
+						try
+						{
+							await (InitializeCollectionsAsync(finalReturnTypes[i], session, results[i], cacheables[i], cancellationToken)).ConfigureAwait(false);
+						}
+						finally
+						{
+							persistenceContext.DefaultReadOnly = defaultReadOnlyOrig;
+						}
+					}
+				}
+			}
+			finally
+			{
+				session.PersistenceContext.BatchFetchQueue.TerminateQueryCacheQueue();
 			}
 
 			return results;
@@ -275,7 +318,33 @@ namespace NHibernate.Cache
 			return cacheable;
 		}
 
-		private async Task<IList> GetResultFromCacheableAsync(
+		private static async Task PerformBeforeAssembleAsync(
+			ICacheAssembler[] returnTypes,
+			ISessionImplementor session,
+			IList cacheable, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (returnTypes.Length == 1)
+			{
+				var returnType = returnTypes[0];
+
+				// Skip first element, it is the timestamp
+				for (var i = 1; i < cacheable.Count; i++)
+				{
+					await (returnType.BeforeAssembleAsync(cacheable[i], session, cancellationToken)).ConfigureAwait(false);
+				}
+			}
+			else
+			{
+				// Skip first element, it is the timestamp
+				for (var i = 1; i < cacheable.Count; i++)
+				{
+					await (TypeHelper.BeforeAssembleAsync((object[]) cacheable[i], returnTypes, session, cancellationToken)).ConfigureAwait(false);
+				}
+			}
+		}
+
+		private async Task<IList> PerformAssembleAsync(
 			QueryKey key,
 			ICacheAssembler[] returnTypes,
 			bool isNaturalKeyLookup,
@@ -283,12 +352,6 @@ namespace NHibernate.Cache
 			IList cacheable, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			Log.Debug("returning cached query results for: {0}", key);
-			if (key.ResultTransformer?.AutoDiscoverTypes == true && cacheable.Count > 0)
-			{
-				returnTypes = GuessTypes(cacheable);
-			}
-
 			try
 			{
 				var result = new List<object>(cacheable.Count - 1);
@@ -299,25 +362,15 @@ namespace NHibernate.Cache
 					// Skip first element, it is the timestamp
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						await (returnType.BeforeAssembleAsync(cacheable[i], session, cancellationToken)).ConfigureAwait(false);
-					}
-
-					for (var i = 1; i < cacheable.Count; i++)
-					{
 						result.Add(await (returnType.AssembleAsync(cacheable[i], session, null, cancellationToken)).ConfigureAwait(false));
 					}
 				}
 				else
 				{
-					var collectionIndexes = new Dictionary<int, ICollectionPersister>();
 					var nonCollectionTypeIndexes = new List<int>();
 					for (var i = 0; i < returnTypes.Length; i++)
 					{
-						if (returnTypes[i] is CollectionType collectionType)
-						{
-							collectionIndexes.Add(i, session.Factory.GetCollectionPersister(collectionType.Role));
-						}
-						else
+						if (!(returnTypes[i] is CollectionType))
 						{
 							nonCollectionTypeIndexes.Add(i);
 						}
@@ -326,23 +379,7 @@ namespace NHibernate.Cache
 					// Skip first element, it is the timestamp
 					for (var i = 1; i < cacheable.Count; i++)
 					{
-						await (TypeHelper.BeforeAssembleAsync((object[]) cacheable[i], returnTypes, session, cancellationToken)).ConfigureAwait(false);
-					}
-
-					for (var i = 1; i < cacheable.Count; i++)
-					{
 						result.Add(await (TypeHelper.AssembleAsync((object[]) cacheable[i], returnTypes, nonCollectionTypeIndexes, session, cancellationToken)).ConfigureAwait(false));
-					}
-
-					// Initialization of the fetched collection must be done at the end in order to be able to batch fetch them
-					// from the cache or database. The collections were already created in the previous for statement so we only
-					// have to initialize them.
-					if (collectionIndexes.Count > 0)
-					{
-						for (var i = 1; i < cacheable.Count; i++)
-						{
-							await (TypeHelper.InitializeCollectionsAsync((object[]) cacheable[i], (object[]) result[i - 1], collectionIndexes, session, cancellationToken)).ConfigureAwait(false);
-						}
 					}
 				}
 
@@ -364,6 +401,66 @@ namespace NHibernate.Cache
 				}
 
 				throw;
+			}
+		}
+
+		private static async Task InitializeCollectionsAsync(
+			ICacheAssembler[] returnTypes,
+			ISessionImplementor session,
+			IList assembleResult,
+			IList cacheResult, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var collectionIndexes = new Dictionary<int, ICollectionPersister>();
+			for (var i = 0; i < returnTypes.Length; i++)
+			{
+				if (returnTypes[i] is CollectionType collectionType)
+				{
+					collectionIndexes.Add(i, session.Factory.GetCollectionPersister(collectionType.Role));
+				}
+			}
+
+			if (collectionIndexes.Count == 0)
+			{
+				return;
+			}
+
+			// Skip first element, it is the timestamp
+			for (var i = 1; i < cacheResult.Count; i++)
+			{
+				// Initialization of the fetched collection must be done at the end in order to be able to batch fetch them
+				// from the cache or database. The collections were already created when their owners were assembled so we only
+				// have to initialize them.
+				await (TypeHelper.InitializeCollectionsAsync(
+					(object[]) cacheResult[i],
+					(object[]) assembleResult[i - 1],
+					collectionIndexes,
+					session, cancellationToken)).ConfigureAwait(false);
+			}
+		}
+
+		private async Task<IList> GetResultFromCacheableAsync(
+			QueryKey key,
+			ICacheAssembler[] returnTypes,
+			bool isNaturalKeyLookup,
+			ISessionImplementor session,
+			IList cacheable, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			Log.Debug("returning cached query results for: {0}", key);
+			returnTypes = GetReturnTypes(key, returnTypes, cacheable);
+			try
+			{
+				session.PersistenceContext.BatchFetchQueue.InitializeQueryCacheQueue();
+
+				await (PerformBeforeAssembleAsync(returnTypes, session, cacheable, cancellationToken)).ConfigureAwait(false);
+				var result = await (PerformAssembleAsync(key, returnTypes, isNaturalKeyLookup, session, cacheable, cancellationToken)).ConfigureAwait(false);
+				await (InitializeCollectionsAsync(returnTypes, session, result, cacheable, cancellationToken)).ConfigureAwait(false);
+				return result;
+			}
+			finally
+			{
+				session.PersistenceContext.BatchFetchQueue.TerminateQueryCacheQueue();
 			}
 		}
 

--- a/src/NHibernate/Async/Engine/BatchFetchQueue.cs
+++ b/src/NHibernate/Async/Engine/BatchFetchQueue.cs
@@ -15,6 +15,7 @@ using NHibernate.Persister.Collection;
 using NHibernate.Persister.Entity;
 using NHibernate.Util;
 using System.Collections.Generic;
+using System.Linq;
 using Iesi.Collections.Generic;
 
 namespace NHibernate.Engine
@@ -395,6 +396,13 @@ namespace NHibernate.Engine
 			{
 				return result;
 			}
+
+			// Do not check the cache when disassembling entities from the cached query that were already checked
+			if (QueryCacheQueue != null && entityKeys.All(o => QueryCacheQueue.WasEntityKeyChecked(persister, o.Key)))
+			{
+				return result;
+			}
+
 			var cacheKeys = new object[keyIndexes.Length];
 			var i = 0;
 			foreach (var index in keyIndexes)
@@ -434,6 +442,13 @@ namespace NHibernate.Engine
 			{
 				return result;
 			}
+
+			// Do not check the cache when disassembling collections from the cached query that were already checked
+			if (QueryCacheQueue != null && collectionKeys.All(o => QueryCacheQueue.WasCollectionEntryChecked(persister, o.Key.Key)))
+			{
+				return result;
+			}
+
 			var cacheKeys = new object[keyIndexes.Length];
 			var i = 0;
 			foreach (var index in keyIndexes)

--- a/src/NHibernate/Async/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -94,10 +94,31 @@ namespace NHibernate.Event.Default
 			var batchSize = persister.GetBatchSize();
 			if (batchSize > 1 && persister.Cache.PreferMultipleGet())
 			{
-				var collectionEntries = new CollectionEntry[batchSize];
 				// The first item in the array is the item that we want to load
-				var collectionBatch = await (source.PersistenceContext.BatchFetchQueue
-				                            .GetCollectionBatchAsync(persister, collectionKey, batchSize, false, collectionEntries, cancellationToken)).ConfigureAwait(false);
+				CollectionEntry[] collectionEntries = null;
+				object[] collectionBatch = null;
+				var queryCacheQueue = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
+				if (queryCacheQueue != null)
+				{
+					collectionBatch = queryCacheQueue.GetCollectionBatch(persister, collectionKey, out collectionEntries);
+					if (collectionBatch != null)
+					{
+						if (collectionBatch.Length == 0)
+						{
+							return false; // The key was already checked
+						}
+
+						batchSize = collectionBatch.Length;
+					}
+				}
+
+				if (collectionBatch == null)
+				{
+					collectionEntries = new CollectionEntry[batchSize];
+					collectionBatch = await (source.PersistenceContext.BatchFetchQueue
+					                        .GetCollectionBatchAsync(persister, collectionKey, batchSize, false, collectionEntries, cancellationToken)).ConfigureAwait(false);
+				}
+
 				// Ignore null values as the retrieved batch may contains them when there are not enough
 				// uninitialized collection in the queue
 				var keys = new List<CacheKey>(batchSize);

--- a/src/NHibernate/Async/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -92,24 +92,20 @@ namespace NHibernate.Event.Default
 			}
 
 			var batchSize = persister.GetBatchSize();
-			if (batchSize > 1 && persister.Cache.PreferMultipleGet())
+			CollectionEntry[] collectionEntries = null;
+			var collectionBatch = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue
+			                            ?.GetCollectionBatch(persister, collectionKey, out collectionEntries);
+			if ((collectionBatch != null || batchSize > 1) && persister.Cache.PreferMultipleGet())
 			{
 				// The first item in the array is the item that we want to load
-				CollectionEntry[] collectionEntries = null;
-				object[] collectionBatch = null;
-				var queryCacheQueue = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
-				if (queryCacheQueue != null)
+				if (collectionBatch != null)
 				{
-					collectionBatch = queryCacheQueue.GetCollectionBatch(persister, collectionKey, out collectionEntries);
-					if (collectionBatch != null)
+					if (collectionBatch.Length == 0)
 					{
-						if (collectionBatch.Length == 0)
-						{
-							return false; // The key was already checked
-						}
-
-						batchSize = collectionBatch.Length;
+						return false; // The key was already checked
 					}
+
+					batchSize = collectionBatch.Length;
 				}
 
 				if (collectionBatch == null)

--- a/src/NHibernate/Async/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultLoadEventListener.cs
@@ -414,23 +414,19 @@ namespace NHibernate.Event.Default
 			}
 			ISessionFactoryImplementor factory = source.Factory;
 			var batchSize = persister.GetBatchSize();
-			if (batchSize > 1 && persister.Cache.PreferMultipleGet())
+			var entityBatch = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue
+			                        ?.GetEntityBatch(persister, @event.EntityId);
+			if ((entityBatch != null || batchSize > 1) && persister.Cache.PreferMultipleGet())
 			{
 				// The first item in the array is the item that we want to load
-				object[] entityBatch = null;
-				var queryCacheQueue = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
-				if (queryCacheQueue != null)
+				if (entityBatch != null)
 				{
-					entityBatch = queryCacheQueue.GetEntityBatch(persister, @event.EntityId);
-					if (entityBatch != null)
+					if (entityBatch.Length == 0)
 					{
-						if (entityBatch.Length == 0)
-						{
-							return null; // The key was already checked
-						}
-
-						batchSize = entityBatch.Length;
+						return null; // The key was already checked
 					}
+
+					batchSize = entityBatch.Length;
 				}
 
 				if (entityBatch == null)

--- a/src/NHibernate/Async/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultLoadEventListener.cs
@@ -417,8 +417,27 @@ namespace NHibernate.Event.Default
 			if (batchSize > 1 && persister.Cache.PreferMultipleGet())
 			{
 				// The first item in the array is the item that we want to load
-				var entityBatch =
-					await (source.PersistenceContext.BatchFetchQueue.GetEntityBatchAsync(persister, @event.EntityId, batchSize, false, cancellationToken)).ConfigureAwait(false);
+				object[] entityBatch = null;
+				var queryCacheQueue = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
+				if (queryCacheQueue != null)
+				{
+					entityBatch = queryCacheQueue.GetEntityBatch(persister, @event.EntityId);
+					if (entityBatch != null)
+					{
+						if (entityBatch.Length == 0)
+						{
+							return null; // The key was already checked
+						}
+
+						batchSize = entityBatch.Length;
+					}
+				}
+
+				if (entityBatch == null)
+				{
+					entityBatch = await (source.PersistenceContext.BatchFetchQueue.GetEntityBatchAsync(persister, @event.EntityId, batchSize, false, cancellationToken)).ConfigureAwait(false);
+				}
+
 				// Ignore null values as the retrieved batch may contains them when there are not enough
 				// uninitialized entities in the queue
 				var keys = new List<CacheKey>(batchSize);

--- a/src/NHibernate/Async/Type/CollectionType.cs
+++ b/src/NHibernate/Async/Type/CollectionType.cs
@@ -111,11 +111,6 @@ namespace NHibernate.Type
 			}
 
 			var persister = GetPersister(session);
-			if (persister.GetBatchSize() <= 1)
-			{
-				return;
-			}
-
 			var key = await (persister.KeyType.AssembleAsync(oid, session, null, cancellationToken)).ConfigureAwait(false);
 			queryCacheQueue.AddCollection(persister, new CollectionKey(persister, key));
 		}

--- a/src/NHibernate/Async/Type/ManyToOneType.cs
+++ b/src/NHibernate/Async/Type/ManyToOneType.cs
@@ -55,7 +55,7 @@ namespace NHibernate.Type
 			// NOTE: the owner of the association is not really the owner of the id!
 			object id = await (GetIdentifierOrUniqueKeyType(session.Factory)
 				.NullSafeGetAsync(rs, names, session, owner, cancellationToken)).ConfigureAwait(false);
-			ScheduleBatchLoadIfNeeded(id, session);
+			ScheduleBatchLoadIfNeeded(id, session, false);
 			return id;
 		}
 
@@ -117,7 +117,7 @@ namespace NHibernate.Type
 		public override async Task BeforeAssembleAsync(object oid, ISessionImplementor session, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			ScheduleBatchLoadIfNeeded(await (AssembleIdAsync(oid, session, cancellationToken)).ConfigureAwait(false), session);
+			ScheduleBatchLoadIfNeeded(await (AssembleIdAsync(oid, session, cancellationToken)).ConfigureAwait(false), session, true);
 		}
 
 		private Task<object> AssembleIdAsync(object oid, ISessionImplementor session, CancellationToken cancellationToken)

--- a/src/NHibernate/Engine/QueryCacheBatchQueue.cs
+++ b/src/NHibernate/Engine/QueryCacheBatchQueue.cs
@@ -188,11 +188,6 @@ namespace NHibernate.Engine
 		/// <param name="key">The entity key.</param>
 		internal void AddEntityKey(EntityKey key)
 		{
-			if (!key.IsBatchLoadable)
-			{
-				return;
-			}
-
 			if (!_queryEntityKeys.TryGetValue(key.EntityName, out var querySet))
 			{
 				querySet = new HashSet<EntityKey>();
@@ -209,11 +204,6 @@ namespace NHibernate.Engine
 		/// <param name="ce">The collection entry.</param>
 		internal void AddCollection(ICollectionPersister persister, CollectionKey ce)
 		{
-			if (persister.GetBatchSize() <= 1)
-			{
-				return;
-			}
-
 			if (!_queryCollectionKeys.TryGetValue(persister.Role, out var querySet))
 			{
 				querySet = new Dictionary<CollectionKey, CollectionEntry>();

--- a/src/NHibernate/Engine/QueryCacheBatchQueue.cs
+++ b/src/NHibernate/Engine/QueryCacheBatchQueue.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Collections.Generic;
+using NHibernate.Persister.Collection;
+using NHibernate.Persister.Entity;
+
+namespace NHibernate.Engine
+{
+	/// <summary>
+	/// A batcher used to retrieve a batch of entity or collection keys that are present in the cached query.
+	/// </summary>
+	internal class QueryCacheBatchQueue
+	{
+		private readonly IPersistenceContext _persistenceContext;
+
+		/// <summary>
+		/// Used to hold information about the entities that are currently eligible for batch-fetching. Ultimately
+		/// used by <see cref="GetEntityBatch" /> to build entity load batches.
+		/// </summary>
+		private readonly IDictionary<string, HashSet<EntityKey>> _queryEntityKeys;
+
+		/// <summary>
+		/// Used to hold information about entity keys that were checked in the cache.
+		/// </summary>
+		private readonly IDictionary<string, HashSet<EntityKey>> _queryCheckedEntityKeys;
+
+		/// <summary>
+		/// Used to hold information about collection entries that are currently eligible for batch-fetching. Ultimately
+		/// used by <see cref="GetCollectionBatch" /> to build collection load batches.
+		/// </summary>
+		private readonly IDictionary<string, IDictionary<CollectionKey, CollectionEntry>> _queryCollectionKeys;
+
+		/// <summary>
+		/// Used to hold information about collection keys that were checked in the cache.
+		/// </summary>
+		private readonly IDictionary<string, HashSet<CollectionKey>> _queryCheckedCollectionKeys;
+
+		/// <summary>
+		/// Used to hold information about collection entries that were checked in the cache.
+		/// </summary>
+		private readonly IDictionary<string, HashSet<CollectionEntry>> _queryCheckedCollectionEntries;
+
+		internal QueryCacheBatchQueue(IPersistenceContext persistenceContext)
+		{
+			_persistenceContext = persistenceContext;
+			_queryEntityKeys = new Dictionary<string, HashSet<EntityKey>>();
+			_queryCheckedEntityKeys = new Dictionary<string, HashSet<EntityKey>>();
+			_queryCollectionKeys = new Dictionary<string, IDictionary<CollectionKey, CollectionEntry>>();
+			_queryCheckedCollectionKeys = new Dictionary<string, HashSet<CollectionKey>>();
+			_queryCheckedCollectionEntries = new Dictionary<string, HashSet<CollectionEntry>>();
+		}
+
+		/// <summary>
+		/// Get a batch of all unloaded identifiers for a given persister that are present in the cached query.
+		/// Once this method is called the unloaded identifiers for a given persister will be cleared in order to prevent
+		/// double checking the same identifier.
+		/// </summary>
+		/// <param name="persister">The persister for the entities being loaded.</param>
+		/// <param name="id">The identifier of the entity currently demanding load.</param>
+		/// <returns>
+		/// An array of identifiers that can be empty if the identifier was already checked or <see langword="null" />
+		/// if the identifier is not present in the cached query.
+		/// </returns>
+		internal object[] GetEntityBatch(IEntityPersister persister, object id)
+		{
+			if (!_queryEntityKeys.TryGetValue(persister.EntityName, out var entityKeys))
+			{
+				return null; // The entity was not present in the cached query
+			}
+
+			var entityKey = new EntityKey(id, persister);
+			if (_queryCheckedEntityKeys.TryGetValue(persister.EntityName, out var checkedEntityKeys) &&
+				checkedEntityKeys.Contains(entityKey))
+			{
+				return Array.Empty<object>();
+			}
+
+			if (!entityKeys.Contains(entityKey))
+			{
+				return null; // The entity was not present in the cached query
+			}
+
+			var result = new object[entityKeys.Count];
+			var i = 0;
+			result[i++] = id;
+
+			if (checkedEntityKeys == null)
+			{
+				checkedEntityKeys = new HashSet<EntityKey>();
+				_queryCheckedEntityKeys.Add(persister.EntityName, checkedEntityKeys);
+			}
+
+			foreach (var key in entityKeys)
+			{
+				if (persister.IdentifierType.IsEqual(id, key.Identifier) || _persistenceContext.ContainsEntity(key))
+				{
+					continue;
+				}
+
+				result[i++] = key.Identifier;
+				checkedEntityKeys.Add(key);
+			}
+
+			entityKeys.Clear();
+
+			return result;
+		}
+
+		/// <summary>
+		/// Get a batch of all uninitialized collection keys for a given role that are present in the cached query.
+		/// Once this method is called the uninitialized collection keys for a given role will be cleared in order to prevent
+		/// double checking the same keys.
+		/// </summary>
+		/// <param name="collectionPersister">The persister for the collection role.</param>
+		/// <param name="key">A key that must be included in the batch fetch.</param>
+		/// <param name="collectionEntries">An array that will be filled with collection entries if set.</param>
+		/// <returns>
+		/// An array of collection keys that can be empty if the key was already checked or <see langword="null" />
+		/// if the key is not present in the cached query.
+		/// </returns>
+		internal object[] GetCollectionBatch(ICollectionPersister collectionPersister, object key, out CollectionEntry[] collectionEntries)
+		{
+			if (!_queryCollectionKeys.TryGetValue(collectionPersister.Role, out var keys))
+			{
+				collectionEntries = null;
+				return null; // The collection was not present in the cached query
+			}
+
+			var collectionKey = new CollectionKey(collectionPersister, key);
+			if (_queryCheckedCollectionKeys.TryGetValue(collectionPersister.Role, out var checkedKeys) &&
+				checkedKeys.Contains(collectionKey))
+			{
+				collectionEntries = null;
+				return Array.Empty<object>();
+			}
+
+			if (!keys.TryGetValue(collectionKey, out var collectionEntry) || collectionEntry == null)
+			{
+				collectionEntries = null;
+				return null; // The collection was not present in the cached query
+			}
+
+			if (checkedKeys == null)
+			{
+				checkedKeys = new HashSet<CollectionKey>();
+				_queryCheckedCollectionKeys.Add(collectionPersister.Role, checkedKeys);
+			}
+
+			if (!_queryCheckedCollectionEntries.TryGetValue(collectionPersister.Role, out var checkedEntries))
+			{
+				checkedEntries = new HashSet<CollectionEntry>();
+				_queryCheckedCollectionEntries.Add(collectionPersister.Role, checkedEntries);
+			}
+
+			var result = new object[keys.Count];
+			collectionEntries = new CollectionEntry[result.Length];
+			var i = 0;
+			result[i++] = key;
+
+			foreach (var pair in keys)
+			{
+				if (pair.Value == null || _persistenceContext.GetCollection(pair.Key)?.WasInitialized != false)
+				{
+					continue; // The collection was not registered or is already initialized
+				}
+
+				if (collectionPersister.KeyType.IsEqual(key, pair.Value.LoadedKey, collectionPersister.Factory))
+				{
+					collectionEntries[0] = pair.Value;
+					checkedKeys.Add(pair.Key);
+					checkedEntries.Add(pair.Value);
+					continue;
+				}
+
+				collectionEntries[i] = pair.Value;
+				result[i++] = pair.Value.LoadedKey;
+				checkedKeys.Add(pair.Key);
+				checkedEntries.Add(pair.Value);
+			}
+
+			keys.Clear();
+
+			return result;
+		}
+
+		/// <summary>
+		/// Adds the entity to the batch.
+		/// </summary>
+		/// <param name="key">The entity key.</param>
+		internal void AddEntityKey(EntityKey key)
+		{
+			if (!key.IsBatchLoadable)
+			{
+				return;
+			}
+
+			if (!_queryEntityKeys.TryGetValue(key.EntityName, out var querySet))
+			{
+				querySet = new HashSet<EntityKey>();
+				_queryEntityKeys.Add(key.EntityName, querySet);
+			}
+
+			querySet.Add(key);
+		}
+
+		/// <summary>
+		/// Adds the collection to the batch.
+		/// </summary>
+		/// <param name="persister">The collection persister.</param>
+		/// <param name="ce">The collection entry.</param>
+		internal void AddCollection(ICollectionPersister persister, CollectionKey ce)
+		{
+			if (persister.GetBatchSize() <= 1)
+			{
+				return;
+			}
+
+			if (!_queryCollectionKeys.TryGetValue(persister.Role, out var querySet))
+			{
+				querySet = new Dictionary<CollectionKey, CollectionEntry>();
+				_queryCollectionKeys.Add(persister.Role, querySet);
+			}
+
+			if (!querySet.ContainsKey(ce))
+			{
+				querySet.Add(ce, null);
+			}
+		}
+
+		/// <summary>
+		/// Links the created collection entry with the stored collection key.
+		/// </summary>
+		/// <param name="ce">The collection entry.</param>
+		internal void LinkCollectionEntry(CollectionEntry ce)
+		{
+			if (!_queryCollectionKeys.TryGetValue(ce.LoadedPersister.Role, out var keys) ||
+				keys.Count <= 0)
+			{
+				return;
+			}
+			var key = new CollectionKey(ce.LoadedPersister, ce.LoadedKey);
+			if (keys.ContainsKey(key))
+			{
+				keys[key] = ce;
+			}
+		}
+
+		/// <summary>
+		/// Checks whether the entity key was already checked in the cache.
+		/// </summary>
+		/// <param name="persister">The entity persister.</param>
+		/// <param name="key">The entity key.</param>
+		/// <returns><see langword="true"/> whether the entity key was checked, <see langword="false"/> otherwise.</returns>
+		internal bool WasEntityKeyChecked(IEntityPersister persister, EntityKey key)
+		{
+			return _queryCheckedEntityKeys.TryGetValue(persister.EntityName, out var checkedKeys) &&
+				   checkedKeys.Contains(key);
+		}
+
+		/// <summary>
+		/// Checks whether the collection entry was already checked in the cache.
+		/// </summary>
+		/// <param name="persister">The collection persister.</param>
+		/// <param name="entry">The collection entry.</param>
+		/// <returns><see langword="true"/> whether the collection entry was checked, <see langword="false"/> otherwise.</returns>
+		internal bool WasCollectionEntryChecked(ICollectionPersister persister, CollectionEntry entry)
+		{
+			return _queryCheckedCollectionEntries.TryGetValue(persister.Role, out var checkedEntries) &&
+				   checkedEntries.Contains(entry);
+		}
+	}
+}

--- a/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -82,10 +82,31 @@ namespace NHibernate.Event.Default
 			var batchSize = persister.GetBatchSize();
 			if (batchSize > 1 && persister.Cache.PreferMultipleGet())
 			{
-				var collectionEntries = new CollectionEntry[batchSize];
 				// The first item in the array is the item that we want to load
-				var collectionBatch = source.PersistenceContext.BatchFetchQueue
-				                            .GetCollectionBatch(persister, collectionKey, batchSize, false, collectionEntries);
+				CollectionEntry[] collectionEntries = null;
+				object[] collectionBatch = null;
+				var queryCacheQueue = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
+				if (queryCacheQueue != null)
+				{
+					collectionBatch = queryCacheQueue.GetCollectionBatch(persister, collectionKey, out collectionEntries);
+					if (collectionBatch != null)
+					{
+						if (collectionBatch.Length == 0)
+						{
+							return false; // The key was already checked
+						}
+
+						batchSize = collectionBatch.Length;
+					}
+				}
+
+				if (collectionBatch == null)
+				{
+					collectionEntries = new CollectionEntry[batchSize];
+					collectionBatch = source.PersistenceContext.BatchFetchQueue
+					                        .GetCollectionBatch(persister, collectionKey, batchSize, false, collectionEntries);
+				}
+
 				// Ignore null values as the retrieved batch may contains them when there are not enough
 				// uninitialized collection in the queue
 				var keys = new List<CacheKey>(batchSize);

--- a/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultInitializeCollectionEventListener.cs
@@ -83,7 +83,7 @@ namespace NHibernate.Event.Default
 			CollectionEntry[] collectionEntries = null;
 			var collectionBatch = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue
 			                            ?.GetCollectionBatch(persister, collectionKey, out collectionEntries);
-			if ((collectionBatch != null || batchSize > 1) && persister.Cache.PreferMultipleGet())
+			if (collectionBatch != null || batchSize > 1 && persister.Cache.PreferMultipleGet())
 			{
 				// The first item in the array is the item that we want to load
 				if (collectionBatch != null)

--- a/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
@@ -427,7 +427,7 @@ namespace NHibernate.Event.Default
 			var batchSize = persister.GetBatchSize();
 			var entityBatch = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue
 			                        ?.GetEntityBatch(persister, @event.EntityId);
-			if ((entityBatch != null || batchSize > 1) && persister.Cache.PreferMultipleGet())
+			if (entityBatch != null || batchSize > 1 && persister.Cache.PreferMultipleGet())
 			{
 				// The first item in the array is the item that we want to load
 				if (entityBatch != null)

--- a/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultLoadEventListener.cs
@@ -428,8 +428,27 @@ namespace NHibernate.Event.Default
 			if (batchSize > 1 && persister.Cache.PreferMultipleGet())
 			{
 				// The first item in the array is the item that we want to load
-				var entityBatch =
-					source.PersistenceContext.BatchFetchQueue.GetEntityBatch(persister, @event.EntityId, batchSize, false);
+				object[] entityBatch = null;
+				var queryCacheQueue = source.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
+				if (queryCacheQueue != null)
+				{
+					entityBatch = queryCacheQueue.GetEntityBatch(persister, @event.EntityId);
+					if (entityBatch != null)
+					{
+						if (entityBatch.Length == 0)
+						{
+							return null; // The key was already checked
+						}
+
+						batchSize = entityBatch.Length;
+					}
+				}
+
+				if (entityBatch == null)
+				{
+					entityBatch = source.PersistenceContext.BatchFetchQueue.GetEntityBatch(persister, @event.EntityId, batchSize, false);
+				}
+
 				// Ignore null values as the retrieved batch may contains them when there are not enough
 				// uninitialized entities in the queue
 				var keys = new List<CacheKey>(batchSize);

--- a/src/NHibernate/Type/CollectionType.cs
+++ b/src/NHibernate/Type/CollectionType.cs
@@ -167,11 +167,6 @@ namespace NHibernate.Type
 			}
 
 			var persister = GetPersister(session);
-			if (persister.GetBatchSize() <= 1)
-			{
-				return;
-			}
-
 			var key = persister.KeyType.Assemble(oid, session, null);
 			queryCacheQueue.AddCollection(persister, new CollectionKey(persister, key));
 		}

--- a/src/NHibernate/Type/CollectionType.cs
+++ b/src/NHibernate/Type/CollectionType.cs
@@ -158,6 +158,24 @@ namespace NHibernate.Type
 			}
 		}
 
+		public override void BeforeAssemble(object oid, ISessionImplementor session)
+		{
+			var queryCacheQueue = session.PersistenceContext.BatchFetchQueue.QueryCacheQueue;
+			if (queryCacheQueue == null)
+			{
+				return;
+			}
+
+			var persister = GetPersister(session);
+			if (persister.GetBatchSize() <= 1)
+			{
+				return;
+			}
+
+			var key = persister.KeyType.Assemble(oid, session, null);
+			queryCacheQueue.AddCollection(persister, new CollectionKey(persister, key));
+		}
+
 		public override object Assemble(object cached, ISessionImplementor session, object owner)
 		{
 			//we must use the "remembered" uk value, since it is 

--- a/src/NHibernate/Type/ManyToOneType.cs
+++ b/src/NHibernate/Type/ManyToOneType.cs
@@ -100,13 +100,13 @@ namespace NHibernate.Type
 			if (uniqueKeyPropertyName == null && id != null)
 			{
 				var persister = session.Factory.GetEntityPersister(GetAssociatedEntityName());
-				if (!persister.IsBatchLoadable)
+				if (!persister.IsBatchLoadable && !addToQueryCacheBatch)
 				{
 					return;
 				}
 
 				var entityKey = session.GenerateEntityKey(id, persister);
-				if (!session.PersistenceContext.ContainsEntity(entityKey))
+				if (persister.IsBatchLoadable && !session.PersistenceContext.ContainsEntity(entityKey))
 				{
 					session.PersistenceContext.BatchFetchQueue.AddBatchLoadableEntityKey(entityKey);
 				}


### PR DESCRIPTION
This PR tends to minimize 2nd level cache calls when retrieving entities/collections from the batchable cache when assembling objects from a cached query. Today, when a cached query is retrieved from the cache the same batching logic is applied as when a lazy entity is initialized, which means that the entity batch fetch size will be used that can be far less that the query result count. To solve this problem a special queue was created that is initialized by the query cache and will replace the current one in order to optimize the cache calls. Once the query cache is done with the assembling the special queue is removed and the old one takes its place.
There is still one optimization that can be done but would require to have the `CacheBatcher` on a sesssion in order to combine multiple entity/collection batch loads when they are not present in the cache. Additionaly a special setting could be added that would allow to batch a bigger number of entities when batching from the database entities that are present in the cached query. 

This PR should be reviewed after #1952