### PR TITLE
WIP Multi-Tenancy: Separate second-level cache per tenant (prototype for discussion)

### DIFF
--- a/src/NHibernate.DomainModel/CustomPersister.cs
+++ b/src/NHibernate.DomainModel/CustomPersister.cs
@@ -29,11 +29,19 @@ namespace NHibernate.DomainModel
 		private static readonly bool[] Nullability = new bool[] { true };
 		private readonly ISessionFactoryImplementor factory;
 
+		[Obsolete]
 		public CustomPersister(PersistentClass model, ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory,
 													 IMapping mapping)
 		{
 			this.factory = factory;
 		}
+
+		//TODO 6.0: Uncomment
+		//public CustomPersister(PersistentClass model, Func<string, ICacheConcurrencyStrategy> cache, ISessionFactoryImplementor factory,
+		//											 IMapping mapping)
+		//{
+		//	this.factory = factory;
+		//}
 
 		#region IEntityPersister Members
 

--- a/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
@@ -16,6 +16,8 @@ using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Linq;
 using NHibernate.Multi;
+using NHibernate.Persister.Collection;
+using NHibernate.Persister.Entity;
 using NHibernate.Test.CacheTest.Caches;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
@@ -108,8 +110,8 @@ namespace NHibernate.Test.CacheTest
 		public async Task MultipleGetReadOnlyCollectionTestAsync()
 		{
 			var persister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
 			var ids = new List<int>();
 			
 			using (var s = Sfi.OpenSession())
@@ -218,8 +220,8 @@ namespace NHibernate.Test.CacheTest
 		public async Task MultipleGetReadOnlyTestAsync()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
 			int[] getIds;
 			int[] loadIds;
 
@@ -380,8 +382,8 @@ namespace NHibernate.Test.CacheTest
 		public async Task MultipleGetReadOnlyItemTestAsync()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
 			int[] getIds;
 			int[] loadIds;
 
@@ -542,9 +544,9 @@ namespace NHibernate.Test.CacheTest
 		public async Task MultiplePutReadWriteTestAsync()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadWrite).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var cache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			var ids = new List<int>();
 
 			await (cache.ClearAsync(CancellationToken.None));
@@ -592,9 +594,9 @@ namespace NHibernate.Test.CacheTest
 		public async Task MultiplePutReadWriteItemTestAsync()
 		{
 			var persister = Sfi.GetCollectionPersister($"{typeof(ReadWrite).FullName}.Items");
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var cache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			var ids = new List<int>();
 
 			await (cache.ClearAsync(CancellationToken.None));
@@ -869,7 +871,7 @@ namespace NHibernate.Test.CacheTest
 		public async Task QueryEntityBatchCacheTestAsync(bool clearEntityCacheAfterQuery, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
-			var cache = (BatchableCache) persister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			var queryCache = GetDefaultQueryCache();
 
 			Sfi.Statistics.Clear();
@@ -945,9 +947,9 @@ namespace NHibernate.Test.CacheTest
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
 			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
 			var collectionPersister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
-			var cache = (BatchableCache) persister.Cache.Cache;
-			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
-			var collectionCache = (BatchableCache) collectionPersister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
+			var itemCache = (BatchableCache) itemPersister.GetCache(null).Cache;
+			var collectionCache = (BatchableCache) collectionPersister.GetCache(null).Cache;
 			var queryCache = GetDefaultQueryCache();
 
 			int middleId;
@@ -1089,8 +1091,8 @@ namespace NHibernate.Test.CacheTest
 
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
 			var parentPersister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
-			var cache = (BatchableCache) persister.Cache.Cache;
-			var parentCache = (BatchableCache) parentPersister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
+			var parentCache = (BatchableCache) parentPersister.GetCache(null).Cache;
 			var queryCache = GetDefaultQueryCache();
 
 			int middleId;
@@ -1217,7 +1219,7 @@ namespace NHibernate.Test.CacheTest
 			where TEntity : CacheEntity
 		{
 			var persister = Sfi.GetEntityPersister(typeof(TEntity).FullName);
-			var cache = (BatchableCache) persister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			await (cache.ClearAsync(cancellationToken));
 
 			if (cacheBeforeLoadFn != null)
@@ -1283,7 +1285,7 @@ namespace NHibernate.Test.CacheTest
 		private async Task AssertMultipleCacheCollectionCallsAsync(List<int> ids, int idIndex, int[][] fetchedIdIndexes, int[] putIdIndexes, Func<int, bool> cacheBeforeLoadFn = null, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var persister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
-			var cache = (BatchableCache) persister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			await (cache.ClearAsync(cancellationToken));
 
 			if (cacheBeforeLoadFn != null)

--- a/src/NHibernate.Test/Async/CacheTest/BatchableCacheSubclassFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BatchableCacheSubclassFixture.cs
@@ -8,13 +8,12 @@
 //------------------------------------------------------------------------------
 
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.DomainModel;
+using NHibernate.Persister.Entity;
 using NHibernate.Test.CacheTest.Caches;
 using NUnit.Framework;
 
@@ -91,14 +90,14 @@ namespace NHibernate.Test.CacheTest
 		public async Task BatchableRootEntityTestAsync()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(Foo).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var fooCache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var fooCache = (BatchableCache) persister.GetCache(null).Cache;
 
 			persister = Sfi.GetEntityPersister(typeof(Bar).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var barCache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var barCache = (BatchableCache) persister.GetCache(null).Cache;
 
 			Assert.That(barCache, Is.EqualTo(fooCache));
 

--- a/src/NHibernate.Test/Async/CacheTest/BuildCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BuildCacheFixture.cs
@@ -15,6 +15,8 @@ using System.Threading;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Engine;
+using NHibernate.Persister.Collection;
+using NHibernate.Persister.Entity;
 using NHibernate.Util;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;

--- a/src/NHibernate.Test/Async/FilterTest/DynamicFilterTest.cs
+++ b/src/NHibernate.Test/Async/FilterTest/DynamicFilterTest.cs
@@ -15,6 +15,7 @@ using log4net;
 using NHibernate.Cache;
 using NHibernate.Cache.Entry;
 using NHibernate.Criterion;
+using NHibernate.Persister.Collection;
 using NHibernate.Transform;
 using NUnit.Framework;
 
@@ -54,7 +55,7 @@ namespace NHibernate.Test.FilterTest
 				var sp = (Salesperson) await (session.LoadAsync(typeof(Salesperson), testData.steveId));
 				await (NHibernateUtil.InitializeAsync(sp.Orders));
 				Assert.IsTrue(persister.HasCache, "No cache for collection");
-				cachedData = (CollectionCacheEntry) await (persister.Cache.Cache.GetAsync(cacheKey, CancellationToken.None));
+				cachedData = (CollectionCacheEntry) await (persister.GetCache(null).Cache.GetAsync(cacheKey, CancellationToken.None));
 				Assert.IsNotNull(cachedData, "collection was not in cache");
 			}
 
@@ -66,7 +67,7 @@ namespace NHibernate.Test.FilterTest
 				                          .UniqueResultAsync());
 				Assert.AreEqual(1, sp.Orders.Count, "Filtered-collection not bypassing 2L-cache");
 
-				CollectionCacheEntry cachedData2 = (CollectionCacheEntry) await (persister.Cache.Cache.GetAsync(cacheKey, CancellationToken.None));
+				CollectionCacheEntry cachedData2 = (CollectionCacheEntry) await (persister.GetCache(null).Cache.GetAsync(cacheKey, CancellationToken.None));
 				Assert.IsNotNull(cachedData2, "collection no longer in cache!");
 				Assert.AreSame(cachedData, cachedData2, "Different cache values!");
 			}

--- a/src/NHibernate.Test/Async/LazyGroup/LazyGroupFixture.cs
+++ b/src/NHibernate.Test/Async/LazyGroup/LazyGroupFixture.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NHibernate.Cache;
 using NHibernate.Cfg;
+using NHibernate.Persister.Entity;
 using NUnit.Framework;
 
 namespace NHibernate.Test.LazyGroup
@@ -135,7 +136,7 @@ namespace NHibernate.Test.LazyGroup
 		public async Task TestCacheAsync()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(Person).FullName);
-			var cache = (HashtableCache) persister.Cache.Cache;
+			var cache = (HashtableCache) persister.GetCache(null).Cache;
 			await (cache.ClearAsync(CancellationToken.None));
 
 			using (var s = OpenSession())
@@ -171,7 +172,7 @@ namespace NHibernate.Test.LazyGroup
 		public async Task TestInitializeFromCacheAsync()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(Person).FullName);
-			var cache = (HashtableCache) persister.Cache.Cache;
+			var cache = (HashtableCache) persister.GetCache(null).Cache;
 			await (cache.ClearAsync(CancellationToken.None));
 			Sfi.Statistics.Clear();
 

--- a/src/NHibernate.Test/BulkManipulation/BulkOperationCleanupActionFixture.cs
+++ b/src/NHibernate.Test/BulkManipulation/BulkOperationCleanupActionFixture.cs
@@ -51,20 +51,20 @@ namespace NHibernate.Test.BulkManipulation
 
 			if (expectedEntityEvictionCount > 0)
 			{
-				_factory.Received(1).EvictEntity(Arg.Is<IEnumerable<string>>(x => x.Count() == expectedEntityEvictionCount));
+				_factory.Received(1).EvictEntity(Arg.Is<IEnumerable<string>>(x => x.Count() == expectedEntityEvictionCount), null);
 			}
 			else
 			{
-				_factory.DidNotReceive().EvictEntity(Arg.Any<IEnumerable<string>>());
+				_factory.DidNotReceive().EvictEntity(Arg.Any<IEnumerable<string>>(), null);
 			}
 
 			if (expectedCollectionEvictionCount > 0)
 			{
-				_factory.Received(1).EvictCollection(Arg.Is<IEnumerable<string>>(x => x.Count() == expectedCollectionEvictionCount));
+				_factory.Received(1).EvictCollection(Arg.Is<IEnumerable<string>>(x => x.Count() == expectedCollectionEvictionCount), null);
 			}
 			else
 			{
-				_factory.DidNotReceive().EvictCollection(Arg.Any<IEnumerable<string>>());
+				_factory.DidNotReceive().EvictCollection(Arg.Any<IEnumerable<string>>(), null);
 			}
 		}
 	}

--- a/src/NHibernate.Test/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/BatchableCacheFixture.cs
@@ -6,6 +6,8 @@ using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Linq;
 using NHibernate.Multi;
+using NHibernate.Persister.Collection;
+using NHibernate.Persister.Entity;
 using NHibernate.Test.CacheTest.Caches;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
@@ -96,8 +98,8 @@ namespace NHibernate.Test.CacheTest
 		public void MultipleGetReadOnlyCollectionTest()
 		{
 			var persister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
 			var ids = new List<int>();
 			
 			using (var s = Sfi.OpenSession())
@@ -206,8 +208,8 @@ namespace NHibernate.Test.CacheTest
 		public void MultipleGetReadOnlyTest()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
 			int[] getIds;
 			int[] loadIds;
 
@@ -368,8 +370,8 @@ namespace NHibernate.Test.CacheTest
 		public void MultipleGetReadOnlyItemTest()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
 			int[] getIds;
 			int[] loadIds;
 
@@ -530,9 +532,9 @@ namespace NHibernate.Test.CacheTest
 		public void MultiplePutReadWriteTest()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadWrite).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var cache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			var ids = new List<int>();
 
 			cache.Clear();
@@ -580,9 +582,9 @@ namespace NHibernate.Test.CacheTest
 		public void MultiplePutReadWriteItemTest()
 		{
 			var persister = Sfi.GetCollectionPersister($"{typeof(ReadWrite).FullName}.Items");
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var cache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			var ids = new List<int>();
 
 			cache.Clear();
@@ -857,7 +859,7 @@ namespace NHibernate.Test.CacheTest
 		public void QueryEntityBatchCacheTest(bool clearEntityCacheAfterQuery)
 		{
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
-			var cache = (BatchableCache) persister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			var queryCache = GetDefaultQueryCache();
 
 			Sfi.Statistics.Clear();
@@ -933,9 +935,9 @@ namespace NHibernate.Test.CacheTest
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
 			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
 			var collectionPersister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
-			var cache = (BatchableCache) persister.Cache.Cache;
-			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
-			var collectionCache = (BatchableCache) collectionPersister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
+			var itemCache = (BatchableCache) itemPersister.GetCache(null).Cache;
+			var collectionCache = (BatchableCache) collectionPersister.GetCache(null).Cache;
 			var queryCache = GetDefaultQueryCache();
 
 			int middleId;
@@ -1077,8 +1079,8 @@ namespace NHibernate.Test.CacheTest
 
 			var persister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
 			var parentPersister = Sfi.GetEntityPersister(typeof(ReadOnly).FullName);
-			var cache = (BatchableCache) persister.Cache.Cache;
-			var parentCache = (BatchableCache) parentPersister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
+			var parentCache = (BatchableCache) parentPersister.GetCache(null).Cache;
 			var queryCache = GetDefaultQueryCache();
 
 			int middleId;
@@ -1205,7 +1207,7 @@ namespace NHibernate.Test.CacheTest
 			where TEntity : CacheEntity
 		{
 			var persister = Sfi.GetEntityPersister(typeof(TEntity).FullName);
-			var cache = (BatchableCache) persister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			cache.Clear();
 
 			if (cacheBeforeLoadFn != null)
@@ -1271,7 +1273,7 @@ namespace NHibernate.Test.CacheTest
 		private void AssertMultipleCacheCollectionCalls(List<int> ids, int idIndex, int[][] fetchedIdIndexes, int[] putIdIndexes, Func<int, bool> cacheBeforeLoadFn = null)
 		{
 			var persister = Sfi.GetCollectionPersister($"{typeof(ReadOnly).FullName}.Items");
-			var cache = (BatchableCache) persister.Cache.Cache;
+			var cache = (BatchableCache) persister.GetCache(null).Cache;
 			cache.Clear();
 
 			if (cacheBeforeLoadFn != null)

--- a/src/NHibernate.Test/CacheTest/BatchableCacheSubclassFixture.cs
+++ b/src/NHibernate.Test/CacheTest/BatchableCacheSubclassFixture.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.DomainModel;
+using NHibernate.Persister.Entity;
 using NHibernate.Test.CacheTest.Caches;
 using NUnit.Framework;
 
@@ -80,14 +79,14 @@ namespace NHibernate.Test.CacheTest
 		public void BatchableRootEntityTest()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(Foo).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var fooCache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var fooCache = (BatchableCache) persister.GetCache(null).Cache;
 
 			persister = Sfi.GetEntityPersister(typeof(Bar).FullName);
-			Assert.That(persister.Cache.Cache, Is.Not.Null);
-			Assert.That(persister.Cache.Cache, Is.TypeOf<BatchableCache>());
-			var barCache = (BatchableCache) persister.Cache.Cache;
+			Assert.That(persister.GetCache(null).Cache, Is.Not.Null);
+			Assert.That(persister.GetCache(null).Cache, Is.TypeOf<BatchableCache>());
+			var barCache = (BatchableCache) persister.GetCache(null).Cache;
 
 			Assert.That(barCache, Is.EqualTo(fooCache));
 

--- a/src/NHibernate.Test/CacheTest/BuildCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/BuildCacheFixture.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Engine;
+using NHibernate.Persister.Collection;
+using NHibernate.Persister.Entity;
 using NHibernate.Util;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
@@ -41,16 +43,16 @@ namespace NHibernate.Test.CacheTest
 				sfi = withPrefix ? BuildSessionFactory() : Sfi;
 				var commonRegionCache = sfi.GetSecondLevelCacheRegion(fullRegion);
 				var entityAName = typeof(EntityA).FullName;
-				var entityAConcurrencyCache = sfi.GetEntityPersister(entityAName).Cache;
+				var entityAConcurrencyCache = sfi.GetEntityPersister(entityAName).GetCache(null);
 				var entityACache = entityAConcurrencyCache.Cache;
 				var entityBName = typeof(EntityB).FullName;
-				var entityBConcurrencyCache = sfi.GetEntityPersister(entityBName).Cache;
+				var entityBConcurrencyCache = sfi.GetEntityPersister(entityBName).GetCache(null);
 				var entityBCache = entityBConcurrencyCache.Cache;
 				var relatedAConcurrencyCache =
-					sfi.GetCollectionPersister(StringHelper.Qualify(entityAName, nameof(EntityA.Related))).Cache;
+					sfi.GetCollectionPersister(StringHelper.Qualify(entityAName, nameof(EntityA.Related))).GetCache(null);
 				var relatedACache = relatedAConcurrencyCache.Cache;
 				var relatedBConcurrencyCache =
-					sfi.GetCollectionPersister(StringHelper.Qualify(entityBName, nameof(EntityB.Related))).Cache;
+					sfi.GetCollectionPersister(StringHelper.Qualify(entityBName, nameof(EntityB.Related))).GetCache(null);
 				var relatedBCache = relatedBConcurrencyCache.Cache;
 				var queryCache = sfi.GetQueryCache(region).Cache;
 				Assert.Multiple(

--- a/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
+++ b/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
@@ -5,6 +5,7 @@ using log4net;
 using NHibernate.Cache;
 using NHibernate.Cache.Entry;
 using NHibernate.Criterion;
+using NHibernate.Persister.Collection;
 using NHibernate.Transform;
 using NUnit.Framework;
 
@@ -42,7 +43,7 @@ namespace NHibernate.Test.FilterTest
 				var sp = (Salesperson) session.Load(typeof(Salesperson), testData.steveId);
 				NHibernateUtil.Initialize(sp.Orders);
 				Assert.IsTrue(persister.HasCache, "No cache for collection");
-				cachedData = (CollectionCacheEntry) persister.Cache.Cache.Get(cacheKey);
+				cachedData = (CollectionCacheEntry) persister.GetCache(null).Cache.Get(cacheKey);
 				Assert.IsNotNull(cachedData, "collection was not in cache");
 			}
 
@@ -54,7 +55,7 @@ namespace NHibernate.Test.FilterTest
 				                          .UniqueResult();
 				Assert.AreEqual(1, sp.Orders.Count, "Filtered-collection not bypassing 2L-cache");
 
-				CollectionCacheEntry cachedData2 = (CollectionCacheEntry) persister.Cache.Cache.Get(cacheKey);
+				CollectionCacheEntry cachedData2 = (CollectionCacheEntry) persister.GetCache(null).Cache.Get(cacheKey);
 				Assert.IsNotNull(cachedData2, "collection no longer in cache!");
 				Assert.AreSame(cachedData, cachedData2, "Different cache values!");
 			}

--- a/src/NHibernate.Test/LazyGroup/LazyGroupFixture.cs
+++ b/src/NHibernate.Test/LazyGroup/LazyGroupFixture.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NHibernate.Cache;
 using NHibernate.Cfg;
+using NHibernate.Persister.Entity;
 using NUnit.Framework;
 
 namespace NHibernate.Test.LazyGroup
@@ -124,7 +125,7 @@ namespace NHibernate.Test.LazyGroup
 		public void TestCache()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(Person).FullName);
-			var cache = (HashtableCache) persister.Cache.Cache;
+			var cache = (HashtableCache) persister.GetCache(null).Cache;
 			cache.Clear();
 
 			using (var s = OpenSession())
@@ -160,7 +161,7 @@ namespace NHibernate.Test.LazyGroup
 		public void TestInitializeFromCache()
 		{
 			var persister = Sfi.GetEntityPersister(typeof(Person).FullName);
-			var cache = (HashtableCache) persister.Cache.Cache;
+			var cache = (HashtableCache) persister.GetCache(null).Cache;
 			cache.Clear();
 			Sfi.Statistics.Clear();
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2568/UsageOfCustomCollectionPersisterTests.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2568/UsageOfCustomCollectionPersisterTests.cs
@@ -47,6 +47,6 @@ namespace NHibernate.Test.NHSpecificTest.NH2568
 
 	public class MyCollectionPersister: OneToManyPersister
 	{
-		public MyCollectionPersister(Mapping.Collection collection, ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory) : base(collection, cache, factory) {}
+		public MyCollectionPersister(Mapping.Collection collection, Func<string, ICacheConcurrencyStrategy> cacheByTenant, ISessionFactoryImplementor factory) : base(collection, cacheByTenant, factory) {}
 	}
 }

--- a/src/NHibernate/Action/BulkOperationCleanupAction.cs
+++ b/src/NHibernate/Action/BulkOperationCleanupAction.cs
@@ -135,7 +135,7 @@ namespace NHibernate.Action
 		{
 			if (affectedCollectionRoles != null && affectedCollectionRoles.Any())
 			{
-				session.Factory.EvictCollection(affectedCollectionRoles);
+				session.Factory.EvictCollection(affectedCollectionRoles, session.GetTenantIdentifier());
 			}
 		}
 
@@ -143,7 +143,7 @@ namespace NHibernate.Action
 		{
 			if (affectedEntityNames != null && affectedEntityNames.Any())
 			{
-				session.Factory.EvictEntity(affectedEntityNames);
+				session.Factory.EvictEntity(affectedEntityNames, session.GetTenantIdentifier());
 			}
 		}
 

--- a/src/NHibernate/Action/CollectionAction.cs
+++ b/src/NHibernate/Action/CollectionAction.cs
@@ -96,11 +96,8 @@ namespace NHibernate.Action
 			// earlier entity actions which actually updates
 			// the database (this action is responsible for
 			// second-level cache invalidation only)
-			if (persister.HasCache)
-			{
-				CacheKey ck = session.GenerateCacheKey(key, persister.KeyType, persister.Role);
-				softLock = persister.Cache.Lock(ck, null);
-			}
+			var ck = session.GetCacheAndKey(key, persister, out var cache);
+			softLock = cache?.Lock(ck, null);
 		}
 
 		/// <summary>Execute this action</summary>
@@ -124,8 +121,8 @@ namespace NHibernate.Action
 
 		public virtual void ExecuteAfterTransactionCompletion(bool success)
 		{
-			var ck = new CacheKey(key, persister.KeyType, persister.Role, Session.Factory);
-			persister.Cache.Release(ck, softLock);
+			var ck = Session.GetCacheAndKey(key, persister, out var cache);
+			cache.Release(ck, softLock);
 		}
 
 		#endregion
@@ -137,11 +134,8 @@ namespace NHibernate.Action
 
 		protected internal void Evict()
 		{
-			if (persister.HasCache)
-			{
-				CacheKey ck = session.GenerateCacheKey(key, persister.KeyType, persister.Role);
-				persister.Cache.Evict(ck);
-			}
+			CacheKey ck = session.GetCacheAndKey(key, persister, out var cache);
+			cache?.Evict(ck);
 		}
 
 		#region IComparable<CollectionAction> Members

--- a/src/NHibernate/Action/CollectionUpdateAction.cs
+++ b/src/NHibernate/Action/CollectionUpdateAction.cs
@@ -118,8 +118,7 @@ namespace NHibernate.Action
 		{
 			// NH Different behavior: to support unlocking collections from the cache.(r3260)
 
-			CacheKey ck = Session.GenerateCacheKey(GetKey(), Persister.KeyType, Persister.Role);
-
+			CacheKey ck = Session.GetCacheAndKey(GetKey(), Persister, out var cache); 
 			if (success)
 			{
 				// we can't disassemble a collection if it was uninitialized 
@@ -127,17 +126,17 @@ namespace NHibernate.Action
 				if (Collection.WasInitialized && Session.PersistenceContext.ContainsCollection(Collection))
 				{
 					CollectionCacheEntry entry = CollectionCacheEntry.Create(Collection, Persister);
-					bool put = Persister.Cache.AfterUpdate(ck, entry, null, Lock);
+					bool put = cache.AfterUpdate(ck, entry, null, Lock);
 
 					if (put && Session.Factory.Statistics.IsStatisticsEnabled)
 					{
-						Session.Factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
+						Session.Factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 					}
 				}
 			}
 			else
 			{
-				Persister.Cache.Release(ck, Lock);
+				cache.Release(ck, Lock);
 			}
 		}
 	}

--- a/src/NHibernate/Action/EntityInsertAction.cs
+++ b/src/NHibernate/Action/EntityInsertAction.cs
@@ -77,12 +77,13 @@ namespace NHibernate.Action
 				CacheEntry ce = CacheEntry.Create(State, persister, version, session, instance);
 				cacheEntry = persister.CacheEntryStructure.Structure(ce);
 
-				CacheKey ck = Session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
-				bool put = persister.Cache.Insert(ck, cacheEntry, version);
+
+				CacheKey ck = Session.GetCacheAndKey(id, persister, out var cache);
+				bool put = cache.Insert(ck, cacheEntry, version);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
 				{
-					factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
+					factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 
@@ -101,12 +102,13 @@ namespace NHibernate.Action
 			IEntityPersister persister = Persister;
 			if (success && IsCachePutEnabled(persister))
 			{
-				CacheKey ck = Session.GenerateCacheKey(Id, persister.IdentifierType, persister.RootEntityName);
-				bool put = persister.Cache.AfterInsert(ck, cacheEntry, version);
+				
+				CacheKey ck = Session.GetCacheAndKey(Id, persister, out var cache);
+				bool put = cache.AfterInsert(ck, cacheEntry, version);
 
 				if (put && Session.Factory.Statistics.IsStatisticsEnabled)
 				{
-					Session.Factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
+					Session.Factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 			if (success)

--- a/src/NHibernate/Async/Action/BulkOperationCleanupAction.cs
+++ b/src/NHibernate/Async/Action/BulkOperationCleanupAction.cs
@@ -76,7 +76,7 @@ namespace NHibernate.Action
 			{
 				if (affectedCollectionRoles != null && affectedCollectionRoles.Any())
 				{
-					return session.Factory.EvictCollectionAsync(affectedCollectionRoles, cancellationToken);
+					return session.Factory.EvictCollectionAsync(affectedCollectionRoles, session.GetTenantIdentifier(), cancellationToken);
 				}
 				return Task.CompletedTask;
 			}
@@ -96,7 +96,7 @@ namespace NHibernate.Action
 			{
 				if (affectedEntityNames != null && affectedEntityNames.Any())
 				{
-					return session.Factory.EvictEntityAsync(affectedEntityNames, cancellationToken);
+					return session.Factory.EvictEntityAsync(affectedEntityNames, session.GetTenantIdentifier(), cancellationToken);
 				}
 				return Task.CompletedTask;
 			}

--- a/src/NHibernate/Async/Action/EntityInsertAction.cs
+++ b/src/NHibernate/Async/Action/EntityInsertAction.cs
@@ -73,12 +73,13 @@ namespace NHibernate.Action
 				CacheEntry ce = await (CacheEntry.CreateAsync(State, persister, version, session, instance, cancellationToken)).ConfigureAwait(false);
 				cacheEntry = persister.CacheEntryStructure.Structure(ce);
 
-				CacheKey ck = Session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
-				bool put = persister.Cache.Insert(ck, cacheEntry, version);
+
+				CacheKey ck = Session.GetCacheAndKey(id, persister, out var cache);
+				bool put = cache.Insert(ck, cacheEntry, version);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
 				{
-					factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
+					factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 
@@ -98,12 +99,13 @@ namespace NHibernate.Action
 			IEntityPersister persister = Persister;
 			if (success && IsCachePutEnabled(persister))
 			{
-				CacheKey ck = Session.GenerateCacheKey(Id, persister.IdentifierType, persister.RootEntityName);
-				bool put = await (persister.Cache.AfterInsertAsync(ck, cacheEntry, version, cancellationToken)).ConfigureAwait(false);
+				
+				CacheKey ck = Session.GetCacheAndKey(Id, persister, out var cache);
+				bool put = await (cache.AfterInsertAsync(ck, cacheEntry, version, cancellationToken)).ConfigureAwait(false);
 
 				if (put && Session.Factory.Statistics.IsStatisticsEnabled)
 				{
-					Session.Factory.StatisticsImplementor.SecondLevelCachePut(Persister.Cache.RegionName);
+					Session.Factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 			if (success)

--- a/src/NHibernate/Async/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Async/Engine/ISessionImplementor.cs
@@ -21,6 +21,7 @@ using NHibernate.Hql;
 using NHibernate.Impl;
 using NHibernate.Loader.Custom;
 using NHibernate.Multi;
+using NHibernate.Persister.Collection;
 using NHibernate.Persister.Entity;
 using NHibernate.Transaction;
 using NHibernate.Type;

--- a/src/NHibernate/Async/Engine/Loading/CollectionLoadContext.cs
+++ b/src/NHibernate/Async/Engine/Loading/CollectionLoadContext.cs
@@ -280,7 +280,7 @@ namespace NHibernate.Engine.Loading
 			}
 
 			CollectionCacheEntry entry = await (CollectionCacheEntry.CreateAsync(lce.Collection, persister, cancellationToken)).ConfigureAwait(false);
-			CacheKey cacheKey = session.GenerateCacheKey(lce.Key, persister.KeyType, persister.Role);
+			var cacheKey = session.GetCacheAndKey(lce.Key, persister, out var cache);
 
 			if (persister.GetBatchSize() > 1)
 			{
@@ -294,13 +294,13 @@ namespace NHibernate.Engine.Loading
 			}
 			else
 			{
-				bool put = await (persister.Cache.PutAsync(cacheKey, persister.CacheEntryStructure.Structure(entry),
+				bool put = await (cache.PutAsync(cacheKey, persister.CacheEntryStructure.Structure(entry),
 				                               session.Timestamp, version, versionComparator,
 				                               factory.Settings.IsMinimalPutsEnabled && session.CacheMode != CacheMode.Refresh, cancellationToken)).ConfigureAwait(false);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
 				{
-					factory.StatisticsImplementor.SecondLevelCachePut(persister.Cache.RegionName);
+					factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 		}

--- a/src/NHibernate/Async/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Async/Engine/TwoPhaseLoad.cs
@@ -124,7 +124,8 @@ namespace NHibernate.Engine
 				object version = Versioning.GetVersion(hydratedState, persister);
 				CacheEntry entry =
 					await (CacheEntry.CreateAsync(hydratedState, persister, version, session, entity, cancellationToken)).ConfigureAwait(false);
-				CacheKey cacheKey = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
+				
+				CacheKey cacheKey = session.GetCacheAndKey(id, persister, out var cache);
 
 				if (cacheBatchingHandler != null && persister.IsBatchLoadable)
 				{
@@ -140,13 +141,13 @@ namespace NHibernate.Engine
 				else
 				{
 					bool put =
-						await (persister.Cache.PutAsync(cacheKey, persister.CacheEntryStructure.Structure(entry), session.Timestamp, version,
+						await (cache.PutAsync(cacheKey, persister.CacheEntryStructure.Structure(entry), session.Timestamp, version,
 						                    persister.IsVersioned ? persister.VersionType.Comparator : null,
 						                    UseMinimalPuts(session, entityEntry), cancellationToken)).ConfigureAwait(false);
 
 					if (put && factory.Statistics.IsStatisticsEnabled)
 					{
-						factory.StatisticsImplementor.SecondLevelCachePut(persister.Cache.RegionName);
+						factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 					}
 				}
 			}

--- a/src/NHibernate/Async/Event/Default/AbstractLockUpgradeEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractLockUpgradeEventListener.cs
@@ -51,18 +51,8 @@ namespace NHibernate.Event.Default
 					log.Debug("locking {0} in mode: {1}", MessageHelper.InfoString(persister, entry.Id, source.Factory), requestedLockMode);
 				}
 
-				ISoftLock slock;
-				CacheKey ck;
-				if (persister.HasCache)
-				{
-					ck = source.GenerateCacheKey(entry.Id, persister.IdentifierType, persister.RootEntityName);
-					slock = await (persister.Cache.LockAsync(ck, entry.Version, cancellationToken)).ConfigureAwait(false);
-				}
-				else
-				{
-					ck = null;
-					slock = null;
-				}
+				CacheKey ck = source.GetCacheAndKey(entry.Id, persister, out var cache);
+				var slock = (cache == null ? null : await (cache.LockAsync(ck, entry.Version, cancellationToken)).ConfigureAwait(false));
 
 				try
 				{
@@ -82,9 +72,18 @@ namespace NHibernate.Event.Default
 				{
 					// the database now holds a lock + the object is flushed from the cache,
 					// so release the soft lock
-					if (persister.HasCache)
+					var releaseTask = cache?.ReleaseAsync(ck, slock, cancellationToken);
+					// the database now holds a lock + the object is flushed from the cache,
+					// so release the soft lock
+					if (releaseTask != null)
+					// the database now holds a lock + the object is flushed from the cache,
+					// so release the soft lock
 					{
-						await (persister.Cache.ReleaseAsync(ck, slock, cancellationToken)).ConfigureAwait(false);
+						// the database now holds a lock + the object is flushed from the cache,
+						// so release the soft lock
+						await (releaseTask).ConfigureAwait(false);
+					// the database now holds a lock + the object is flushed from the cache,
+					// so release the soft lock
 					}
 				}
 			}

--- a/src/NHibernate/Async/Event/Default/DefaultRefreshEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultRefreshEventListener.cs
@@ -108,10 +108,11 @@ namespace NHibernate.Event.Default
 					await (new EvictVisitor(source).ProcessAsync(obj, persister, cancellationToken)).ConfigureAwait(false);
 			}
 
-			if (persister.HasCache)
+			var ck = source.GetCacheAndKey(id, persister, out var cache);
+			var removeTask = cache?.RemoveAsync(ck, cancellationToken);
+			if (removeTask != null)
 			{
-				CacheKey ck = source.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
-				await (persister.Cache.RemoveAsync(ck, cancellationToken)).ConfigureAwait(false);
+				await (removeTask).ConfigureAwait(false);
 			}
 
 			await (EvictCachedCollectionsAsync(persister, id, source.Factory, cancellationToken)).ConfigureAwait(false);

--- a/src/NHibernate/Async/ISessionFactory.cs
+++ b/src/NHibernate/Async/ISessionFactory.cs
@@ -112,38 +112,28 @@ namespace NHibernate
 			await (ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictEntityAsync(entityName, id, tenantIdentifier, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public static Task EvictCollectionAsync(this ISessionFactory factory, IEnumerable<string> roleNames, string tenantIdentifier, CancellationToken cancellationToken = default(CancellationToken))
+		public static async Task EvictCollectionAsync(this ISessionFactory factory, IEnumerable<string> roleNames, string tenantIdentifier, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			if (roleNames == null)
-				throw new ArgumentNullException(nameof(roleNames));
-			if (cancellationToken.IsCancellationRequested)
+			cancellationToken.ThrowIfCancellationRequested();
+			if (tenantIdentifier == null)
 			{
-				return Task.FromCanceled<object>(cancellationToken);
+				await (EvictCollectionAsync(factory, roleNames, cancellationToken)).ConfigureAwait(false);
+				return;
 			}
-			return InternalEvictCollectionAsync();
-			async Task InternalEvictCollectionAsync()
-			{
 
-				if (tenantIdentifier == null)
-				{
-					await (EvictCollectionAsync(factory, roleNames, cancellationToken)).ConfigureAwait(false);
-					return;
-				}
-
-				foreach (var roleName in roleNames)
-				{
-					await (ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictCollectionAsync(roleName, null, tenantIdentifier, cancellationToken)).ConfigureAwait(false);
-				}
-			}
+			await (ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictCollectionAsync(roleNames, tenantIdentifier, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public static async Task EvictEntityAsync(this ISessionFactory factory, IEnumerable<string> entityNames, string tenantIdentifier, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			foreach (var entityName in entityNames)
+			if (tenantIdentifier == null)
 			{
-				await (EvictEntityAsync(factory, entityName, null, tenantIdentifier, cancellationToken)).ConfigureAwait(false);
+				await (EvictEntityAsync(factory, entityNames, cancellationToken)).ConfigureAwait(false);
+				return;
 			}
+
+			await (ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictEntityAsync(entityNames, tenantIdentifier, cancellationToken)).ConfigureAwait(false);
 		}
 	}
 

--- a/src/NHibernate/Async/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Async/Impl/StatelessSessionImpl.cs
@@ -571,10 +571,11 @@ namespace NHibernate.Impl
 				//			);
 				//		}
 
-				if (persister.HasCache)
+				CacheKey ck = this.GetCacheAndKey(id, persister, out var cache);
+				var removeTask = cache?.RemoveAsync(ck, cancellationToken);
+				if (removeTask != null)
 				{
-					CacheKey ck = GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
-					await (persister.Cache.RemoveAsync(ck, cancellationToken)).ConfigureAwait(false);
+					await (removeTask).ConfigureAwait(false);
 				}
 
 				string previousFetchProfile = FetchProfile;

--- a/src/NHibernate/Async/Loader/Collection/BatchingCollectionInitializer.cs
+++ b/src/NHibernate/Async/Loader/Collection/BatchingCollectionInitializer.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Loader.Collection
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			object[] batch =
-				await (session.PersistenceContext.BatchFetchQueue.GetCollectionBatchAsync(collectionPersister, id, batchSizes[0], cancellationToken)).ConfigureAwait(false);
+				await (session.PersistenceContext.BatchFetchQueue.GetCollectionBatchAsync(collectionPersister, id, batchSizes[0], null, collectionPersister.GetCache(session.GetTenantIdentifier()), cancellationToken)).ConfigureAwait(false);
 
 			for (int i = 0; i < batchSizes.Length; i++)
 			{

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -845,7 +845,7 @@ namespace NHibernate.Loader
 			var state = persister.GetPropertyValues(obj);
 			var version = Versioning.GetVersion(state, persister);
 			var cacheEntry = await (CacheEntry.CreateAsync(state, persister, version, session, obj, cancellationToken)).ConfigureAwait(false);
-			var cacheKey = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
+			var cacheKey = session.GetCacheAndKey(id, persister, out var cache);
 
 			if (cacheBatchingHandler != null && persister.IsBatchLoadable)
 			{
@@ -861,13 +861,13 @@ namespace NHibernate.Loader
 			else
 			{
 				var put =
-					await (persister.Cache.PutAsync(cacheKey, persister.CacheEntryStructure.Structure(cacheEntry), session.Timestamp, version,
+					await (cache.PutAsync(cacheKey, persister.CacheEntryStructure.Structure(cacheEntry), session.Timestamp, version,
 										persister.IsVersioned ? persister.VersionType.Comparator : null,
 										false, cancellationToken)).ConfigureAwait(false);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
 				{
-					factory.StatisticsImplementor.SecondLevelCachePut(persister.Cache.RegionName);
+					factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 		}

--- a/src/NHibernate/Async/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Async/Persister/Collection/AbstractCollectionPersister.cs
@@ -40,7 +40,7 @@ namespace NHibernate.Persister.Collection
 	using System.Threading.Tasks;
 	using System.Threading;
 	public abstract partial class AbstractCollectionPersister : ICollectionMetadata, ISqlLoadableCollection,
-		IPostInsertIdentityPersister, ISupportSelectModeJoinable, ICompositeKeyPostInsertIdentityPersister
+		IPostInsertIdentityPersister, ISupportSelectModeJoinable, ICompositeKeyPostInsertIdentityPersister, ICacheablePersister
 	{
 
 		public Task InitializeAsync(object key, ISessionImplementor session, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Persister/Collection/ICollectionPersister.cs
+++ b/src/NHibernate/Async/Persister/Collection/ICollectionPersister.cs
@@ -19,12 +19,15 @@ using NHibernate.Id;
 using NHibernate.Metadata;
 using NHibernate.Persister.Entity;
 using NHibernate.Type;
+using NHibernate.Util;
 
 namespace NHibernate.Persister.Collection
 {
 	using System.Threading.Tasks;
 	using System.Threading;
 	public partial interface ICollectionPersister
+		//TODO 6.0: Uncomment
+		//,ICacheablePersister
 	{
 
 		/// <summary>

--- a/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
@@ -45,7 +45,7 @@ namespace NHibernate.Persister.Entity
 	using System.Threading;
 	public abstract partial class AbstractEntityPersister : IOuterJoinLoadable, IQueryable, IClassMetadata,
 		IUniqueKeyLoadable, ISqlLoadable, ILazyPropertyInitializer, IPostInsertIdentityPersister, ILockable,
-		ISupportSelectModeJoinable, ICompositeKeyPostInsertIdentityPersister
+		ISupportSelectModeJoinable, ICompositeKeyPostInsertIdentityPersister, ICacheablePersister
 	{
 
 		private partial class GeneratedIdentifierBinder : IBinder
@@ -1201,8 +1201,8 @@ namespace NHibernate.Persister.Entity
 			// check to see if it is in the second-level cache
 			if (HasCache && session.CacheMode.HasFlag(CacheMode.Get))
 			{
-				CacheKey ck = session.GenerateCacheKey(id, IdentifierType, RootEntityName);
-				if (await (Cache.GetAsync(ck, session.Timestamp, cancellationToken)).ConfigureAwait(false) != null)
+				CacheKey ck = session.GetCacheAndKey(id, this, out var cache);
+				if (await (cache.GetAsync(ck, session.Timestamp, cancellationToken)).ConfigureAwait(false) != null)
 					return false;
 			}
 

--- a/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/IEntityPersister.cs
@@ -27,6 +27,8 @@ namespace NHibernate.Persister.Entity
 	using System.Threading;
 
 	public partial interface IEntityPersister : IOptimisticCacheSource
+		//TODO 6.0: Uncomment
+		//,ICacheablePersister
 	{
 
 		#region stuff that is persister-centric and/or EntityInfo-centric

--- a/src/NHibernate/Cache/CacheBatcher.cs
+++ b/src/NHibernate/Cache/CacheBatcher.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Cache
 			{
 				Log.Debug("Adding a put operation to batch for entity {0} and key {1}", persister.EntityName, data.Key);
 			}
-			AddToBatch(persister.Cache, data);
+			AddToBatch(persister.GetCache(_session.GetTenantIdentifier()), data);
 		}
 
 		/// <summary>
@@ -48,7 +48,7 @@ namespace NHibernate.Cache
 			{
 				Log.Debug("Adding a put operation to batch for collection role {0} and key {1}", persister.Role, data.Key);
 			}
-			AddToBatch(persister.Cache, data);
+			AddToBatch(persister.GetCache(_session.GetTenantIdentifier()), data);
 		}
 
 		private void AddToBatch(ICacheConcurrencyStrategy cache, CachePutData data)

--- a/src/NHibernate/Cfg/Settings.cs
+++ b/src/NHibernate/Cfg/Settings.cs
@@ -135,7 +135,10 @@ namespace NHibernate.Cfg
 		public ILinqToHqlGeneratorsRegistry LinqToHqlGeneratorsRegistry { get; internal set; }
 
 		public IQueryModelRewriterFactory QueryModelRewriterFactory { get; internal set; }
-		
+
+		//TODO: Implement
+		public bool IsMultiTenancyEnabled => false;
+
 		#endregion
 
 		internal string GetFullCacheRegionName(string name)

--- a/src/NHibernate/Engine/BatchFetchQueue.cs
+++ b/src/NHibernate/Engine/BatchFetchQueue.cs
@@ -214,7 +214,7 @@ namespace NHibernate.Engine
 		/// <returns>an array of collection keys, of length batchSize (padded with nulls)</returns>
 		public object[] GetCollectionBatch(ICollectionPersister collectionPersister, object id, int batchSize)
 		{
-			return GetCollectionBatch(collectionPersister, id, batchSize, true, null);
+			return GetCollectionBatch(collectionPersister, id, batchSize, null, collectionPersister.GetCache(null));
 		}
 
 		/// <summary>
@@ -223,11 +223,11 @@ namespace NHibernate.Engine
 		/// <param name="collectionPersister">The persister for the collection role.</param>
 		/// <param name="key">A key that must be included in the batch fetch</param>
 		/// <param name="batchSize">the maximum number of keys to return</param>
-		/// <param name="checkCache">Whether to check the cache for uninitialized collection keys.</param>
 		/// <param name="collectionEntries">An array that will be filled with collection entries if set.</param>
+		/// <param name="cache">Will check cache if not null is provided</param>
 		/// <returns>An array of collection keys, of length <paramref name="batchSize"/> (padded with nulls)</returns>
-		internal object[] GetCollectionBatch(ICollectionPersister collectionPersister, object key, int batchSize, bool checkCache,
-		                                     CollectionEntry[] collectionEntries)
+		internal object[] GetCollectionBatch(ICollectionPersister collectionPersister, object key, int batchSize,
+		                                     CollectionEntry[] collectionEntries, ICacheConcurrencyStrategy cache)
 		{
 			var keys = new object[batchSize];
 			keys[0] = key; // The first element of array is reserved for the actual instance we are loading
@@ -238,8 +238,9 @@ namespace NHibernate.Engine
 			// List of collection entries that haven't been checked for their existance in the cache. Besides the collection entry,
 			// the index where the entry was found is also stored in order to correctly order the returning keys.
 			var collectionKeys = new List<KeyValuePair<KeyValuePair<CollectionEntry, IPersistentCollection>, int>>(batchSize);
-			var batchableCache = collectionPersister.Cache?.GetCacheBase();
-
+			var batchableCache = cache?.GetCacheBase();
+			bool checkCache = batchableCache != null;
+			
 			if (!batchLoadableCollections.TryGetValue(collectionPersister.Role, out var map))
 			{
 				return keys;
@@ -336,7 +337,7 @@ namespace NHibernate.Engine
 					}
 					keyIndex = index;
 				}
-				else if (!checkCache || batchableCache == null)
+				else if (!checkCache)
 				{
 					if (index < map.Count && (!keyIndex.HasValue || index < keyIndex.Value))
 					{
@@ -396,7 +397,7 @@ namespace NHibernate.Engine
 		/// <returns>an array of identifiers, of length batchSize (possibly padded with nulls)</returns>
 		public object[] GetEntityBatch(IEntityPersister persister, object id, int batchSize)
 		{
-			return GetEntityBatch(persister, id, batchSize, true);
+			return GetEntityBatch(persister, id, batchSize, persister.GetCache(null));
 		}
 
 		/// <summary>
@@ -407,9 +408,9 @@ namespace NHibernate.Engine
 		/// <param name="persister">The persister for the entities being loaded.</param>
 		/// <param name="id">The identifier of the entity currently demanding load.</param>
 		/// <param name="batchSize">The maximum number of keys to return</param>
-		/// <param name="checkCache">Whether to check the cache for uninitialized keys.</param>
+		/// <param name="cache">Cache to check or null to skip cache check</param>
 		/// <returns>An array of identifiers, of length <paramref name="batchSize"/> (possibly padded with nulls)</returns>
-		internal object[] GetEntityBatch(IEntityPersister persister, object id, int batchSize, bool checkCache)
+		internal object[] GetEntityBatch(IEntityPersister persister, object id, int batchSize, ICacheConcurrencyStrategy cache)
 		{
 			var ids = new object[batchSize];
 			ids[0] = id; // The first element of array is reserved for the actual instance we are loading
@@ -421,7 +422,8 @@ namespace NHibernate.Engine
 			// the index where the key was found is also stored in order to correctly order the returning keys.
 			var entityKeys = new List<KeyValuePair<EntityKey, int>>(batchSize);
 			// If there is a cache, obsolete or not, batchableCache will not be null.
-			var batchableCache = persister.Cache?.GetCacheBase();
+			var batchableCache = cache?.GetCacheBase();
+			var checkCache = batchableCache != null;
 
 			if (!batchLoadableEntityKeys.TryGetValue(persister.EntityName, out var set))
 			{
@@ -498,7 +500,7 @@ namespace NHibernate.Engine
 				{
 					idIndex = index;
 				}
-				else if (!checkCache || batchableCache == null)
+				else if (!checkCache)
 				{
 					if (index < set.Count && (!idIndex.HasValue || index < idIndex.Value))
 					{

--- a/src/NHibernate/Engine/ISessionImplementor.cs
+++ b/src/NHibernate/Engine/ISessionImplementor.cs
@@ -11,6 +11,7 @@ using NHibernate.Hql;
 using NHibernate.Impl;
 using NHibernate.Loader.Custom;
 using NHibernate.Multi;
+using NHibernate.Persister.Collection;
 using NHibernate.Persister.Entity;
 using NHibernate.Transaction;
 using NHibernate.Type;
@@ -21,6 +22,32 @@ namespace NHibernate.Engine
 	// 6.0 TODO: Convert to interface methods, excepted SwitchCacheMode
 	internal static partial class SessionImplementorExtensions
 	{
+		//TODO: REMOVE
+		internal static string GetTenantIdentifier(this ISessionImplementor session)
+		{
+			return null;
+		}
+
+		//NOTE: DO NOT merge (keep as internal extension)
+		internal  static CacheKey GetCacheAndKey(this ISessionImplementor session, object id,  IEntityPersister persister, out ICacheConcurrencyStrategy cache)
+		{
+			cache = null;
+			if (!persister.HasCache)
+				return null;
+			cache = persister.GetCache(session.GetTenantIdentifier());
+			return session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
+		}
+
+		//NOTE: DO NOT merge (keep as internal extension)
+		internal  static CacheKey GetCacheAndKey(this ISessionImplementor session, object id,  ICollectionPersister persister, out ICacheConcurrencyStrategy cache)
+		{
+			cache = null;
+			if (!persister.HasCache)
+				return null;
+			cache = persister.GetCache(session.GetTenantIdentifier());
+			return session.GenerateCacheKey(id, persister.KeyType, persister.Role);
+		}
+
 		/// <summary>
 		/// Instantiate the entity class, initializing with the given identifier
 		/// </summary>

--- a/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
+++ b/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
@@ -376,7 +376,7 @@ namespace NHibernate.Engine.Loading
 			}
 
 			CollectionCacheEntry entry = CollectionCacheEntry.Create(lce.Collection, persister);
-			CacheKey cacheKey = session.GenerateCacheKey(lce.Key, persister.KeyType, persister.Role);
+			var cacheKey = session.GetCacheAndKey(lce.Key, persister, out var cache);
 
 			if (persister.GetBatchSize() > 1)
 			{
@@ -390,13 +390,13 @@ namespace NHibernate.Engine.Loading
 			}
 			else
 			{
-				bool put = persister.Cache.Put(cacheKey, persister.CacheEntryStructure.Structure(entry),
+				bool put = cache.Put(cacheKey, persister.CacheEntryStructure.Structure(entry),
 				                               session.Timestamp, version, versionComparator,
 				                               factory.Settings.IsMinimalPutsEnabled && session.CacheMode != CacheMode.Refresh);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
 				{
-					factory.StatisticsImplementor.SecondLevelCachePut(persister.Cache.RegionName);
+					factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 		}

--- a/src/NHibernate/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Engine/TwoPhaseLoad.cs
@@ -153,7 +153,8 @@ namespace NHibernate.Engine
 				object version = Versioning.GetVersion(hydratedState, persister);
 				CacheEntry entry =
 					CacheEntry.Create(hydratedState, persister, version, session, entity);
-				CacheKey cacheKey = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
+				
+				CacheKey cacheKey = session.GetCacheAndKey(id, persister, out var cache);
 
 				if (cacheBatchingHandler != null && persister.IsBatchLoadable)
 				{
@@ -169,13 +170,13 @@ namespace NHibernate.Engine
 				else
 				{
 					bool put =
-						persister.Cache.Put(cacheKey, persister.CacheEntryStructure.Structure(entry), session.Timestamp, version,
+						cache.Put(cacheKey, persister.CacheEntryStructure.Structure(entry), session.Timestamp, version,
 						                    persister.IsVersioned ? persister.VersionType.Comparator : null,
 						                    UseMinimalPuts(session, entityEntry));
 
 					if (put && factory.Statistics.IsStatisticsEnabled)
 					{
-						factory.StatisticsImplementor.SecondLevelCachePut(persister.Cache.RegionName);
+						factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 					}
 				}
 			}

--- a/src/NHibernate/Event/Default/AbstractLockUpgradeEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractLockUpgradeEventListener.cs
@@ -43,18 +43,8 @@ namespace NHibernate.Event.Default
 					log.Debug("locking {0} in mode: {1}", MessageHelper.InfoString(persister, entry.Id, source.Factory), requestedLockMode);
 				}
 
-				ISoftLock slock;
-				CacheKey ck;
-				if (persister.HasCache)
-				{
-					ck = source.GenerateCacheKey(entry.Id, persister.IdentifierType, persister.RootEntityName);
-					slock = persister.Cache.Lock(ck, entry.Version);
-				}
-				else
-				{
-					ck = null;
-					slock = null;
-				}
+				CacheKey ck = source.GetCacheAndKey(entry.Id, persister, out var cache);
+				var slock = cache?.Lock(ck, entry.Version);
 
 				try
 				{
@@ -74,10 +64,7 @@ namespace NHibernate.Event.Default
 				{
 					// the database now holds a lock + the object is flushed from the cache,
 					// so release the soft lock
-					if (persister.HasCache)
-					{
-						persister.Cache.Release(ck, slock);
-					}
+					cache?.Release(ck, slock);
 				}
 			}
 		}

--- a/src/NHibernate/Event/Default/DefaultRefreshEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultRefreshEventListener.cs
@@ -90,11 +90,8 @@ namespace NHibernate.Event.Default
 					new EvictVisitor(source).Process(obj, persister);
 			}
 
-			if (persister.HasCache)
-			{
-				CacheKey ck = source.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
-				persister.Cache.Remove(ck);
-			}
+			var ck = source.GetCacheAndKey(id, persister, out var cache);
+			cache?.Remove(ck);
 
 			EvictCachedCollections(persister, id, source.Factory);
 

--- a/src/NHibernate/ISessionFactory.cs
+++ b/src/NHibernate/ISessionFactory.cs
@@ -7,6 +7,7 @@ using NHibernate.Engine;
 using NHibernate.Impl;
 using NHibernate.Metadata;
 using NHibernate.Stat;
+using NHibernate.Util;
 
 namespace NHibernate
 {
@@ -82,6 +83,39 @@ namespace NHibernate
 				{
 					factory.EvictCollection(role);
 				}
+			}
+		}
+
+		public static void EvictEntity(this ISessionFactory factory, string entityName, object id, string tenantIdentifier)
+		{
+			if (tenantIdentifier == null)
+				factory.EvictEntity(entityName, id);
+
+			ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictEntity(entityName, id, tenantIdentifier);
+		}
+
+		public static void EvictCollection(this ISessionFactory factory, IEnumerable<string> roleNames, string tenantIdentifier)
+		{
+			if (roleNames == null)
+				throw new ArgumentNullException(nameof(roleNames));
+
+			if (tenantIdentifier == null)
+			{
+				EvictCollection(factory, roleNames);
+				return;
+			}
+
+			foreach (var roleName in roleNames)
+			{
+				ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictCollection(roleName, null, tenantIdentifier);
+			}
+		}
+
+		public static void EvictEntity(this ISessionFactory factory, IEnumerable<string> entityNames, string tenantIdentifier)
+		{
+			foreach (var entityName in entityNames)
+			{
+				EvictEntity(factory, entityName, null, tenantIdentifier);
 			}
 		}
 	}

--- a/src/NHibernate/ISessionFactory.cs
+++ b/src/NHibernate/ISessionFactory.cs
@@ -96,27 +96,24 @@ namespace NHibernate
 
 		public static void EvictCollection(this ISessionFactory factory, IEnumerable<string> roleNames, string tenantIdentifier)
 		{
-			if (roleNames == null)
-				throw new ArgumentNullException(nameof(roleNames));
-
 			if (tenantIdentifier == null)
 			{
 				EvictCollection(factory, roleNames);
 				return;
 			}
 
-			foreach (var roleName in roleNames)
-			{
-				ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictCollection(roleName, null, tenantIdentifier);
-			}
+			ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictCollection(roleNames, tenantIdentifier);
 		}
 
 		public static void EvictEntity(this ISessionFactory factory, IEnumerable<string> entityNames, string tenantIdentifier)
 		{
-			foreach (var entityName in entityNames)
+			if (tenantIdentifier == null)
 			{
-				EvictEntity(factory, entityName, null, tenantIdentifier);
+				EvictEntity(factory, entityNames);
+				return;
 			}
+
+			ReflectHelper.CastOrThrow<SessionFactoryImpl>(factory, "multi-tenancy").EvictEntity(entityNames, tenantIdentifier);
 		}
 	}
 

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -650,11 +650,8 @@ namespace NHibernate.Impl
 				//			);
 				//		}
 
-				if (persister.HasCache)
-				{
-					CacheKey ck = GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
-					persister.Cache.Remove(ck);
-				}
+				CacheKey ck = this.GetCacheAndKey(id, persister, out var cache);
+				cache?.Remove(ck);
 
 				string previousFetchProfile = FetchProfile;
 				object result;

--- a/src/NHibernate/Loader/Collection/BatchingCollectionInitializer.cs
+++ b/src/NHibernate/Loader/Collection/BatchingCollectionInitializer.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Loader.Collection
 		public void Initialize(object id, ISessionImplementor session)
 		{
 			object[] batch =
-				session.PersistenceContext.BatchFetchQueue.GetCollectionBatch(collectionPersister, id, batchSizes[0]);
+				session.PersistenceContext.BatchFetchQueue.GetCollectionBatch(collectionPersister, id, batchSizes[0], null, collectionPersister.GetCache(session.GetTenantIdentifier()));
 
 			for (int i = 0; i < batchSizes.Length; i++)
 			{

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1221,7 +1221,7 @@ namespace NHibernate.Loader
 			var state = persister.GetPropertyValues(obj);
 			var version = Versioning.GetVersion(state, persister);
 			var cacheEntry = CacheEntry.Create(state, persister, version, session, obj);
-			var cacheKey = session.GenerateCacheKey(id, persister.IdentifierType, persister.RootEntityName);
+			var cacheKey = session.GetCacheAndKey(id, persister, out var cache);
 
 			if (cacheBatchingHandler != null && persister.IsBatchLoadable)
 			{
@@ -1237,13 +1237,13 @@ namespace NHibernate.Loader
 			else
 			{
 				var put =
-					persister.Cache.Put(cacheKey, persister.CacheEntryStructure.Structure(cacheEntry), session.Timestamp, version,
+					cache.Put(cacheKey, persister.CacheEntryStructure.Structure(cacheEntry), session.Timestamp, version,
 										persister.IsVersioned ? persister.VersionType.Comparator : null,
 										false);
 
 				if (put && factory.Statistics.IsStatisticsEnabled)
 				{
-					factory.StatisticsImplementor.SecondLevelCachePut(persister.Cache.RegionName);
+					factory.StatisticsImplementor.SecondLevelCachePut(cache.RegionName);
 				}
 			}
 		}

--- a/src/NHibernate/Persister/Collection/BasicCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/BasicCollectionPersister.cs
@@ -22,8 +22,13 @@ namespace NHibernate.Persister.Collection
 	/// </summary>
 	public partial class BasicCollectionPersister : AbstractCollectionPersister
 	{
+		//Since 5.3
+		[Obsolete("Use constructor with cacheByTenant delegate")]
 		public BasicCollectionPersister(Mapping.Collection collection, ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory) 
-			: base(collection, cache, factory) { }
+			: this(collection, tenantId => cache, factory) { }
+
+		public BasicCollectionPersister(Mapping.Collection collection, Func<string, ICacheConcurrencyStrategy> cacheByTenant, ISessionFactoryImplementor factory) 
+			: base(collection, cacheByTenant, factory) { }
 
 		public override bool CascadeDeleteEnabled
 		{

--- a/src/NHibernate/Persister/Collection/ICollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/ICollectionPersister.cs
@@ -9,6 +9,7 @@ using NHibernate.Id;
 using NHibernate.Metadata;
 using NHibernate.Persister.Entity;
 using NHibernate.Type;
+using NHibernate.Util;
 
 namespace NHibernate.Persister.Collection
 {
@@ -29,10 +30,14 @@ namespace NHibernate.Persister.Collection
 	/// May be considered an immutable view of the mapping object
 	/// </remarks>
 	public partial interface ICollectionPersister
+		//TODO 6.0: Uncomment
+		//,ICacheablePersister
 	{
+		//Since 5.3
 		/// <summary>
 		/// Get the cache
 		/// </summary>
+		[Obsolete("Use ICacheablePersister.GetCache instead")]
 		ICacheConcurrencyStrategy Cache { get; }
 
 		/// <summary> Get the cache structure</summary>
@@ -285,6 +290,7 @@ namespace NHibernate.Persister.Collection
 		object NotFoundObject { get; }
 	}
 
+	//6.0 TODO: Merge into ICollectionPersister
 	public static class CollectionPersisterExtensions
 	{
 		/// <summary>
@@ -303,6 +309,16 @@ namespace NHibernate.Persister.Collection
 				.Warn("Collection persister of {0} type is not supported, returning 1 as a batch size.", persister?.GetType());
 
 			return 1;
+		}
+
+		public static ICacheConcurrencyStrategy GetCache(this ICollectionPersister persister, string tenantIdentifier)
+		{
+#pragma warning disable 618
+			if (tenantIdentifier == null)
+				return persister.Cache;
+#pragma warning restore 618
+
+			return ReflectHelper.CastOrThrow<ICacheablePersister>(persister, "multi-tenancy").GetCache(tenantIdentifier);
 		}
 	}
 }

--- a/src/NHibernate/Persister/Collection/OneToManyPersister.cs
+++ b/src/NHibernate/Persister/Collection/OneToManyPersister.cs
@@ -23,8 +23,15 @@ namespace NHibernate.Persister.Collection
 		private readonly bool _keyIsNullable;
 		private readonly bool _keyIsUpdateable;
 
+		//Since 5.3
+		[Obsolete("Use constructor with cacheByTenant delegate")]
 		public OneToManyPersister(Mapping.Collection collection, ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory)
-			: base(collection, cache, factory)
+			: base(collection, tenantId => cache, factory)
+		{
+		}
+
+		public OneToManyPersister(Mapping.Collection collection, Func<string, ICacheConcurrencyStrategy> cacheByTenant, ISessionFactoryImplementor factory)
+			: base(collection, cacheByTenant, factory)
 		{
 			_cascadeDeleteEnabled = collection.Key.IsCascadeDeleteEnabled && factory.Dialect.SupportsCascadeDelete;
 			_keyIsNullable = collection.Key.IsNullable;

--- a/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
@@ -88,6 +88,14 @@ namespace NHibernate.Persister.Entity
 		private readonly string discriminatorSQLString;
 		private readonly object discriminatorValue;
 
+		public JoinedSubclassEntityPersister(
+			PersistentClass persistentClass,
+			ICacheConcurrencyStrategy cache,
+			ISessionFactoryImplementor factory,
+			IMapping mapping): this(persistentClass, tenantId => cache, factory, mapping)
+		{
+		}
+
 		/// <summary>
 		/// Constructs the NormalizedEntityPerister for the PersistentClass.
 		/// </summary>
@@ -95,7 +103,7 @@ namespace NHibernate.Persister.Entity
 		/// <param name="cache">The configured <see cref="ICacheConcurrencyStrategy" />.</param>
 		/// <param name="factory">The SessionFactory that this EntityPersister will be stored in.</param>
 		/// <param name="mapping">The mapping used to retrieve type information.</param>
-		public JoinedSubclassEntityPersister(PersistentClass persistentClass, ICacheConcurrencyStrategy cache,
+		public JoinedSubclassEntityPersister(PersistentClass persistentClass, Func<string, ICacheConcurrencyStrategy> cache,
 											 ISessionFactoryImplementor factory, IMapping mapping)
 			: base(persistentClass, cache, factory)
 		{

--- a/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/SingleTableEntityPersister.cs
@@ -76,7 +76,17 @@ namespace NHibernate.Persister.Entity
 		//provided so we can join to keys other than the primary key
 		private readonly Dictionary<int, string[]> joinToKeyColumns;
 
-		public SingleTableEntityPersister(PersistentClass persistentClass, ICacheConcurrencyStrategy cache,
+		[Obsolete("Use constructor with cacheByTenant delegate")]
+		public SingleTableEntityPersister(
+			PersistentClass persistentClass,
+			ICacheConcurrencyStrategy cache,
+			ISessionFactoryImplementor factory,
+			IMapping mapping)
+			: this(persistentClass, tenantId => cache, factory, mapping)
+		{
+		}
+
+		public SingleTableEntityPersister(PersistentClass persistentClass, Func<string, ICacheConcurrencyStrategy> cache,
 																			ISessionFactoryImplementor factory, IMapping mapping)
 			: base(persistentClass, cache, factory)
 		{

--- a/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/UnionSubclassEntityPersister.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NHibernate.Cache;
@@ -25,8 +26,18 @@ namespace NHibernate.Persister.Entity
 		private readonly string[] constraintOrderedTableNames;
 		private readonly string[][] constraintOrderedKeyColumnNames;
 
-		public UnionSubclassEntityPersister(PersistentClass persistentClass, ICacheConcurrencyStrategy cache, 
-			ISessionFactoryImplementor factory, IMapping mapping):base(persistentClass, cache, factory)
+		[Obsolete("Use constructor with cacheByTenant delegate")]
+		public UnionSubclassEntityPersister(
+			PersistentClass persistentClass,
+			ICacheConcurrencyStrategy cache,
+			ISessionFactoryImplementor factory,
+			IMapping mapping) : this(persistentClass, tenantId => cache, factory, mapping)
+		{
+		}
+
+		public UnionSubclassEntityPersister(PersistentClass persistentClass,
+											Func<string, ICacheConcurrencyStrategy> cacheByTenant, 
+			ISessionFactoryImplementor factory, IMapping mapping):base(persistentClass, cacheByTenant, factory)
 		{
 			if (IdentifierGenerator is IdentityGenerator)
 			{

--- a/src/NHibernate/Persister/PersisterFactory.cs
+++ b/src/NHibernate/Persister/PersisterFactory.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text;
 using NHibernate.Cache;
 using NHibernate.Engine;
+using NHibernate.Impl;
 using NHibernate.Mapping;
 using NHibernate.Persister.Collection;
 using NHibernate.Persister.Entity;
@@ -18,23 +19,10 @@ namespace NHibernate.Persister
 		//TODO: make ClassPersisters *not* depend on ISessionFactoryImplementor
 		// interface, if possible
 
-		static readonly System.Type[] PersisterConstructorArgs = {
-			typeof(PersistentClass),
-			typeof(ICacheConcurrencyStrategy),
-			typeof(ISessionFactoryImplementor),
-			typeof(IMapping)
-		};
-
-		static readonly System.Type[] CollectionPersisterConstructorArgs =
-		{
-			typeof(Mapping.Collection),
-			typeof(ICacheConcurrencyStrategy),
-			typeof(ISessionFactoryImplementor)
-		};
-
 		/// <summary>
 		/// Creates a built in Entity Persister or a custom Persister.
 		/// </summary>
+		[Obsolete("Use overload with cacheByTenant delegate")]
 		public static IEntityPersister CreateClassPersister(PersistentClass model, ICacheConcurrencyStrategy cache,
 															ISessionFactoryImplementor factory, IMapping cfg)
 		{
@@ -58,6 +46,30 @@ namespace NHibernate.Persister
 			}
 		}
 
+		public static IEntityPersister CreateClassPersister(PersistentClass model, Func<string, ICacheConcurrencyStrategy> cacheByTenant, SessionFactoryImpl factory, IMapping cfg)
+		{
+			System.Type persisterClass = model.EntityPersisterClass;
+
+			if (persisterClass == null || persisterClass == typeof(SingleTableEntityPersister))
+			{
+				return new SingleTableEntityPersister(model, cacheByTenant, factory, cfg);
+			}
+			else if (persisterClass == typeof(JoinedSubclassEntityPersister))
+			{
+				return new JoinedSubclassEntityPersister(model, cacheByTenant, factory, cfg);
+			}
+			else if (persisterClass == typeof(UnionSubclassEntityPersister))
+			{
+				return new UnionSubclassEntityPersister(model, cacheByTenant, factory, cfg);
+			}
+			else
+			{
+				return Create(persisterClass, model, cacheByTenant, factory, cfg);
+			}
+		}
+
+		//Since 5.3
+		[Obsolete("Use overload with cacheByTenant delegate")]
 		public static ICollectionPersister CreateCollectionPersister(Mapping.Collection model, ICacheConcurrencyStrategy cache,
 																	 ISessionFactoryImplementor factory)
 		{
@@ -76,17 +88,36 @@ namespace NHibernate.Persister
 			}
 		}
 
+		public static ICollectionPersister CreateCollectionPersister(Mapping.Collection model, Func<string, ICacheConcurrencyStrategy> cacheByTenant, SessionFactoryImpl factory)
+		{
+			System.Type persisterClass = model.CollectionPersisterClass;
+			if (persisterClass == null)
+			{
+				// default behaviour
+				if (model.IsOneToMany)
+					return new OneToManyPersister(model, cacheByTenant, factory);
+				return new BasicCollectionPersister(model, cacheByTenant, factory);
+			}
+
+			return Create(persisterClass, model, cacheByTenant, factory);
+		}
+
 		/// <summary>
 		/// Creates a specific Persister - could be a built in or custom persister.
 		/// </summary>
 		public static IEntityPersister Create(System.Type persisterClass, PersistentClass model,
-											  ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory,
-											  IMapping cfg)
+											Func<string, ICacheConcurrencyStrategy> cache, ISessionFactoryImplementor factory,
+											IMapping cfg)
 		{
 			ConstructorInfo pc;
 			try
 			{
-				pc = persisterClass.GetConstructor(PersisterConstructorArgs);
+				pc = persisterClass.GetConstructor(new[] {
+					TypeOf(model),
+					TypeOf(cache),
+					TypeOf(factory),
+					TypeOf(cfg)
+				});
 			}
 			catch (Exception e)
 			{
@@ -115,13 +146,58 @@ namespace NHibernate.Persister
 			}
 		}
 
-		public static ICollectionPersister Create(System.Type persisterClass, Mapping.Collection model,
-												  ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory)
+		[Obsolete("Please use overload with cacheByTenant delegate")]
+		public static IEntityPersister Create(System.Type persisterClass, PersistentClass model,
+											  ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory,
+											  IMapping cfg)
 		{
 			ConstructorInfo pc;
 			try
 			{
-				pc = persisterClass.GetConstructor(CollectionPersisterConstructorArgs);
+				pc = persisterClass.GetConstructor(new[] {
+					TypeOf(model),
+					TypeOf(cache),
+					TypeOf(factory),
+					TypeOf(cfg)
+				});
+			}
+			catch (Exception e)
+			{
+				throw new MappingException("Could not get constructor for " + persisterClass.Name, e);
+			}
+
+			try
+			{
+				return (IEntityPersister) pc.Invoke(new object[] {model, cache, factory, cfg});
+			}
+			catch (TargetInvocationException tie)
+			{
+				Exception e = tie.InnerException;
+				if (e is HibernateException)
+				{
+					throw ReflectHelper.UnwrapTargetInvocationException(tie);
+				}
+				else
+				{
+					throw new MappingException("Could not instantiate persister " + persisterClass.Name, e);
+				}
+			}
+			catch (Exception e)
+			{
+				throw new MappingException("Could not instantiate persister " + persisterClass.Name, e);
+			}
+		}
+
+		//Since 5.3
+		[Obsolete("Use overload with cacheByTenant delegate")]
+		public static ICollectionPersister Create(System.Type persisterClass, Mapping.Collection model,
+												  ICacheConcurrencyStrategy cache, ISessionFactoryImplementor factory)
+		{
+			ConstructorInfo pc;
+			var ctorArgs = new[] {TypeOf(model), TypeOf(cache), TypeOf(factory)};
+			try
+			{
+				pc = persisterClass.GetConstructor(ctorArgs);
 			}
 			catch (Exception e)
 			{
@@ -131,8 +207,8 @@ namespace NHibernate.Persister
 			{
 				var messageBuilder = new StringBuilder();
 				messageBuilder.Append("Could not find a public constructor for ").Append(persisterClass.Name).AppendLine(";");
-				messageBuilder.Append("- The ctor may have ").Append(CollectionPersisterConstructorArgs.Length).AppendLine(" parameters of types (in order):");
-				System.Array.ForEach(CollectionPersisterConstructorArgs, t=> messageBuilder.AppendLine(t.FullName));
+				messageBuilder.Append("- The ctor may have ").Append(ctorArgs.Length).AppendLine(" parameters of types (in order):");
+				System.Array.ForEach(ctorArgs, t=> messageBuilder.AppendLine(t.FullName));
 				throw new MappingException(messageBuilder.ToString());
 			}
 			try
@@ -155,6 +231,59 @@ namespace NHibernate.Persister
 			{
 				throw new MappingException("Could not instantiate collection persister " + persisterClass.Name, e);
 			}
+		}
+
+		public static ICollectionPersister Create(System.Type persisterClass, Mapping.Collection model,
+												  Func<string, ICacheConcurrencyStrategy> cacheByTenant, ISessionFactoryImplementor factory)
+		{
+			ConstructorInfo pc;
+			var ctorArgs = new[]
+			{
+				TypeOf(model),
+				TypeOf(cacheByTenant),
+				TypeOf(factory)
+			};
+			try
+			{
+				pc = persisterClass.GetConstructor(ctorArgs);
+			}
+			catch (Exception e)
+			{
+				throw new MappingException("Could not get constructor for " + persisterClass.Name, e);
+			}
+			if(pc == null)
+			{
+				var messageBuilder = new StringBuilder();
+				messageBuilder.Append("Could not find a public constructor for ").Append(persisterClass.Name).AppendLine(";");
+				messageBuilder.Append("- The ctor may have ").Append(ctorArgs.Length).AppendLine(" parameters of types (in order):");
+				System.Array.ForEach(ctorArgs, t=> messageBuilder.AppendLine(t.FullName));
+				throw new MappingException(messageBuilder.ToString());
+			}
+			try
+			{
+				return (ICollectionPersister) pc.Invoke(new object[] {model, cacheByTenant, factory});
+			}
+			catch (TargetInvocationException tie)
+			{
+				Exception e = tie.InnerException;
+				if (e is HibernateException)
+				{
+					throw ReflectHelper.UnwrapTargetInvocationException(tie);
+				}
+				else
+				{
+					throw new MappingException("Could not instantiate collection persister " + persisterClass.Name, e);
+				}
+			}
+			catch (Exception e)
+			{
+				throw new MappingException("Could not instantiate collection persister " + persisterClass.Name, e);
+			}
+		}
+
+		private static System.Type TypeOf<T>(T param)
+		{
+			return typeof(T);
 		}
 	}
 }

--- a/src/NHibernate/Persister/PersisterFactory.cs
+++ b/src/NHibernate/Persister/PersisterFactory.cs
@@ -118,6 +118,14 @@ namespace NHibernate.Persister
 					TypeOf(factory),
 					TypeOf(cfg)
 				});
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				//To support legacy custom persisters
+				if (pc == null)
+				{
+					return Create(persisterClass, model, cache(null), factory, cfg);
+				}
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 			catch (Exception e)
 			{
@@ -201,7 +209,7 @@ namespace NHibernate.Persister
 			}
 			catch (Exception e)
 			{
-				throw new MappingException("Could not get constructor for " + persisterClass.Name, e);
+				throw new MappingException("Could not get constructor for " + persisterClass.Name, e);				
 			}
 			if(pc == null)
 			{
@@ -246,6 +254,14 @@ namespace NHibernate.Persister
 			try
 			{
 				pc = persisterClass.GetConstructor(ctorArgs);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				//To support legacy custom persisters
+				if (pc == null)
+				{
+					return Create(persisterClass, model, cacheByTenant(null), factory);
+				}
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
This is prototype just for discussion so please ignore any breaking or non-functional changes
Follow up to #2108

I think we should create separate cache per tenant for better data separation and to allow tenant specific cache clean up (must have feature from my multi-tenant experience) and other actions (like `ISessionFactory.EvictEntity`, `EvictCollection`, ....). Without this change `BulkOperationCleanupAction` cleans up cache for all tenants  when it's executed for some specific tenant. I don't see that it's somehow handled in hibernate so seems they clean cache for all tenants too (also found related complaints [here](https://stackoverflow.com/questions/46584489/hibernate-5-multitenancy-ehcache-configure-cache-for-each-tenant))

So my idea is to create cache dynamically by `tenantIdentifier` and provide to persisters cache creation delegate instead of already created instance of cache.

Some pending questions if you agree with this plan:
1) Should we still keep `tenantIdentifier` as part of `CacheKey`?
*me:* for now seems unnecessary.
2) Should `tenantIdentifier` be part of cache region name or stored as separate value and added as `CacheBase.TenantIdentifier`?
*me:* ~keep as separate value looks more cleaner solution.~  Made as part of cache region to minimize overall changes
3) Should we do something similar for `QueryCache`? For query cache user externally provides `regionName` and in this context `tenantIdentifier` is also available so we can leave it to user. 
*me:* should apply same logic

Any objections? Any other ideas how it should be implemented or suggestions?