### PR TITLE
Fix lazy property caching

### DIFF
--- a/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
+++ b/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
@@ -4,6 +4,7 @@
 					namespace="NHibernate.Test.LazyProperty">
 	
 	<class name="Book">
+		<cache usage="nonstrict-read-write" include="non-lazy" />
 		<id name="Id">
 			<generator class="assigned" />
 		</id>

--- a/src/NHibernate/Async/Cache/Entry/CacheEntry.cs
+++ b/src/NHibernate/Async/Cache/Entry/CacheEntry.cs
@@ -29,7 +29,12 @@ namespace NHibernate.Cache.Entry
 			return new CacheEntry
 			{
 				//disassembled state gets put in a new array (we write to cache by value!)
-				DisassembledState = await (TypeHelper.DisassembleAsync(state, persister.PropertyTypes, null, session, owner, cancellationToken)).ConfigureAwait(false),
+				DisassembledState = await (TypeHelper.DisassembleAsync(
+					state,
+					persister.PropertyTypes,
+					persister.IsLazyPropertiesCacheable ? null : persister.PropertyLaziness,
+					session,
+					owner, cancellationToken)).ConfigureAwait(false),
 				AreLazyPropertiesUnfetched = unfetched || !persister.IsLazyPropertiesCacheable,
 				Subclass = persister.EntityName,
 				Version = version

--- a/src/NHibernate/Cache/Entry/CacheEntry.cs
+++ b/src/NHibernate/Cache/Entry/CacheEntry.cs
@@ -40,7 +40,12 @@ namespace NHibernate.Cache.Entry
 			return new CacheEntry
 			{
 				//disassembled state gets put in a new array (we write to cache by value!)
-				DisassembledState = TypeHelper.Disassemble(state, persister.PropertyTypes, null, session, owner),
+				DisassembledState = TypeHelper.Disassemble(
+					state,
+					persister.PropertyTypes,
+					persister.IsLazyPropertiesCacheable ? null : persister.PropertyLaziness,
+					session,
+					owner),
 				AreLazyPropertiesUnfetched = unfetched || !persister.IsLazyPropertiesCacheable,
 				Subclass = persister.EntityName,
 				Version = version

--- a/src/NHibernate/Cfg/XmlHbmBinding/RootClassBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/RootClassBinder.cs
@@ -268,6 +268,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 			{
 				rootClass.CacheConcurrencyStrategy = cacheSchema.usage.ToCacheConcurrencyStrategy();
 				rootClass.CacheRegionName = cacheSchema.region;
+				rootClass.SetLazyPropertiesCacheable(cacheSchema.include == HbmCacheInclude.All);
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes the caching of lazy properties when they are ignored by `class-cache` from the session factory configuration, which currently does not work as `CacheEntry.Create` ignores `IsLazyPropertiesCacheable` when disassembling the entity state. In addition the cache's include attribute is fixed as currently is ignored.