### PR TITLE
Optimize StaticProxyFactory GetProxy and GetFieldInterceptionProxy methods

### DIFF
--- a/src/NHibernate/Proxy/StaticProxyFactory.cs
+++ b/src/NHibernate/Proxy/StaticProxyFactory.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using NHibernate.Engine;
 using NHibernate.Intercept;
+using NHibernate.Type;
 
 namespace NHibernate.Proxy
 {
@@ -10,26 +13,48 @@ namespace NHibernate.Proxy
 	{
 		private static readonly ConcurrentDictionary<ProxyCacheEntry, Func<ILazyInitializer, NHibernateProxyFactoryInfo, INHibernateProxy>>
 			Cache = new ConcurrentDictionary<ProxyCacheEntry, Func<ILazyInitializer, NHibernateProxyFactoryInfo, INHibernateProxy>>();
-		private static readonly ConcurrentDictionary<ProxyCacheEntry, Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor>>
-			FieldInterceptorCache = new ConcurrentDictionary<ProxyCacheEntry, Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor>>();
+		private static readonly ConcurrentDictionary<System.Type, Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor>>
+			FieldInterceptorCache = new ConcurrentDictionary<System.Type, Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor>>();
 
 		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(StaticProxyFactory));
+
+		private NHibernateProxyFactoryInfo _proxyFactoryInfo;
+		private ProxyCacheEntry _cacheEntry;
 
 		public override INHibernateProxy GetProxy(object id, ISessionImplementor session)
 		{
 			try
 			{
-				var cacheEntry = new ProxyCacheEntry(IsClassProxy ? PersistentClass : typeof(object), Interfaces);
-				var proxyActivator = Cache.GetOrAdd(cacheEntry, pke => CreateProxyActivator(pke));
+				var proxyActivator = Cache.GetOrAdd(_cacheEntry, pke => CreateProxyActivator(pke));
 				return proxyActivator(
 					new LiteLazyInitializer(EntityName, id, session, PersistentClass),
-					new NHibernateProxyFactoryInfo(EntityName, PersistentClass, Interfaces, GetIdentifierMethod, SetIdentifierMethod, ComponentIdType));
+					_proxyFactoryInfo);
 			}
 			catch (Exception ex)
 			{
 				Log.Error(ex, "Creating a proxy instance failed");
 				throw new HibernateException("Creating a proxy instance failed", ex);
 			}
+		}
+
+		public override void PostInstantiate(
+			string entityName,
+			System.Type persistentClass,
+			ISet<System.Type> interfaces,
+			MethodInfo getIdentifierMethod,
+			MethodInfo setIdentifierMethod,
+			IAbstractComponentType componentIdType)
+		{
+			base.PostInstantiate(entityName, persistentClass, interfaces, getIdentifierMethod, setIdentifierMethod, componentIdType);
+
+			_proxyFactoryInfo = new NHibernateProxyFactoryInfo(
+				EntityName,
+				PersistentClass,
+				Interfaces,
+				GetIdentifierMethod,
+				SetIdentifierMethod,
+				ComponentIdType);
+			_cacheEntry = new ProxyCacheEntry(IsClassProxy ? PersistentClass : typeof(object), Interfaces);
 		}
 
 		private Func<ILazyInitializer, NHibernateProxyFactoryInfo, INHibernateProxy> CreateProxyActivator(ProxyCacheEntry pke)
@@ -51,15 +76,13 @@ namespace NHibernate.Proxy
 
 		public object GetFieldInterceptionProxy()
 		{
-			var cacheEntry = new ProxyCacheEntry(PersistentClass, System.Type.EmptyTypes);
-			var proxyActivator = FieldInterceptorCache.GetOrAdd(cacheEntry, CreateFieldInterceptionProxyActivator);
-			return proxyActivator(
-				new NHibernateProxyFactoryInfo(EntityName, PersistentClass, Interfaces, GetIdentifierMethod, SetIdentifierMethod, ComponentIdType));
+			var proxyActivator = FieldInterceptorCache.GetOrAdd(PersistentClass, CreateFieldInterceptionProxyActivator);
+			return proxyActivator(_proxyFactoryInfo);
 		}
 
-		private Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor> CreateFieldInterceptionProxyActivator(ProxyCacheEntry pke)
+		private Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor> CreateFieldInterceptionProxyActivator(System.Type baseType)
 		{
-			var type = FieldInterceptorProxyBuilder.CreateProxyType(pke.BaseType);
+			var type = FieldInterceptorProxyBuilder.CreateProxyType(baseType);
 			var ctor = type.GetConstructor(new[] { typeof(NHibernateProxyFactoryInfo) });
 			var pf = Expression.Parameter(typeof(NHibernateProxyFactoryInfo));
 			return Expression.Lambda<Func<NHibernateProxyFactoryInfo, IFieldInterceptorAccessor>>(Expression.New(ctor, pf), pf).Compile();


### PR DESCRIPTION
The optimization reuses the same `NHibernateProxyFactoryInfo` and `ProxyCacheEntry` instances in order to reduce memory usage.
Here are some benchmark results from `RawDataAccessBencher`, before:
```
Async eager Load fetches
-------------------------
# of elements fetched: 6768 (4768 + 1000 + 1000).    Fetch took: 93.425.240,00ms. Allocated bytes: 93425240.

Change tracking fetches, set fetches (20 runs), no caching
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.2.0) : 2.114,26ms (77,83ms)   Enum: 1,79ms (0,23ms)

Memory usage, per iteration
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.2.0) : 215.322 KB (220.490.360 bytes)
```

after:
```
Async eager Load fetches
-------------------------
# of elements fetched: 6768 (4768 + 1000 + 1000).    Fetch took: 90.673.920,00ms. Allocated bytes: 90673920.

Change tracking fetches, set fetches (20 runs), no caching
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.2.0) : 2.050,20ms (58,98ms)   Enum: 1,71ms (0,08ms)

Memory usage, per iteration
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.2.0) : 195.868 KB (200.569.192 bytes)
```