### PR TITLE
Avoid unnecessary locking via MethodImplOptions.Synchronized

### DIFF
--- a/src/NHibernate/Stat/StatisticsImpl.cs
+++ b/src/NHibernate/Stat/StatisticsImpl.cs
@@ -1,19 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
-
-using NHibernate.Cache;
 using NHibernate.Engine;
-using NHibernate.Util;
 using System.Linq;
 
 namespace NHibernate.Stat
 {
 	public class StatisticsImpl : IStatistics, IStatisticsImplementor
 	{
-		private object _syncRoot;
+		private readonly object _syncRoot = new object();
 
 		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(StatisticsImpl));
 		private readonly ISessionFactoryImplementor sessionFactory;
@@ -79,17 +74,6 @@ namespace NHibernate.Stat
 			: this()
 		{
 			this.sessionFactory = sessionFactory;
-		}
-
-		private object SyncRoot
-		{
-			get
-			{
-				if (_syncRoot == null)
-					Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-
-				return _syncRoot;
-			}
 		}
 
 		#region IStatistics Members
@@ -305,10 +289,9 @@ namespace NHibernate.Stat
 			get { return optimisticFailureCount; }
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void Clear()
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				secondLevelCacheHitCount = 0;
 				secondLevelCacheMissCount = 0;
@@ -355,10 +338,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public EntityStatistics GetEntityStatistics(string entityName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				EntityStatistics es;
 				if (!entityStatistics.TryGetValue(entityName, out es))
@@ -370,10 +352,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public CollectionStatistics GetCollectionStatistics(string role)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				CollectionStatistics cs;
 				if (!collectionStatistics.TryGetValue(role, out cs))
@@ -385,10 +366,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public SecondLevelCacheStatistics GetSecondLevelCacheStatistics(string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				SecondLevelCacheStatistics slcs;
 
@@ -406,10 +386,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public QueryStatistics GetQueryStatistics(string queryString)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				QueryStatistics qs;
 				if (!queryStatistics.TryGetValue(queryString, out qs))
@@ -460,10 +439,9 @@ namespace NHibernate.Stat
 			{
 				return operationThreshold;
 			}
-			[MethodImpl(MethodImplOptions.Synchronized)]
 			set
 			{
-				lock (SyncRoot)
+				lock (_syncRoot)
 				{
 					operationThreshold = value;
 				}
@@ -474,46 +452,41 @@ namespace NHibernate.Stat
 
 		#region IStatisticsImplementor Members
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void OpenSession()
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				sessionOpenCount++;
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void CloseSession()
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				sessionCloseCount++;
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void Flush()
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				flushCount++;
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void Connect()
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				connectCount++;
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void LoadEntity(string entityName, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				entityLoadCount++;
 				GetEntityStatistics(entityName).loadCount++;
@@ -524,10 +497,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void FetchEntity(string entityName, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				entityFetchCount++;
 				GetEntityStatistics(entityName).fetchCount++;
@@ -538,10 +510,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void UpdateEntity(string entityName, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				entityUpdateCount++;
 				GetEntityStatistics(entityName).updateCount++;
@@ -552,10 +523,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void InsertEntity(string entityName, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				entityInsertCount++;
 				GetEntityStatistics(entityName).insertCount++;
@@ -566,10 +536,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void DeleteEntity(string entityName, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				entityDeleteCount++;
 				GetEntityStatistics(entityName).deleteCount++;
@@ -580,10 +549,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void LoadCollection(string role, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				collectionLoadCount++;
 				GetCollectionStatistics(role).loadCount++;
@@ -594,10 +562,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void FetchCollection(string role, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				collectionFetchCount++;
 				GetCollectionStatistics(role).fetchCount++;
@@ -608,10 +575,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void UpdateCollection(string role, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				collectionUpdateCount++;
 				GetCollectionStatistics(role).updateCount++;
@@ -622,10 +588,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void RecreateCollection(string role, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				collectionRecreateCount++;
 				GetCollectionStatistics(role).recreateCount++;
@@ -636,24 +601,22 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void RemoveCollection(string role, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				collectionRemoveCount++;
 				GetCollectionStatistics(role).removeCount++;
 			}
 			if (operationThreshold < time)
 			{
-				LogOperation(OperationRecreateCollection, role, time);
+				LogOperation(OperationRemoveCollection, role, time);
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void SecondLevelCachePut(string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				SecondLevelCacheStatistics slc = GetSecondLevelCacheStatistics(regionName);
 				if (slc != null)
@@ -664,10 +627,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void SecondLevelCacheHit(string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				SecondLevelCacheStatistics slc = GetSecondLevelCacheStatistics(regionName);
 				if (slc != null)
@@ -678,10 +640,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void SecondLevelCacheMiss(string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				SecondLevelCacheStatistics slc = GetSecondLevelCacheStatistics(regionName);
 				if (slc != null)
@@ -692,10 +653,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void QueryExecuted(string hql, int rows, TimeSpan time)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				queryExecutionCount++;
 				if (queryExecutionMaxTime < time)
@@ -715,10 +675,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void QueryCacheHit(string hql, string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				queryCacheHitCount++;
 				if (hql != null)
@@ -734,10 +693,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void QueryCacheMiss(string hql, string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				queryCacheMissCount++;
 				if (hql != null)
@@ -753,10 +711,9 @@ namespace NHibernate.Stat
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void QueryCachePut(string hql, string regionName)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				queryCachePutCount++;
 				if (hql != null)

--- a/src/NHibernate/Util/SimpleMRUCache.cs
+++ b/src/NHibernate/Util/SimpleMRUCache.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-using System.Threading;
 
 namespace NHibernate.Util
 {
@@ -19,7 +17,7 @@ namespace NHibernate.Util
 	{
 		private const int DefaultStrongRefCount = 128;
 
-		private object _syncRoot;
+		private readonly object _syncRoot = new object();
 
 		private readonly int strongReferenceCount;
 
@@ -35,17 +33,6 @@ namespace NHibernate.Util
 			cache = new LRUMap(strongReferenceCount);
 		}
 
-		private object SyncRoot
-		{
-			get
-			{
-				if (_syncRoot == null)
-					Interlocked.CompareExchange(ref _syncRoot, new object(), null);
-
-				return _syncRoot;
-			}
-		}
-
 		#region IDeserializationCallback Members
 
 		void IDeserializationCallback.OnDeserialization(object sender)
@@ -57,20 +44,18 @@ namespace NHibernate.Util
 
 		public object this[object key]
 		{
-			[MethodImpl(MethodImplOptions.Synchronized)]
 			get
 			{
-				lock (SyncRoot)
+				lock (_syncRoot)
 				{
 					return cache[key];
 				}
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void Put(object key, object value)
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				cache.Add(key, value);
 			}
@@ -78,20 +63,18 @@ namespace NHibernate.Util
 
 		public int Count
 		{
-			[MethodImpl(MethodImplOptions.Synchronized)]
 			get
 			{
-				lock (SyncRoot)
+				lock (_syncRoot)
 				{
 					return cache.Count;
 				}
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void Clear()
 		{
-			lock (SyncRoot)
+			lock (_syncRoot)
 			{
 				cache.Clear();
 			}


### PR DESCRIPTION
SoftLimitMRUCache, SimpleMRUCache and StatisticsImpl use inside dedicated lock object so `MethodImplOptions.Synchronized` is unnecessary and were removed.