### PR TITLE
Dispose session in cascade tests

### DIFF
--- a/src/NHibernate.Test/Async/Cascade/Circle/MultiPathCircleCascadeTest.cs
+++ b/src/NHibernate.Test/Async/Cascade/Circle/MultiPathCircleCascadeTest.cs
@@ -9,17 +9,14 @@
 
 
 using System;
-using System.Collections;
 using System.Linq;
-using NHibernate.Engine;
-using NHibernate.Test;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Cascade.Circle
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	
+
 	/**
 	* The test case uses the following model:
 	*
@@ -42,7 +39,7 @@ namespace NHibernate.Test.Cascade.Circle
 	*
 	* @author Pavol Zibrita, Gail Badner
 	*/
-	
+
 	[TestFixture]
 	public class MultiPathCircleCascadeTestAsync : TestCase
 	{
@@ -81,7 +78,7 @@ namespace NHibernate.Test.Cascade.Circle
 			routeNew.Nodes.Add(node);
 			node.Route = routeNew;
 	
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				try
@@ -100,10 +97,6 @@ namespace NHibernate.Test.Cascade.Circle
 //						assertTrue( ex instanceof JDBCException );
 //					}
 				}
-				finally
-				{
-					await (transaction.RollbackAsync());
-				}
 			}
 		}
 
@@ -115,7 +108,7 @@ namespace NHibernate.Test.Cascade.Circle
 			route.Nodes.Remove(node);
 			node.Route = null;
 	
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				try
@@ -134,10 +127,6 @@ namespace NHibernate.Test.Cascade.Circle
 //						assertTrue( ex instanceof JDBCException );
 //					}
 				}
-				finally
-				{
-					await (transaction.RollbackAsync());
-				}
 			}
 		}
 		
@@ -147,7 +136,7 @@ namespace NHibernate.Test.Cascade.Circle
 			Node node = route.Nodes.First();
 			node.Name = null;
 	
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				try
@@ -167,113 +156,114 @@ namespace NHibernate.Test.Cascade.Circle
 //						assertTrue( ex instanceof JDBCException );
 //					}
 				}
-				finally
-				{
-					await (transaction.RollbackAsync(cancellationToken));
-				}
 			}
 		}
-		
+
 		[Test]
 		public async Task MergeRouteAsync()
 		{
 			Route route = await (this.GetUpdatedDetachedEntityAsync());
-	
+
 			ClearCounts();
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
-			await (s.MergeAsync(route));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				await (s.MergeAsync(route));
+				await (s.Transaction.CommitAsync());
+			}
+
 			AssertInsertCount(4);
 			AssertUpdateCount(1);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			route = await (s.GetAsync<Route>(route.RouteId));
-			CheckResults(route, true);
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = await (s.GetAsync<Route>(route.RouteId));
+				CheckResults(route, true);
+				await (s.Transaction.CommitAsync());
+			}
 		}
-		
+
 		[Test]
 		public async Task MergePickupNodeAsync()
 		{
 			Route route = await (GetUpdatedDetachedEntityAsync());
-	
-			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
 
-			Node pickupNode = route.Nodes.First(n => n.Name == "pickupNodeB");
-			pickupNode = (Node)await (s.MergeAsync(pickupNode));
-			
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			ClearCounts();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Node pickupNode = route.Nodes.First(n => n.Name == "pickupNodeB");
+				pickupNode = (Node) await (s.MergeAsync(pickupNode));
+
+				await (s.Transaction.CommitAsync());
+			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = await (s.GetAsync<Route>(route.RouteId));
-			CheckResults(route, false);
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = await (s.GetAsync<Route>(route.RouteId));
+				CheckResults(route, false);
+				await (s.Transaction.CommitAsync());
+			}
 		}
-		
+
 		[Test]
 		public async Task MergeDeliveryNodeAsync()
 		{
 			Route route = await (GetUpdatedDetachedEntityAsync());
-	
-			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
 
-			Node deliveryNode = route.Nodes.First(n => n.Name == "deliveryNodeB");
-			deliveryNode = (Node)await (s.MergeAsync(deliveryNode));
-			
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			ClearCounts();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Node deliveryNode = route.Nodes.First(n => n.Name == "deliveryNodeB");
+				deliveryNode = (Node) await (s.MergeAsync(deliveryNode));
+				await (s.Transaction.CommitAsync());
+			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = await (s.GetAsync<Route>(route.RouteId));
-			CheckResults(route, false);
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = await (s.GetAsync<Route>(route.RouteId));
+				CheckResults(route, false);
+				await (s.Transaction.CommitAsync());
+			}
 		}
-		
+
 		[Test]
 		public async Task MergeTourAsync()
 		{
 			Route route = await (GetUpdatedDetachedEntityAsync());
-	
+
 			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			Tour tour = (Tour)await (s.MergeAsync(route.Nodes.First().Tour));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Tour tour = await (s.MergeAsync(route.Nodes.First().Tour));
+				await (s.Transaction.CommitAsync());
+			}
+
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = await (s.GetAsync<Route>(route.RouteId));
-			CheckResults(route, false);
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = await (s.GetAsync<Route>(route.RouteId));
+				CheckResults(route, false);
+				await (s.Transaction.CommitAsync());
+			}
 		}
 		
 		[Test]
@@ -282,46 +272,46 @@ namespace NHibernate.Test.Cascade.Circle
 			Route route = await (GetUpdatedDetachedEntityAsync());
 	
 			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
-	
-			Node node = route.Nodes.First();
-			Transport transport = null;
-			
-			if (node.PickupTransports.Count == 1)
-				transport = node.PickupTransports.First();
-			else
-				transport = node.DeliveryTransports.First();
-	
-			transport = (Transport)await (s.MergeAsync(transport));
-	
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Node node = route.Nodes.First();
+				Transport transport = null;
+
+				if (node.PickupTransports.Count == 1)
+					transport = node.PickupTransports.First();
+				else
+					transport = node.DeliveryTransports.First();
+
+				transport = (Transport) await (s.MergeAsync(transport));
+
+				await (s.Transaction.CommitAsync());
+			}
 	
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = await (s.GetAsync<Route>(route.RouteId));
-			CheckResults(route, false);
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = await (s.GetAsync<Route>(route.RouteId));
+				CheckResults(route, false);
+				await (s.Transaction.CommitAsync());
+			}
 		}
-		
+
 		private async Task<Route> GetUpdatedDetachedEntityAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
-			ISession s = OpenSession();
-			s.BeginTransaction();
-	
 			Route route = new Route();
-			route.Name = "routeA";
-	
-			await (s.SaveAsync(route, cancellationToken));
-			await (s.Transaction.CommitAsync(cancellationToken));
-			s.Close();
-	
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route.Name = "routeA";
+
+				await (s.SaveAsync(route, cancellationToken));
+				await (s.Transaction.CommitAsync(cancellationToken));
+			}
 			route.Name = "new routeA";
 			route.TransientField = "sfnaouisrbn";
 	
@@ -423,7 +413,7 @@ namespace NHibernate.Test.Cascade.Circle
 		
 		protected override void OnTearDown()
 		{
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				session.CreateQuery("delete from Transport").ExecuteUpdate();

--- a/src/NHibernate.Test/Async/Cascade/MultiPathCascadeTest.cs
+++ b/src/NHibernate.Test/Async/Cascade/MultiPathCascadeTest.cs
@@ -8,12 +8,8 @@
 //------------------------------------------------------------------------------
 
 
-using System;
-using System.Collections;
 using System.Linq;
-using NHibernate.Engine;
 using NHibernate.Proxy;
-using NHibernate.Test;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Cascade
@@ -37,23 +33,25 @@ namespace NHibernate.Test.Cascade
 		public async Task MultiPathMergeModifiedDetachedAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+			
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)await (s.MergeAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = await (s.MergeAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 	
 			await (this.VerifyModificationsAsync(a.Id));
 		}
@@ -62,25 +60,25 @@ namespace NHibernate.Test.Cascade
 		public async Task MultiPathMergeModifiedDetachedIntoProxyAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			A aLoaded = await (s.LoadAsync<A>(a.Id));
-			Assert.That(aLoaded, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(await (s.MergeAsync(a)), Is.SameAs(aLoaded));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				A aLoaded = await (s.LoadAsync<A>(a.Id));
+				Assert.That(aLoaded, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(await (s.MergeAsync(a)), Is.SameAs(aLoaded));
+				await (s.Transaction.CommitAsync());
+			}
 	
 			await (this.VerifyModificationsAsync(a.Id));
 		}
@@ -89,24 +87,25 @@ namespace NHibernate.Test.Cascade
 		public async Task MultiPathUpdateModifiedDetachedAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 	
 			// modify detached entity
 			this.ModifyEntity(a);
-			
-			s = base.OpenSession();
-			s.BeginTransaction();
-			await (s.UpdateAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				await (s.UpdateAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			await (this.VerifyModificationsAsync(a.Id));
 		}
 	
@@ -114,23 +113,24 @@ namespace NHibernate.Test.Cascade
 		public async Task MultiPathGetAndModifyAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			// retrieve the previously saved instance from the database, and update it
-			a = await (s.GetAsync<A>(a.Id));
-			this.ModifyEntity(a);
-			await (s.Transaction.CommitAsync());
-			s.Close();
 
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				// retrieve the previously saved instance from the database, and update it
+				a = await (s.GetAsync<A>(a.Id));
+				this.ModifyEntity(a);
+				await (s.Transaction.CommitAsync());
+			}
 			await (this.VerifyModificationsAsync(a.Id));
 		}
 	
@@ -138,24 +138,24 @@ namespace NHibernate.Test.Cascade
 		public async Task MultiPathMergeNonCascadedTransientEntityInCollectionAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}	
 			// modify detached entity
 			this.ModifyEntity(a);
-			
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)await (s.MergeAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = await (s.MergeAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			await (this.VerifyModificationsAsync(a.Id));
 	
 			// add a new (transient) G to collection in h
@@ -166,48 +166,45 @@ namespace NHibernate.Test.Cascade
 			gNew.Data = "Gail";
 			gNew.Hs.Add(h);
 			h.Gs.Add(gNew);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			try
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
 			{
-				await (s.MergeAsync(a));
-				await (s.MergeAsync(h));
-				Assert.Fail("should have thrown TransientObjectException");
+				try
+				{
+					await (s.MergeAsync(a));
+					await (s.MergeAsync(h));
+					Assert.Fail("should have thrown TransientObjectException");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+				}
 			}
-			catch (TransientObjectException)
-			{
-				// expected
-			}
-			finally
-			{
-				await (s.Transaction.RollbackAsync());
-			}
-			s.Close();
 		}
 	
 		[Test]
 		public async Task MultiPathMergeNonCascadedTransientEntityInOneToOneAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)await (s.MergeAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = (A) await (s.MergeAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			await (this.VerifyModificationsAsync(a.Id));
 	
 			// change the one-to-one association from g to be a new (transient) A
@@ -218,48 +215,45 @@ namespace NHibernate.Test.Cascade
 			aNew.Data = "Alice";
 			g.A = aNew;
 			aNew.G = g;
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			try
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
 			{
-				await (s.MergeAsync(a));
-				await (s.MergeAsync(g));
-				Assert.Fail("should have thrown TransientObjectException");
+				try
+				{
+					await (s.MergeAsync(a));
+					await (s.MergeAsync(g));
+					Assert.Fail("should have thrown TransientObjectException");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+				}
 			}
-			catch (TransientObjectException )
-			{
-				// expected
-			}
-			finally
-			{
-				await (s.Transaction.RollbackAsync());
-			}
-			s.Close();
 		}
 	
 		[Test]
 		public async Task MultiPathMergeNonCascadedTransientEntityInManyToOneAsync()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			await (s.SaveAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				await (s.SaveAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)await (s.MergeAsync(a));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = (A) await (s.MergeAsync(a));
+				await (s.Transaction.CommitAsync());
+			}
 			await (this.VerifyModificationsAsync(a.Id));
 	
 			// change the many-to-one association from h to be a new (transient) A
@@ -270,29 +264,26 @@ namespace NHibernate.Test.Cascade
 			A aNew = new A();
 			aNew.Data = "Alice";
 			aNew.AddH(h);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			try
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
 			{
-				await (s.MergeAsync(a));
-				await (s.MergeAsync(h));
-				Assert.Fail("should have thrown TransientObjectException");
+				try
+				{
+					await (s.MergeAsync(a));
+					await (s.MergeAsync(h));
+					Assert.Fail("should have thrown TransientObjectException");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+				}
 			}
-			catch (TransientObjectException)
-			{
-				// expected
-			}
-			finally
-			{
-				await (s.Transaction.RollbackAsync());
-			}
-			s.Close();
 		}
 		
 		protected override void OnTearDown()
 		{
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				session.Delete("from H");
@@ -326,36 +317,36 @@ namespace NHibernate.Test.Cascade
 	
 		private async Task VerifyModificationsAsync(long aId, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
-	
-			// retrieve the A object and check it
-			A a = await (s.GetAsync<A>(aId, cancellationToken));
-			Assert.That(a.Id, Is.EqualTo(aId));
-			Assert.That(a.Data, Is.EqualTo("Anthony"));
-			Assert.That(a.G, Is.Not.Null);
-			Assert.That(a.Hs, Is.Not.Null);
-			Assert.That(a.Hs.Count, Is.EqualTo(1));
-	
-			G gFromA = a.G;
-			H hFromA = a.Hs.First();
-	
-			// check the G object
-			Assert.That(gFromA.Data, Is.EqualTo("Giovanni"));
-			Assert.That(gFromA.A, Is.SameAs(a));
-			Assert.That(gFromA.Hs, Is.Not.Null);
-			Assert.That(gFromA.Hs, Is.EqualTo(a.Hs));
-			Assert.That(gFromA.Hs.First(), Is.SameAs(hFromA));
-	
-			// check the H object
-			Assert.That(hFromA.Data, Is.EqualTo("Hellen"));
-			Assert.That(hFromA.A, Is.SameAs(a));
-			Assert.That(hFromA.Gs, Is.Not.Null);
-			Assert.That(hFromA.Gs.Count, Is.EqualTo(1));
-			Assert.That(hFromA.Gs.First(), Is.SameAs(gFromA));
-	
-			await (s.Transaction.CommitAsync(cancellationToken));
-			s.Close();
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				// retrieve the A object and check it
+				A a = await (s.GetAsync<A>(aId, cancellationToken));
+				Assert.That(a.Id, Is.EqualTo(aId));
+				Assert.That(a.Data, Is.EqualTo("Anthony"));
+				Assert.That(a.G, Is.Not.Null);
+				Assert.That(a.Hs, Is.Not.Null);
+				Assert.That(a.Hs.Count, Is.EqualTo(1));
+
+				G gFromA = a.G;
+				H hFromA = a.Hs.First();
+
+				// check the G object
+				Assert.That(gFromA.Data, Is.EqualTo("Giovanni"));
+				Assert.That(gFromA.A, Is.SameAs(a));
+				Assert.That(gFromA.Hs, Is.Not.Null);
+				Assert.That(gFromA.Hs, Is.EqualTo(a.Hs));
+				Assert.That(gFromA.Hs.First(), Is.SameAs(hFromA));
+
+				// check the H object
+				Assert.That(hFromA.Data, Is.EqualTo("Hellen"));
+				Assert.That(hFromA.A, Is.SameAs(a));
+				Assert.That(hFromA.Gs, Is.Not.Null);
+				Assert.That(hFromA.Gs.Count, Is.EqualTo(1));
+				Assert.That(hFromA.Gs.First(), Is.SameAs(gFromA));
+
+				await (s.Transaction.CommitAsync(cancellationToken));
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Cascade/Circle/MultiPathCircleCascadeTest.cs
+++ b/src/NHibernate.Test/Cascade/Circle/MultiPathCircleCascadeTest.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections;
 using System.Linq;
-using NHibernate.Engine;
-using NHibernate.Test;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Cascade.Circle
 {
-	
+
 	/**
 	* The test case uses the following model:
 	*
@@ -30,7 +27,7 @@ namespace NHibernate.Test.Cascade.Circle
 	*
 	* @author Pavol Zibrita, Gail Badner
 	*/
-	
+
 	[TestFixture]
 	public class MultiPathCircleCascadeTest : TestCase
 	{
@@ -69,7 +66,7 @@ namespace NHibernate.Test.Cascade.Circle
 			routeNew.Nodes.Add(node);
 			node.Route = routeNew;
 	
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				try
@@ -88,10 +85,6 @@ namespace NHibernate.Test.Cascade.Circle
 //						assertTrue( ex instanceof JDBCException );
 //					}
 				}
-				finally
-				{
-					transaction.Rollback();
-				}
 			}
 		}
 
@@ -103,7 +96,7 @@ namespace NHibernate.Test.Cascade.Circle
 			route.Nodes.Remove(node);
 			node.Route = null;
 	
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				try
@@ -122,10 +115,6 @@ namespace NHibernate.Test.Cascade.Circle
 //						assertTrue( ex instanceof JDBCException );
 //					}
 				}
-				finally
-				{
-					transaction.Rollback();
-				}
 			}
 		}
 		
@@ -135,7 +124,7 @@ namespace NHibernate.Test.Cascade.Circle
 			Node node = route.Nodes.First();
 			node.Name = null;
 	
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				try
@@ -154,113 +143,114 @@ namespace NHibernate.Test.Cascade.Circle
 //						assertTrue( ex instanceof JDBCException );
 //					}
 				}
-				finally
-				{
-					transaction.Rollback();
-				}
 			}
 		}
-		
+
 		[Test]
 		public void MergeRoute()
 		{
 			Route route = this.GetUpdatedDetachedEntity();
-	
+
 			ClearCounts();
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
-			s.Merge(route);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				s.Merge(route);
+				s.Transaction.Commit();
+			}
+
 			AssertInsertCount(4);
 			AssertUpdateCount(1);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			route = s.Get<Route>(route.RouteId);
-			CheckResults(route, true);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = s.Get<Route>(route.RouteId);
+				CheckResults(route, true);
+				s.Transaction.Commit();
+			}
 		}
-		
+
 		[Test]
 		public void MergePickupNode()
 		{
 			Route route = GetUpdatedDetachedEntity();
-	
-			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
 
-			Node pickupNode = route.Nodes.First(n => n.Name == "pickupNodeB");
-			pickupNode = (Node)s.Merge(pickupNode);
-			
-			s.Transaction.Commit();
-			s.Close();
+			ClearCounts();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Node pickupNode = route.Nodes.First(n => n.Name == "pickupNodeB");
+				pickupNode = (Node) s.Merge(pickupNode);
+
+				s.Transaction.Commit();
+			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = s.Get<Route>(route.RouteId);
-			CheckResults(route, false);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = s.Get<Route>(route.RouteId);
+				CheckResults(route, false);
+				s.Transaction.Commit();
+			}
 		}
-		
+
 		[Test]
 		public void MergeDeliveryNode()
 		{
 			Route route = GetUpdatedDetachedEntity();
-	
-			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
 
-			Node deliveryNode = route.Nodes.First(n => n.Name == "deliveryNodeB");
-			deliveryNode = (Node)s.Merge(deliveryNode);
-			
-			s.Transaction.Commit();
-			s.Close();
+			ClearCounts();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Node deliveryNode = route.Nodes.First(n => n.Name == "deliveryNodeB");
+				deliveryNode = (Node) s.Merge(deliveryNode);
+				s.Transaction.Commit();
+			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = s.Get<Route>(route.RouteId);
-			CheckResults(route, false);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = s.Get<Route>(route.RouteId);
+				CheckResults(route, false);
+				s.Transaction.Commit();
+			}
 		}
-		
+
 		[Test]
 		public void MergeTour()
 		{
 			Route route = GetUpdatedDetachedEntity();
-	
+
 			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			Tour tour = (Tour)s.Merge(route.Nodes.First().Tour);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Tour tour = s.Merge(route.Nodes.First().Tour);
+				s.Transaction.Commit();
+			}
+
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = s.Get<Route>(route.RouteId);
-			CheckResults(route, false);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = s.Get<Route>(route.RouteId);
+				CheckResults(route, false);
+				s.Transaction.Commit();
+			}
 		}
 		
 		[Test]
@@ -269,46 +259,46 @@ namespace NHibernate.Test.Cascade.Circle
 			Route route = GetUpdatedDetachedEntity();
 	
 			ClearCounts();
-	
-			ISession s = OpenSession();
-			s.BeginTransaction();
-	
-			Node node = route.Nodes.First();
-			Transport transport = null;
-			
-			if (node.PickupTransports.Count == 1)
-				transport = node.PickupTransports.First();
-			else
-				transport = node.DeliveryTransports.First();
-	
-			transport = (Transport)s.Merge(transport);
-	
-			s.Transaction.Commit();
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				Node node = route.Nodes.First();
+				Transport transport = null;
+
+				if (node.PickupTransports.Count == 1)
+					transport = node.PickupTransports.First();
+				else
+					transport = node.DeliveryTransports.First();
+
+				transport = (Transport) s.Merge(transport);
+
+				s.Transaction.Commit();
+			}
 	
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			route = s.Get<Route>(route.RouteId);
-			CheckResults(route, false);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route = s.Get<Route>(route.RouteId);
+				CheckResults(route, false);
+				s.Transaction.Commit();
+			}
 		}
-		
+
 		private Route GetUpdatedDetachedEntity()
 		{
-			ISession s = OpenSession();
-			s.BeginTransaction();
-	
 			Route route = new Route();
-			route.Name = "routeA";
-	
-			s.Save(route);
-			s.Transaction.Commit();
-			s.Close();
-	
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				route.Name = "routeA";
+
+				s.Save(route);
+				s.Transaction.Commit();
+			}
 			route.Name = "new routeA";
 			route.TransientField = "sfnaouisrbn";
 	
@@ -410,7 +400,7 @@ namespace NHibernate.Test.Cascade.Circle
 		
 		protected override void OnTearDown()
 		{
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				session.CreateQuery("delete from Transport").ExecuteUpdate();

--- a/src/NHibernate.Test/Cascade/MultiPathCascadeTest.cs
+++ b/src/NHibernate.Test/Cascade/MultiPathCascadeTest.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Linq;
-using NHibernate.Engine;
+﻿using System.Linq;
 using NHibernate.Proxy;
-using NHibernate.Test;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Cascade
@@ -25,23 +21,25 @@ namespace NHibernate.Test.Cascade
 		public void MultiPathMergeModifiedDetached()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+			
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)s.Merge(a);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = s.Merge(a);
+				s.Transaction.Commit();
+			}
 	
 			this.VerifyModifications(a.Id);
 		}
@@ -50,25 +48,25 @@ namespace NHibernate.Test.Cascade
 		public void MultiPathMergeModifiedDetachedIntoProxy()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			A aLoaded = s.Load<A>(a.Id);
-			Assert.That(aLoaded, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(s.Merge(a), Is.SameAs(aLoaded));
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				A aLoaded = s.Load<A>(a.Id);
+				Assert.That(aLoaded, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(s.Merge(a), Is.SameAs(aLoaded));
+				s.Transaction.Commit();
+			}
 	
 			this.VerifyModifications(a.Id);
 		}
@@ -77,24 +75,25 @@ namespace NHibernate.Test.Cascade
 		public void MultiPathUpdateModifiedDetached()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}
 	
 			// modify detached entity
 			this.ModifyEntity(a);
-			
-			s = base.OpenSession();
-			s.BeginTransaction();
-			s.Update(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (ISession s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				s.Update(a);
+				s.Transaction.Commit();
+			}
 			this.VerifyModifications(a.Id);
 		}
 	
@@ -102,23 +101,24 @@ namespace NHibernate.Test.Cascade
 		public void MultiPathGetAndModify()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			// retrieve the previously saved instance from the database, and update it
-			a = s.Get<A>(a.Id);
-			this.ModifyEntity(a);
-			s.Transaction.Commit();
-			s.Close();
 
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				// retrieve the previously saved instance from the database, and update it
+				a = s.Get<A>(a.Id);
+				this.ModifyEntity(a);
+				s.Transaction.Commit();
+			}
 			this.VerifyModifications(a.Id);
 		}
 	
@@ -126,24 +126,24 @@ namespace NHibernate.Test.Cascade
 		public void MultiPathMergeNonCascadedTransientEntityInCollection()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}	
 			// modify detached entity
 			this.ModifyEntity(a);
-			
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)s.Merge(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = s.Merge(a);
+				s.Transaction.Commit();
+			}
 			this.VerifyModifications(a.Id);
 	
 			// add a new (transient) G to collection in h
@@ -154,48 +154,45 @@ namespace NHibernate.Test.Cascade
 			gNew.Data = "Gail";
 			gNew.Hs.Add(h);
 			h.Gs.Add(gNew);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			try
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
 			{
-				s.Merge(a);
-				s.Merge(h);
-				Assert.Fail("should have thrown TransientObjectException");
+				try
+				{
+					s.Merge(a);
+					s.Merge(h);
+					Assert.Fail("should have thrown TransientObjectException");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+				}
 			}
-			catch (TransientObjectException)
-			{
-				// expected
-			}
-			finally
-			{
-				s.Transaction.Rollback();
-			}
-			s.Close();
 		}
 	
 		[Test]
 		public void MultiPathMergeNonCascadedTransientEntityInOneToOne()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)s.Merge(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = (A) s.Merge(a);
+				s.Transaction.Commit();
+			}
 			this.VerifyModifications(a.Id);
 	
 			// change the one-to-one association from g to be a new (transient) A
@@ -206,48 +203,45 @@ namespace NHibernate.Test.Cascade
 			aNew.Data = "Alice";
 			g.A = aNew;
 			aNew.G = g;
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			try
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
 			{
-				s.Merge(a);
-				s.Merge(g);
-				Assert.Fail("should have thrown TransientObjectException");
+				try
+				{
+					s.Merge(a);
+					s.Merge(g);
+					Assert.Fail("should have thrown TransientObjectException");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+				}
 			}
-			catch (TransientObjectException )
-			{
-				// expected
-			}
-			finally
-			{
-				s.Transaction.Rollback();
-			}
-			s.Close();
 		}
 	
 		[Test]
 		public void MultiPathMergeNonCascadedTransientEntityInManyToOne()
 		{
 			// persist a simple A in the database
-	
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
 			A a = new A();
-			a.Data = "Anna";
-			s.Save(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a.Data = "Anna";
+				s.Save(a);
+				s.Transaction.Commit();
+			}
 			// modify detached entity
 			this.ModifyEntity(a);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			a = (A)s.Merge(a);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				a = (A) s.Merge(a);
+				s.Transaction.Commit();
+			}
 			this.VerifyModifications(a.Id);
 	
 			// change the many-to-one association from h to be a new (transient) A
@@ -258,29 +252,26 @@ namespace NHibernate.Test.Cascade
 			A aNew = new A();
 			aNew.Data = "Alice";
 			aNew.AddH(h);
-	
-			s = base.OpenSession();
-			s.BeginTransaction();
-			try
+
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
 			{
-				s.Merge(a);
-				s.Merge(h);
-				Assert.Fail("should have thrown TransientObjectException");
+				try
+				{
+					s.Merge(a);
+					s.Merge(h);
+					Assert.Fail("should have thrown TransientObjectException");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+				}
 			}
-			catch (TransientObjectException)
-			{
-				// expected
-			}
-			finally
-			{
-				s.Transaction.Rollback();
-			}
-			s.Close();
 		}
 		
 		protected override void OnTearDown()
 		{
-			using (ISession session = base.OpenSession())
+			using (ISession session = OpenSession())
 			using (ITransaction transaction = session.BeginTransaction())
 			{
 				session.Delete("from H");
@@ -314,36 +305,36 @@ namespace NHibernate.Test.Cascade
 	
 		private void VerifyModifications(long aId)
 		{
-			ISession s = base.OpenSession();
-			s.BeginTransaction();
-	
-			// retrieve the A object and check it
-			A a = s.Get<A>(aId);
-			Assert.That(a.Id, Is.EqualTo(aId));
-			Assert.That(a.Data, Is.EqualTo("Anthony"));
-			Assert.That(a.G, Is.Not.Null);
-			Assert.That(a.Hs, Is.Not.Null);
-			Assert.That(a.Hs.Count, Is.EqualTo(1));
-	
-			G gFromA = a.G;
-			H hFromA = a.Hs.First();
-	
-			// check the G object
-			Assert.That(gFromA.Data, Is.EqualTo("Giovanni"));
-			Assert.That(gFromA.A, Is.SameAs(a));
-			Assert.That(gFromA.Hs, Is.Not.Null);
-			Assert.That(gFromA.Hs, Is.EqualTo(a.Hs));
-			Assert.That(gFromA.Hs.First(), Is.SameAs(hFromA));
-	
-			// check the H object
-			Assert.That(hFromA.Data, Is.EqualTo("Hellen"));
-			Assert.That(hFromA.A, Is.SameAs(a));
-			Assert.That(hFromA.Gs, Is.Not.Null);
-			Assert.That(hFromA.Gs.Count, Is.EqualTo(1));
-			Assert.That(hFromA.Gs.First(), Is.SameAs(gFromA));
-	
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				// retrieve the A object and check it
+				A a = s.Get<A>(aId);
+				Assert.That(a.Id, Is.EqualTo(aId));
+				Assert.That(a.Data, Is.EqualTo("Anthony"));
+				Assert.That(a.G, Is.Not.Null);
+				Assert.That(a.Hs, Is.Not.Null);
+				Assert.That(a.Hs.Count, Is.EqualTo(1));
+
+				G gFromA = a.G;
+				H hFromA = a.Hs.First();
+
+				// check the G object
+				Assert.That(gFromA.Data, Is.EqualTo("Giovanni"));
+				Assert.That(gFromA.A, Is.SameAs(a));
+				Assert.That(gFromA.Hs, Is.Not.Null);
+				Assert.That(gFromA.Hs, Is.EqualTo(a.Hs));
+				Assert.That(gFromA.Hs.First(), Is.SameAs(hFromA));
+
+				// check the H object
+				Assert.That(hFromA.Data, Is.EqualTo("Hellen"));
+				Assert.That(hFromA.A, Is.SameAs(a));
+				Assert.That(hFromA.Gs, Is.Not.Null);
+				Assert.That(hFromA.Gs.Count, Is.EqualTo(1));
+				Assert.That(hFromA.Gs.First(), Is.SameAs(gFromA));
+
+				s.Transaction.Commit();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Not sure why MergeDeliveryNodeAsync is unstable on appveyor. But at least fail shouldn't lead to lock in db. 

<details>
<summary>Test exception stacktrace just in case</summary>
<pre>
System.Collections.Generic.KeyNotFoundException : The given key was not present in the dictionary.
[00:08:22]    at System.ThrowHelper.ThrowKeyNotFoundException()
[00:08:22]    at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
[00:08:22]    at NHibernate.Engine.StatefulPersistenceContext.ReplaceDelayedEntityIdentityInsertKeys(EntityKey oldKey, Object generatedId) in C:\projects\nhibernate-core\src\NHibernate\Engine\StatefulPersistenceContext.cs:line 1356
[00:08:22]    at NHibernate.Action.EntityIdentityInsertAction.<PostInsertAsync>d__18.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Action\EntityIdentityInsertAction.cs:line 73
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Action.EntityIdentityInsertAction.<ExecuteAsync>d__17.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Action\EntityIdentityInsertAction.cs:line 63
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Engine.ActionQueue.<InnerExecuteAsync>d__3.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Engine\ActionQueue.cs:line 74
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Engine.ActionQueue.<ExecuteActionsAsync>d__0.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Engine\ActionQueue.cs:line 35
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Engine.ActionQueue.<ExecuteActionsAsync>d__5.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Engine\ActionQueue.cs:line 108
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at NHibernate.Engine.ActionQueue.<ExecuteActionsAsync>d__5.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Engine\ActionQueue.cs:line 117
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Event.Default.AbstractFlushingEventListener.<PerformExecutionsAsync>d__6.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Event\Default\AbstractFlushingEventListener.cs:line 255
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Event.Default.DefaultFlushEventListener.<OnFlushAsync>d__0.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Event\Default\DefaultFlushEventListener.cs:line 28
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Impl.SessionImpl.<FlushAsync>d__64.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Impl\SessionImpl.cs:line 1005
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Impl.SessionImpl.<BeforeTransactionCompletionAsync>d__77.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Impl\SessionImpl.cs:line 1248
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Transaction.AdoTransaction.<CommitAsync>d__1.MoveNext() in C:\projects\nhibernate-core\src\NHibernate\Async\Transaction\AdoTransaction.cs:line 59
[00:08:22] --- End of stack trace from previous location where exception was thrown ---
[00:08:22]    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[00:08:22]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:08:22]    at NHibernate.Test.Cascade.Circle.MultiPathCircleCascadeTestAsync.<MergeDeliveryNodeAsync>d__11.MoveNext() in C:\projects\nhibernate-core\src\NHibernate.Test\Async\Cascade\Circle\MultiPathCircleCascadeTest.cs:line 228
</pre>
</details>