### PR TITLE
Reduce SessionIdLoggingContext creation

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/GH1391/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1391/Fixture.cs
@@ -56,11 +56,11 @@ namespace NHibernate.Test.NHSpecificTest.GH1391
 		public void Enabled()
 		{
 			var guid = Guid.NewGuid();
-			using (new SessionIdLoggingContext(guid))
+			using (SessionIdLoggingContext.CreateOrNull(guid))
 			{
 				Assert.That(SessionIdLoggingContext.SessionId, Is.EqualTo(guid));
 				var guid2 = Guid.NewGuid();
-				using (new SessionIdLoggingContext(guid2))
+				using (SessionIdLoggingContext.CreateOrNull(guid2))
 				{
 					Assert.That(SessionIdLoggingContext.SessionId, Is.EqualTo(guid2));
 				}
@@ -73,14 +73,14 @@ namespace NHibernate.Test.NHSpecificTest.GH1391
 		public async Task EnabledAsync()
 		{
 			var guid = Guid.NewGuid();
-			using (new SessionIdLoggingContext(guid))
+			using (SessionIdLoggingContext.CreateOrNull(guid))
 			{
 				Assert.That(SessionIdLoggingContext.SessionId, Is.EqualTo(guid));
 				await Task.Delay(1).ConfigureAwait(false);
 				Assert.That(SessionIdLoggingContext.SessionId, Is.EqualTo(guid));
 
 				var guid2 = Guid.NewGuid();
-				using (new SessionIdLoggingContext(guid2))
+				using (SessionIdLoggingContext.CreateOrNull(guid2))
 				{
 					Assert.That(SessionIdLoggingContext.SessionId, Is.EqualTo(guid2));
 					await Task.Delay(1).ConfigureAwait(false);
@@ -95,10 +95,10 @@ namespace NHibernate.Test.NHSpecificTest.GH1391
 		public void Disabled()
 		{
 			var guid = Guid.Empty;
-			using (new SessionIdLoggingContext(guid))
+			using (SessionIdLoggingContext.CreateOrNull(guid))
 			{
 				Assert.That(SessionIdLoggingContext.SessionId, Is.Null);
-				using (new SessionIdLoggingContext(guid))
+				using (SessionIdLoggingContext.CreateOrNull(guid))
 				{
 					Assert.That(SessionIdLoggingContext.SessionId, Is.Null);
 				}
@@ -111,13 +111,13 @@ namespace NHibernate.Test.NHSpecificTest.GH1391
 		public async Task DisabledAsync()
 		{
 			var guid = Guid.Empty;
-			using (new SessionIdLoggingContext(guid))
+			using (SessionIdLoggingContext.CreateOrNull(guid))
 			{
 				Assert.That(SessionIdLoggingContext.SessionId, Is.Null);
 				await Task.Delay(1).ConfigureAwait(false);
 				Assert.That(SessionIdLoggingContext.SessionId, Is.Null);
 				
-				using (new SessionIdLoggingContext(guid))
+				using (SessionIdLoggingContext.CreateOrNull(guid))
 				{
 					Assert.That(SessionIdLoggingContext.SessionId, Is.Null);
 					await Task.Delay(1).ConfigureAwait(false);

--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -105,7 +105,7 @@ namespace NHibernate.Transaction
 		public async Task RollbackAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(sessionId))
+			using (SessionIdLoggingContext.CreateOrNull(sessionId))
 			{
 				CheckNotDisposed();
 				CheckBegun();
@@ -157,7 +157,7 @@ namespace NHibernate.Transaction
 		protected virtual async Task DisposeAsync(bool isDisposing, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			using (new SessionIdLoggingContext(sessionId))
+			using (SessionIdLoggingContext.CreateOrNull(sessionId))
 			{
 				if (_isAlreadyDisposed)
 				{

--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Engine
 		{
 			if (session == null)
 				return null;
-			return (session as AbstractSessionImpl)?.BeginContext() ?? new SessionIdLoggingContext(session.SessionId);
+			return (session as AbstractSessionImpl)?.BeginContext() ?? SessionIdLoggingContext.CreateOrNull(session.SessionId);
 		}
 
 		internal static IDisposable BeginProcess(this ISessionImplementor session)
@@ -35,7 +35,7 @@ namespace NHibernate.Engine
 			return (session as AbstractSessionImpl)?.BeginProcess() ??
 				// This method has only replaced bare call to setting the id, so this fallback is enough for avoiding a
 				// breaking change in case a custom session implementation is used.
-				new SessionIdLoggingContext(session.SessionId);
+				SessionIdLoggingContext.CreateOrNull(session.SessionId);
 		}
 
 		//6.0 TODO: Expose as ISessionImplementor.FutureBatch and replace method usages with property

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -370,7 +370,7 @@ namespace NHibernate.Impl
 		/// </returns>
 		public IDisposable BeginContext()
 		{
-			return _processing ? null : new SessionIdLoggingContext(SessionId);
+			return _processing ? null : SessionIdLoggingContext.CreateOrNull(SessionId);
 		}
 
 		[NonSerialized]
@@ -379,12 +379,12 @@ namespace NHibernate.Impl
 		private sealed class ProcessHelper : IDisposable
 		{
 			private AbstractSessionImpl _session;
-			private SessionIdLoggingContext _context;
+			private IDisposable _context;
 
 			public ProcessHelper(AbstractSessionImpl session)
 			{
 				_session = session;
-				_context = new SessionIdLoggingContext(session.SessionId);
+				_context = SessionIdLoggingContext.CreateOrNull(session.SessionId);
 				try
 				{
 					_session.CheckAndUpdateSessionStatus();
@@ -392,7 +392,7 @@ namespace NHibernate.Impl
 				}
 				catch
 				{
-					_context.Dispose();
+					_context?.Dispose();
 					_context = null;
 					throw;
 				}

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -246,7 +246,7 @@ namespace NHibernate.Transaction
 		/// </exception>
 		public void Rollback()
 		{
-			using (new SessionIdLoggingContext(sessionId))
+			using (SessionIdLoggingContext.CreateOrNull(sessionId))
 			{
 				CheckNotDisposed();
 				CheckBegun();
@@ -363,7 +363,7 @@ namespace NHibernate.Transaction
 		/// </remarks>
 		protected virtual void Dispose(bool isDisposing)
 		{
-			using (new SessionIdLoggingContext(sessionId))
+			using (SessionIdLoggingContext.CreateOrNull(sessionId))
 			{
 				if (_isAlreadyDisposed)
 				{


### PR DESCRIPTION
1) Do not create `SessionIdLoggingContext` if `SessionId` is empty or not changed;
2) Set context on session creation;
It's the simplest way to avoid objects creation in most common scenarios - operations scoped to single session:
```C#
using(var session = OpenSession())
{
session.Method1();
...
using(var session2 = OpenSession())
{
....
}
...
session.MethodN()
}
```

This change may lead to scenarios when SessionId is not properly reset:
```C#
session1 = Open();
session2 = Open();

session1.Dispose();// <- SessionId is set to null
...
session2.Dispose();// <- SessionId is set to value from session1
```
But what's harm in it? It's barely valid scenarios and inside session methods it will be properly set again by `BeginContext` methods.
