### PR TITLE
Update symbol package format and add Sourcelink

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -26,8 +26,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
     <PackageReleaseNotes>https://github.com/nhibernate/nhibernate-core/blob/$(VersionPrefix)/releasenotes.txt</PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/nhibernate/nhibernate-core.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />

--- a/default.build
+++ b/default.build
@@ -319,21 +319,10 @@
 			<in>
 				<items>
 					<include name="${nuget.nupackages.dir}/*.nupkg"/>
-					<exclude name="${nuget.nupackages.dir}/*.symbols.nupkg"/>
 				</items>
 			</in>
 			<do>
 				<echo message="nuget push -source https://nuget.org/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
-			</do>
-		</foreach>
-		<foreach item="File" property="filename">
-			<in>
-				<items>
-					<include name="${nuget.nupackages.dir}/*.symbols.nupkg"/>
-				</items>
-			</in>
-			<do>
-				<echo message="nuget push -source https://nuget.smbsrc.net/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
 			</do>
 		</foreach>
 	</target>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -41,6 +41,7 @@
     </PackageReference>
     <PackageReference Include="Antlr3.Runtime" Version="[3.5.1, 4.0)" />
     <PackageReference Include="Iesi.Collections" Version="[4.0.4, 5.0)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
     <PackageReference Include="Remotion.Linq" Version="[2.2.0, 3.0)" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="[2.2.0, 3.0)" />
   </ItemGroup>


### PR DESCRIPTION
NHibernate goes on building symbol.nupkg since v5.0 although they are no more consumable with library built from `Sdk` projects (new .csproj format).

We should switch to building snupkg, and to ease furthermore debugging, add SourceLink as requested by #1971.

Fixes #1971.
Replaces #2018.