### PR TITLE
Fix possible issue with async code for delayed entity inserts

### DIFF
--- a/src/NHibernate/Action/DelayedPostInsertIdentifier.cs
+++ b/src/NHibernate/Action/DelayedPostInsertIdentifier.cs
@@ -21,22 +21,7 @@ namespace NHibernate.Action
 
 		public DelayedPostInsertIdentifier()
 		{
-			sequence = GetNextSequence();
-		}
-
-		private static long GetNextSequence()
-		{
-			long initialValue, computedValue;
-			do
-			{
-				initialValue = GlobalSequence;
-				computedValue =
-					initialValue == long.MaxValue
-						? 1
-						: initialValue + 1;
-			} while (Interlocked.CompareExchange(ref GlobalSequence, computedValue, initialValue) != initialValue);
-
-			return computedValue;
+			sequence = Interlocked.Increment(ref GlobalSequence);
 		}
 
 		public override bool Equals(object obj)

--- a/src/NHibernate/Action/DelayedPostInsertIdentifier.cs
+++ b/src/NHibernate/Action/DelayedPostInsertIdentifier.cs
@@ -15,19 +15,21 @@ namespace NHibernate.Action
 	[Serializable]
 	public class DelayedPostInsertIdentifier
 	{
-		[ThreadStatic]
-		private static long _Sequence = 0;
+		private static long GloablSequence = 0;
+		private static readonly object SyncRoot = new object();
+
 		private readonly long sequence;
 
 		public DelayedPostInsertIdentifier()
 		{
-			lock (typeof(DelayedPostInsertIdentifier))
+			lock (SyncRoot)
 			{
-				if (_Sequence == long.MaxValue)
+				if (GloablSequence == long.MaxValue)
 				{
-					_Sequence = 0;
+					GloablSequence = 0;
 				}
-				sequence = _Sequence++;
+
+				sequence = GloablSequence++;
 			}
 		}
 

--- a/src/NHibernate/Action/EntityIdentityInsertAction.cs
+++ b/src/NHibernate/Action/EntityIdentityInsertAction.cs
@@ -9,7 +9,6 @@ namespace NHibernate.Action
 	[Serializable]
 	public sealed partial class EntityIdentityInsertAction : AbstractEntityInsertAction
 	{
-		private readonly object lockObject = new object();
 		private readonly bool isDelayed;
 		private readonly EntityKey delayedEntityKey;
 		//private CacheEntry cacheEntry;
@@ -19,7 +18,9 @@ namespace NHibernate.Action
 			: base(null, state, instance, persister, session)
 		{
 			this.isDelayed = isDelayed;
-			delayedEntityKey = this.isDelayed ? GenerateDelayedEntityKey() : null;
+			delayedEntityKey = this.isDelayed
+				? Session.GenerateEntityKey(new DelayedPostInsertIdentifier(), Persister)
+				: null;
 		}
 
 		public object GeneratedId
@@ -30,17 +31,6 @@ namespace NHibernate.Action
 		public EntityKey DelayedEntityKey
 		{
 			get { return delayedEntityKey; }
-		}
-
-		private EntityKey GenerateDelayedEntityKey()
-		{
-			lock (lockObject)
-			{
-				if (!isDelayed)
-					throw new HibernateException("Cannot request delayed entity-key for non-delayed post-insert-id generation");
-
-				return Session.GenerateEntityKey(new DelayedPostInsertIdentifier(), Persister);
-			}
 		}
 
 		protected internal override bool HasPostCommitEventListeners

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -1384,9 +1384,8 @@ namespace NHibernate.Engine
 		
 		public void ReplaceDelayedEntityIdentityInsertKeys(EntityKey oldKey, object generatedId)
 		{
-			if (!entitiesByKey.Remove(oldKey, out var tempObject))
-				throw new KeyNotFoundException($"Delayed entity key '{oldKey}' not found.");
-
+			object tempObject = entitiesByKey[oldKey];
+			entitiesByKey.Remove(oldKey);
 			object entity = tempObject;
 			object tempObject2 = entityEntries[entity];
 			entityEntries.Remove(entity);

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -1384,8 +1384,9 @@ namespace NHibernate.Engine
 		
 		public void ReplaceDelayedEntityIdentityInsertKeys(EntityKey oldKey, object generatedId)
 		{
-			object tempObject = entitiesByKey[oldKey];
-			entitiesByKey.Remove(oldKey);
+			if (!entitiesByKey.Remove(oldKey, out var tempObject))
+				throw new KeyNotFoundException($"Delayed entity key '{oldKey}' not found.");
+
 			object entity = tempObject;
 			object tempObject2 = entityEntries[entity];
 			entityEntries.Remove(entity);


### PR DESCRIPTION
`ThreadStatic` shouldn't be used in async code.
I believe it should fix intermittent and annoying `MergeDeliveryNodeAsync` test fail on AppVeyor CI.