### PR TITLE
 Use a statically resolved dialect when building the session factory 

### DIFF
--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -239,6 +239,40 @@ namespace NHibernate.Cfg
 				NHibernate.Dialect.Dialect.GetDialect(configuration.Properties);
 		}
 
+		[Serializable]
+		private class StaticDialectMappingWrapper : IMapping
+		{
+			private readonly IMapping _mapping;
+
+			public StaticDialectMappingWrapper(IMapping mapping)
+			{
+				_mapping = mapping;
+				Dialect = mapping.Dialect;
+			}
+
+			public IType GetIdentifierType(string className)
+			{
+				return _mapping.GetIdentifierType(className);
+			}
+
+			public string GetIdentifierPropertyName(string className)
+			{
+				return _mapping.GetIdentifierPropertyName(className);
+			}
+
+			public IType GetReferencedPropertyType(string className, string propertyName)
+			{
+				return _mapping.GetReferencedPropertyType(className, propertyName);
+			}
+
+			public bool HasNonIdentifierPropertyNamedId(string className)
+			{
+				return _mapping.HasNonIdentifierPropertyNamedId(className);
+			}
+
+			public Dialect.Dialect Dialect { get; }
+		}
+
 		private IMapping mapping;
 
 		protected Configuration(SettingsFactory settingsFactory)
@@ -1272,7 +1306,7 @@ namespace NHibernate.Cfg
 			// Ok, don't need schemas anymore, so free them
 			Schemas = null;
 
-			return new SessionFactoryImpl(this, mapping, settings, GetInitializedEventListeners());
+			return new SessionFactoryImpl(this, new StaticDialectMappingWrapper(mapping), settings, GetInitializedEventListeners());
 		}
 
 		/// <summary>

--- a/src/NHibernate/Cfg/Configuration.cs
+++ b/src/NHibernate/Cfg/Configuration.cs
@@ -1288,6 +1288,7 @@ namespace NHibernate.Cfg
 
 			#endregion
 		}
+
 		/// <summary>
 		/// Instantiate a new <see cref="ISessionFactory" />, using the properties and mappings in this
 		/// configuration. The <see cref="ISessionFactory" /> will be immutable, so changes made to the
@@ -1296,17 +1297,33 @@ namespace NHibernate.Cfg
 		/// <returns>An <see cref="ISessionFactory" /> instance.</returns>
 		public ISessionFactory BuildSessionFactory()
 		{
+			var dynamicDialectMapping = mapping;
+			// Use a mapping which does store the dialect instead of instantiating a new one
+			// at each access. The dialect does not change while building a session factory.
+			// It furthermore allows some hack on NHibernate.Spatial side to go on working,
+			// See nhibernate/NHibernate.Spatial#104
+			mapping = new StaticDialectMappingWrapper(mapping);
+			try
+			{
+				ConfigureProxyFactoryFactory();
+				SecondPassCompile();
+				Validate();
+				Environment.VerifyProperties(properties);
+				Settings settings = BuildSettings();
 
-			ConfigureProxyFactoryFactory();
-			SecondPassCompile();
-			Validate();
-			Environment.VerifyProperties(properties);
-			Settings settings = BuildSettings();
+				// Ok, don't need schemas anymore, so free them
+				Schemas = null;
 
-			// Ok, don't need schemas anymore, so free them
-			Schemas = null;
-
-			return new SessionFactoryImpl(this, new StaticDialectMappingWrapper(mapping), settings, GetInitializedEventListeners());
+				return new SessionFactoryImpl(
+					this,
+					mapping,
+					settings,
+					GetInitializedEventListeners());
+			}
+			finally
+			{
+				mapping = dynamicDialectMapping;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
This change is more a trivial optimization: when building the session factory, the dialect has no reason to change, and so we can use the same dialect instance from the start of the process to its end.
#1951, merged in v5.3, was already doing most of the work, by supplying to the built session factory an `IMapping` resolving the dialect at instantiation rather than dynamically.

This PR cherry-pick #1951 into 5.2.x, and furthermore switch `Configuration.mapping` member to the mapping having a static dialect, for the duration of the build.

So if anything does use the `mapping.Dialect` in steps prior to factory instantiation, it will now use that static one instead of instantiating it.

Well, that does probably not actually optimize anything in most cases as far as I know.

But it allows to restore a hack used by NHibernate.Spatial, which relies on having its dialect instantiated early in the factory building process. Without that hack, Spatial users cannot upgrade to NHibernate 5.2.x.
See nhibernate/NHibernate.Spatial#104.

That is why I issue this PR, targeting the 5.2.x branch.