### PR TITLE
Add virtual DefaultQueryProvider.CreateWithOptions

### DIFF
--- a/src/NHibernate.Test/Async/CfgTest/ConfigurationFixture.cs
+++ b/src/NHibernate.Test/Async/CfgTest/ConfigurationFixture.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using NHibernate.Cfg;
 using NHibernate.DomainModel;
@@ -106,6 +107,15 @@ namespace NHibernate.Test.CfgTest
 			public SampleQueryProvider(ISessionImplementor session) : base(session)
 			{
 
+			}
+
+			protected SampleQueryProvider(ISessionImplementor session, object collection,  NhQueryableOptions options) : base(session, collection, options)
+			{
+			}
+
+			protected override IQueryProvider CreateWithOptions(NhQueryableOptions options)
+			{
+				return new SampleQueryProvider(Session, Collection, options);
 			}
 		}
 

--- a/src/NHibernate.Test/CfgTest/ConfigurationFixture.cs
+++ b/src/NHibernate.Test/CfgTest/ConfigurationFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using NHibernate.Cfg;
 using NHibernate.DomainModel;
@@ -426,6 +427,15 @@ namespace NHibernate.Test.CfgTest
 			{
 
 			}
+
+			protected SampleQueryProvider(ISessionImplementor session, object collection,  NhQueryableOptions options) : base(session, collection, options)
+			{
+			}
+
+			protected override IQueryProvider CreateWithOptions(NhQueryableOptions options)
+			{
+				return new SampleQueryProvider(Session, Collection, options);
+			}
 		}
 
 		[Test]
@@ -442,6 +452,12 @@ namespace NHibernate.Test.CfgTest
 				using (var session = sessionFactory.OpenSession())
 				{
 					var query = session.Query<NHibernate.DomainModel.A>();
+					Assert.IsInstanceOf(typeof(SampleQueryProvider), query.Provider);
+				}
+
+				using (var session = sessionFactory.OpenSession())
+				{
+					var query = session.Query<NHibernate.DomainModel.A>().WithOptions(x => x.SetReadOnly(true));
 					Assert.IsInstanceOf(typeof(SampleQueryProvider), query.Provider);
 				}
 			}

--- a/src/NHibernate/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Linq/DefaultQueryProvider.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Linq
 			Collection = collection;
 		}
 
-		private DefaultQueryProvider(ISessionImplementor session, object collection, NhQueryableOptions options)
+		protected DefaultQueryProvider(ISessionImplementor session, object collection, NhQueryableOptions options)
 			: this(session, collection)
 		{
 			_options = options;

--- a/src/NHibernate/Linq/DefaultQueryProvider.cs
+++ b/src/NHibernate/Linq/DefaultQueryProvider.cs
@@ -108,6 +108,11 @@ namespace NHibernate.Linq
 				? _options.Clone()
 				: new NhQueryableOptions();
 			setOptions(options);
+			return CreateWithOptions(options);
+		}
+
+		protected virtual IQueryProvider CreateWithOptions(NhQueryableOptions options)
+		{
 			return new DefaultQueryProvider(Session, Collection, options);
 		}
 


### PR DESCRIPTION
It should simplify implementation of custom providers based on `DefaultQueryProvider`. As currently there is no easy way to override `WithOptions` implementation (see example of [CustomQueryProvider ](https://stackoverflow.com/a/56245218/9667775) for suggested workaround)