### PR TITLE
Use DateTime.UtcNow for timestamps

### DIFF
--- a/src/NHibernate/Cache/NoCacheProvider.cs
+++ b/src/NHibernate/Cache/NoCacheProvider.cs
@@ -41,7 +41,7 @@ namespace NHibernate.Cache
 			// This is used by SessionFactoryImpl to hand to the generated SessionImpl;
 			// was the only reason I could see that we cannot just use null as
 			// Settings.CacheProvider
-			return DateTime.Now.Ticks / (100 * TimeSpan.TicksPerMillisecond);
+			return DateTime.UtcNow.Ticks / (100 * TimeSpan.TicksPerMillisecond);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Cache/Timestamper.cs
+++ b/src/NHibernate/Cache/Timestamper.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Cache
 			{
 				// Ticks is accurate down to 100 nanoseconds - hibernate uses milliseconds
 				// to help calculate next time so drop the nanoseconds portion.(1ms==1000000ns)
-				long newTime = ((DateTime.Now.Ticks / 10000) - baseDateMs) << BinDigits;
+				long newTime = ((DateTime.UtcNow.Ticks / 10000) - baseDateMs) << BinDigits;
 				if (time < newTime)
 				{
 					time = newTime;

--- a/src/NHibernate/Id/CounterGenerator.cs
+++ b/src/NHibernate/Id/CounterGenerator.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Id
 			// one year Count only serves to avoid collision for entities persisted in the same 100ns. Maybe it should
 			// have been (DateTime.Now.Ticks && 0xffff) instead, with count serving to avoid collision for up to 37767
 			// entities in the same 6.5535ms. But changing this would be a breaking change for existing values.
-			return unchecked ((DateTime.Now.Ticks << 16) + Count);
+			return unchecked ((DateTime.UtcNow.Ticks << 16) + Count);
 		}
 	}
 }


### PR DESCRIPTION
as it's quicker to access than `DateTime.Now`