### PR TITLE
Throw for DML on filter

### DIFF
--- a/src/NHibernate.Test/Async/LinqBulkManipulation/Fixture.cs
+++ b/src/NHibernate.Test/Async/LinqBulkManipulation/Fixture.cs
@@ -1158,6 +1158,18 @@ namespace NHibernate.Test.LinqBulkManipulation
 			}
 		}
 
+		[Test]
+		public async Task DeleteOnFilterThrowsAsync()
+		{
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				var a = await (s.Query<SimpleEntityWithAssociation>().Take(1).SingleOrDefaultAsync());
+				var query = a.AssociatedEntities.AsQueryable();
+				Assert.That(() => query.Delete(), Throws.InstanceOf<NotSupportedException>());
+			}
+		}
+
 		#endregion
 	}
 }

--- a/src/NHibernate.Test/LinqBulkManipulation/Fixture.cs
+++ b/src/NHibernate.Test/LinqBulkManipulation/Fixture.cs
@@ -1199,6 +1199,18 @@ namespace NHibernate.Test.LinqBulkManipulation
 			}
 		}
 
+		[Test]
+		public void DeleteOnFilterThrows()
+		{
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				var a = s.Query<SimpleEntityWithAssociation>().Take(1).SingleOrDefault();
+				var query = a.AssociatedEntities.AsQueryable();
+				Assert.That(() => query.Delete(), Throws.InstanceOf<NotSupportedException>());
+			}
+		}
+
 		#endregion
 	}
 }

--- a/src/NHibernate/Async/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Async/Linq/DefaultQueryProvider.cs
@@ -73,12 +73,15 @@ namespace NHibernate.Linq
 
 		public Task<int> ExecuteDmlAsync<T>(QueryMode queryMode, Expression expression, CancellationToken cancellationToken)
 		{
+			if (Collection != null)
+				throw new NotSupportedException("DML operations are not supported for filters.");
 			if (cancellationToken.IsCancellationRequested)
 			{
 				return Task.FromCanceled<int>(cancellationToken);
 			}
 			try
 			{
+
 				var nhLinqExpression = new NhLinqDmlExpression<T>(queryMode, expression, Session.Factory);
 
 				var query = Session.CreateQuery(nhLinqExpression);

--- a/src/NHibernate/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Linq/DefaultQueryProvider.cs
@@ -282,6 +282,9 @@ namespace NHibernate.Linq
 
 		public int ExecuteDml<T>(QueryMode queryMode, Expression expression)
 		{
+			if (Collection != null)
+				throw new NotSupportedException("DML operations are not supported for filters.");
+
 			var nhLinqExpression = new NhLinqDmlExpression<T>(queryMode, expression, Session.Factory);
 
 			var query = Session.CreateQuery(nhLinqExpression);


### PR DESCRIPTION
As otherwise DML is executed on the whole table.
Though it would be cool to support it.