### PR TITLE
DB2 dialect enhancements

### DIFF
--- a/src/NHibernate.Test/DialectTest/FunctionTests/SubstringSupportFixture.cs
+++ b/src/NHibernate.Test/DialectTest/FunctionTests/SubstringSupportFixture.cs
@@ -41,12 +41,10 @@ namespace NHibernate.Test.DialectTest.FunctionTests
 				case SybaseASE15Dialect _:
 					Assert.That(substringFunction, Is.TypeOf<EmulatedLengthSubstringFunction>());
 					break;
-				case DB2Dialect _:
-					Assert.That(substringFunction, Is.TypeOf<SQLFunctionTemplate>());
-					break;
 				case SybaseSQLAnywhere10Dialect _:
 					Assert.That(substringFunction, Is.TypeOf<VarArgsSQLFunction>());
 					break;
+				case DB2Dialect _:
 				case Oracle8iDialect _:
 				case SQLiteDialect _:
 				case HanaDialectBase _:
@@ -56,7 +54,6 @@ namespace NHibernate.Test.DialectTest.FunctionTests
 					Assert.That(substringFunction, Is.TypeOf<AnsiSubstringFunction>());
 					break;
 			}
-
 		}
 	}
 }

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -131,6 +131,12 @@ namespace NHibernate.Dialect
 
 			// DB2 does not support ANSI substring syntax.
 			RegisterFunction("substring", new SQLFunctionTemplate(NHibernateUtil.String, "substring(?1, ?2, ?3)"));
+			
+			// Bitwise operations
+			RegisterFunction("band", new Function.BitwiseFunctionOperation("bitand"));
+			RegisterFunction("bor", new Function.BitwiseFunctionOperation("bitor"));
+			RegisterFunction("bxor", new Function.BitwiseFunctionOperation("bitxor"));
+			RegisterFunction("bnot", new Function.BitwiseFunctionOperation("bitnot"));
 
 			DefaultProperties[Environment.ConnectionDriver] = "NHibernate.Driver.DB2Driver";
 		}

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -55,6 +55,7 @@ namespace NHibernate.Dialect
 			RegisterColumnType(DbType.String, 8000, "VARCHAR($l)");
 			RegisterColumnType(DbType.String, 2147483647, "CLOB");
 			RegisterColumnType(DbType.Time, "TIME");
+			RegisterColumnType(DbType.Guid, "CHAR(16) FOR BIT DATA");
 
 			RegisterFunction("abs", new StandardSQLFunction("abs"));
 			RegisterFunction("absval", new StandardSQLFunction("absval"));

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -63,7 +63,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));
 			RegisterFunction("ceil", new StandardSQLFunction("ceil"));
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
-			RegisterFunction("round", new StandardSQLFunction("round"));
+			RegisterFunction("round", new StandardSQLFunctionWithRequiredParameters("round", new object[] { null, "0" }));
 
 			RegisterFunction("acos", new StandardSQLFunction("acos", NHibernateUtil.Double));
 			RegisterFunction("asin", new StandardSQLFunction("asin", NHibernateUtil.Double));

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -137,6 +137,8 @@ namespace NHibernate.Dialect
 			RegisterFunction("bxor", new Function.BitwiseFunctionOperation("bitxor"));
 			RegisterFunction("bnot", new Function.BitwiseFunctionOperation("bitnot"));
 
+			RegisterFunction("current_timestamp", new NoArgSQLFunction("current_timestamp", NHibernateUtil.DateTime, false));
+
 			DefaultProperties[Environment.ConnectionDriver] = "NHibernate.Driver.DB2Driver";
 		}
 

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -292,6 +292,8 @@ namespace NHibernate.Dialect
 		/// <inheritdoc />
 		public override int MaxAliasLength => 32;
 
+		public override long TimestampResolutionInTicks => 10L; // Microseconds.
+
 		#region Overridden informational metadata
 
 		public override bool SupportsEmptyInList => false;

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -1,7 +1,9 @@
 using System.Data;
+using System.Data.Common;
 using System.Text;
 using NHibernate.Cfg;
 using NHibernate.Dialect.Function;
+using NHibernate.Dialect.Schema;
 using NHibernate.SqlCommand;
 
 namespace NHibernate.Dialect
@@ -191,6 +193,11 @@ namespace NHibernate.Dialect
 		public override string GetDropSequenceString(string sequenceName)
 		{
 			return string.Concat("drop sequence ", sequenceName, " restrict");
+		}
+
+		public override IDataBaseSchema GetDataBaseSchema(DbConnection connection)
+		{
+			return new DB2MetaData(connection);
 		}
 
 		/// <summary></summary>

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -129,9 +129,8 @@ namespace NHibernate.Dialect
 
 			RegisterFunction("mod", new StandardSQLFunction("mod", NHibernateUtil.Int32));
 
-			// DB2 does not support ANSI substring syntax.
-			RegisterFunction("substring", new SQLFunctionTemplate(NHibernateUtil.String, "substring(?1, ?2, ?3)"));
-			
+			RegisterFunction("substring", new StandardSQLFunction("substr", NHibernateUtil.String));
+
 			// Bitwise operations
 			RegisterFunction("band", new Function.BitwiseFunctionOperation("bitand"));
 			RegisterFunction("bor", new Function.BitwiseFunctionOperation("bitor"));

--- a/src/NHibernate/Dialect/Schema/DB2MetaData.cs
+++ b/src/NHibernate/Dialect/Schema/DB2MetaData.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+
+namespace NHibernate.Dialect.Schema
+{
+	public class DB2MetaData : AbstractDataBaseSchema
+	{
+		public DB2MetaData(DbConnection connection) : base(connection)
+		{
+		}
+
+		public override ITableMetadata GetTableMetadata(DataRow rs, bool extras)
+		{
+			return new DB2TableMetaData(rs, this, extras);
+		}
+
+		public override DataTable GetIndexColumns(string catalog, string schemaPattern, string tableName, string indexName)
+		{
+			var restrictions = new[] {tableName, indexName};
+			return Connection.GetSchema("Indexes", restrictions);
+		}
+
+		public override ISet<string> GetReservedWords()
+		{
+			var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			var dtReservedWords = Connection.GetSchema(DbMetaDataCollectionNames.ReservedWords);
+			foreach (DataRow row in dtReservedWords.Rows)
+			{
+				result.Add(row["ReservedWord"].ToString());
+			}
+
+			if (IncludeDataTypesInReservedWords)
+			{
+				var dtTypes = Connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
+				foreach (DataRow row in dtTypes.Rows)
+				{
+					result.Add(row["SQL_TYPE_NAME"].ToString());
+				}
+			}
+
+			return result;
+		}
+	}
+
+	public class DB2TableMetaData : AbstractTableMetadata
+	{
+		public DB2TableMetaData(DataRow rs, IDataBaseSchema meta, bool extras) : base(rs, meta, extras)
+		{
+		}
+
+		protected override IColumnMetadata GetColumnMetadata(DataRow rs)
+		{
+			return new DB2ColumnMetaData(rs);
+		}
+
+		protected override string GetColumnName(DataRow rs)
+		{
+			return Convert.ToString(rs["COLUMN_NAME"]);
+		}
+
+		protected override string GetConstraintName(DataRow rs)
+		{
+			return Convert.ToString(rs["FK_NAME"]);
+		}
+
+		protected override IForeignKeyMetadata GetForeignKeyMetadata(DataRow rs)
+		{
+			return new DB2ForeignKeyMetaData(rs);
+		}
+
+		protected override IIndexMetadata GetIndexMetadata(DataRow rs)
+		{
+			return new DB2IndexMetaData(rs);
+		}
+
+		protected override string GetIndexName(DataRow rs)
+		{
+			return Convert.ToString(rs["INDEX_NAME"]);
+		}
+
+		protected override void ParseTableInfo(DataRow rs)
+		{
+			Catalog = Convert.ToString(rs["TABLE_CATALOG"]);
+			Schema = Convert.ToString(rs["TABLE_SCHEMA"]);
+			if (string.IsNullOrEmpty(Catalog)) Catalog = null;
+			if (string.IsNullOrEmpty(Schema)) Schema = null;
+			Name = Convert.ToString(rs["TABLE_NAME"]);
+		}
+	}
+
+	public class DB2ColumnMetaData : AbstractColumnMetaData
+	{
+		public DB2ColumnMetaData(DataRow rs) : base(rs)
+		{
+			Name = Convert.ToString(rs["COLUMN_NAME"]);
+			Nullable = Convert.ToString(rs["IS_NULLABLE"]);
+			TypeName = Convert.ToString(rs["DATA_TYPE_NAME"]);
+		}
+	}
+
+	public class DB2IndexMetaData : AbstractIndexMetadata
+	{
+		public DB2IndexMetaData(DataRow rs) : base(rs)
+		{
+			Name = Convert.ToString(rs["INDEX_NAME"]);
+		}
+	}
+
+	public class DB2ForeignKeyMetaData : AbstractForeignKeyMetadata
+	{
+		public DB2ForeignKeyMetaData(DataRow rs) : base(rs)
+		{
+			Name = Convert.ToString(rs["FK_NAME"]);
+		}
+	}
+}

--- a/src/NHibernate/Driver/DB2DriverBase.cs
+++ b/src/NHibernate/Driver/DB2DriverBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using NHibernate.Engine;
+using NHibernate.SqlTypes;
 
 namespace NHibernate.Driver
 {
@@ -47,7 +48,15 @@ namespace NHibernate.Driver
 
 		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
 		{
-			dbParam.DbType = sqlType.DbType;
+			switch (sqlType.DbType)
+			{
+				case DbType.Guid:
+					dbParam.DbType = DbType.Binary;
+					break;
+				default:
+					dbParam.DbType = sqlType.DbType;
+					break;
+			}
 		}
 	}
 }

--- a/src/NHibernate/Driver/DB2DriverBase.cs
+++ b/src/NHibernate/Driver/DB2DriverBase.cs
@@ -53,6 +53,9 @@ namespace NHibernate.Driver
 				case DbType.Guid:
 					dbParam.DbType = DbType.Binary;
 					break;
+				case DbType.Byte:
+					dbParam.DbType = DbType.Int16;
+					break;
 				default:
 					dbParam.DbType = sqlType.DbType;
 					break;

--- a/src/NHibernate/Driver/DB2DriverBase.cs
+++ b/src/NHibernate/Driver/DB2DriverBase.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Data;
+using System.Data.Common;
 using NHibernate.Engine;
 
 namespace NHibernate.Driver
@@ -40,6 +43,11 @@ namespace NHibernate.Driver
 		public override IResultSetsCommand GetResultSetsCommand(ISessionImplementor session)
 		{
 			return new BasicResultSetsCommand(session);
+		}
+
+		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
+		{
+			dbParam.DbType = sqlType.DbType;
 		}
 	}
 }

--- a/src/NHibernate/Type/ByteType.cs
+++ b/src/NHibernate/Type/ByteType.cs
@@ -43,9 +43,10 @@ namespace NHibernate.Type
 
 		public override void Set(DbCommand cmd, object value, int index, ISessionImplementor session)
 		{
-			cmd.Parameters[index].Value = Convert.ToByte(value);
-		}
+			var dp = cmd.Parameters[index];
+			dp.Value = dp.DbType == DbType.Int16 ? Convert.ToInt16(value) : Convert.ToByte(value);
 
+		}
 		public override string Name
 		{
 			get { return "Byte"; }


### PR DESCRIPTION
- Add schema update capability
- Fix generating parameter names
- Register bit operations
- Fix `substring` function registration 
- Fix `current_timestamp` function registration
- Fix `round` function registration
- Fix timestamp resolution in ticks
- Fix DbType.Guid type registration
- Fix DbType.Byte handling

Replaces #474 