### PR TITLE
Skip null entities when bag is populated

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1994/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1994/Fixture.cs
@@ -117,6 +117,23 @@ namespace NHibernate.Test.NHSpecificTest.GH1994
 			}
 		}
 
+		[Test]
+		public async Task TestFilteredBagQueryOverAsync()
+		{
+			using (var s = OpenSession())
+			{
+				s.EnableFilter("deletedFilter").SetParameter("deletedParam", false);
+
+				var query = await (s.QueryOver<Asset>()
+				             .Fetch(SelectMode.Fetch, x => x.DocumentsBag)
+				             .TransformUsing(Transformers.DistinctRootEntity)
+				             .ListAsync<Asset>());
+
+				Assert.That(query.Count, Is.EqualTo(1), "filtered assets");
+				Assert.That(query[0].DocumentsBag.Count, Is.EqualTo(1), "filtered asset documents");
+			}
+		}
+
 		//NH-2991
 		[Test]
 		public async Task TestQueryOverRestrictionWithClauseAsync()

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH750/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH750/Fixture.cs
@@ -66,7 +66,8 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				dv2 = (Device) await (s.LoadAsync(typeof(Device), dvSavedId[1]));
 			}
 			Assert.AreEqual(2, dv1.Drives.Count);
-			Assert.AreEqual(2, dv2.Drives.Count);
+			// Verify one is missing
+			Assert.AreEqual(1, dv2.Drives.Count);
 			// Verify dv1 unchanged
 			Assert.IsTrue(dv1.Drives.Contains(dr1));
 			Assert.IsTrue(dv1.Drives.Contains(dr2));
@@ -74,13 +75,6 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			// Verify dv2
 			Assert.IsTrue(dv2.Drives.Contains(dr1));
 			Assert.IsFalse(dv2.Drives.Contains(dr3));
-			// Verify one null
-			int nullCount = 0;
-			for (int i = 0; i < dv2.Drives.Count; i++)
-			{
-				if (dv2.Drives[i] == null) nullCount++;
-			}
-			Assert.AreEqual(1, nullCount);
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH750/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH750/Fixture.cs
@@ -97,7 +97,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				await (t.CommitAsync());
 			}
 
-			await (VerifyResultAsync( expectedInCollection:1, expectedInDb: 2, "not modified collection"));
+			await (VerifyResultAsync(expectedInCollection: 1, expectedInDb: 2, msg: "not modified collection"));
 
 			//Many-to-many clears collection and recreates it so not-found ignore records are lost
 			using (var s = Sfi.OpenSession())
@@ -108,7 +108,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				await (t.CommitAsync());
 			}
 
-			await (VerifyResultAsync(2,2, "modified collection"));
+			await (VerifyResultAsync(2,2,  msg: "modified collection"));
 
 			async Task VerifyResultAsync(int expectedInCollection, int expectedInDb, string msg)
 			{

--- a/src/NHibernate.Test/NHSpecificTest/GH1994/Entity.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1994/Entity.cs
@@ -14,6 +14,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1994
 	{
 		public virtual ISet<Document> Documents { get; set; } = new HashSet<Document>();
 		public virtual ISet<Document> DocumentsFiltered { get; set; } = new HashSet<Document>();
+		public virtual IList<Document> DocumentsBag { get; set; } = new List<Document>();
 	}
 
 	public class Document : Base

--- a/src/NHibernate.Test/NHSpecificTest/GH1994/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1994/Fixture.cs
@@ -106,6 +106,23 @@ namespace NHibernate.Test.NHSpecificTest.GH1994
 			}
 		}
 
+		[Test]
+		public void TestFilteredBagQueryOver()
+		{
+			using (var s = OpenSession())
+			{
+				s.EnableFilter("deletedFilter").SetParameter("deletedParam", false);
+
+				var query = s.QueryOver<Asset>()
+				             .Fetch(SelectMode.Fetch, x => x.DocumentsBag)
+				             .TransformUsing(Transformers.DistinctRootEntity)
+				             .List<Asset>();
+
+				Assert.That(query.Count, Is.EqualTo(1), "filtered assets");
+				Assert.That(query[0].DocumentsBag.Count, Is.EqualTo(1), "filtered asset documents");
+			}
+		}
+
 		//NH-2991
 		[Test]
 		public void TestQueryOverRestrictionWithClause()

--- a/src/NHibernate.Test/NHSpecificTest/GH1994/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/GH1994/Mappings.hbm.xml
@@ -18,6 +18,12 @@
 				<filter name="deletedFilter" condition="IsDeleted = :deletedParam"/>
 			</many-to-many>
 		</set>
+    <bag name="DocumentsBag" table="asset_to_document" lazy="true" cascade="none">
+      <key column="AssetId"/>
+      <many-to-many class="Document" column="DocumentId">
+        <filter name="deletedFilter" condition="IsDeleted = :deletedParam"/>
+      </many-to-many>
+    </bag>
 		<set name="DocumentsFiltered" table="asset_to_document" lazy="true" cascade="none">
 			<key column="AssetId"/>
 			<many-to-many class="Document" column="DocumentId" where="IsDeleted = 0"/>

--- a/src/NHibernate.Test/NHSpecificTest/NH750/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/Fixture.cs
@@ -86,7 +86,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				t.Commit();
 			}
 
-			VerifyResult( expectedInCollection:1, expectedInDb: 2, "not modified collection");
+			VerifyResult(expectedInCollection: 1, expectedInDb: 2, msg: "not modified collection");
 
 			//Many-to-many clears collection and recreates it so not-found ignore records are lost
 			using (var s = Sfi.OpenSession())
@@ -97,7 +97,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				t.Commit();
 			}
 
-			VerifyResult(2,2, "modified collection");
+			VerifyResult(2, 2, msg: "modified collection");
 
 			void VerifyResult(int expectedInCollection, int expectedInDb, string msg)
 			{

--- a/src/NHibernate.Test/NHSpecificTest/NH750/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/Fixture.cs
@@ -55,7 +55,8 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				dv2 = (Device) s.Load(typeof(Device), dvSavedId[1]);
 			}
 			Assert.AreEqual(2, dv1.Drives.Count);
-			Assert.AreEqual(2, dv2.Drives.Count);
+			// Verify one is missing
+			Assert.AreEqual(1, dv2.Drives.Count);
 			// Verify dv1 unchanged
 			Assert.IsTrue(dv1.Drives.Contains(dr1));
 			Assert.IsTrue(dv1.Drives.Contains(dr2));
@@ -63,13 +64,6 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			// Verify dv2
 			Assert.IsTrue(dv2.Drives.Contains(dr1));
 			Assert.IsFalse(dv2.Drives.Contains(dr3));
-			// Verify one null
-			int nullCount = 0;
-			for (int i = 0; i < dv2.Drives.Count; i++)
-			{
-				if (dv2.Drives[i] == null) nullCount++;
-			}
-			Assert.AreEqual(1, nullCount);
 		}
 	}
 }

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
@@ -154,11 +154,9 @@ namespace NHibernate.Collection.Generic
 			// note that if we load this collection from a cartesian product
 			// the multiplicity would be broken ... so use an idbag instead
 			var element = await (role.ReadElementAsync(reader, owner, descriptor.SuffixedElementAliases, Session, cancellationToken)).ConfigureAwait(false);
-			// NH Different behavior : we don't check for null
-			// The NH-750 test show how checking for null we are ignoring the not-found tag and
-			// the DB may have some records ignored by NH. This issue may need some more deep consideration.
-			//if (element != null)
-			_gbag.Add((T) element);
+
+			if (element != null)
+				_gbag.Add((T) element);
 			return element;
 		}
 	}

--- a/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
@@ -448,11 +448,9 @@ namespace NHibernate.Collection.Generic
 			// note that if we load this collection from a cartesian product
 			// the multiplicity would be broken ... so use an idbag instead
 			var element = role.ReadElement(reader, owner, descriptor.SuffixedElementAliases, Session);
-			// NH Different behavior : we don't check for null
-			// The NH-750 test show how checking for null we are ignoring the not-found tag and
-			// the DB may have some records ignored by NH. This issue may need some more deep consideration.
-			//if (element != null)
-			_gbag.Add((T) element);
+
+			if (element != null)
+				_gbag.Add((T) element);
 			return element;
 		}
 


### PR DESCRIPTION
That's the way it's done in hibernate so I see no good reasons why we do it differently. And also null elements break filtering for many-to-many collections.

