### PR TITLE
Optimize ProxyCacheEntry equality for the same instance

### DIFF
--- a/src/NHibernate/Proxy/ProxyCacheEntry.cs
+++ b/src/NHibernate/Proxy/ProxyCacheEntry.cs
@@ -53,6 +53,9 @@ namespace NHibernate.Proxy
 
 		public bool Equals(ProxyCacheEntry other)
 		{
+			if (ReferenceEquals(this, other))
+				return true;
+
 			if (ReferenceEquals(null, other) ||
 				// hashcode inequality allows an early exit, but their equality is not enough for guaranteeing instances equality.
 				_hashCode != other._hashCode ||


### PR DESCRIPTION
It reduces allocations in RawBencher by about 3mb