### PR TITLE
IN clause support in hql for composite keys on databases without row value constructor support

### DIFF
--- a/src/NHibernate.Test/CompositeId/ClassWithCompositeIdFixture.cs
+++ b/src/NHibernate.Test/CompositeId/ClassWithCompositeIdFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Linq;
 using NHibernate.Criterion;
 using NUnit.Framework;
 
@@ -232,9 +233,7 @@ namespace NHibernate.Test.CompositeId
 		[Test]
 		public void HqlInClause()
 		{
-			//Need to port changes from InLogicOperatorNode.mutateRowValueConstructorSyntaxInInListSyntax
-			if (!Dialect.SupportsRowValueConstructorSyntaxInInList)
-				Assert.Ignore();
+			var id3 = new Id(id.KeyString, id.GetKeyShort(), secondId.KeyDateTime);
 
 			// insert the new objects
 			using (ISession s = OpenSession())
@@ -242,18 +241,38 @@ namespace NHibernate.Test.CompositeId
 			{
 				s.Save(new ClassWithCompositeId(id) {OneProperty = 5});
 				s.Save(new ClassWithCompositeId(secondId) {OneProperty = 10});
-				s.Save(new ClassWithCompositeId(new Id(id.KeyString, id.GetKeyShort(), secondId.KeyDateTime)));
+				s.Save(new ClassWithCompositeId(id3));
 
 				t.Commit();
 			}
 
 			using (var s = OpenSession())
 			{
-				var results = s.CreateQuery("from ClassWithCompositeId x where  x.Id in (:id1, :id2)")
+				var results1 = s.CreateQuery("from ClassWithCompositeId x where x.Id in (:id1, :id2)")
 								.SetParameter("id1", id)
 								.SetParameter("id2", secondId)
 								.List<ClassWithCompositeId>();
-				Assert.That(results.Count, Is.EqualTo(2));
+				var results2 = s.CreateQuery("from ClassWithCompositeId x where  x.Id in (:id1)")
+								.SetParameter("id1", id)
+								.List<ClassWithCompositeId>();
+				var results3 = s.CreateQuery("from ClassWithCompositeId x where  x.Id not in (:id1)")
+								.SetParameter("id1", id)
+								.List<ClassWithCompositeId>();
+				var results4 = s.CreateQuery("from ClassWithCompositeId x where x.Id not in (:id1, :id2)")
+								.SetParameter("id1", id)
+								.SetParameter("id2", secondId)
+								.List<ClassWithCompositeId>();
+
+				Assert.Multiple(
+					() =>
+					{
+						Assert.That(results1.Count, Is.EqualTo(2), "in multiple ids"); 
+						Assert.That(results2.Count, Is.EqualTo(1), "in single id");
+						Assert.That(results3.Count, Is.EqualTo(2), "not in single id");
+						Assert.That(results3.First().Id, Is.EqualTo(id).Or.EqualTo(id3), "not in single id");
+						Assert.That(results4.Count, Is.EqualTo(1), "not in multiple ids");
+						Assert.That(results4.Single().Id, Is.EqualTo(id3), "not in multiple ids");
+					});
 			}
 		}
 

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
@@ -200,8 +200,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			return embeddedParameters.ToArray();
 		}
 
-		//TODO 6.0: Change to private protected (C#7.2 feature)
-		internal string Translate(int valueElements, string comparisonText, string[] lhsElementTexts, string[] rhsElementTexts)
+		private protected string Translate(int valueElements, string comparisonText, string[] lhsElementTexts, string[] rhsElementTexts)
 		{
 			var multicolumnComparisonClauses = new string[valueElements];
 			for (int i = 0; i < valueElements; i++)
@@ -211,8 +210,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			return string.Concat("(", string.Join(" and ", multicolumnComparisonClauses), ")");
 		}
 
-		//TODO 6.0: Change to private protected (C#7.2 feature)
-		internal static string[] ExtractMutationTexts(IASTNode operand, int count) 
+		private protected static string[] ExtractMutationTexts(IASTNode operand, int count) 
 		{
 			if ( operand is ParameterNode )
 			{

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
@@ -200,17 +200,19 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			return embeddedParameters.ToArray();
 		}
 
-		private string Translate(int valueElements, string comparisonText, string[] lhsElementTexts, string[] rhsElementTexts)
+		//TODO 6.0: Change to private protected (C#7.2 feature)
+		internal string Translate(int valueElements, string comparisonText, string[] lhsElementTexts, string[] rhsElementTexts)
 		{
-			var multicolumnComparisonClauses = new List<string>();
+			var multicolumnComparisonClauses = new string[valueElements];
 			for (int i = 0; i < valueElements; i++)
 			{
-				multicolumnComparisonClauses.Add(string.Format("{0} {1} {2}", lhsElementTexts[i], comparisonText, rhsElementTexts[i]));
+				multicolumnComparisonClauses[i] = string.Join(" ", lhsElementTexts[i], comparisonText, rhsElementTexts[i]);
 			}
-			return "(" + string.Join(" and ", multicolumnComparisonClauses.ToArray()) + ")";
+			return string.Concat("(", string.Join(" and ", multicolumnComparisonClauses), ")");
 		}
 
-		private static string[] ExtractMutationTexts(IASTNode operand, int count) 
+		//TODO 6.0: Change to private protected (C#7.2 feature)
+		internal static string[] ExtractMutationTexts(IASTNode operand, int count) 
 		{
 			if ( operand is ParameterNode )
 			{

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/InLogicOperatorNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/InLogicOperatorNode.cs
@@ -82,10 +82,13 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		/// <summary>
 		/// this is possible for parameter lists and explicit lists. It is completely unreasonable for sub-queries.
 		/// </summary>
-		private static bool IsNodeAcceptable(IASTNode rhsNode) =>
-			rhsNode == null /* empty IN list */ || rhsNode is LiteralNode
-												|| rhsNode is ParameterNode
-												|| rhsNode.Type == HqlSqlWalker.VECTOR_EXPR;
+		private static bool IsNodeAcceptable(IASTNode rhsNode)
+		{
+			return rhsNode == null /* empty IN list */
+				|| rhsNode is LiteralNode
+				|| rhsNode is ParameterNode
+				|| rhsNode.Type == HqlSqlWalker.VECTOR_EXPR;
+		}
 
 		/// <summary>
 		///  Mutate the subtree relating to a row-value-constructor in "in" list to instead use

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/InLogicOperatorNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/InLogicOperatorNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Antlr.Runtime;
 using NHibernate.Type;
 
@@ -39,9 +40,10 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			// some form of property ref and that the children of the in-list represent
 			// one-or-more params.
 			var lhsNode = lhs as SqlNode;
+			IType lhsType = null;
 			if (lhsNode != null)
 			{
-				IType lhsType = lhsNode.DataType;
+				lhsType = lhsNode.DataType;
 				IASTNode inListChild = inList.GetChild(0);
 				while (inListChild != null)
 				{
@@ -53,6 +55,81 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 					inListChild = inListChild.NextSibling;
 				}
 			}
+
+			var sessionFactory = SessionFactoryHelper.Factory;
+			if (sessionFactory.Dialect.SupportsRowValueConstructorSyntaxInInList)
+				return;
+
+			lhsType = lhsType ?? ExtractDataType(lhs);
+			if (lhsType == null)
+				return;
+
+			var rhsNode = inList.GetFirstChild();
+			if (rhsNode == null || !IsNodeAcceptable(rhsNode))
+				return;
+
+			var lhsColumnSpan = lhsType.GetColumnSpan(sessionFactory);
+			var rhsColumnSpan = rhsNode.Type == HqlSqlWalker.VECTOR_EXPR
+				? rhsNode.ChildCount
+				: ExtractDataType(rhsNode)?.GetColumnSpan(sessionFactory) ?? 0;
+
+			if (lhsColumnSpan > 1 && rhsColumnSpan > 1)
+			{
+				MutateRowValueConstructorSyntaxInInListSyntax(lhs, lhsColumnSpan, rhsNode, rhsColumnSpan);
+			}
+		}
+
+		/// <summary>
+		/// this is possible for parameter lists and explicit lists. It is completely unreasonable for sub-queries.
+		/// </summary>
+		private static bool IsNodeAcceptable(IASTNode rhsNode) =>
+			rhsNode == null /* empty IN list */ || rhsNode is LiteralNode
+												|| rhsNode is ParameterNode
+												|| rhsNode.Type == HqlSqlWalker.VECTOR_EXPR;
+
+		/// <summary>
+		///  Mutate the subtree relating to a row-value-constructor in "in" list to instead use
+		/// a series of ORen and ANDed predicates.  This allows multi-column type comparisons
+		/// and explicit row-value-constructor in "in" list syntax even on databases which do
+		/// not support row-value-constructor in "in" list.
+		/// 
+		/// For example, here we'd mutate "... where (col1, col2) in ( ('val1', 'val2'), ('val3', 'val4') ) ..." to
+		/// "... where (col1 = 'val1' and col2 = 'val2') or (col1 = 'val3' and val2 = 'val4') ..."
+		/// </summary>
+		private void MutateRowValueConstructorSyntaxInInListSyntax(IASTNode lhsNode, int lhsColumnSpan, IASTNode rhsNode, int rhsColumnSpan)
+		{
+			//NHibenate specific: In hibernate they recreate new tree in HQL. In NHibernate we just replace node with generated SQL
+			// (same as it's done in BinaryLogicOperatorNode)
+
+			string[] lhsElementTexts = ExtractMutationTexts(lhsNode, lhsColumnSpan);
+
+			if (lhsNode is ParameterNode lhsParam && lhsParam.HqlParameterSpecification != null)
+			{
+				AddEmbeddedParameter(lhsParam.HqlParameterSpecification);
+			}
+
+			var negated = Type == HqlSqlWalker.NOT_IN;
+
+			var andElementsNodeList = new List<string>();
+
+			while (rhsNode != null)
+			{
+				string[] rhsElementTexts = ExtractMutationTexts(rhsNode, rhsColumnSpan);
+				if (rhsNode is ParameterNode rhsParam && rhsParam.HqlParameterSpecification != null)
+				{
+					AddEmbeddedParameter(rhsParam.HqlParameterSpecification);
+				}
+
+				var text = Translate(lhsColumnSpan, "=", lhsElementTexts, rhsElementTexts);
+
+				andElementsNodeList.Add(negated ? string.Concat("( not ", text, ")") : text);
+				rhsNode = rhsNode.NextSibling;
+			}
+
+			ClearChildren();
+			Type = HqlSqlWalker.SQL_TOKEN;
+			var sqlToken = string.Join(negated ? " and " : " or ", andElementsNodeList);
+			Text = andElementsNodeList.Count > 1 ? string.Concat("(", sqlToken, ")") : sqlToken;
 		}
 	}
 }

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -12,6 +12,7 @@
 
     <PackageDescription>NHibernate is a mature, open source object-relational mapper for the .NET framework. It is actively developed, fully featured and used in thousands of successful projects.</PackageDescription>
     <PackageTags>ORM; O/RM; DataBase; DAL; ObjectRelationalMapping; NHibernate; ADO.Net; Core</PackageTags>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Port hibernate [`mutateRowValueConstructorSyntaxInInListSyntax`](https://github.com/hibernate/hibernate-orm/blob/e5dc635a52362f69b69acb8d5b166b69b165dbbd/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/InLogicOperatorNode.java#L119).

Allows to use `IN (compositeId1, compositeId2)`  in hql  (and `Contains` queries in LINQ) for DBs like SQL Server.

~Depends on #2211 (without it "mutate" logic applies for all dialects)~