### PR TITLE
Avoid unnecessary join for entity comparisons in with clause

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -407,9 +407,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				// this is the regression style determination which matches the logic of the classic translator
 				joinIsNeeded = generateJoin && ( !Walker.IsInSelect || !Walker.IsShallowQuery);
 			}
-			else 
+			else
 			{
-				joinIsNeeded = generateJoin || ( (Walker.IsInSelect && !Walker.IsInCase ) || Walker.IsInFrom );
+				joinIsNeeded = generateJoin || ((Walker.IsInSelect && !Walker.IsInCase) || (Walker.IsInFrom && !Walker.IsComparativeExpressionClause));
 			}
 
 			if ( joinIsNeeded ) 


### PR DESCRIPTION
Hql queries like:
`from Parent p inner join Child c with c.Parent = p`
Currently lead to unnecessary join for `c.Parent` in SQL. Issue is not entity join specific and can be reproduced for fetch joins also.