### PR TITLE
Hql entity join fixes

### DIFF
--- a/src/NHibernate.Test/Async/Hql/Ast/WithClauseFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/WithClauseFixture.cs
@@ -9,6 +9,7 @@
 
 
 using System.Collections;
+using NHibernate.Exceptions;
 using NHibernate.Hql.Ast.ANTLR;
 using NUnit.Framework;
 
@@ -52,34 +53,36 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
-		public async Task InvalidWithSemanticsAsync()
+		public async Task ValidWithSemanticsAsync()
 		{
-			ISession s = OpenSession();
-			ITransaction txn = s.BeginTransaction();
+			using (var s = OpenSession())
+			{
+				await (s.CreateQuery(
+					"from Animal a inner join a.offspring o inner join o.mother as m inner join m.father as f with o.bodyWeight > 1").ListAsync());
+			}
+		}
 
-			// PROBLEM : f.bodyWeight is a reference to a column on the Animal table; however, the 'f'
-			// alias relates to the Human.friends collection which the aonther Human entity.  The issue
-			// here is the way JoinSequence and Joinable (the persister) interact to generate the
-			// joins relating to the sublcass/superclass tables
-			Assert.ThrowsAsync<InvalidWithClauseException>(
-				() =>
-				s.CreateQuery("from Human h inner join h.friends as f with f.bodyWeight < :someLimit").SetDouble("someLimit", 1).
-					ListAsync());
+		[Test]
+		public void InvalidWithSemanticsAsync()
+		{
+			using(new SqlLogSpy())
+			using (ISession s = OpenSession())
+			{
+				// PROBLEM : f.bodyWeight is a reference to a column on the Animal table; however, the 'f'
+				// alias relates to the Human.friends collection which the aonther Human entity.  The issue
+				// here is the way JoinSequence and Joinable (the persister) interact to generate the
+				// joins relating to the sublcass/superclass tables
+				Assert.ThrowsAsync<InvalidWithClauseException>(
+					() =>
+						s.CreateQuery("from Human h inner join h.friends as f with f.bodyWeight < :someLimit").SetDouble("someLimit", 1).ListAsync());
 
-			Assert.ThrowsAsync<InvalidWithClauseException>(
-				() =>
-				s.CreateQuery(
-					"from Animal a inner join a.offspring o inner join o.mother as m inner join m.father as f with o.bodyWeight > 1").
-					ListAsync());
-
-			Assert.ThrowsAsync<InvalidWithClauseException>(
-				async () =>
-				await (s.CreateQuery("from Human h inner join h.offspring o with o.mother.father = :cousin").SetEntity("cousin",
-				                                                                                                await (s.LoadAsync<Human>(123L)))
-					.ListAsync()));
-
-			await (txn.CommitAsync());
-			s.Close();
+				//The query below is no longer throw InvalidWithClauseException but generates invalid SQL to better support various with join clauses.
+				Assert.ThrowsAsync<GenericADOException>(
+					() =>
+						s.CreateQuery("from Human h inner join h.offspring o with o.mother.father = :cousin")
+						.SetInt32("cousin", 123)
+						.ListAsync());
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Async/Hql/Ast/WithClauseFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/WithClauseFixture.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Collections;
 using NHibernate.Exceptions;
 using NHibernate.Hql.Ast.ANTLR;
@@ -63,7 +64,7 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
-		public void InvalidWithSemanticsAsync()
+		public async Task InvalidWithSemanticsAsync()
 		{
 			using (ISession s = OpenSession())
 			{
@@ -75,12 +76,18 @@ namespace NHibernate.Test.Hql.Ast
 					() =>
 						s.CreateQuery("from Human h inner join h.friends as f with f.bodyWeight < :someLimit").SetDouble("someLimit", 1).ListAsync());
 
-				//The query below is no longer throw InvalidWithClauseException but generates invalid SQL to better support various with join clauses.
-				Assert.ThrowsAsync<GenericADOException>(
-					() =>
-						s.CreateQuery("from Human h inner join h.offspring o with o.mother.father = :cousin")
-						.SetInt32("cousin", 123)
-						.ListAsync());
+				//The query below is no longer throw InvalidWithClauseException but generates "invalid" SQL to better support complex with join clauses.
+				//Invalid SQL means that additional joins for "o.mother.father" are currently added after "offspring" join. Some DBs can process such query and some can't.
+				try
+				{
+					await (s.CreateQuery("from Human h inner join h.offspring o with o.mother.father = :cousin")
+					.SetInt32("cousin", 123)
+					.ListAsync());
+				}
+				catch (GenericADOException)
+				{
+					//Apparently SQLite can process queries with wrong join orders
+				}
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Hql/Ast/WithClauseFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/WithClauseFixture.cs
@@ -65,7 +65,6 @@ namespace NHibernate.Test.Hql.Ast
 		[Test]
 		public void InvalidWithSemanticsAsync()
 		{
-			using(new SqlLogSpy())
 			using (ISession s = OpenSession())
 			{
 				// PROBLEM : f.bodyWeight is a reference to a column on the Animal table; however, the 'f'

--- a/src/NHibernate.Test/Hql/Ast/WithClauseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/WithClauseFixture.cs
@@ -53,7 +53,6 @@ namespace NHibernate.Test.Hql.Ast
 		[Test]
 		public void InvalidWithSemantics()
 		{
-			using(new SqlLogSpy())
 			using (ISession s = OpenSession())
 			{
 				// PROBLEM : f.bodyWeight is a reference to a column on the Animal table; however, the 'f'

--- a/src/NHibernate.Test/Hql/Ast/WithClauseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/WithClauseFixture.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using NHibernate.Exceptions;
 using NHibernate.Hql.Ast.ANTLR;
 using NUnit.Framework;
 
@@ -40,34 +41,36 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
+		public void ValidWithSemantics()
+		{
+			using (var s = OpenSession())
+			{
+				s.CreateQuery(
+					"from Animal a inner join a.offspring o inner join o.mother as m inner join m.father as f with o.bodyWeight > 1").List();
+			}
+		}
+
+		[Test]
 		public void InvalidWithSemantics()
 		{
-			ISession s = OpenSession();
-			ITransaction txn = s.BeginTransaction();
+			using(new SqlLogSpy())
+			using (ISession s = OpenSession())
+			{
+				// PROBLEM : f.bodyWeight is a reference to a column on the Animal table; however, the 'f'
+				// alias relates to the Human.friends collection which the aonther Human entity.  The issue
+				// here is the way JoinSequence and Joinable (the persister) interact to generate the
+				// joins relating to the sublcass/superclass tables
+				Assert.Throws<InvalidWithClauseException>(
+					() =>
+						s.CreateQuery("from Human h inner join h.friends as f with f.bodyWeight < :someLimit").SetDouble("someLimit", 1).List());
 
-			// PROBLEM : f.bodyWeight is a reference to a column on the Animal table; however, the 'f'
-			// alias relates to the Human.friends collection which the aonther Human entity.  The issue
-			// here is the way JoinSequence and Joinable (the persister) interact to generate the
-			// joins relating to the sublcass/superclass tables
-			Assert.Throws<InvalidWithClauseException>(
-				() =>
-				s.CreateQuery("from Human h inner join h.friends as f with f.bodyWeight < :someLimit").SetDouble("someLimit", 1).
-					List());
-
-			Assert.Throws<InvalidWithClauseException>(
-				() =>
-				s.CreateQuery(
-					"from Animal a inner join a.offspring o inner join o.mother as m inner join m.father as f with o.bodyWeight > 1").
-					List());
-
-			Assert.Throws<InvalidWithClauseException>(
-				() =>
-				s.CreateQuery("from Human h inner join h.offspring o with o.mother.father = :cousin").SetEntity("cousin",
-				                                                                                                s.Load<Human>(123L))
-					.List());
-
-			txn.Commit();
-			s.Close();
+				//The query below is no longer throw InvalidWithClauseException but generates invalid SQL to better support various with join clauses.
+				Assert.Throws<GenericADOException>(
+					() =>
+						s.CreateQuery("from Human h inner join h.offspring o with o.mother.father = :cousin")
+						.SetInt32("cousin", 123)
+						.List());
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -203,6 +203,67 @@ namespace NHibernate.Test.Hql
 		}
 
 
+		[Test]
+		public void WithClauseOnOtherAssociation()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				session
+					.CreateQuery("select ex " +
+						"from EntityComplex ex join fetch ex.SameTypeChild stc " +
+						"join ex.SameTypeChild2 stc2 with stc.Version != stc2.Version ")
+						.SetMaxResults(1)
+					.UniqueResult<EntityComplex>();
+
+				Assert.That(entityComplex, Is.Null);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
+		public void EntityJoinNoTablesInWithClause()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						"left join EntityComplex ex with 1 = 2")
+						.SetMaxResults(1)
+					.UniqueResult<EntityComplex>();
+
+				Assert.That(entityComplex, Is.Null);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
+		public void EntityJoinWithFetches()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						"left join EntityComplex ex with root.Complex1Id = ex.Id " +
+						"inner join fetch ex.SameTypeChild st")
+						.SetMaxResults(1)
+					.UniqueResult<EntityComplex>();
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(entityComplex.SameTypeChild, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex.SameTypeChild), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
 		[Test, Ignore("Failing for unrelated reasons")]
 		public void CrossJoinAndWithClause()
 		{
@@ -237,6 +298,7 @@ namespace NHibernate.Test.Hql
 
 					rc.ManyToOne(ep => ep.SameTypeChild, m => m.Column("SameTypeChildId"));
 
+					rc.ManyToOne(ep => ep.SameTypeChild2, m => m.Column("SameTypeChild2Id"));
 
 				});
 
@@ -320,7 +382,12 @@ namespace NHibernate.Test.Hql
 					SameTypeChild = new EntityComplex()
 					{
 						Name = "ComplexEntityChild"
+					},
+					SameTypeChild2 = new EntityComplex()
+					{
+						Name = "ComplexEntityChild2"
 					}
+
 				};
 
 				_entityWithCompositeId = new EntityWithCompositeId
@@ -334,6 +401,7 @@ namespace NHibernate.Test.Hql
 				};
 
 				session.Save(parent.SameTypeChild);
+				session.Save(parent.SameTypeChild2);
 				session.Save(parent);
 				session.Save(_entityWithCompositeId);
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
@@ -13,6 +13,7 @@ namespace NHibernate.Test.Hql.EntityJoinHqlTestEntities
 		public virtual string LazyProp { get; set; }
 
 		public virtual EntityComplex SameTypeChild { get; set; }
+		public virtual EntityComplex SameTypeChild2 { get; set; }
 
 	}
 

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -1201,7 +1201,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 				NodeTraverser traverser = new NodeTraverser(visitor);
 				traverser.TraverseDepthFirst(hqlSqlWithNode);
 				FromElement referencedFromElement = visitor.GetReferencedFromElement();
-				if (referencedFromElement != fromElement)
+				if (referencedFromElement != fromElement && referencedFromElement != null)
 				{
 					if (!referencedFromElement.IsEntityJoin() && !fromElement.IsEntityJoin())
 						throw new InvalidWithClauseException(

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -1200,13 +1200,6 @@ namespace NHibernate.Hql.Ast.ANTLR
 				WithClauseVisitor visitor = new WithClauseVisitor(fromElement);
 				NodeTraverser traverser = new NodeTraverser(visitor);
 				traverser.TraverseDepthFirst(hqlSqlWithNode);
-				FromElement referencedFromElement = visitor.GetReferencedFromElement();
-				if (referencedFromElement != fromElement && referencedFromElement != null)
-				{
-					if (!referencedFromElement.IsEntityJoin() && !fromElement.IsEntityJoin())
-						throw new InvalidWithClauseException(
-							"with-clause expressions did not reference from-clause element to which the with-clause was associated");
-				}
 				SqlGenerator sql = new SqlGenerator(_sessionFactoryHelper.Factory, new CommonTreeNodeStream(adaptor, hqlSqlWithNode.GetChild(0)));
 
 				sql.whereExpr();
@@ -1232,15 +1225,15 @@ namespace NHibernate.Hql.Ast.ANTLR
 	class WithClauseVisitor : IVisitationStrategy 
 	{
 		private readonly FromElement _joinFragment;
-		private FromElement _referencedFromElement;
-		private String _joinAlias;
+		private readonly bool _multiTable;
 
 		public WithClauseVisitor(FromElement fromElement) 
 		{
 			_joinFragment = fromElement;
+			_multiTable = (fromElement.EntityPersister as IQueryable)?.IsMultiTable == true;
 		}
 
-		public void Visit(IASTNode node) 
+		public void Visit(IASTNode node)
 		{
 			// todo : currently expects that the individual with expressions apply to the same sql table join.
 			//      This may not be the case for joined-subclass where the property values
@@ -1252,32 +1245,30 @@ namespace NHibernate.Hql.Ast.ANTLR
 			//          2) here we would need to track each comparison individually, along with
 			//              the join alias to which it applies and then pass that information
 			//              back to the FromElement so it can pass it along to the JoinSequence
-			if ( node is DotNode ) 
+			if (_multiTable && node is DotNode dotNode)
 			{
-				DotNode dotNode = ( DotNode ) node;
 				FromElement fromElement = dotNode.FromElement;
-				if ( _referencedFromElement == null )
+				if (_joinFragment == fromElement)
 				{
-					_referencedFromElement = fromElement;
-					_joinAlias = ExtractAppliedAlias( dotNode );
-
+					var joinAlias = ExtractAppliedAlias(dotNode);
+					//See WithClauseFixture.InvalidWithSemantics to understand the logic behind this check
 					// todo : temporary
 					//      needed because currently persister is the one that
 					//      creates and renders the join fragments for inheritence
 					//      hierarchies...
-					if ( _joinAlias != _referencedFromElement.TableAlias) 
+					if (joinAlias != _joinFragment.TableAlias)
 					{
-						throw new InvalidWithClauseException( "with clause can only reference columns in the driving table" );
+						throw new InvalidWithClauseException("with clause can only reference columns in the driving table");
 					}
 				}
 			}
-			else if ( node is ParameterNode ) 
+			else if (node is ParameterNode paramNode)
 			{
-				ApplyParameterSpecification(((ParameterNode) node).HqlParameterSpecification);
+				ApplyParameterSpecification(paramNode.HqlParameterSpecification);
 			}
-			else if ( node is IParameterContainer ) 
+			else if (node is IParameterContainer paramContainer)
 			{
-				ApplyParameterSpecifications( ( IParameterContainer ) node );
+				ApplyParameterSpecifications(paramContainer);
 			}
 		}
 
@@ -1303,15 +1294,9 @@ namespace NHibernate.Hql.Ast.ANTLR
 			return dotNode.Text.Substring( 0, dotNode.Text.IndexOf( '.' ) );
 		}
 
-		public FromElement GetReferencedFromElement() 
+		public String GetJoinAlias()
 		{
-			return _referencedFromElement;
-		}
-
-		public String GetJoinAlias() 
-		{
-			return _joinAlias;
+			return _joinFragment.TableAlias;
 		}
 	}
-
 }

--- a/src/NHibernate/Hql/Ast/ANTLR/SqlGenerator.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/SqlGenerator.g
@@ -188,7 +188,7 @@ fromTable
 	// Write the table node (from fragment) and all the join fragments associated with it.
 	: ^( a=FROM_FRAGMENT  { Out(a); } (tableJoin [ a ])* )
 	| ^( a=JOIN_FRAGMENT  { Out(a); } (tableJoin [ a ])* )
-	| ^( a=ENTITY_JOIN    { Out(a); } )
+	| ^( a=ENTITY_JOIN    { Out(a); } (tableJoin [ a ])* )
 	;
 
 tableJoin [ IASTNode parent ]


### PR DESCRIPTION
Ported fix [HHH-11340](https://hibernate.atlassian.net/browse/HHH-11340) ([commit](https://github.com/hibernate/hibernate-orm/commit/a2781e6654a940ba581a825bb165da0eb05092b2))
And adapted WITH clause processing for entity joins

@hazzik I believe that it should fix all remaining tests in your linq PR (except uncommented `CrossJoinAndWithClause` )