### PR TITLE
Add a shortcut to reduce Transaction.Current reads

### DIFF
--- a/src/NHibernate.Test/Async/SystemTransactions/SystemTransactionFixture.cs
+++ b/src/NHibernate.Test/Async/SystemTransactions/SystemTransactionFixture.cs
@@ -10,15 +10,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Transactions;
 using NHibernate.Cfg;
 using NHibernate.Driver;
 using NHibernate.Engine;
-using NHibernate.Linq;
 using NHibernate.Test.TransactionTest;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.SystemTransactions
 {

--- a/src/NHibernate.Test/SystemTransactions/SystemTransactionFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/SystemTransactionFixture.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Transactions;
 using NHibernate.Cfg;
 using NHibernate.Driver;
 using NHibernate.Engine;
-using NHibernate.Linq;
 using NHibernate.Test.TransactionTest;
 using NUnit.Framework;
 
@@ -520,6 +520,44 @@ namespace NHibernate.Test.SystemTransactions
 			using (var s = OpenSession())
 			{
 				Assert.DoesNotThrow(() => s.JoinTransaction());
+			}
+		}
+
+		[Theory, Explicit("Bench")]
+		public void BenchTransactionAccess(bool inTransaction)
+		{
+			var currentTransaction = System.Transactions.Transaction.Current;
+			using (inTransaction ? new TransactionScope() : null)
+			using (var s = OpenSession())
+			{
+				var impl = s.GetSessionImplementation();
+				var transactionContext = impl.TransactionContext;
+				if (inTransaction)
+					s.JoinTransaction();
+
+				// warm-up
+				for (var i = 0; i < 10; i++)
+					currentTransaction = System.Transactions.Transaction.Current;
+				for (var i = 0; i < 10; i++)
+					transactionContext = impl.TransactionContext;
+
+				var sw = new Stopwatch();
+				for (var j = 0; j < 4; j++)
+				{
+					sw.Restart();
+					for (var i = 0; i < 10000; i++)
+						currentTransaction = System.Transactions.Transaction.Current;
+					sw.Stop();
+					Assert.That(currentTransaction, inTransaction ? Is.Not.Null : Is.Null);
+
+					Console.WriteLine($"Current transaction reads have taken {sw.Elapsed}");
+					sw.Restart();
+					for (var i = 0; i < 10000; i++)
+						transactionContext = impl.TransactionContext;
+					sw.Stop();
+					Assert.That(transactionContext, inTransaction ? Is.Not.Null : Is.Null);
+					Console.WriteLine($"Transaction context reads have taken {sw.Elapsed}");
+				}
 			}
 		}
 	}

--- a/src/NHibernate/Async/Transaction/AdoNetWithSystemTransactionFactory.cs
+++ b/src/NHibernate/Async/Transaction/AdoNetWithSystemTransactionFactory.cs
@@ -16,7 +16,6 @@ using System.Transactions;
 using NHibernate.AdoNet;
 using NHibernate.Engine;
 using NHibernate.Engine.Transaction;
-using NHibernate.Impl;
 using NHibernate.Util;
 
 namespace NHibernate.Transaction

--- a/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
@@ -46,15 +46,18 @@ namespace NHibernate.Transaction
 			if (session == null)
 				throw new ArgumentNullException(nameof(session));
 
-			var connectionManager = session.ConnectionManager;
-			if (!connectionManager.ShouldAutoJoinTransaction ||
-				// Shortcut for avoiding accessing Transaction.Current, which is costly.
-				session.TransactionContext != null && !connectionManager.ProcessingFromSystemTransaction)
-			{
+			if (!ShouldAutoJoinSystemTransaction(session))
 				return;
-			}
 
 			JoinSystemTransaction(session, System.Transactions.Transaction.Current);
+		}
+
+		private static bool ShouldAutoJoinSystemTransaction(ISessionImplementor session)
+		{
+			var connectionManager = session.ConnectionManager;
+			return connectionManager.ShouldAutoJoinTransaction &&
+				// Shortcut for avoiding accessing Transaction.Current, which is costly.
+				(session.TransactionContext == null || connectionManager.ProcessingFromSystemTransaction);
 		}
 
 		/// <inheritdoc />

--- a/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
+++ b/src/NHibernate/Transaction/AdoNetWithSystemTransactionFactory.cs
@@ -6,7 +6,6 @@ using System.Transactions;
 using NHibernate.AdoNet;
 using NHibernate.Engine;
 using NHibernate.Engine.Transaction;
-using NHibernate.Impl;
 using NHibernate.Util;
 
 namespace NHibernate.Transaction
@@ -47,7 +46,10 @@ namespace NHibernate.Transaction
 			if (session == null)
 				throw new ArgumentNullException(nameof(session));
 
-			if (!session.ConnectionManager.ShouldAutoJoinTransaction)
+			var connectionManager = session.ConnectionManager;
+			if (!connectionManager.ShouldAutoJoinTransaction ||
+				// Shortcut for avoiding accessing Transaction.Current, which is costly.
+				session.TransactionContext != null && !connectionManager.ProcessingFromSystemTransaction)
 			{
 				return;
 			}


### PR DESCRIPTION
Since some users complain of a reduction performance with transactions and NHibernate v5.x, I have a look in which changes may have an impact. See [here](https://groups.google.com/forum/#!topic/nhusers/7C6z352w7ro) and [here](https://groups.google.com/forum/#!topic/nhusers/c6TUQwj3Ze0) for the reports on performance losses.

In v4.x and previous versions, there was a shortcut avoiding to read `Transaction.Current` when the session was already having a transaction context.

So I have made a bench for comparing accessing the session transaction context vs the current transaction. The later is around twenty times slower on my setup.

As a consequence I propose re-adding that shortcut.

(Still the first thread states the negative impact occurs also with regular transactions, while upgrading from NHv3.3. But with regular transactions, there is never a transaction context on the session, so the shortcut is not taken, and the current transaction is read. And in v3.3, the default transaction factory was already the system transaction one. The only explanation I could have would be that the performance of reading the current transaction itself has also dropped with .Net Framework v4, those old projects upgrades having probably also upgraded from an old framework.) 