### PR TITLE
Use compiled expression in AliasToBeanResultTransformer

### DIFF
--- a/src/NHibernate.Test/Async/TransformTests/AliasToBeanResultTransformerFixture.cs
+++ b/src/NHibernate.Test/Async/TransformTests/AliasToBeanResultTransformerFixture.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using System.Reflection;
 using NHibernate.Transform;
 using NHibernate.Util;
@@ -225,7 +224,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				var transformer = Transformers.AliasToBean<NewPropertiesSimpleDTO>();
+				var transformer = GetTransformer<NewPropertiesSimpleDTO>();
 				var l = await (s.CreateSQLQuery("select id as ID, Name as NamE from Simple")
 						.SetResultTransformer(transformer)
 						.ListAsync<NewPropertiesSimpleDTO>());
@@ -244,7 +243,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				var transformer = Transformers.AliasToBean<PropertiesInsensitivelyDuplicated>();
+				var transformer = GetTransformer<PropertiesInsensitivelyDuplicated>();
 				Assert.ThrowsAsync<AmbiguousMatchException>(() =>
 				{
 					return s.CreateSQLQuery("select * from Simple")
@@ -268,7 +267,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				transformer = transformer ?? Transformers.AliasToBean<T>();
+				transformer = transformer ?? GetTransformer<T>();
 				var l = await (s.CreateSQLQuery("select * from Simple")
 						.SetResultTransformer(transformer)
 						.ListAsync<T>(cancellationToken));
@@ -285,7 +284,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				var transformer = Transformers.AliasToBean<T>();
+				var transformer = GetTransformer<T>();
 				var l = await (s.CreateSQLQuery(queryString)
 						.SetResultTransformer(transformer)
 						.ListAsync<T>(cancellationToken));
@@ -301,15 +300,20 @@ namespace NHibernate.Test.TransformTests
 		{
 			try
 			{
-				var transformer = Transformers.AliasToBean<T>();
+				var transformer = GetTransformer<T>();
 				var bytes = SerializationHelper.Serialize(transformer);
-				transformer = (IResultTransformer)SerializationHelper.Deserialize(bytes);
+				transformer = (IResultTransformer) SerializationHelper.Deserialize(bytes);
 				return AssertCardinalityNameAndIdAsync<T>(transformer: transformer, cancellationToken: cancellationToken);
 			}
 			catch (System.Exception ex)
 			{
 				return Task.FromException<object>(ex);
 			}
+		}
+
+		protected IResultTransformer GetTransformer<T>()
+		{
+			return Transformers.AliasToBean<T>();
 		}
 	}
 }

--- a/src/NHibernate.Test/TransformTests/AliasToBeanResultTransformerFixture.cs
+++ b/src/NHibernate.Test/TransformTests/AliasToBeanResultTransformerFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Reflection;
 using NHibernate.Transform;
 using NHibernate.Util;
@@ -213,7 +212,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				var transformer = Transformers.AliasToBean<NewPropertiesSimpleDTO>();
+				var transformer = GetTransformer<NewPropertiesSimpleDTO>();
 				var l = s.CreateSQLQuery("select id as ID, Name as NamE from Simple")
 						.SetResultTransformer(transformer)
 						.List<NewPropertiesSimpleDTO>();
@@ -232,7 +231,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				var transformer = Transformers.AliasToBean<PropertiesInsensitivelyDuplicated>();
+				var transformer = GetTransformer<PropertiesInsensitivelyDuplicated>();
 				Assert.Throws<AmbiguousMatchException>(() =>
 				{
 					s.CreateSQLQuery("select * from Simple")
@@ -256,7 +255,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				transformer = transformer ?? Transformers.AliasToBean<T>();
+				transformer = transformer ?? GetTransformer<T>();
 				var l = s.CreateSQLQuery("select * from Simple")
 						.SetResultTransformer(transformer)
 						.List<T>();
@@ -273,7 +272,7 @@ namespace NHibernate.Test.TransformTests
 		{
 			using (var s = OpenSession())
 			{
-				var transformer = Transformers.AliasToBean<T>();
+				var transformer = GetTransformer<T>();
 				var l = s.CreateSQLQuery(queryString)
 						.SetResultTransformer(transformer)
 						.List<T>();
@@ -287,10 +286,15 @@ namespace NHibernate.Test.TransformTests
 
 		private void AssertSerialization<T>()
 		{
-			var transformer = Transformers.AliasToBean<T>();
+			var transformer = GetTransformer<T>();
 			var bytes = SerializationHelper.Serialize(transformer);
-			transformer = (IResultTransformer)SerializationHelper.Deserialize(bytes);
+			transformer = (IResultTransformer) SerializationHelper.Deserialize(bytes);
 			AssertCardinalityNameAndId<T>(transformer: transformer);
+		}
+
+		protected IResultTransformer GetTransformer<T>()
+		{
+			return Transformers.AliasToBean<T>();
 		}
 	}
 }

--- a/src/NHibernate/Transform/Transformers.cs
+++ b/src/NHibernate/Transform/Transformers.cs
@@ -15,6 +15,7 @@ namespace NHibernate.Transform
 		/// <summary>
 		/// Creates a result transformer that will inject aliased values into instances
 		/// of <paramref name="target"/> via property methods or fields.
+		/// NOTE: This transformer can't be reused by different queries as it caches query aliases on first transformation
 		/// </summary>
 		/// <param name="target">The type of the instances to build.</param>
 		/// <returns>A result transformer for supplied type.</returns>
@@ -31,6 +32,7 @@ namespace NHibernate.Transform
 		/// <summary>
 		/// Creates a result transformer that will inject aliased values into instances
 		/// of <typeparamref name="T"/> via property methods or fields.
+		/// NOTE: This transformer can't be reused by different queries as it caches query aliases on first transformation
 		/// </summary>
 		/// <typeparam name="T">The type of the instances to build.</typeparam>
 		/// <returns>A result transformer for supplied type.</returns>


### PR DESCRIPTION
Possible breaking change:
As now expression is compiled on first transformation - now this transformer can't be reused for different queries. Transfomer can still be reused but only for the same query.

Perf comparison for 5 aliases and 50 000 transformations on my machine (see #2015 with side by side comparison):
300 ms vs 15 ms for Compiled version





