### PR TITLE
ComponentType will always return a non-null collection, even if all the entries are null.

### DIFF
--- a/src/NHibernate/Type/ComponentType.cs
+++ b/src/NHibernate/Type/ComponentType.cs
@@ -468,7 +468,6 @@ namespace NHibernate.Type
 		public override object Hydrate(DbDataReader rs, string[] names, ISessionImplementor session, object owner)
 		{
 			int begin = 0;
-			bool notNull = false;
 			object[] values = new object[propertySpan];
 			for (int i = 0; i < propertySpan; i++)
 			{
@@ -482,18 +481,11 @@ namespace NHibernate.Type
 						return null; //different nullability rules for pk/fk
 					}
 				}
-				else
-				{
-					notNull = true;
-				}
 				values[i] = val;
 				begin += length;
 			}
 
-			if (ReturnedClass.IsValueType)
-				return values;
-			else
-				return notNull ? values : null;
+			return values;
 		}
 
 		public override object ResolveIdentifier(object value, ISessionImplementor session, object owner)


### PR DESCRIPTION
If all the columns in a dynamic component are null, then rather than returning an IDictionary with keys and null values, it just returns a null reference. Having even one column with a non-null value will cause the dictionary to be populated.

This causes two problems: first is you have an unexpected null reference, and if you want to create a dictionary you won't know what keys to add to it. Second, if you do add a reference to a dictionary with the correct keys, NHibernate will attempt to INSERT rather than UPDATE. This will either cause a duplicate record or a primary key violation.