### PR TITLE
Do not call GC.SuppressFinalize from finalizer thread

### DIFF
--- a/src/NHibernate/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/AdoNet/AbstractBatcher.cs
@@ -616,13 +616,13 @@ namespace NHibernate.AdoNet
 			if (isDisposing)
 			{
 				CloseCommands();
+				// nothing for Finalizer to do - so tell the GC to ignore it
+				GC.SuppressFinalize(this);
 			}
 
 			// free unmanaged resources here
 
 			_isAlreadyDisposed = true;
-			// nothing for Finalizer to do - so tell the GC to ignore it
-			GC.SuppressFinalize(this);
 		}
 
 		#endregion

--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -181,13 +181,13 @@ namespace NHibernate.Transaction
 						// Assume we are rolled back
 						await (AfterTransactionCompletionAsync(false, cancellationToken)).ConfigureAwait(false);
 					}
+					// nothing for Finalizer to do - so tell the GC to ignore it
+					GC.SuppressFinalize(this);
 				}
 
 				// free unmanaged resources here
 
 				_isAlreadyDisposed = true;
-				// nothing for Finalizer to do - so tell the GC to ignore it
-				GC.SuppressFinalize(this);
 			}
 		}
 

--- a/src/NHibernate/Connection/ConnectionProvider.cs
+++ b/src/NHibernate/Connection/ConnectionProvider.cs
@@ -198,13 +198,13 @@ namespace NHibernate.Connection
 			if (isDisposing)
 			{
 				log.Debug("Disposing of ConnectionProvider.");
+				// nothing for Finalizer to do - so tell the GC to ignore it
+				GC.SuppressFinalize(this);
 			}
 
 			// free unmanaged resources here
 
 			_isAlreadyDisposed = true;
-			// nothing for Finalizer to do - so tell the GC to ignore it
-			GC.SuppressFinalize(this);
 		}
 
 		#endregion

--- a/src/NHibernate/Impl/EnumerableImpl.cs
+++ b/src/NHibernate/Impl/EnumerableImpl.cs
@@ -310,13 +310,13 @@ namespace NHibernate.Impl
 					_currentResult = null;
 					_session.Batcher.CloseCommand(_cmd, _reader);
 				}
+				// nothing for Finalizer to do - so tell the GC to ignore it
+				GC.SuppressFinalize(this);
 			}
 
 			// free unmanaged resources here
 
 			_isAlreadyDisposed = true;
-			// nothing for Finalizer to do - so tell the GC to ignore it
-			GC.SuppressFinalize(this);
 		}
 
 		#endregion

--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -1543,17 +1543,18 @@ namespace NHibernate.Impl
 
 				// free managed resources that are being managed by the session if we
 				// know this call came through Dispose()
-				if (isDisposing && !IsClosed)
+				if (isDisposing)
 				{
-					Close();
+					if (!IsClosed)
+					{
+						Close();
+					}
+					// nothing for Finalizer to do - so tell the GC to ignore it
+					GC.SuppressFinalize(this);
 				}
 
 				// free unmanaged resources here
-
 				IsAlreadyDisposed = true;
-
-				// nothing for Finalizer to do - so tell the GC to ignore it
-				GC.SuppressFinalize(this);
 			}
 		}
 

--- a/src/NHibernate/Impl/StatelessSessionImpl.cs
+++ b/src/NHibernate/Impl/StatelessSessionImpl.cs
@@ -812,16 +812,19 @@ namespace NHibernate.Impl
 
 				// free managed resources that are being managed by the session if we
 				// know this call came through Dispose()
-				if (isDisposing && !IsClosed)
+				if (isDisposing)
 				{
-					Close();
+					if (!IsClosed)
+					{
+						Close();
+					}
+
+					// nothing for Finalizer to do - so tell the GC to ignore it
+					GC.SuppressFinalize(this);
 				}
 
 				// free unmanaged resources here
-
 				_isAlreadyDisposed = true;
-				// nothing for Finalizer to do - so tell the GC to ignore it
-				GC.SuppressFinalize(this);
 			}
 			_context?.Dispose();
 		}

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -387,13 +387,13 @@ namespace NHibernate.Transaction
 						// Assume we are rolled back
 						AfterTransactionCompletion(false);
 					}
+					// nothing for Finalizer to do - so tell the GC to ignore it
+					GC.SuppressFinalize(this);
 				}
 
 				// free unmanaged resources here
 
 				_isAlreadyDisposed = true;
-				// nothing for Finalizer to do - so tell the GC to ignore it
-				GC.SuppressFinalize(this);
 			}
 		}
 

--- a/src/NHibernate/Util/JoinedEnumerable.cs
+++ b/src/NHibernate/Util/JoinedEnumerable.cs
@@ -159,13 +159,13 @@ namespace NHibernate.Util
 							currentDisposable.Dispose();
 						}
 					}
+					// nothing for Finalizer to do - so tell the GC to ignore it
+					GC.SuppressFinalize(this);
 				}
 
 				// free unmanaged resources here
 
 				_isAlreadyDisposed = true;
-				// nothing for Finalizer to do - so tell the GC to ignore it
-				GC.SuppressFinalize(this);
 			}
 
 			#endregion
@@ -241,7 +241,6 @@ namespace NHibernate.Util
 			public void Dispose()
 			{
 				Dispose(true);
-				GC.SuppressFinalize(this);
 			}
 
 			private void Dispose(bool disposing)
@@ -249,9 +248,11 @@ namespace NHibernate.Util
 				if (!disposed)
 				{
 					if (disposing)
+					{
 						for (; currentEnumIdx < enumerators.Length; currentEnumIdx++)
 							enumerators[currentEnumIdx].Dispose();
-					GC.SuppressFinalize(this);
+						GC.SuppressFinalize(this);
+					}
 					disposed = true;
 				}
 			}


### PR DESCRIPTION
Actually it seems most of finalizers can be safely removed. As most Dispose methods do some clean up only when `isDispose` true otherwise it's no op. So we mark those objects to be finalized for no reasons at all - just addding additional pressure for GC finalizer thread.