### PR TITLE
Release 5.2.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.2.5.{build}
+version: 5.2.6.{build}
 image: Visual Studio 2017
 environment:
   matrix:

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">2</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">5</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">6</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -13,8 +13,8 @@
 
 	<!-- This is used only for build folder -->
 	<!-- TODO: Either remove or refactor to use NHibernate.props -->
-	<property name="project.version" value="5.2.5" overwrite="false" />
-	<property name="project.version.numeric" value="5.2.5" overwrite="false" />
+	<property name="project.version" value="5.2.6" overwrite="false" />
+	<property name="project.version.numeric" value="5.2.6" overwrite="false" />
 
 	<!-- properties used to connect to database for testing -->
 	<include buildfile="nhibernate-properties.xml" />

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,3 +1,30 @@
+Build 5.2.6
+=============================
+
+Release notes - NHibernate - Version 5.2.6
+
+11 issues were resolved in this release.
+
+** Bug
+
+   * #2190 Cannot instantiate a SessionFactory using Prevalence cache
+   * #2177 New Fetch() method in QueryOver returns IQueryOver<> instead of QueryOver<>
+   * #2172 Using DependentTransaction fails
+   * #2175 Subcriteria on component collection generates incorrect join alias 
+   * #2173 Futures not batching correctly in NH 5.2.x
+   * #2141 Undefined call to Equals object in collection during flush just before commit 
+   * #2127 StackExchangeRedisCache with PreferMultipleGet = true calls GetMany multiple times
+   * #2110 Wrong GUID to string conversion with SQLite  BinaryGuid=False
+
+** Task
+
+   * #2200 Release 5.2.6
+   * #2199 Upgrade AsyncGenerator to 0.8.2.12
+
+** Tests
+
+   * #2132 Add GetMany for ReadWriteCache tests
+
 Build 5.2.5
 =============================
 


### PR DESCRIPTION
Preparing the release. It currently accounts for pending PRs, async update and dependent transaction fix. If some of them are discarded or delayed to another release, this PR will have to be updated accordingly.

As written by @bahusoid [here](https://github.com/nhibernate/nhibernate-core/pull/2174#discussion_r293383930), some care should be taken when merging to master after the release:

> When merging to master this change should be ignored. The following code is expected in master (no need to wrap in `new List`):
> ```C#
> queryInfo.ResultToCache = queryCacheBuilder.Result;
> ```