### PR TITLE
Missing cast when comparing a guid and string columns in SAP SQL Anywhere

### DIFF
--- a/src/NHibernate/Dialect/SapSQLAnywhere17Dialect.cs
+++ b/src/NHibernate/Dialect/SapSQLAnywhere17Dialect.cs
@@ -66,6 +66,8 @@ namespace NHibernate.Dialect
 			// SQL Anywhere locate arguments are inverted compared to other databases. As fixing this is likely
 			// a breaking change for users of older versions, changing it only in the new dialect.
 			RegisterFunction("locate", new SQLFunctionTemplateWithRequiredParameters(NHibernateUtil.Int32, "locate(?2, ?1, ?3)", new object[] { null, null, "1" }));
+
+			RegisterFunction("strguid", new SQLFunctionTemplate(NHibernateUtil.String, "cast(?1 as char(36))"));
 		}
 
 		protected override void RegisterMathFunctions()


### PR DESCRIPTION
Fixes #2040 for SAP SQL Anywhere.

In its case, that is not technically a regression, since that dialect has been release in 5.2.0.
(For previous (Sybase) SQL Anywhere dialects, #1856 has changed a bug for another: prior to it, converting guid to string was already failing with those dialects because they are mapping the HQL `str` (meant for converting to string) to the ANSI SQL `str` (meant for formatting floats).)