### PR TITLE
Support LINQ GroupBy subquery

### DIFF
--- a/src/NHibernate.Test/Async/Linq/NestedSelectsTests.cs
+++ b/src/NHibernate.Test/Async/Linq/NestedSelectsTests.cs
@@ -362,5 +362,38 @@ namespace NHibernate.Test.Linq
 			Assert.That(orders.Count, Is.EqualTo(830));
 			Assert.That(orders[0].OrderLinesIds, Is.Empty);
 		}
+
+		[Test]
+		public async Task NoNestedSelects_AnyOnGroupBySubqueryAsync()
+		{
+			var subQuery = from vms in db.Animals
+							group vms by vms.Father
+							into vmReqs
+							select vmReqs.Max(x => x.Id);
+
+			var outerQuery = from vm in db.Animals
+							where subQuery.Any(x => vm.Id == x)
+							select vm;
+			var animals = await (outerQuery.ToListAsync());
+			Assert.That(animals.Count, Is.EqualTo(2));
+		}
+
+		//NH-3155
+		[Test]
+		public async Task NoNestedSelects_ContainsOnGroupBySubqueryAsync()
+		{
+			var subQuery = from vms in db.Animals
+							where vms.BodyWeight > 0
+							group vms by vms.Father
+							into vmReqs
+							select vmReqs.Max(x => x.Id);
+
+			var outerQuery = from vm in db.Animals
+							where subQuery.Contains(vm.Id)
+							select vm;
+
+			var animals = await (outerQuery.ToListAsync());
+			Assert.That(animals.Count, Is.EqualTo(2));
+		}
 	}
 }

--- a/src/NHibernate.Test/Linq/NestedSelectsTests.cs
+++ b/src/NHibernate.Test/Linq/NestedSelectsTests.cs
@@ -364,5 +364,38 @@ namespace NHibernate.Test.Linq
 			Assert.That(orders.Count, Is.EqualTo(830));
 			Assert.That(orders[0].OrderLinesIds, Is.Empty);
 		}
+
+		[Test]
+		public void NoNestedSelects_AnyOnGroupBySubquery()
+		{
+			var subQuery = from vms in db.Animals
+							group vms by vms.Father
+							into vmReqs
+							select vmReqs.Max(x => x.Id);
+
+			var outerQuery = from vm in db.Animals
+							where subQuery.Any(x => vm.Id == x)
+							select vm;
+			var animals = outerQuery.ToList();
+			Assert.That(animals.Count, Is.EqualTo(2));
+		}
+
+		//NH-3155
+		[Test]
+		public void NoNestedSelects_ContainsOnGroupBySubquery()
+		{
+			var subQuery = from vms in db.Animals
+							where vms.BodyWeight > 0
+							group vms by vms.Father
+							into vmReqs
+							select vmReqs.Max(x => x.Id);
+
+			var outerQuery = from vm in db.Animals
+							where subQuery.Contains(vm.Id)
+							select vm;
+
+			var animals = outerQuery.ToList();
+			Assert.That(animals.Count, Is.EqualTo(2));
+		}
 	}
 }

--- a/src/NHibernate/Linq/GroupBy/AggregatingGroupByRewriter.cs
+++ b/src/NHibernate/Linq/GroupBy/AggregatingGroupByRewriter.cs
@@ -38,7 +38,8 @@ namespace NHibernate.Linq.GroupBy
 				typeof(FirstResultOperator),
 				typeof(SingleResultOperator),
 				typeof(AnyResultOperator),
-				typeof(AllResultOperator)
+				typeof(AllResultOperator),
+				typeof(ContainsResultOperator),
 			};
 
 		public static void ReWrite(QueryModel queryModel)

--- a/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
@@ -44,6 +44,9 @@ namespace NHibernate.Linq.NestedSelects
 					replacements.Add(expression, processed);
 			}
 
+			if (!replacements.Any())
+				return;
+
 			var key = Expression.Property(group, IGroupingKeyProperty);
 
 			var expressions = new List<ExpressionHolder>();
@@ -92,6 +95,10 @@ namespace NHibernate.Linq.NestedSelects
 
 		private static Expression ProcessSubquery(ISessionFactory sessionFactory, ICollection<ExpressionHolder> elementExpression, QueryModel queryModel, Expression @group, QueryModel subQueryModel)
 		{
+			var resultTypeOverride = subQueryModel.ResultTypeOverride;
+			if (resultTypeOverride != null && !resultTypeOverride.IsArray && !resultTypeOverride.IsEnumerableOfT())
+				return null;
+
 			var subQueryMainFromClause = subQueryModel.MainFromClause;
 
 			var restrictions = subQueryModel.BodyClauses


### PR DESCRIPTION
Fixes #1124

Yet another workaround to make LINQ GroupBy subquery works. IMHO it's less intrusive than last @oskarb  attempt in https://github.com/oskarb/nhibernate-core/tree/NH-3155-alt2. And doesn't look very hackish to me - allows type mismatch and doesn't fail in specific places.