### PR TITLE
Backport Query space invalidation doesn't work for bulk actions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.1.3.{build}
+version: 5.1.4.{build}
 image: Visual Studio 2017
 environment:
   matrix:

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">1</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">3</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">4</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -13,8 +13,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.1.3" overwrite="false" />
-	<property name="project.version.numeric" value="5.1.3" overwrite="false" />
+	<property name="project.version" value="5.1.4" overwrite="false" />
+	<property name="project.version.numeric" value="5.1.4" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,3 +1,12 @@
+Build 5.1.4
+=============================
+
+Release notes - NHibernate - Version 5.1.4
+
+** Bug
+
+   * #1959 Backport Query space invalidation doesn't work for bulk actions
+
 Build 5.1.3
 =============================
 

--- a/src/NHibernate.Test/Async/SecondLevelCacheTest/InvalidationTests.cs
+++ b/src/NHibernate.Test/Async/SecondLevelCacheTest/InvalidationTests.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Impl;
+using NHibernate.Linq;
 using NHibernate.Test.SecondLevelCacheTests;
 using NSubstitute;
 using NUnit.Framework;
@@ -59,6 +60,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 
 			using (var session = OpenSession())
 			{
+				//Add Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -70,6 +72,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 					await (tx.CommitAsync());
 				}
 
+				//Update Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -81,6 +84,7 @@ namespace NHibernate.Test.SecondLevelCacheTest
 					await (tx.CommitAsync());
 				}
 
+				//Delete Item
 				using (var tx = session.BeginTransaction())
 				{
 					foreach (var i in Enumerable.Range(1, 10))
@@ -91,14 +95,44 @@ namespace NHibernate.Test.SecondLevelCacheTest
 
 					await (tx.CommitAsync());
 				}
+
+				//Update Item using HQL
+				using (var tx = session.BeginTransaction())
+				{
+					await (session.CreateQuery("UPDATE Item SET Name='Test'").ExecuteUpdateAsync());
+
+					await (tx.CommitAsync());
+				}
+
+
+				//Update Item using LINQ
+				using (var tx = session.BeginTransaction())
+				{
+					await (session.Query<Item>()
+					       .UpdateBuilder()
+					       .Set(x => x.Name, "Test")
+					       .UpdateAsync(CancellationToken.None));
+
+					await (tx.CommitAsync());
+				}
+
+				//Update Item using SQL
+				using (var tx = session.BeginTransaction())
+				{
+					await (session.CreateSQLQuery("UPDATE Item SET Name='Test'")
+					       .ExecuteUpdateAsync());
+
+					await (tx.CommitAsync());
+				}
 			}
 
-			//Should receive one preinvalidation and one invalidation per commit
+			//Should receive one preinvalidation per non-DML commit
 			Assert.That(preInvalidations, Has.Count.EqualTo(3));
 			Assert.That(preInvalidations, Has.All.Count.EqualTo(1).And.Contains("Item"));
 
-			Assert.That(invalidations, Has.Count.EqualTo(3));
-			Assert.That(invalidations, Has.All.Count.EqualTo(1).And.Contains("Item"));
+			///...and one invalidation per commit
+			Assert.That(invalidations, Has.Count.EqualTo(6));
+			Assert.That(invalidations, Has.All.Contains("Item"));
 		}
 
 		protected override void OnTearDown()

--- a/src/NHibernate/Async/Engine/ActionQueue.cs
+++ b/src/NHibernate/Async/Engine/ActionQueue.cs
@@ -82,10 +82,6 @@ namespace NHibernate.Engine
 			}
 			finally
 			{
-				if (executable.PropertySpaces != null)
-				{
-					executedSpaces.UnionWith(executable.PropertySpaces);
-				}
 				RegisterCleanupActions(executable);
 			}
 		}

--- a/src/NHibernate/Engine/ActionQueue.cs
+++ b/src/NHibernate/Engine/ActionQueue.cs
@@ -185,10 +185,6 @@ namespace NHibernate.Engine
 			}
 			finally
 			{
-				if (executable.PropertySpaces != null)
-				{
-					executedSpaces.UnionWith(executable.PropertySpaces);
-				}
 				RegisterCleanupActions(executable);
 			}
 		}
@@ -197,6 +193,10 @@ namespace NHibernate.Engine
 		{
 			beforeTransactionProcesses.Register(executable.BeforeTransactionCompletionProcess);
 			afterTransactionProcesses.Register(executable.AfterTransactionCompletionProcess);
+			if (executable.PropertySpaces != null)
+			{
+				executedSpaces.UnionWith(executable.PropertySpaces);
+			}
 		}
 
 		/// <summary> 


### PR DESCRIPTION
This backports #1953.

Some changes had to be done due to #1392 being done only in 5.2.0.

This PR also directly includes the release changes. Should they stay as a separated commits? Or does it seem right to squash it all together? I would tend to squash it all.