### PR TITLE
Update symbol package format

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -28,6 +28,9 @@
     <PackageReleaseNotes>https://github.com/nhibernate/nhibernate-core/blob/$(VersionPrefix)/releasenotes.txt</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/nhibernate/nhibernate-core.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />

--- a/default.build
+++ b/default.build
@@ -308,7 +308,7 @@
 			commandline="src\NHibernate\nhibernate-mapping.xsd /classes /fields /order /namespace:NHibernate.Cfg.MappingSchema /out:src\NHibernate\Cfg\MappingSchema\"/>
 		
 	</target>
-	
+
 	<target name="nugetpushbat" depends="init binaries common.download-nuget nuget.set-properties"
 					description="Creates files for the release on nuget gallery.">
 
@@ -319,25 +319,14 @@
 			<in>
 				<items>
 					<include name="${nuget.nupackages.dir}/*.nupkg"/>
-					<exclude name="${nuget.nupackages.dir}/*.symbols.nupkg"/>
 				</items>
 			</in>
 			<do>
 				<echo message="nuget push -source https://nuget.org/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
 			</do>
 		</foreach>
-		<foreach item="File" property="filename">
-			<in>
-				<items>
-					<include name="${nuget.nupackages.dir}/*.symbols.nupkg"/>
-				</items>
-			</in>
-			<do>
-				<echo message="nuget push -source https://nuget.smbsrc.net/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
-			</do>
-		</foreach>
 	</target>
-	
+
 	<target name="nugetpush" depends="init binaries common.download-nuget nuget.set-properties"
 					description="Push packages on nuget gallery.">
 		<!-- In order to use this task you have to be sure you have executed 'nuget SetApiKey' -->


### PR DESCRIPTION
NHibernate goes on building symbol.nupkg since v5.0 although they are no more consumable with library built from `Sdk` projects (new .csproj format).

We should switch to building snupkg.

Related: #1971. (Sourcelink cannot be added yet because it implies adding a pre-release dependency.)