### PR TITLE
Optimize DistinctRootEntityResultTransformer

### DIFF
--- a/src/NHibernate/Linq/IntermediateHqlTree.cs
+++ b/src/NHibernate/Linq/IntermediateHqlTree.cs
@@ -110,7 +110,7 @@ namespace NHibernate.Linq
 			if (!_hasDistinctRootOperator)
 			{
 				Expression<Func<IEnumerable<object>, IList>> x =
-					l => new DistinctRootEntityResultTransformer().TransformList(l.ToList());
+					l => DistinctRootEntityResultTransformer.TransformList(l);
 
 				_listTransformers.Add(x);
 				_hasDistinctRootOperator = true;


### PR DESCRIPTION
Use comparer instead of object wrapping
Added shortcut exit
Avoid ToList conversion for LINQ