### PR TITLE
ComponentType will always return a non-null collection, even if all the entries are null.

### DIFF
--- a/src/NHibernate/Type/ComponentType.cs
+++ b/src/NHibernate/Type/ComponentType.cs
@@ -490,10 +490,11 @@ namespace NHibernate.Type
 				begin += length;
 			}
 
-			if (ReturnedClass.IsValueType)
-				return values;
-			else
-				return notNull ? values : null;
+			// CZ: Always return a non-null collection, even if all the entries are null.
+			//if (ReturnedClass.IsValueType)
+			return values;
+			//else
+			//	return notNull ? values : null;
 		}
 
 		public override object ResolveIdentifier(object value, ISessionImplementor session, object owner)


### PR DESCRIPTION
If all the columns in a dynamic component are null, then rather than returning an IDictionary with keys and null values, it just returns a null reference.  Having even one column with a non-null value will cause the dictionary to be populated. 

This causes two problems: first is you have an unexpected null reference, and if you want to create a dictionary you won't know what keys to add to it.  Second, if you do add a reference to a dictionary with the correct keys, NHibernate will attempt to INSERT rather than UPDATE.  This will either cause a duplicate record or a primary key violation.