### PR TITLE
Avoid some cases of Type -> string -> Type conversion in Mapping By Code

### DIFF
--- a/src/NHibernate.Test/TypesTest/TimestampTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TimestampTypeFixture.cs
@@ -24,10 +24,7 @@ namespace NHibernate.Test.TypesTest
 					var log = spy.GetWholeLog();
 					Assert.That(
 						log,
-						Does.Contain("NHibernate.Type.TimestampType is obsolete. Please use DateTimeType instead.").IgnoreCase);
-					Assert.That(
-						log,
-						Does.Not.Contain($"{NHibernateUtil.Timestamp.Name} is obsolete. Please use DateTimeType instead.").IgnoreCase);
+						Does.Contain($"NHibernate.Type.TimestampType ({NHibernateUtil.Timestamp.Name}) is obsolete. Please use DateTimeType instead.").IgnoreCase);
 				}
 			}
 		}

--- a/src/NHibernate.Test/TypesTest/TypeFactoryFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TypeFactoryFixture.cs
@@ -56,6 +56,7 @@ namespace NHibernate.Test.TypesTest
 			//Assert.AreEqual(int64Type, TypeFactory.HeuristicType("Int64?"), "'Int64?' should return a NH Int64Type");
 
 			System.Type reflectedType = Util.ReflectHelper.ReflectedPropertyClass( typeof(GenericPropertyClass), "GenericInt64", "property" );
+			Assert.AreEqual( int64Type, TypeFactory.HeuristicType( reflectedType ), "using System.Type should return nh Int64Type" );
 			Assert.AreEqual( int64Type, TypeFactory.HeuristicType( reflectedType.AssemblyQualifiedName ), "using AQN should return nh Int64Type" );
 			Assert.AreEqual( int64Type, TypeFactory.HeuristicType( reflectedType.FullName ), "using FullName should return nh Int64Type" );
 
@@ -141,6 +142,20 @@ namespace NHibernate.Test.TypesTest
 		public void WhenUseNullableEnumThenReturnGenericEnumType()
 		{
 			var iType = TypeFactory.HeuristicType(typeof(MyEnum?).AssemblyQualifiedName);
+			Assert.That(iType, Is.TypeOf<EnumType<MyEnum>>());
+		}
+		
+		[Test]
+		public void WhenUseEnumTypeThenReturnGenericEnumType()
+		{
+			var iType = TypeFactory.HeuristicType(typeof (MyEnum));
+			Assert.That(iType, Is.TypeOf<EnumType<MyEnum>>());
+		}
+
+		[Test]
+		public void WhenUseNullableEnumTypeThenReturnGenericEnumType()
+		{
+			var iType = TypeFactory.HeuristicType(typeof(MyEnum?));
 			Assert.That(iType, Is.TypeOf<EnumType<MyEnum>>());
 		}
 	}

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/JavaConstantNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/JavaConstantNode.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
                 }
                 
                 _constantValue = ReflectHelper.GetConstantValue(base.Text, _factory);
-                _heuristicType = TypeFactory.HeuristicType(_constantValue.GetType().AssemblyQualifiedName);
+                _heuristicType = TypeFactory.HeuristicType(_constantValue.GetType());
                 _processedText = true;
             }
         }

--- a/src/NHibernate/Mapping/ByCode/Impl/TypeNameUtil.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/TypeNameUtil.cs
@@ -8,7 +8,7 @@ namespace NHibernate.Mapping.ByCode.Impl
 		public static string GetNhTypeName(this System.Type type)
 		{
 			string typeName;
-			IType nhType = TypeFactory.HeuristicType(type.AssemblyQualifiedName);
+			IType nhType = TypeFactory.HeuristicType(type);
 			if (nhType != null)
 			{
 				typeName = nhType.Name;

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -654,7 +654,7 @@ namespace NHibernate.Type
 			if (length.HasValue)
 				return GetSerializableType(typeClass, length.Value);
 
-			return GetSerializedOrBasicType(typeClass);
+			return GetSerializableType(typeClass);
 		}
 
 		/// <summary>
@@ -723,11 +723,6 @@ namespace NHibernate.Type
 		/// </remarks>
 		public static NullableType GetSerializableType(System.Type serializableType)
 		{
-			return (NullableType) GetSerializedOrBasicType(serializableType);
-		}
-
-		private static IType GetSerializedOrBasicType(System.Type serializableType)
-		{
 			var key = serializableType.AssemblyQualifiedName;
 
 			// The value factory may be run concurrently, but only one resulting value will be yielded to all threads.
@@ -747,7 +742,7 @@ namespace NHibernate.Type
 				throw new HibernateException($"Another item with the key {type.Name} has already been added to typeByTypeOfName.");
 			}
 
-			return type;
+			return (NullableType) type;
 		}
 
 		public static NullableType GetSerializableType(System.Type serializableType, int length)

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -582,9 +582,9 @@ namespace NHibernate.Type
 			{
 				typeClass = ReflectHelper.ClassForName(parsedTypeName[0]); //typeName);
 			}
-			catch (Exception ex)
+			catch (Exception)
 			{
-				throw new MappingException("Could not find IType for given" + typeName + ": " + ex, ex);
+				return null;
 			}
 			return HeuristicType(typeClass, parameters, length, false);
 		}

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -582,9 +582,9 @@ namespace NHibernate.Type
 			{
 				typeClass = ReflectHelper.ClassForName(parsedTypeName[0]); //typeName);
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
-				return null;
+				throw new MappingException("Could not find IType for given" + typeName + ": " + ex, ex);
 			}
 			return HeuristicType(typeClass, parameters, length, false);
 		}

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -405,6 +405,11 @@ namespace NHibernate.Type
 		/// </remarks>
 		public static IType Basic(string name, IDictionary<string, string> parameters)
 		{
+			return Basic(name, parameters, parseName: true);
+		}
+
+		private static IType Basic(string name, IDictionary<string, string> parameters, bool parseName)
+		{
 			string typeName;
 
 			// Use the basic name (such as String or String(255)) to get the
@@ -425,6 +430,9 @@ namespace NHibernate.Type
 				}
 				return returnType;
 			}
+
+			if (!parseName)
+				return null;
 
 			// if we get to here then the basic type with the length or precision/scale
 			// combination doesn't exists - so lets figure out which one we have and
@@ -593,7 +601,7 @@ namespace NHibernate.Type
 		{
 			if(tryBasic)
 			{
-				IType type = Basic(typeClass.AssemblyQualifiedName, parameters);
+				IType type = Basic(typeClass.AssemblyQualifiedName, parameters, parseName: false);
 
 				if (type != null)
 					return type;

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -608,7 +608,7 @@ namespace NHibernate.Type
 					var obsolete = typeClass.GetCustomAttribute<ObsoleteAttribute>(false);
 					if (obsolete != null)
 					{
-						_log.Warn("{0} is obsolete. {1}", typeClass.AssemblyQualifiedName, obsolete.Message);
+						_log.Warn("{0} ({1}) is obsolete. {2}", typeClass.Namespace + "." + typeClass.Name, type.Name, obsolete.Message);
 					}
 					return type;
 				}

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -540,8 +540,8 @@ namespace NHibernate.Type
 		/// </remarks>
 		public static IType HeuristicType(System.Type type)
 		{
-			return GetBasicTypeByName(type.AssemblyQualifiedName, null) ??
-			       HeuristicType(type, null, null);
+			return GetBasicTypeByName(type.AssemblyQualifiedName, null)
+				?? GetBySystemType(type, null, null);
 		}
 
 		/// <summary>
@@ -593,10 +593,10 @@ namespace NHibernate.Type
 				return null;
 			}
 
-			return HeuristicType(typeClass, parameters, length);
+			return GetBySystemType(typeClass, parameters, length);
 		}
 
-		private static IType HeuristicType(System.Type typeClass, IDictionary<string, string> parameters, int? length)
+		private static IType GetBySystemType(System.Type typeClass, IDictionary<string, string> parameters, int? length)
 		{
 			if (typeof(IType).IsAssignableFrom(typeClass))
 			{

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -293,7 +293,7 @@ namespace NHibernate.Util
 
 			var heuristicClass = propertyClass.UnwrapIfNullable();
 
-			return TypeFactory.HeuristicType(heuristicClass.AssemblyQualifiedName);
+			return TypeFactory.HeuristicType(heuristicClass);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Currently Mapping By Code can do excessive calls to `TypeNameParser.ParseTypeName` with pretty hardcore clean up/parse logic inside. But it's not needed for already known types.