### PR TITLE
Allow configuring auto-join transaction globally

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -907,6 +907,25 @@ var session = sessions.OpenSession(conn);
                     </row>
                     <row>
                         <entry>
+                            <literal>transaction.auto_join</literal>
+                        </entry>
+                        <entry>
+                            Should sessions check on every operation whether there is an ongoing system transaction or not, and enlist
+                            into it if any?
+                            <para>
+                                Default is <literal>true</literal>. It can also be controlled at session opening, with
+                                <literal>ISessionFactory.WithOptions</literal>. A session can also be instructed to explicitly join the current
+                                transaction by calling <literal>ISession.JoinTransaction</literal>. This setting has no effect when using a
+                                transaction factory that is not system transactions aware.
+                            </para>
+                            <para>
+                                <emphasis role="strong">eg.</emphasis>
+                                <literal>false</literal>
+                            </para>
+                        </entry>
+                    </row>
+                    <row>
+                        <entry>
                             <literal>default_flush_mode</literal>
                         </entry>
                         <entry>

--- a/doc/reference/modules/transactions.xml
+++ b/doc/reference/modules/transactions.xml
@@ -633,9 +633,11 @@ finally
                     will then fail to use it.
                 </para>
                 <para>
-                    As of NHibernate v5.0, session auto-enlistment can be disabled from the session builder
+                    Session auto-enlistment can be controlled from the session builder
                     obtained with <literal>ISessionFactory.WithOptions()</literal>, using the
-                    <literal>AutoJoinTransaction</literal> option. The connection may still enlist itself
+                    <literal>AutoJoinTransaction</literal> option. It can also be controlled at the configuration level,
+                    see <literal>transaction.auto_join</literal> in <xref linkend="configuration-optional"/>.
+                    When auto-join is disabled, the connection may still enlist itself
                     if connection string <literal>Enlist</literal> setting is not <literal>false</literal>.
                     A session can explicitly join the current system transaction by calling
                     <literal>ISession.JoinTransaction()</literal>.

--- a/src/NHibernate.Test/SystemTransactions/AutoJoinSettingFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/AutoJoinSettingFixture.cs
@@ -1,0 +1,55 @@
+using System.Transactions;
+using NHibernate.Cfg;
+using NUnit.Framework;
+
+namespace NHibernate.Test.SystemTransactions
+{
+	[TestFixture(true)]
+	[TestFixture(false)]
+	[TestFixture(new object[] { null })]
+	public class AutoJoinSettingFixture : TestCase
+	{
+		private readonly bool? _autoJoinTransaction;
+
+		public AutoJoinSettingFixture(bool? autoJoinTransaction)
+		{
+			_autoJoinTransaction = autoJoinTransaction;
+		}
+
+		protected override string[] Mappings => new[] { "TransactionTest.Person.hbm.xml" };
+
+		protected override string MappingsAssembly => "NHibernate.Test";
+
+		protected override void Configure(Configuration configuration)
+		{
+			if (_autoJoinTransaction.HasValue)
+				configuration.SetProperty(Environment.AutoJoinTransaction, _autoJoinTransaction.ToString());
+			else
+				configuration.Properties.Remove(Environment.AutoJoinTransaction);
+		}
+
+		[Test]
+		public void CheckTransactionJoined()
+		{
+			using (new TransactionScope())
+			using (var s = OpenSession())
+			{
+				Assert.That(
+					s.GetSessionImplementation().TransactionContext,
+					_autoJoinTransaction != false ? Is.Not.Null : Is.Null);
+			}
+		}
+
+		[Theory]
+		public void CanOverrideAutoJoin(bool autoJoin)
+		{
+			using (new TransactionScope())
+			using (var s = Sfi.WithOptions().AutoJoinTransaction(autoJoin).OpenSession())
+			{
+				Assert.That(
+					s.GetSessionImplementation().TransactionContext,
+					autoJoin ? Is.Not.Null : Is.Null);
+			}
+		}
+	}
+}

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -123,6 +123,10 @@ namespace NHibernate.Cfg
 		[Obsolete("This setting has no usages and will be removed in a future version")]
 		public const string OutputStylesheet = "xml.output_stylesheet";
 
+		/// <summary>
+		/// The class name of a custom <see cref="Transaction.ITransactionFactory"/> implementation. Defaults to the
+		/// built-in <see cref="Transaction.AdoNetWithSystemTransactionFactory" />.
+		/// </summary>
 		public const string TransactionStrategy = "transaction.factory_class";
 		/// <summary>
 		/// <para>Timeout duration in milliseconds for the system transaction completion lock.</para>
@@ -144,6 +148,14 @@ namespace NHibernate.Cfg
 		/// transaction preparation, while still benefiting from <see cref="FlushMode.Auto"/> on querying.
 		/// </summary>
 		public const string UseConnectionOnSystemTransactionPrepare = "transaction.use_connection_on_system_prepare";
+		/// <summary>
+		/// Should sessions check on every operation whether there is an ongoing system transaction or not, and enlist
+		/// into it if any? Default is <see langword="true"/>. It can also be controlled at session opening, see
+		/// <see cref="ISessionFactory.WithOptions" />. A session can also be instructed to explicitly join the current
+		/// transaction by calling <see cref="ISession.JoinTransaction" />. This setting has no effect when using a
+		/// transaction factory that is not system transactions aware.
+		/// </summary>
+		public const string AutoJoinTransaction = "transaction.auto_join";
 
 		// Since v5.0.1
 		[Obsolete("This setting has no usages and will be removed in a future version")]

--- a/src/NHibernate/Cfg/Settings.cs
+++ b/src/NHibernate/Cfg/Settings.cs
@@ -53,6 +53,15 @@ namespace NHibernate.Cfg
 
 		public string SessionFactoryName { get; internal set; }
 
+		/// <summary>
+		/// Should sessions check on every operation whether there is an ongoing system transaction or not, and enlist
+		/// into it if any? Default is <see langword="true"/>. It can also be controlled at session opening, see
+		/// <see cref="ISessionFactory.WithOptions" />. A session can also be instructed to explicitly join the current
+		/// transaction by calling <see cref="ISession.JoinTransaction" />. This setting has no effect if using a
+		/// transaction factory that is not system transactions aware.
+		/// </summary>
+		public bool AutoJoinTransaction { get; internal set; }
+
 		public bool IsAutoCreateSchema { get; internal set; }
 
 		public bool IsAutoDropSchema { get; internal set; }

--- a/src/NHibernate/Cfg/SettingsFactory.cs
+++ b/src/NHibernate/Cfg/SettingsFactory.cs
@@ -291,6 +291,7 @@ namespace NHibernate.Cfg
 			settings.TransactionFactory = transactionFactory;
 			// Not ported - TransactionManagerLookup
 			settings.SessionFactoryName = sessionFactoryName;
+			settings.AutoJoinTransaction = PropertiesHelper.GetBoolean(Environment.AutoJoinTransaction, properties, true);
 			settings.MaximumFetchDepth = maxFetchDepth;
 			settings.IsQueryCacheEnabled = useQueryCache;
 			settings.IsSecondLevelCacheEnabled = useSecondLevelCache;

--- a/src/NHibernate/ISession.cs
+++ b/src/NHibernate/ISession.cs
@@ -771,7 +771,8 @@ namespace NHibernate
 		/// <para>
 		/// Sessions auto-join current transaction by default on their first usage within a scope.
 		/// This can be disabled with <see cref="ISessionBuilder{T}.AutoJoinTransaction(bool)"/> from
-		/// a session builder obtained with <see cref="ISessionFactory.WithOptions()"/>.
+		/// a session builder obtained with <see cref="ISessionFactory.WithOptions()"/>, or with the
+		/// auto-join transaction configuration setting.
 		/// </para>
 		/// <para>
 		/// This method allows to explicitly join the current transaction. It does nothing if it is already

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -1415,7 +1415,7 @@ namespace NHibernate.Impl
 			private ConnectionReleaseMode _connectionReleaseMode;
 			private FlushMode _flushMode;
 			private bool _autoClose;
-			private bool _autoJoinTransaction = true;
+			private bool _autoJoinTransaction;
 
 			public SessionBuilderImpl(SessionFactoryImpl sessionFactory)
 			{
@@ -1424,6 +1424,7 @@ namespace NHibernate.Impl
 				// set up default builder values...
 				_connectionReleaseMode = sessionFactory.Settings.ConnectionReleaseMode;
 				_autoClose = sessionFactory.Settings.IsAutoCloseSessionEnabled;
+				_autoJoinTransaction = sessionFactory.Settings.AutoJoinTransaction;
 				// NH different implementation: not using Settings.IsFlushBeforeCompletionEnabled
 				_flushMode = sessionFactory.Settings.DefaultFlushMode;
 			}

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -92,7 +92,14 @@
 										<xs:enumeration value="show_sql" />
 										<xs:enumeration value="max_fetch_depth" />
 										<xs:enumeration value="current_session_context_class" />
-										<xs:enumeration value="transaction.factory_class" />
+										<xs:enumeration value="transaction.factory_class">
+											<xs:annotation>
+												<xs:documentation>
+													The class name of a custom ITransactionFactory implementation.
+													Defaults to the built-in AdoNetWithSystemTransactionFactory.
+												</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
 										<xs:enumeration value="cache.provider_class" />
 										<xs:enumeration value="cache.use_query_cache" />
 										<xs:enumeration value="cache.query_cache_factory" />
@@ -171,6 +178,17 @@
 													sessions and their connections till transaction end, and may trigger undesired transaction promotions to
 													distributed. Set to false for disabling using connections from system
 													transaction preparation, while still benefiting from FlushMode.Auto on querying.
+												</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="transaction.auto_join">
+											<xs:annotation>
+												<xs:documentation>
+													Should sessions check on every operation whether there is an ongoing system transaction or not, and enlist
+													into it if any? Default is true. It can also be controlled at session opening, with
+													ISessionFactory.WithOptions. A session can also be instructed to explicitly join the current
+													transaction by calling ISession.JoinTransaction. This setting has no effect when using a
+													transaction factory that is not system transactions aware.
 												</xs:documentation>
 											</xs:annotation>
 										</xs:enumeration>


### PR DESCRIPTION
For application willing to enlist in current system transaction only explicitly, it would be better to be able to configure the auto-join transaction option globally rather than at each session opening.

This PR add the option as a configuration option.

Disabling auto-join may improve performance for applications which are not using transaction scopes, or which are using them seldom and takes care of re-enabling auto-join or joining explicitly in those cases.