### PR TITLE
Refactor sequential select

### DIFF
--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -793,7 +793,7 @@ namespace NHibernate.Loader
 								? EntityAliases[i].SuffixedPropertyAliases
 								: GetSubclassEntityAliases(i, persister);
 
-			object[] values = await (persister.HydrateAsync(rs, id, obj, rootPersister, cols, eagerPropertyFetch, session, cancellationToken)).ConfigureAwait(false);
+			object[] values = await (persister.HydrateAsync(rs, id, obj, cols, eagerPropertyFetch, session, cancellationToken)).ConfigureAwait(false);
 
 			object rowId = persister.HasRowId ? rs[EntityAliases[i].RowIdAlias] : null;
 

--- a/src/NHibernate/Async/Persister/Entity/ILoadable.cs
+++ b/src/NHibernate/Async/Persister/Entity/ILoadable.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using NHibernate.Type;
 using NHibernate.Engine;
 using System.Data.Common;
@@ -23,7 +24,46 @@ namespace NHibernate.Persister.Entity
 		/// <summary>
 		/// Retrieve property values from one row of a result set
 		/// </summary>
+		//Since 5.3
+		[Obsolete("Use the extension method without the rootLoadable parameter instead")]
 		Task<object[]> HydrateAsync(DbDataReader rs, object id, object obj, ILoadable rootLoadable, string[][] suffixedPropertyColumns,
 						 bool allProperties, ISessionImplementor session, CancellationToken cancellationToken);
+	}
+
+	public static partial class LoadableExtensions
+	{
+		public static Task<object[]> HydrateAsync(
+			this ILoadable loadable,
+			DbDataReader rs,
+			object id,
+			object obj,
+			string[][] suffixedPropertyColumns,
+			bool allProperties,
+			ISessionImplementor session, CancellationToken cancellationToken)
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromCanceled<object[]>(cancellationToken);
+			}
+			try
+			{
+				if (loadable is AbstractEntityPersister entityPersister)
+				{
+					return entityPersister.HydrateAsync(rs, id, obj, suffixedPropertyColumns, allProperties, session, cancellationToken);
+				}
+
+				var rootLoadable = loadable.RootEntityName == loadable.EntityName
+				? loadable
+				: (ILoadable) loadable.Factory.GetEntityPersister(loadable.RootEntityName);
+
+#pragma warning disable 618
+				return loadable.HydrateAsync(rs, id, obj, rootLoadable, suffixedPropertyColumns, allProperties, session, cancellationToken);
+#pragma warning restore 618
+			}
+			catch (Exception ex)
+			{
+				return Task.FromException<object[]>(ex);
+			}
+		}
 	}
 }

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1144,7 +1144,7 @@ namespace NHibernate.Loader
 								? EntityAliases[i].SuffixedPropertyAliases
 								: GetSubclassEntityAliases(i, persister);
 
-			object[] values = persister.Hydrate(rs, id, obj, rootPersister, cols, eagerPropertyFetch, session);
+			object[] values = persister.Hydrate(rs, id, obj, cols, eagerPropertyFetch, session);
 
 			object rowId = persister.HasRowId ? rs[EntityAliases[i].RowIdAlias] : null;
 


### PR DESCRIPTION
This PR moves the generated sequential statements form the root entity to its subclasses which then simplifies the `ILoadable.Hydrate` method as the root persister parameter is not needed anymore.