### PR TITLE
Allow using ON instead of WITH in hql

### DIFF
--- a/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
@@ -48,6 +48,26 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public async Task CanJoinNotAssociatedEntity_OnKeywordAsync()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				await (session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						"left join EntityComplex ex on root.Complex1Id = ex.Id")
+						.SetMaxResults(1)
+					.UniqueResultAsync<EntityComplex>());
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
 		public async Task EntityJoinForCompositeKeyAsync()
 		{
 			using (var sqlLog = new SqlLogSpy())

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -37,6 +37,26 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public void CanJoinNotAssociatedEntity_OnKeyword()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						"left join EntityComplex ex on root.Complex1Id = ex.Id")
+						.SetMaxResults(1)
+					.UniqueResult<EntityComplex>();
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
 		public void EntityJoinForCompositeKey()
 		{
 			using (var sqlLog = new SqlLogSpy())

--- a/src/NHibernate/Hql/Ast/ANTLR/Hql.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/Hql.g
@@ -259,6 +259,9 @@ fromJoin
 
 withClause
 	: WITH^ logicalExpression
+	| ON logicalExpression 
+	// it's really just a WITH clause, so treat it as such...
+		-> ^(WITH["with"] logicalExpression)
 	;
 
 fromRange

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -1104,8 +1104,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 		{
 			get
 			{
-				// Note: once we add support for "JOIN ... ON ...",
-				// the ON clause needs to get included here
+				//Note: "JOIN ... ON ..." case is treated as "JOIN ... WITH ..." by parser 
 				return CurrentClauseType == WHERE ||
 						CurrentClauseType == WITH ||
 						IsInCase;


### PR DESCRIPTION
In hibernate it's supported since 2012 https://github.com/hibernate/hibernate-orm/commit/0a374404315c923e0714131d528f86ddb1538623

And it looks more natural with entity joins
