### PR TITLE
Fix code sample in docs, section 10.4.2

### DIFF
--- a/doc/reference/modules/manipulating_data.xml
+++ b/doc/reference/modules/manipulating_data.xml
@@ -529,8 +529,7 @@ firstSession.Save(potentialMate);
 cat.Mate = potentialMate;
 
 // later, in a new session
-secondSession.Update(cat);  // update cat
-secondSession.Update(mate); // update mate]]></programlisting>
+secondSession.Update(cat);  // update cat]]></programlisting>
 
             <para>
                 If the <literal>Cat</literal> with identifier <literal>catId</literal> had already


### PR DESCRIPTION
There is no variable `mate` in [this code sample](https://nhibernate.info/doc/nhibernate-reference/manipulatingdata.html#manipulatingdata-updating-detached), so the code `secondSession.Update(mate);` won't compile.

The line can easily be removed. It may have been copied & pasted from a similar sample a few lines below.