### PR TITLE
Skip lookup for non cachable LINQ query plan

### DIFF
--- a/src/NHibernate/Engine/Query/QueryPlanCache.cs
+++ b/src/NHibernate/Engine/Query/QueryPlanCache.cs
@@ -51,8 +51,7 @@ namespace NHibernate.Engine.Query
 
 		public IQueryExpressionPlan GetHQLQueryPlan(IQueryExpression queryExpression, bool shallow, IDictionary<string, IFilter> enabledFilters)
 		{
-			// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
-			if (queryExpression is NhLinqExpression linqExpression && !linqExpression.CanCachePlan)
+			if (IsPlanNotCacheable(queryExpression))
 			{
 				log.Debug("Query plan not cacheable");
 				return new QueryExpressionPlan(queryExpression, shallow, enabledFilters, factory);
@@ -80,6 +79,12 @@ namespace NHibernate.Engine.Query
 			}
 
 			return plan;
+		}
+
+		private bool IsPlanNotCacheable(IQueryExpression queryExpression)
+		{
+			// 6.0 TODO: add IsPlanCacheable to IQueryExpression interface
+			return queryExpression is NhLinqExpression linqExpression && !linqExpression.IsPlanCacheable(factory);
 		}
 
 		private static QueryExpressionPlan CopyIfRequired(QueryExpressionPlan plan, IQueryExpression queryExpression)
@@ -112,10 +117,9 @@ namespace NHibernate.Engine.Query
 
 		public IQueryExpressionPlan GetFilterQueryPlan(IQueryExpression queryExpression, string collectionRole, bool shallow, IDictionary<string, IFilter> enabledFilters)
 		{
-			// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
-			if (queryExpression is NhLinqExpression linqExpression && !linqExpression.CanCachePlan)
+			if (IsPlanNotCacheable(queryExpression))
 			{
-				log.Debug("Query plan not cacheable");
+				log.Debug("Collection-filter query plan not cacheable");
 				return new FilterQueryPlan(queryExpression, collectionRole, shallow, enabledFilters, factory);
 			}
 

--- a/src/NHibernate/Engine/Query/QueryPlanCache.cs
+++ b/src/NHibernate/Engine/Query/QueryPlanCache.cs
@@ -51,6 +51,13 @@ namespace NHibernate.Engine.Query
 
 		public IQueryExpressionPlan GetHQLQueryPlan(IQueryExpression queryExpression, bool shallow, IDictionary<string, IFilter> enabledFilters)
 		{
+			// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
+			if (queryExpression is NhLinqExpression linqExpression && !linqExpression.CanCachePlan)
+			{
+				log.Debug("Query plan not cacheable");
+				return new QueryExpressionPlan(queryExpression, shallow, enabledFilters, factory);
+			}
+
 			var key = new HQLQueryPlanKey(queryExpression, shallow, enabledFilters);
 			var plan = (QueryExpressionPlan)planCache[key];
 
@@ -61,11 +68,7 @@ namespace NHibernate.Engine.Query
 					log.Debug("unable to locate HQL query plan in cache; generating ({0})", queryExpression.Key);
 				}
 				plan = new QueryExpressionPlan(queryExpression, shallow, enabledFilters, factory);
-				// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
-				if (!(queryExpression is NhLinqExpression linqExpression) || linqExpression.CanCachePlan)
-					planCache.Put(key, plan);
-				else
-					log.Debug("Query plan not cacheable");
+				planCache.Put(key, plan);
 			}
 			else
 			{
@@ -109,6 +112,13 @@ namespace NHibernate.Engine.Query
 
 		public IQueryExpressionPlan GetFilterQueryPlan(IQueryExpression queryExpression, string collectionRole, bool shallow, IDictionary<string, IFilter> enabledFilters)
 		{
+			// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
+			if (queryExpression is NhLinqExpression linqExpression && !linqExpression.CanCachePlan)
+			{
+				log.Debug("Query plan not cacheable");
+				return new FilterQueryPlan(queryExpression, collectionRole, shallow, enabledFilters, factory);
+			}
+
 			var key = new FilterQueryPlanKey(queryExpression.Key, collectionRole, shallow, enabledFilters);
 			var plan = (QueryExpressionPlan) planCache[key];
 
@@ -116,11 +126,7 @@ namespace NHibernate.Engine.Query
 			{
 				log.Debug("unable to locate collection-filter query plan in cache; generating ({0} : {1})", collectionRole, queryExpression.Key);
 				plan = new FilterQueryPlan(queryExpression, collectionRole, shallow, enabledFilters, factory);
-				// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
-				if (!(queryExpression is NhLinqExpression linqExpression) || linqExpression.CanCachePlan)
-					planCache.Put(key, plan);
-				else
-					log.Debug("Query plan not cacheable");
+				planCache.Put(key, plan);
 			}
 			else
 			{


### PR DESCRIPTION
This lookup looks [quite heavy](https://github.com/nhibernate/nhibernate-core/blob/48b3bb9d433e411344bd2b7e50c88b4f57e607ec/src/NHibernate/Util/SoftLimitMRUCache.cs#L73-L88) and involves locking ( actually looks like it contains unnecessary double locking - I will create additional PR for this).