### PR TITLE
Fix NullReferenceException in EntityEntry.GetLoadedValue while Update…

### DIFF
--- a/src/NHibernate/Async/Engine/Cascade.cs
+++ b/src/NHibernate/Async/Engine/Cascade.cs
@@ -130,7 +130,11 @@ namespace NHibernate.Engine
 								// which association may be null) in the loadedState of the parent. The unwrap flag
 								// causes it to support having a null implementation, instead of throwing an entity
 								// not found error.
-								loadedValue = await (eventSource.PersistenceContext.UnproxyAndReassociateAsync(loadedValue, cancellationToken)).ConfigureAwait(false);
+								loadedValue = loadedValue != null
+									? await (eventSource.PersistenceContext.UnproxyAndReassociateAsync(
+										loadedValue,
+										cancellationToken)).ConfigureAwait(false)
+									: null;
 							}
 							else
 							{

--- a/src/NHibernate/Engine/Cascade.cs
+++ b/src/NHibernate/Engine/Cascade.cs
@@ -182,7 +182,9 @@ namespace NHibernate.Engine
 								// which association may be null) in the loadedState of the parent. The unwrap flag
 								// causes it to support having a null implementation, instead of throwing an entity
 								// not found error.
-								loadedValue = eventSource.PersistenceContext.UnproxyAndReassociate(loadedValue);
+								loadedValue = loadedValue != null
+									? eventSource.PersistenceContext.UnproxyAndReassociate(loadedValue)
+									: null;
 							}
 							else
 							{

--- a/src/NHibernate/Engine/EntityEntry.cs
+++ b/src/NHibernate/Engine/EntityEntry.cs
@@ -205,6 +205,7 @@ namespace NHibernate.Engine
 
 		public object GetLoadedValue(string propertyName)
 		{
+			if (loadedState == null) return null;
 			int propertyIndex = ((IUniqueKeyLoadable) persister).GetPropertyIndex(propertyName);
 			return loadedState[propertyIndex];
 		}


### PR DESCRIPTION
… on detached entity with null logical one-to-one reference
I had to apply this fix, to make 5.2.3 work with our system after migration from 4.0.0
The use case is rather exotic and triggered an exception on not so nice written test code, using entity, having a dependent one to many (effective one-to-one) child. In first session the entity is inserted (the child entity as a property is not set), than the entity is modified and updated in a second session (detached). Result was a NullReferenceException in EntityEntry.GetLoadedValue. The entity was never loaded from database, so loadedState is null. I added the check if the loaded state is null, and modified Cascade(Async).CascadeProperty to handle EntityEntry.GetLoadedValue returning a null safely.
With this fix it pass all tests and works fine on our system.  I didn't find out how to add a test though..