### PR TITLE
Fix nuget symbol push

### DIFF
--- a/default.build
+++ b/default.build
@@ -323,7 +323,7 @@
 				</items>
 			</in>
 			<do>
-				<echo message="nuget push -source https://nuget.org/ ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
+				<echo message="nuget push -source https://api.nuget.org/v3/index.json ${path::get-file-name(filename)} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
 			</do>
 		</foreach>
 	</target>


### PR DESCRIPTION
They are pushed only with the v3 api url, see
https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package

Fix the #2019 PR which is in the same milestone.