### PR TITLE
Cache query plan for DML LINQ queries

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ConstantTest.cs
+++ b/src/NHibernate.Test/Async/Linq/ConstantTest.cs
@@ -250,17 +250,33 @@ namespace NHibernate.Test.Linq
 
 			using (session.BeginTransaction())
 			{
+				await (db.Customers.Where(c => c.CustomerId == "UNKNOWN").UpdateAsync(x => new Customer {CompanyName = "Constant1"}));
 				await (db.Customers.Where(c => c.CustomerId == "ALFKI").UpdateAsync(x => new Customer {CompanyName = x.CompanyName}));
 				Assert.That(
 					cache,
-					Has.Count.EqualTo(1),
-					"First query plan should be cached.");
+					Has.Count.EqualTo(2),
+					"Query plans should be cached.");
 
 				using (var spy = new LogSpy(queryPlanCacheType))
 				{
-					// Should hit plan cache.
-					await (db.Customers.Where(c => c.CustomerId == "ANATR").UpdateAsync(x => new Customer {CompanyName = x.CompanyName}));
-					Assert.That(cache, Has.Count.EqualTo(1), "Second query should not cause a plan to be cached.");
+					//Queries below should hit plan cache.
+					using (var sqlSpy = new SqlLogSpy())
+					{
+						await (db.Customers.Where(c => c.CustomerId == "ANATR").UpdateAsync(x => new Customer {CompanyName = x.CompanyName}));
+						await (db.Customers.Where(c => c.CustomerId == "UNKNOWN").UpdateAsync(x => new Customer {CompanyName = "Constant2"}));
+
+						var sqlEvents = sqlSpy.Appender.GetEvents();
+						Assert.That(
+							sqlEvents[0].RenderedMessage,
+							Does.Contain("ANATR").And.Not.Contain("UNKNOWN").And.Not.Contain("Constant1"),
+							"Unexpected constant parameter value");
+						Assert.That(
+							sqlEvents[1].RenderedMessage,
+							Does.Contain("UNKNOWN").And.Contain("Constant2").And.Not.Contain("Constant1"),
+							"Unexpected constant parameter value");
+					}
+
+					Assert.That(cache, Has.Count.EqualTo(2), "Additional queries should not cause a plan to be cached.");
 					Assert.That(
 						spy.GetWholeLog(),
 						Does
@@ -268,7 +284,7 @@ namespace NHibernate.Test.Linq
 							.And.Not.Contain("unable to locate HQL query plan in cache"));
 
 					await (db.Customers.Where(c => c.CustomerId == "ANATR").UpdateAsync(x => new Customer {ContactName = x.ContactName}));
-					Assert.That(cache, Has.Count.EqualTo(2), "Third query should be cached");
+					Assert.That(cache, Has.Count.EqualTo(3), "Query should be cached");
 				}
 			}
 		}

--- a/src/NHibernate/Linq/NhLinqExpression.cs
+++ b/src/NHibernate/Linq/NhLinqExpression.cs
@@ -88,13 +88,16 @@ namespace NHibernate.Linq
 
 			ParameterDescriptors = requiredHqlParameters.AsReadOnly();
 
-			CanCachePlan = CanCachePlan &&
-				// If some constants do not have matching HQL parameters, their values from first query will
-				// be embedded in the plan and reused for subsequent queries: do not cache the plan.
-				!ParameterValuesByName
+			if (QueryMode == QueryMode.Select && CanCachePlan)
+			{
+				CanCachePlan =
+					// If some constants do not have matching HQL parameters, their values from first query will
+					// be embedded in the plan and reused for subsequent queries: do not cache the plan.
+					!ParameterValuesByName
 					.Keys
 					.Except(requiredHqlParameters.Select(p => p.Name))
 					.Any();
+			}
 
 			// The ast node may be altered by caller, duplicate it for preserving the original one.
 			return DuplicateTree(ExpressionToHqlTranslationResults.Statement.AstNode);


### PR DESCRIPTION
Fixes #2222

Maybe I'm wrong but it seems cached constants are not possible with DML queries (as no result transformers are supported). So let's just ignore `CanCachePlan` check for DML queries.

Regarding  changes in #1544. I think of another fix for cached constants - we should "parametrize" them. So that such queries should be cachable. I mean  for query like:
```C#
from c in db.Customers
where c.CustomerId == "ALFKI"
select new { c.CustomerId, c.ContactName, Constant = 1 }
```
Currently transformer is generated with embedded constants inside. Which for query above should generate something like:
```C#
public object ItemTransfomer(object[] row)
{
return new{CustomerId = row[0], ContactName = row[1], Constant = 1};
}
```
Instead we should generate something like this:
```C#
public object ItemTransfomer(object[] row, IDictionoray<string, object> parameters)
{
return new{CustomerId = row[0], ContactName = row[1], Constant = (int)parameters["p1"]};
}
```
And provide `NhLinqExpression.ParameterValuesByName` for `parameters` parameter.
