### PR TITLE
Simplify handling of lazy property groups

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElement.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElement.cs
@@ -337,9 +337,10 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		/// <returns>the property select SQL fragment.</returns>
 		public string RenderPropertySelect(int size, int k)
 		{
-			return IsAllPropertyFetch
-				? _elementType.RenderPropertySelect(size, k, IsAllPropertyFetch)
-				: _elementType.RenderPropertySelect(size, k, _fetchLazyProperties);
+			return _elementType.RenderPropertySelect(
+				size,
+				k,
+				IsAllPropertyFetch || _fetchLazyProperties?.Contains(TableAlias) == true);
 		}
 
 		public override SqlString RenderText(Engine.ISessionFactoryImplementor sessionFactory)

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementType.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementType.cs
@@ -195,31 +195,17 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		/// </summary>
 		/// <param name="size">The total number of returned types.</param>
 		/// <param name="k">The sequence of the current returned type.</param>
-		/// <param name="allProperties"></param>
+		/// <param name="fetch"></param>
 		/// <returns>the property select SQL fragment.</returns>
-		public string RenderPropertySelect(int size, int k, bool allProperties)
-		{
-			return RenderPropertySelect(size, k, null, allProperties);
-		}
-
-		public string RenderPropertySelect(int size, int k, string[] fetchLazyProperties)
-		{
-			return RenderPropertySelect(size, k, fetchLazyProperties, false);
-		}
-
-		private string RenderPropertySelect(int size, int k, string[] fetchLazyProperties, bool allProperties)
+		public string RenderPropertySelect(int size, int k, bool fetch)
 		{
 			CheckInitialized();
 
 			var queryable = Queryable;
 			if (queryable == null)
-				return "";
+				return string.Empty;
 
-			// Use the old method when fetchProperties is null to prevent any breaking changes
-			// 6.0 TODO: simplify condition by removing the fetchProperties part
-			string fragment = fetchLazyProperties == null || allProperties
-				? queryable.PropertySelectFragment(TableAlias, GetSuffix(size, k), allProperties)
-				: queryable.PropertySelectFragment(TableAlias, GetSuffix(size, k), fetchLazyProperties);
+			var fragment = queryable.PropertySelectFragment(TableAlias, GetSuffix(size, k), fetch);
 
 			return TrimLeadingCommaAndSpaces(fragment);
 		}

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1639,8 +1639,8 @@ namespace NHibernate.Persister.Entity
 		public string PropertySelectFragment(string name, string suffix, bool fetch)
 		{
 			var select = new SelectFragment(Factory.Dialect)
-			              .SetSuffix(suffix)
-			              .SetUsedAliases(IdentifierAliases);
+				.SetSuffix(suffix)
+				.SetUsedAliases(IdentifierAliases);
 
 			int[] columnTableNumbers = SubclassColumnTableNumberClosure;
 			string[] columnAliases = SubclassColumnAliasClosure;
@@ -1649,8 +1649,8 @@ namespace NHibernate.Persister.Entity
 			for (int i = 0; i < columns.Length; i++)
 			{
 				bool selectable = (fetch || subclassColumnLazyClosure[i]) &&
-				                  !IsSubclassTableSequentialSelect(columnTableNumbers[i]) &&
-				                  subclassColumnSelectableClosure[i];
+					!IsSubclassTableSequentialSelect(columnTableNumbers[i]) &&
+					subclassColumnSelectableClosure[i];
 				if (selectable)
 				{
 					string subalias = GenerateTableAlias(name, columnTableNumbers[i]);
@@ -1663,7 +1663,8 @@ namespace NHibernate.Persister.Entity
 			string[] formulaAliases = SubclassFormulaAliasClosure;
 			for (int i = 0; i < formulaTemplates.Length; i++)
 			{
-				bool selectable = (fetch || subclassFormulaLazyClosure[i]) && !IsSubclassTableSequentialSelect(formulaTableNumbers[i]);
+				bool selectable = (fetch || subclassFormulaLazyClosure[i]) &&
+					!IsSubclassTableSequentialSelect(formulaTableNumbers[i]);
 				if (selectable)
 				{
 					string subalias = GenerateTableAlias(name, formulaTableNumbers[i]);

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -177,7 +177,6 @@ namespace NHibernate.Persister.Entity
 		private readonly string[][] subclassPropertyColumnNameClosure;
 		private readonly FetchMode[] subclassPropertyFetchModeClosure;
 		private readonly bool[] subclassPropertyNullabilityClosure;
-		private readonly bool[] subclassPropertyLazyClosure;
 		protected bool[] propertyDefinedOnSubclass;
 		private readonly int[][] subclassPropertyColumnNumberClosure;
 		private readonly int[][] subclassPropertyFormulaNumberClosure;

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1648,7 +1648,7 @@ namespace NHibernate.Persister.Entity
 
 			for (int i = 0; i < columns.Length; i++)
 			{
-				bool selectable = (fetch || subclassColumnLazyClosure[i]) &&
+				bool selectable = (fetch || !subclassColumnLazyClosure[i]) &&
 					!IsSubclassTableSequentialSelect(columnTableNumbers[i]) &&
 					subclassColumnSelectableClosure[i];
 				if (selectable)
@@ -1663,7 +1663,7 @@ namespace NHibernate.Persister.Entity
 			string[] formulaAliases = SubclassFormulaAliasClosure;
 			for (int i = 0; i < formulaTemplates.Length; i++)
 			{
-				bool selectable = (fetch || subclassFormulaLazyClosure[i]) &&
+				bool selectable = (fetch || !subclassFormulaLazyClosure[i]) &&
 					!IsSubclassTableSequentialSelect(formulaTableNumbers[i]);
 				if (selectable)
 				{

--- a/src/NHibernate/Persister/Entity/IQueryable.cs
+++ b/src/NHibernate/Persister/Entity/IQueryable.cs
@@ -10,19 +10,6 @@ namespace NHibernate.Persister.Entity
 		SuperClass
 	}
 
-	internal static class AbstractEntityPersisterExtensions
-	{
-		/// <summary>
-		/// Given a query alias and an identifying suffix, render the property select fragment.
-		/// </summary>
-		//6.0 TODO: Merge into IQueryable
-		public static string PropertySelectFragment(this IQueryable query, string alias, string suffix, string[] fetchProperties)
-		{
-			return ReflectHelper.CastOrThrow<AbstractEntityPersister>(query, "individual lazy property fetches")
-			                    .PropertySelectFragment(alias, suffix, fetchProperties);
-		}
-	}
-
 	/// <summary>
 	/// Extends the generic <c>ILoadable</c> contract to add operations required by HQL
 	/// </summary>


### PR DESCRIPTION
By moving out the decision of when include the property or not I was able to remove overloads which were added in #1922.
