### PR TITLE
Optimize ILoadable.Hydrate method

### DIFF
--- a/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
@@ -785,12 +785,13 @@ possible solutions:
 
 		public override void PostInstantiate()
 		{
-			base.PostInstantiate();
 			if (_hasSequentialSelect && !IsAbstract)
 			{
 				var rootLoadable = (AbstractEntityPersister) Factory.GetEntityPersister(RootEntityName);
 				_sequentialSelectString = rootLoadable.GenerateSequentialSelect(this);
 			}
+
+			base.PostInstantiate();
 		}
 	}
 }


### PR DESCRIPTION
This optimization uses a compiled lambda expression delegate for hydrating values from the data reader. The most noticeable difference is in the async test as currently NHibernate uses `HydrateAsync` method which most of the time just forwards the call to the a sync method.
Here are some benchmark results from `RawDataAccessBencher`, before:
```
Async eager Load fetches
-------------------------
# of elements fetched: 6768 (4768 + 1000 + 1000).    Fetch took: 482,10ms. Allocated bytes: 87030520.

Change tracking fetches, set fetches (20 runs), no caching
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.3.0) : 1.853,22ms (44,01ms)   Enum: 1,71ms (0,14ms)

Memory usage, per iteration
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.3.0) : 173.057 KB (177.210.400 bytes)
```

after:
```
Starting bench runs...
Async eager Load fetches
-------------------------
# of elements fetched: 6768 (4768 + 1000 + 1000).    Fetch took: 445,91ms. Allocated bytes: 75274424.

Change tracking fetches, set fetches (20 runs), no caching
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.3.0) : 1.797,11ms (21,23ms)   Enum: 2,54ms (1,73ms)

Memory usage, per iteration
------------------------------------------------------------------------------
NHibernate v5.2.0.0 (v5.2.3.0) : 171.526 KB (175.643.184 bytes)
```