### PR TITLE
Fixed Equals method for transformers

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3957/ResultTransformerEqualityFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3957/ResultTransformerEqualityFixture.cs
@@ -18,22 +18,22 @@ namespace NHibernate.Test.NHSpecificTest.NH3957
 		{
 			var transf1 = new AliasToEntityMapResultTransformer();
 			var transf2 = new AliasToEntityMapResultTransformer();
-			var custom = new CustomAliasToEntityMapResultTransformer();
-			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, custom, };
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
 
-			Assert.That(set.Count, Is.EqualTo(2));
+			Assert.That(set.Count, Is.EqualTo(1));
 			Assert.IsTrue(transf1.Equals(transf2));
 			Assert.IsTrue(transf2.Equals(transf1));
-			Assert.False(custom.Equals(transf1));
-			Assert.False(transf1.Equals(custom));
 		}
 
 		[Test]
 		public void AliasToEntityMapAndDistinctRootEntityInequality()
 		{
 			var transf1 = new AliasToEntityMapResultTransformer();
-			var transf2 = new DistinctRootEntityResultTransformer();
+			var transf2 = new CustomAliasToEntityMapResultTransformer();
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
 
+			Assert.That(transf1.GetHashCode(), Is.EqualTo(transf2.GetHashCode()), "prerequisite");
+			Assert.That(set.Count, Is.EqualTo(2));
 			Assert.IsFalse(transf1.Equals(transf2));
 			Assert.IsFalse(transf2.Equals(transf1));
 		}
@@ -44,14 +44,24 @@ namespace NHibernate.Test.NHSpecificTest.NH3957
 		{
 			var transf1 = new DistinctRootEntityResultTransformer();
 			var transf2 = new DistinctRootEntityResultTransformer();
-			var custom = new CustomDistinctRootEntityResultTransformer();
-			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, custom, };
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
 
-			Assert.That(set.Count, Is.EqualTo(2));
+			Assert.That(set.Count, Is.EqualTo(1));
 			Assert.IsTrue(transf1.Equals(transf2));
 			Assert.IsTrue(transf2.Equals(transf1));
-			Assert.False(custom.Equals(transf1));
-			Assert.False(transf1.Equals(custom));
+		}
+
+		[Test]
+		public void DistinctRootEntityEqualityInequality()
+		{
+			var transf1 = new DistinctRootEntityResultTransformer();
+			var transf2 = new CustomDistinctRootEntityResultTransformer();
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
+
+			Assert.That(transf1.GetHashCode(), Is.EqualTo(transf2.GetHashCode()), "prerequisite");
+			Assert.That(set.Count, Is.EqualTo(2));
+			Assert.IsFalse(transf1.Equals(transf2));
+			Assert.IsFalse(transf2.Equals(transf1));
 		}
 
 		// Non reg test case
@@ -60,22 +70,22 @@ namespace NHibernate.Test.NHSpecificTest.NH3957
 		{
 			var transf1 = new PassThroughResultTransformer();
 			var transf2 = new PassThroughResultTransformer();
-			var custom = new CustomPassThroughResultTransformer();
-			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, custom, };
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
 
-			Assert.That(set.Count, Is.EqualTo(2));
+			Assert.That(set.Count, Is.EqualTo(1));
 			Assert.IsTrue(transf1.Equals(transf2));
 			Assert.IsTrue(transf2.Equals(transf1));
-			Assert.False(custom.Equals(transf1));
-			Assert.False(transf1.Equals(custom));
 		}
 
 		[Test]
 		public void PassThroughAndRootEntityInequality()
 		{
 			var transf1 = new PassThroughResultTransformer();
-			var transf2 = new RootEntityResultTransformer();
-			
+			var transf2 = new CustomPassThroughResultTransformer();
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
+
+			Assert.That(transf1.GetHashCode(), Is.EqualTo(transf2.GetHashCode()), "prerequisite");
+			Assert.That(set.Count, Is.EqualTo(2));
 			Assert.IsFalse(transf1.Equals(transf2));
 			Assert.IsFalse(transf2.Equals(transf1));
 		}
@@ -86,22 +96,22 @@ namespace NHibernate.Test.NHSpecificTest.NH3957
 		{
 			var transf1 = new RootEntityResultTransformer();
 			var transf2 = new RootEntityResultTransformer();
-			var custom = new CustomRootEntityResultTransformer();
-			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, custom, };
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
 
-			Assert.That(set.Count, Is.EqualTo(2));
+			Assert.That(set.Count, Is.EqualTo(1));
 			Assert.IsTrue(transf1.Equals(transf2));
 			Assert.IsTrue(transf2.Equals(transf1));
-			Assert.False(custom.Equals(transf1));
-			Assert.False(transf1.Equals(custom));
 		}
 
 		[Test]
 		public void RootEntityAndToListInequality()
 		{
 			var transf1 = new RootEntityResultTransformer();
-			var transf2 = new ToListResultTransformer();
-			
+			var transf2 = new CustomRootEntityResultTransformer();
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, };
+
+			Assert.That(transf1.GetHashCode(), Is.EqualTo(transf2.GetHashCode()), "prerequisite");
+			Assert.That(set.Count, Is.EqualTo(2));
 			Assert.IsFalse(transf1.Equals(transf2));
 			Assert.IsFalse(transf2.Equals(transf1));
 		}
@@ -112,14 +122,11 @@ namespace NHibernate.Test.NHSpecificTest.NH3957
 		{
 			var transf1 = new ToListResultTransformer();
 			var transf2 = new ToListResultTransformer();
-			var custom = new CustomRootEntityResultTransformer();
-			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2, custom, };
+			HashSet<IResultTransformer> set = new HashSet<IResultTransformer>() { transf1, transf2 };
 
-			Assert.That(set.Count, Is.EqualTo(2));
+			Assert.That(set.Count, Is.EqualTo(1));
 			Assert.IsTrue(transf1.Equals(transf2));
 			Assert.IsTrue(transf2.Equals(transf1));
-			Assert.False(custom.Equals(transf1));
-			Assert.False(transf1.Equals(custom));
 		}
 	}
 }

--- a/src/NHibernate/Criterion/CriteriaSpecification.cs
+++ b/src/NHibernate/Criterion/CriteriaSpecification.cs
@@ -31,10 +31,10 @@ namespace NHibernate.Criterion
 
 		static CriteriaSpecification()
 		{
-			AliasToEntityMap = new AliasToEntityMapResultTransformer();
-			RootEntity = new RootEntityResultTransformer();
-			DistinctRootEntity = new DistinctRootEntityResultTransformer();
-			Projection = new PassThroughResultTransformer();
+			AliasToEntityMap = AliasToEntityMapResultTransformer.Instance;
+			RootEntity = RootEntityResultTransformer.Instance;
+			DistinctRootEntity = DistinctRootEntityResultTransformer.Instance;
+			Projection = PassThroughResultTransformer.Instance;
 			InnerJoin = JoinType.InnerJoin;
 			FullJoin = JoinType.FullJoin;
 			LeftJoin = JoinType.LeftOuterJoin;

--- a/src/NHibernate/Linq/IntermediateHqlTree.cs
+++ b/src/NHibernate/Linq/IntermediateHqlTree.cs
@@ -110,7 +110,7 @@ namespace NHibernate.Linq
 			if (!_hasDistinctRootOperator)
 			{
 				Expression<Func<IEnumerable<object>, IList>> x =
-					l => new DistinctRootEntityResultTransformer().TransformList(l.ToList());
+					l => DistinctRootEntityResultTransformer.Instance.TransformList(l.ToList());
 
 				_listTransformers.Add(x);
 				_hasDistinctRootOperator = true;

--- a/src/NHibernate/Linq/IntermediateHqlTree.cs
+++ b/src/NHibernate/Linq/IntermediateHqlTree.cs
@@ -110,7 +110,7 @@ namespace NHibernate.Linq
 			if (!_hasDistinctRootOperator)
 			{
 				Expression<Func<IEnumerable<object>, IList>> x =
-					l => DistinctRootEntityResultTransformer.Instance.TransformList(l.ToList());
+					l => new DistinctRootEntityResultTransformer().TransformList(l.ToList());
 
 				_listTransformers.Add(x);
 				_hasDistinctRootOperator = true;

--- a/src/NHibernate/Transform/AliasToEntityMapResultTransformer.cs
+++ b/src/NHibernate/Transform/AliasToEntityMapResultTransformer.cs
@@ -6,7 +6,7 @@ namespace NHibernate.Transform
 	[Serializable]
 	public class AliasToEntityMapResultTransformer : AliasedTupleSubsetResultTransformer
 	{
-		private static readonly object Hasher = new object();
+		internal static readonly AliasToEntityMapResultTransformer Instance = new AliasToEntityMapResultTransformer();
 
 		public override object TransformTuple(object[] tuple, string[] aliases)
 		{
@@ -37,18 +37,16 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
-			{
+			if (ReferenceEquals(obj, this))
+				return true;
+			if (obj == null)
 				return false;
-			}
-			// NH-3957: do not rely on hashcode alone.
-			// Must be the exact same type
-			return obj.GetType() == typeof(AliasToEntityMapResultTransformer);
+			return obj.GetType() == GetType();
 		}
 
 		public override int GetHashCode()
 		{
-			return Hasher.GetHashCode();
+			return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Instance);
 		}
 	}
 }

--- a/src/NHibernate/Transform/CacheableResultTransformer.cs
+++ b/src/NHibernate/Transform/CacheableResultTransformer.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Transform
 		// is private (as it should be for a singleton)
 		//private const PassThroughResultTransformer ACTUAL_TRANSFORMER =
 		//    PassThroughResultTransformer.INSTANCE;
-		private readonly PassThroughResultTransformer _actualTransformer = new PassThroughResultTransformer();
+		private readonly PassThroughResultTransformer _actualTransformer = PassThroughResultTransformer.Instance;
 
 		public bool AutoDiscoverTypes { get; }
 
@@ -358,7 +358,7 @@ namespace NHibernate.Transform
 			if (this == o)
 				return true;
 
-			if (o == null || typeof (CacheableResultTransformer) != o.GetType())
+			if (o == null || GetType() != o.GetType())
 				return false;
 
 			var that = (CacheableResultTransformer) o;

--- a/src/NHibernate/Transform/DistinctRootEntityResultTransformer.cs
+++ b/src/NHibernate/Transform/DistinctRootEntityResultTransformer.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Transform
 	public class DistinctRootEntityResultTransformer : IResultTransformer, ITupleSubsetResultTransformer
 	{
 		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(DistinctRootEntityResultTransformer));
-		private static readonly object Hasher = new object();
+		internal static readonly DistinctRootEntityResultTransformer Instance = new DistinctRootEntityResultTransformer();
 
 		internal sealed class Identity
 		{
@@ -62,33 +62,26 @@ namespace NHibernate.Transform
 
 		public bool[] IncludeInTransform(String[] aliases, int tupleLength)
 		{
-			//return RootEntityResultTransformer.INSTANCE.includeInTransform(aliases, tupleLength);
-			var transformer = new RootEntityResultTransformer();
-			return transformer.IncludeInTransform(aliases, tupleLength);
+			return RootEntityResultTransformer.Instance.IncludeInTransform(aliases, tupleLength);
 		}
-
 
 		public bool IsTransformedValueATupleElement(String[] aliases, int tupleLength)
 		{
-			//return RootEntityResultTransformer.INSTANCE.isTransformedValueATupleElement(null, tupleLength);
-			var transformer = new RootEntityResultTransformer();
-			return transformer.IsTransformedValueATupleElement(null, tupleLength);
+			return RootEntityResultTransformer.Instance.IsTransformedValueATupleElement(null, tupleLength);
 		}
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
-			{
+			if (ReferenceEquals(obj, this))
+				return true;
+			if (obj == null)
 				return false;
-			}
-			// NH-3957: do not rely on hashcode alone.
-			// Must be the exact same type
-			return obj.GetType() == typeof(DistinctRootEntityResultTransformer);
+			return obj.GetType() == GetType();
 		}
 
 		public override int GetHashCode()
 		{
-			return Hasher.GetHashCode();
+			return RuntimeHelpers.GetHashCode(Instance);
 		}
 	}
 }

--- a/src/NHibernate/Transform/PassThroughResultTransformer.cs
+++ b/src/NHibernate/Transform/PassThroughResultTransformer.cs
@@ -7,7 +7,7 @@ namespace NHibernate.Transform
 	[Serializable]
 	public class PassThroughResultTransformer : IResultTransformer, ITupleSubsetResultTransformer
 	{
-		private static readonly object Hasher = new object();
+		internal static readonly PassThroughResultTransformer Instance = new PassThroughResultTransformer();
 
 		#region IResultTransformer Members
 
@@ -58,21 +58,18 @@ namespace NHibernate.Transform
 			return isSingleResult ? new[] {transformed} : (object[]) transformed;
 		}
 
-
 		public override bool Equals(object obj)
 		{
-			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
-			{
+			if (ReferenceEquals(obj, this))
+				return true;
+			if (obj == null)
 				return false;
-			}
-			// NH-3957: do not rely on hashcode alone.
-			// Must be the exact same type
-			return obj.GetType() == typeof(PassThroughResultTransformer);
+			return obj.GetType() == GetType();
 		}
 
 		public override int GetHashCode()
 		{
-			return Hasher.GetHashCode();
+			return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Instance);
 		}
 	}
 }

--- a/src/NHibernate/Transform/RootEntityResultTransformer.cs
+++ b/src/NHibernate/Transform/RootEntityResultTransformer.cs
@@ -7,7 +7,7 @@ namespace NHibernate.Transform
 	[Serializable]
 	public class RootEntityResultTransformer : IResultTransformer, ITupleSubsetResultTransformer
 	{
-		private static readonly object Hasher = new object();
+		internal static readonly RootEntityResultTransformer Instance = new RootEntityResultTransformer();
 
 		public object TransformTuple(object[] tuple, string[] aliases)
 		{
@@ -19,12 +19,10 @@ namespace NHibernate.Transform
 			return collection;
 		}
 
-
 		public bool IsTransformedValueATupleElement(String[] aliases, int tupleLength)
 		{
 			return true;
 		}
-
 
 		public bool[] IncludeInTransform(String[] aliases, int tupleLength)
 		{
@@ -43,18 +41,16 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
-			{
+			if (ReferenceEquals(obj, this))
+				return true;
+			if (obj == null)
 				return false;
-			}
-			// NH-3957: do not rely on hashcode alone.
-			// Must be the exact same type
-			return obj.GetType() == typeof(RootEntityResultTransformer);
+			return obj.GetType() == GetType();
 		}
 
 		public override int GetHashCode()
 		{
-			return Hasher.GetHashCode();
+			return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Instance);
 		}
 	}
 }

--- a/src/NHibernate/Transform/ToListResultTransformer.cs
+++ b/src/NHibernate/Transform/ToListResultTransformer.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Transform
 	[Serializable]
 	public class ToListResultTransformer : IResultTransformer
 	{
-		private static readonly object Hasher = new object();
+		internal static readonly ToListResultTransformer Instance = new ToListResultTransformer();
 
 		public object TransformTuple(object[] tuple, string[] aliases)
 		{
@@ -25,18 +25,16 @@ namespace NHibernate.Transform
 
 		public override bool Equals(object obj)
 		{
-			if (obj == null || obj.GetHashCode() != Hasher.GetHashCode())
-			{
+			if (ReferenceEquals(obj, this))
+				return true;
+			if (obj == null)
 				return false;
-			}
-			// NH-3957: do not rely on hashcode alone.
-			// Must be the exact same type
-			return obj.GetType() == typeof(ToListResultTransformer);
+			return obj.GetType() == GetType();
 		}
 
 		public override int GetHashCode()
 		{
-			return Hasher.GetHashCode();
+			return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Instance);
 		}
 	}
 }

--- a/src/NHibernate/Transform/Transformers.cs
+++ b/src/NHibernate/Transform/Transformers.cs
@@ -7,10 +7,10 @@ namespace NHibernate.Transform
 		/// <summary>
 		/// Each row of results is a map (<see cref="IDictionary" />) from alias to values/entities
 		/// </summary>
-		public static readonly IResultTransformer AliasToEntityMap = new AliasToEntityMapResultTransformer();
+		public static readonly IResultTransformer AliasToEntityMap = AliasToEntityMapResultTransformer.Instance;
 
 		/// <summary> Each row of results is a <see cref="IList"/></summary>
-		public static readonly ToListResultTransformer ToList = new ToListResultTransformer();
+		public static readonly ToListResultTransformer ToList = ToListResultTransformer.Instance;
 
 		/// <summary>
 		/// Creates a result transformer that will inject aliased values into instances
@@ -44,15 +44,15 @@ namespace NHibernate.Transform
 			return AliasToBean(typeof(T));
 		}
 
-		public static readonly IResultTransformer DistinctRootEntity = new DistinctRootEntityResultTransformer();
+		public static readonly IResultTransformer DistinctRootEntity = DistinctRootEntityResultTransformer.Instance;
 
 		public static IResultTransformer AliasToBeanConstructor(System.Reflection.ConstructorInfo constructor)
 		{
 			return new AliasToBeanConstructorResultTransformer(constructor);
 		}
 
-		public static readonly IResultTransformer PassThrough = new PassThroughResultTransformer();
+		public static readonly IResultTransformer PassThrough = PassThroughResultTransformer.Instance;
 
-		public static readonly IResultTransformer RootEntity = new RootEntityResultTransformer();
+		public static readonly IResultTransformer RootEntity = RootEntityResultTransformer.Instance;
 	}
 }


### PR DESCRIPTION
Fixed possible equality issue:
```C#
public class MyTransformer: DistinctRootEntityResultTransformer {}
var myTransformer = new MyTransformer();
var distinctTransformer = new DistinctRootEntityResultTransformer();
myTransformer.Equals(distinctTransformer); // true. Should be false
distinctTransformer.Equals(myTransformer); // false
```
Also reuse instances when possible