### PR TITLE
 Improve exception on user types lacking some interfaces 

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/GH1963/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/Entity.cs
@@ -6,14 +6,6 @@ namespace NHibernate.Test.NHSpecificTest.GH1963
 	{
 		public virtual Guid Id { get; set; }
 		public virtual string Name { get; set; }
-		public virtual bool? Flag { get; set; }
-		public virtual EntityChild Child { get; set; }
-	}
-
-	public class EntityChild
-	{
-		public virtual Guid Id { get; set; }
-		public virtual string Name { get; set; }
-		public virtual bool? Flag { get; set; }
+		public virtual bool Flag { get; set; }
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/GH1963/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/Entity.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace NHibernate.Test.NHSpecificTest.GH1963
+{
+	public class Entity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual bool? Flag { get; set; }
+		public virtual EntityChild Child { get; set; }
+	}
+
+	public class EntityChild
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+		public virtual bool? Flag { get; set; }
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/GH1963/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/Fixture.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace NHibernate.Test.NHSpecificTest.GH1963
+{
+	[TestFixture]
+	public class Fixture : BugTestCase
+	{
+		protected override void OnSetUp()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				var e1 = new EntityChild {Name = "Bob", Flag = true};
+				session.Save(e1);
+
+				var e2 = new Entity {Name = "Sally", Child = e1};
+				session.Save(e2);
+
+				transaction.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				// The HQL delete does all the job inside the database without loading the entities, but it does
+				// not handle delete order for avoiding violating constraints if any. Use
+				// session.Delete("from System.Object");
+				// instead if in need of having NHibernate ordering the deletes, but this will cause
+				// loading the entities in the session.
+				session.CreateQuery("delete from System.Object").ExecuteUpdate();
+
+				transaction.Commit();
+			}
+		}
+
+		[Test]
+		public void LinqFilterOnCustomType()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var result = from e in session.Query<Entity>()
+							 where e.Child.Flag == true
+							 select e;
+
+				Assert.That(result.ToList(), Has.Count.EqualTo(1));
+			}
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/GH1963/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/Mappings.hbm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.GH1963">
+
+  <class name="Entity">
+    <id name="Id" generator="guid.comb"/>
+    <property name="Name"/>
+    <property name="Flag" type="NHibernate.Test.NHSpecificTest.GH1963.SqlBoolean, NHibernate.Test" />
+    <many-to-one name="Child" />
+  </class>
+
+  <class name="EntityChild">
+    <id name="Id" generator="guid.comb"/>
+    <property name="Name"/>
+    <property name="Flag" type="NHibernate.Test.NHSpecificTest.GH1963.SqlBoolean, NHibernate.Test" />
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/GH1963/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/Mappings.hbm.xml
@@ -6,13 +6,6 @@
     <id name="Id" generator="guid.comb"/>
     <property name="Name"/>
     <property name="Flag" type="NHibernate.Test.NHSpecificTest.GH1963.SqlBoolean, NHibernate.Test" />
-    <many-to-one name="Child" />
-  </class>
-
-  <class name="EntityChild">
-    <id name="Id" generator="guid.comb"/>
-    <property name="Name"/>
-    <property name="Flag" type="NHibernate.Test.NHSpecificTest.GH1963.SqlBoolean, NHibernate.Test" />
   </class>
 
 </hibernate-mapping>

--- a/src/NHibernate.Test/NHSpecificTest/GH1963/SqlBoolean.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/SqlBoolean.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+using NHibernate.UserTypes;
+
+namespace NHibernate.Test.NHSpecificTest.GH1963
+{
+	[Serializable]
+	public class SqlBoolean : IUserType
+	{
+		/// <summary>
+		/// Compare two instances of the class mapped by this type for persistent "equality"
+		/// ie. equality of persistent state
+		/// </summary>
+		/// <param name="x"/><param name="y"/>
+		/// <returns/>
+		public new bool Equals(object x, object y)
+		{
+			if (x == y) return true;
+			if (x == null || y == null) return false;
+
+			return x.Equals(y);
+		}
+
+		/// <summary>
+		/// Get a hashcode for the instance, consistent with persistence "equality"
+		/// </summary>
+		public int GetHashCode(object x)
+		{
+			return x.GetHashCode();
+		}
+
+		/// <summary>
+		/// Retrieve an instance of the mapped class from a JDBC resultset.
+		/// Implementors should handle possibility of null values.
+		/// </summary>
+		/// <param name="rs">a IDataReader</param><param name="names">column names</param>
+		/// <param name="session"></param>
+		/// <param name="owner">the containing entity</param>
+		/// <returns/>
+		/// <exception cref="T:NHibernate.HibernateException">HibernateException</exception>
+		public object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner)
+		{
+			object result = NHibernateUtil.String.NullSafeGet(rs, names[0], session, owner);
+
+			if (result == null)
+				return default(bool?);
+			else
+				return result.ToString() == "1";
+		}
+
+		/// <summary>
+		/// Write an instance of the mapped class to a prepared statement.
+		/// Implementors should handle possibility of null values.
+		/// A multi-column type should be written to parameters starting from index.
+		/// </summary>
+		/// <param name="cmd">a IDbCommand</param><param name="value">the object to write</param>
+		/// <param name="index">command parameter index</param>
+		/// <param name="session"></param>
+		/// <exception cref="T:NHibernate.HibernateException">HibernateException</exception>
+		public void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
+		{
+			var result = value != null ? Convert.ToInt16(bool.Parse(value.ToString())) : default(short?);
+
+			NHibernateUtil.Int16.NullSafeSet(cmd, result, index, session);
+		}
+
+		/// <summary>
+		/// Return a deep copy of the persistent state, stopping at entities and at collections.
+		/// </summary>
+		/// <param name="value">generally a collection element or entity field</param>
+		/// <returns>
+		/// a copy
+		/// </returns>
+		public object DeepCopy(object value)
+		{
+			return value;
+		}
+
+		/// <summary>
+		/// During merge, replace the existing (<paramref name="target"/>) value in the entity
+		/// we are merging to with a new (<paramref name="original"/>) value from the detached
+		/// entity we are merging. For immutable objects, or null values, it is safe to simply
+		/// return the first parameter. For mutable objects, it is safe to return a copy of the
+		/// first parameter. For objects with component values, it might make sense to
+		/// recursively replace component values.
+		/// </summary>
+		/// <param name="original">the value from the detached entity being merged</param>
+		/// <param name="target">the value in the managed entity</param>
+		/// <param name="owner">the managed entity</param>
+		/// <returns>
+		/// the value to be merged
+		/// </returns>
+		public object Replace(object original, object target, object owner)
+		{
+			return DeepCopy(original);
+		}
+
+		/// <summary>
+		/// Reconstruct an object from the cacheable representation. At the very least this
+		/// method should perform a deep copy if the type is mutable. (optional operation)
+		/// </summary>
+		/// <param name="cached">the object to be cached</param><param name="owner">the owner of the cached object</param>
+		/// <returns>
+		/// a reconstructed object from the cachable representation
+		/// </returns>
+		public object Assemble(object cached, object owner)
+		{
+			return DeepCopy(cached);
+		}
+
+		/// <summary>
+		/// Transform the object into its cacheable representation. At the very least this
+		/// method should perform a deep copy if the type is mutable. That may not be enough
+		/// for some implementations, however; for example, associations must be cached as
+		/// identifier values. (optional operation)
+		/// </summary>
+		/// <param name="value">the object to be cached</param>
+		/// <returns>
+		/// a cacheable representation of the object
+		/// </returns>
+		public object Disassemble(object value)
+		{
+			return DeepCopy(value);
+		}
+
+		/// <summary>
+		/// The SQL types for the columns mapped by this type. 
+		/// </summary>
+		public SqlType[] SqlTypes
+		{
+			get { return new[] { new SqlType(DbType.Int16) }; }
+		}
+
+		/// <summary>
+		/// The type returned by <c>NullSafeGet()</c>
+		/// </summary>
+		public System.Type ReturnedType
+		{
+			get { return typeof(bool?); }
+		}
+
+		/// <summary>
+		/// Are objects of this type mutable?
+		/// </summary>
+		public bool IsMutable
+		{
+			get { return false; }
+		}
+	}
+}

--- a/src/NHibernate.Test/NHSpecificTest/GH1963/SqlBoolean.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1963/SqlBoolean.cs
@@ -9,6 +9,8 @@ namespace NHibernate.Test.NHSpecificTest.GH1963
 {
 	[Serializable]
 	public class SqlBoolean : IUserType
+		// Uncomment for checking implementing this solves the query exception
+		//, IEnhancedUserType
 	{
 		/// <summary>
 		/// Compare two instances of the class mapped by this type for persistent "equality"
@@ -148,6 +150,32 @@ namespace NHibernate.Test.NHSpecificTest.GH1963
 		public bool IsMutable
 		{
 			get { return false; }
+		}
+
+		public object FromXMLString(string xml)
+		{
+			if (bool.TryParse(xml, out var value))
+				return value;
+			return null;
+		}
+
+		public string ObjectToSQLString(object value)
+		{
+			var val = value as bool?;
+			switch (val)
+			{
+				case true:
+					return "1";
+				case false:
+					return "0";
+				default:
+					return "null";
+			}
+		}
+
+		public string ToXMLString(object value)
+		{
+			return value?.ToString();
 		}
 	}
 }

--- a/src/NHibernate/Async/Type/CustomType.cs
+++ b/src/NHibernate/Async/Type/CustomType.cs
@@ -92,7 +92,7 @@ namespace NHibernate.Type
 
 		public Task<object> NextAsync(object current, ISessionImplementor session, CancellationToken cancellationToken)
 		{
-			if (_userVersionType == null)
+			if (!(userType is IUserVersionType userVersionType))
 				throw new InvalidOperationException(
 					$"User type {userType} does not implement {nameof(IUserVersionType)}, Either implement it, or " +
 					$"avoid using this user type as a version type.");
@@ -112,7 +112,7 @@ namespace NHibernate.Type
 
 		public Task<object> SeedAsync(ISessionImplementor session, CancellationToken cancellationToken)
 		{
-			if (_userVersionType == null)
+			if (!(userType is IUserVersionType userVersionType))
 				throw new InvalidOperationException(
 					$"User type {userType} does not implement {nameof(IUserVersionType)}, Either implement it, or " +
 					$"avoid using this user type as a version type.");

--- a/src/NHibernate/Async/Type/CustomType.cs
+++ b/src/NHibernate/Async/Type/CustomType.cs
@@ -92,6 +92,10 @@ namespace NHibernate.Type
 
 		public Task<object> NextAsync(object current, ISessionImplementor session, CancellationToken cancellationToken)
 		{
+			if (_userVersionType == null)
+				throw new InvalidOperationException(
+					$"User type {userType} does not implement {nameof(IUserVersionType)}, Either implement it, or " +
+					$"avoid using this user type as a version type.");
 			if (cancellationToken.IsCancellationRequested)
 			{
 				return Task.FromCanceled<object>(cancellationToken);
@@ -108,6 +112,10 @@ namespace NHibernate.Type
 
 		public Task<object> SeedAsync(ISessionImplementor session, CancellationToken cancellationToken)
 		{
+			if (_userVersionType == null)
+				throw new InvalidOperationException(
+					$"User type {userType} does not implement {nameof(IUserVersionType)}, Either implement it, or " +
+					$"avoid using this user type as a version type.");
 			if (cancellationToken.IsCancellationRequested)
 			{
 				return Task.FromCanceled<object>(cancellationToken);


### PR DESCRIPTION
When user types lack some capabilities for the usages done by users, they fail with invalid cast exceptions. This change aims at throwing more explicit exceptions.

Related: #1963