### PR TITLE
Fix future queries with non lazy associations

### DIFF
--- a/src/AsyncGenerator.yml
+++ b/src/AsyncGenerator.yml
@@ -5,6 +5,10 @@
   applyChanges: true
   analyzation:
     methodConversion:
+#TODO 6.0: Remove ignore rule for IQueryBatchItem.ProcessResults  
+    - conversion: Ignore
+      name: ProcessResults
+      containingTypeName: IQueryBatchItem
     - conversion: Ignore
       name: PostProcessInsert
       containingTypeName: HqlSqlWalker

--- a/src/NHibernate.Test/Async/Futures/QueryBatchFixture.cs
+++ b/src/NHibernate.Test/Async/Futures/QueryBatchFixture.cs
@@ -520,8 +520,10 @@ namespace NHibernate.Test.Futures
 				Sfi.Statistics.Clear();
 				//EntityEager.EagerEntity is lazy initialized instead of being loaded by the second query 
 				s.QueryOver<EntityEager>().Fetch(SelectMode.Skip, x => x.EagerEntity).Future();
-				s.QueryOver<EntityEager>().Fetch(SelectMode.Fetch, x => x.EagerEntity).Future().ToList();
-				Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
+				await (s.QueryOver<EntityEager>().Fetch(SelectMode.Fetch, x => x.EagerEntity).Future().GetEnumerableAsync());
+
+				if(SupportsMultipleQueries)
+					Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate.Test/Futures/Entities.cs
+++ b/src/NHibernate.Test/Futures/Entities.cs
@@ -36,11 +36,18 @@ namespace NHibernate.Test.Futures
 		public virtual EntityEager Parent { get; set; }
 	}
 
+	public class EntityEagerChild
+	{
+		public Guid Id { get; set; }
+		public string Name { get; set; }
+	}
+	
 	public class EntityEager
 	{
 		public Guid Id { get; set; }
 		public string Name { get; set; }
 
+		public EntityEagerChild EagerEntity { get; set; }
 		public IList<EntitySubselectChild> ChildrenListSubselect { get; set; }
 		public IList<EntitySimpleChild> ChildrenListEager { get; set; } //= new HashSet<EntitySimpleChild>();
 	}

--- a/src/NHibernate.Test/Futures/QueryBatchFixture.cs
+++ b/src/NHibernate.Test/Futures/QueryBatchFixture.cs
@@ -508,8 +508,10 @@ namespace NHibernate.Test.Futures
 				Sfi.Statistics.Clear();
 				//EntityEager.EagerEntity is lazy initialized instead of being loaded by the second query 
 				s.QueryOver<EntityEager>().Fetch(SelectMode.Skip, x => x.EagerEntity).Future();
-				s.QueryOver<EntityEager>().Fetch(SelectMode.Fetch, x => x.EagerEntity).Future().ToList();
-				Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
+				s.QueryOver<EntityEager>().Fetch(SelectMode.Fetch, x => x.EagerEntity).Future().GetEnumerable();
+
+				if(SupportsMultipleQueries)
+					Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate/Async/Multi/IQueryBatchItem.cs
+++ b/src/NHibernate/Async/Multi/IQueryBatchItem.cs
@@ -36,4 +36,9 @@ namespace NHibernate.Multi
 		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
 		Task ExecuteNonBatchedAsync(CancellationToken cancellationToken);
 	}
+
+	internal partial interface IQueryBatchItemWithAsyncProcessResults
+	{
+		Task ProcessResultsAsync(CancellationToken cancellationToken);
+	}
 }

--- a/src/NHibernate/Async/Multi/QueryBatch.cs
+++ b/src/NHibernate/Async/Multi/QueryBatch.cs
@@ -127,18 +127,19 @@ namespace NHibernate.Multi
 			}
 
 			var rowCount = 0;
+			CacheBatcher cacheBatcher = null;
 			try
 			{
 				if (resultSetsCommand.HasQueries)
 				{
+					cacheBatcher = new CacheBatcher(Session);
 					using (var reader = await (resultSetsCommand.GetReaderAsync(Timeout, cancellationToken)).ConfigureAwait(false))
 					{
-						var cacheBatcher = new CacheBatcher(Session);
 						foreach (var query in _queries)
 						{
 							if (query.CachingInformation != null)
 							{
-								foreach (var cachingInfo in query.CachingInformation.Where(ci => ci.IsCacheable))
+								foreach (var cachingInfo in query.CachingInformation)
 								{
 									cachingInfo.SetCacheBatcher(cacheBatcher);
 								}
@@ -146,13 +147,8 @@ namespace NHibernate.Multi
 
 							rowCount += await (query.ProcessResultsSetAsync(reader, cancellationToken)).ConfigureAwait(false);
 						}
-						await (cacheBatcher.ExecuteBatchAsync(cancellationToken)).ConfigureAwait(false);
 					}
 				}
-
-				// Query cacheable results must be cached untransformed: the put does not need to wait for
-				// the ProcessResults.
-				await (PutCacheableResultsAsync(cancellationToken)).ConfigureAwait(false);
 
 				foreach (var query in _queries)
 				{
@@ -162,6 +158,17 @@ namespace NHibernate.Multi
 					else
 						query.ProcessResults();
 				}
+
+				var executeBatchTask = cacheBatcher?.ExecuteBatchAsync(cancellationToken);
+
+				if (executeBatchTask != null)
+
+				{
+
+					await (executeBatchTask).ConfigureAwait(false);
+
+				}
+				await (PutCacheableResultsAsync(cancellationToken)).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException) { throw; }
 			catch (Exception sqle)

--- a/src/NHibernate/Async/Multi/QueryBatch.cs
+++ b/src/NHibernate/Async/Multi/QueryBatch.cs
@@ -156,7 +156,11 @@ namespace NHibernate.Multi
 
 				foreach (var query in _queries)
 				{
-					query.ProcessResults();
+					//TODO 6.0: Replace with query.ProcessResults();
+					if (query is IQueryBatchItemWithAsyncProcessResults q)
+						await (q.ProcessResultsAsync(cancellationToken)).ConfigureAwait(false);
+					else
+						query.ProcessResults();
 				}
 			}
 			catch (OperationCanceledException) { throw; }

--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -108,8 +108,9 @@ namespace NHibernate.Multi
 					await (reader.NextResultAsync(cancellationToken)).ConfigureAwait(false);
 				}
 
-				await (InitializeEntitiesAndCollectionsAsync(reader, hydratedObjects, cancellationToken)).ConfigureAwait(false);
-
+				StopLoadingCollections(reader);
+				_reader = reader;
+				_hydratedObjects = hydratedObjects;
 				return rowCount;
 			}
 		}
@@ -123,19 +124,5 @@ namespace NHibernate.Multi
 		}
 
 		protected abstract Task<IList<TResult>> GetResultsNonBatchedAsync(CancellationToken cancellationToken);
-
-		private async Task InitializeEntitiesAndCollectionsAsync(DbDataReader reader, List<object>[] hydratedObjects, CancellationToken cancellationToken)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			for (var i = 0; i < _queryInfos.Count; i++)
-			{
-				var queryInfo = _queryInfos[i];
-				if (queryInfo.IsResultFromCache)
-					continue;
-				await (queryInfo.Loader.InitializeEntitiesAndCollectionsAsync(
-					hydratedObjects[i], reader, Session, queryInfo.Parameters.IsReadOnly(Session),
-					queryInfo.CacheBatcher, cancellationToken)).ConfigureAwait(false);
-			}
-		}
 	}
 }

--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -103,7 +103,7 @@ namespace NHibernate.Multi
 
 					queryInfo.Result = tmpResults;
 					if (queryInfo.CanPutToCache)
-						queryInfo.ResultToCache = tmpResults;
+						queryInfo.ResultToCache = new List<object>(tmpResults);
 
 					await (reader.NextResultAsync(cancellationToken)).ConfigureAwait(false);
 				}

--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -121,7 +121,9 @@ namespace NHibernate.Multi
 			cancellationToken.ThrowIfCancellationRequested();
 			ThrowIfNotInitialized();
 
-			await (InitializeEntitiesAndCollectionsAsync(_reader, _hydratedObjects, cancellationToken)).ConfigureAwait(false);
+			using (Session.SwitchCacheMode(_cacheMode))
+				await (InitializeEntitiesAndCollectionsAsync(_reader, _hydratedObjects, cancellationToken)).ConfigureAwait(false);
+
 			for (var i = 0; i < _queryInfos.Count; i++)
 			{
 				var queryInfo = _queryInfos[i];

--- a/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
+++ b/src/NHibernate/Engine/Loading/CollectionLoadContext.cs
@@ -124,6 +124,8 @@ namespace NHibernate.Engine.Loading
 			}
 			else
 			{
+				if (loadingCollectionEntry.StopLoading)
+					return null;
 				if (loadingCollectionEntry.ResultSet == resultSet)
 				{
 					log.Debug("found loading collection bound to current result set processing; reading row");
@@ -397,6 +399,18 @@ namespace NHibernate.Engine.Loading
 		public override string ToString()
 		{
 			return base.ToString() + "<rs=" + ResultSet + ">";
+		}
+
+		internal void StopLoadingCollections(ICollectionPersister[] collectionPersisters)
+		{
+			foreach (var collectionKey in localLoadingCollectionKeys)
+			{
+				var loadingCollectionEntry = LoadContext.LocateLoadingCollectionEntry(collectionKey);
+				if (loadingCollectionEntry != null && Array.IndexOf(collectionPersisters, loadingCollectionEntry.Persister) >= 0)
+				{
+					loadingCollectionEntry.StopLoading = true;
+				}
+			}
 		}
 	}
 }

--- a/src/NHibernate/Engine/Loading/LoadingCollectionEntry.cs
+++ b/src/NHibernate/Engine/Loading/LoadingCollectionEntry.cs
@@ -44,6 +44,8 @@ namespace NHibernate.Engine.Loading
 			get { return collection; }
 		}
 
+		public bool StopLoading { get; set; }
+
 		public override string ToString()
 		{
 			return GetType().FullName + "<rs=" + ResultSet + ", coll=" + MessageHelper.InfoString(Persister.Role, Key) + ">@" + Convert.ToString(GetHashCode(), 16);

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -672,6 +672,9 @@ namespace NHibernate.Loader
 			}
 		}
 
+		/// <summary>
+		/// Stops further collection population without actual collection initialization.
+		/// </summary>
 		internal void StopLoadingCollections(ISessionImplementor session, DbDataReader reader)
 		{
 			var collectionPersisters = CollectionPersisters;

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -672,6 +672,15 @@ namespace NHibernate.Loader
 			}
 		}
 
+		internal void StopLoadingCollections(ISessionImplementor session, DbDataReader reader)
+		{
+			var collectionPersisters = CollectionPersisters;
+			if (collectionPersisters == null || collectionPersisters.Length == 0)
+				return;
+
+			session.PersistenceContext.LoadContexts.GetCollectionLoadContext(reader).StopLoadingCollections(collectionPersisters);
+		}
+
 		private void EndCollectionLoad(DbDataReader reader, ISessionImplementor session, ICollectionPersister collectionPersister)
 		{
 			//this is a query and we are loading multiple instances of the same collection role

--- a/src/NHibernate/Multi/IQueryBatchItem.cs
+++ b/src/NHibernate/Multi/IQueryBatchItem.cs
@@ -80,4 +80,10 @@ namespace NHibernate.Multi
 		/// </summary>
 		void ExecuteNonBatched();
 	}
+
+	//TODO 6.0: Remove along with ignore rule for IQueryBatchItem.ProcessResults in AsyncGenerator.yml
+	internal partial interface IQueryBatchItemWithAsyncProcessResults
+	{
+		void ProcessResults();
+	}
 }

--- a/src/NHibernate/Multi/QueryBatch.cs
+++ b/src/NHibernate/Multi/QueryBatch.cs
@@ -182,7 +182,11 @@ namespace NHibernate.Multi
 
 				foreach (var query in _queries)
 				{
-					query.ProcessResults();
+					//TODO 6.0: Replace with query.ProcessResults();
+					if (query is IQueryBatchItemWithAsyncProcessResults q)
+						q.ProcessResults();
+					else
+						query.ProcessResults();
 				}
 			}
 			catch (Exception sqle)

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -261,7 +261,9 @@ namespace NHibernate.Multi
 		{
 			ThrowIfNotInitialized();
 
-			InitializeEntitiesAndCollections(_reader, _hydratedObjects);
+			using (Session.SwitchCacheMode(_cacheMode))
+				InitializeEntitiesAndCollections(_reader, _hydratedObjects);
+
 			for (var i = 0; i < _queryInfos.Count; i++)
 			{
 				var queryInfo = _queryInfos[i];

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -244,7 +244,7 @@ namespace NHibernate.Multi
 
 					queryInfo.Result = tmpResults;
 					if (queryInfo.CanPutToCache)
-						queryInfo.ResultToCache = tmpResults;
+						queryInfo.ResultToCache = new List<object>(tmpResults);
 
 					reader.NextResult();
 				}

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Multi
 	/// <summary>
 	/// Base class for both ICriteria and IQuery queries
 	/// </summary>
-	public abstract partial class QueryBatchItemBase<TResult> : IQueryBatchItem<TResult>
+	public abstract partial class QueryBatchItemBase<TResult> : IQueryBatchItem<TResult>, IQueryBatchItemWithAsyncProcessResults
 	{
 		protected ISessionImplementor Session;
 		private List<EntityKey[]>[] _subselectResultKeys;
@@ -256,7 +256,7 @@ namespace NHibernate.Multi
 			}
 		}
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="IQueryBatchItem.ProcessResults" />
 		public void ProcessResults()
 		{
 			ThrowIfNotInitialized();


### PR DESCRIPTION
Fixes #2173 (some technical details behind this issue can be  found [here](https://github.com/nhibernate/nhibernate-core/issues/2173#issuecomment-501019937))

Implemented the following fix:
* Moved actual collection initialization logic after all queries are processed (as it's done in legacy `MultiCriteriaImpl`/`MultiQueryImpl`)
* Introduced `LoadingCollectionEntry.StopLoading` flag that indicates that collection should not be populated. This allows to delay actual collection initialization till all other batch queries are processed (so it's a fix for #1293)
 
Issue is introduced in 5.2 with new `QueryBatch` implementation.