### PR TITLE
Release 5.1.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.1.4.{build}
+version: 5.1.5.{build}
 image: Visual Studio 2017
 environment:
   matrix:

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">1</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">4</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">5</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -13,8 +13,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.1.4" overwrite="false" />
-	<property name="project.version.numeric" value="5.1.4" overwrite="false" />
+	<property name="project.version" value="5.1.5" overwrite="false" />
+	<property name="project.version.numeric" value="5.1.5" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,3 +1,21 @@
+Build 5.1.5
+=============================
+
+Release notes - NHibernate - Version 5.1.5
+
+    ##### Possible Breaking Changes #####
+        * Using DML on an entity collection was applying the changes without
+          filtering according to the entity. It will now throw a
+          NotSupportedException.
+
+** Bug
+
+   * #2043 System.Reflection.TargetException when an interface is used as class mapping proxy definition
+   * #2020 Throw for DML on filter
+
+** Task
+   * #2074 Release 5.1.5
+
 Build 5.1.4
 =============================
 
@@ -242,6 +260,24 @@ Release notes - NHibernate - Version 5.1.0
 
 As part of releasing 5.1.0, a missing 5.0.0 possible breaking change has been added about inequality semantic in LINQ
 queries. See 5.0.0 possible breaking changes.
+
+﻿Build 5.0.7
+=============================
+
+Release notes - NHibernate - Version 5.0.7
+
+    ##### Possible Breaking Changes #####
+        * Using DML on an entity collection was applying the changes without
+          filtering according to the entity. It will now throw a
+          NotSupportedException.
+
+** Bug
+
+   * #2043 System.Reflection.TargetException when an interface is used as class mapping proxy definition
+   * #2020 Throw for DML on filter
+
+** Task
+   * #2073 Release 5.0.7
 
 Build 5.0.6
 =============================


### PR DESCRIPTION
We may have a missing possible breaking change to add, depending on further investigations on #2052.

The missing possible breaking would be the fact that all interfaces of the proxy base class are now by default implemented and delegated to the loaded state. That is a change I was convinced the static proxy factory has done. But it seems some @bahusoid tests contradict this.