### PR TITLE
Add sqlite.binaryguid to configuration schema

### DIFF
--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -218,6 +218,18 @@
 												</xs:documentation>
 											</xs:annotation>
 										</xs:enumeration>
+										<xs:enumeration value="sqlite.binaryguid">
+											<xs:annotation>
+												<xs:documentation>
+													SQLite can store GUIDs in binary or text form, controlled by the BinaryGuid
+													connection string parameter (default is 'true'). The BinaryGuid setting will affect
+													how to cast GUID to string in SQL. NHibernate will attempt to detect this
+													setting automatically from the connection string, but if the connection
+													or connection string is being handled by the application instead of by NHibernate,
+													you can use the 'sqlite.binaryguid' NHibernate setting to override the behavior.
+												</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
 										<xs:enumeration value="sql_types.keep_datetime">
 											<xs:annotation>
 												<xs:documentation>


### PR DESCRIPTION
As mentioned [here](https://github.com/nhibernate/nhibernate-core/pull/2205#discussion_r322021720), a new setting added in 5.2.x is lacking its declaration in the configuration xsd, causing it to be unusable inside the configuration file.

Ideally this should be fixed in 5.2.x, but I do not think it is worth a 5.2.x release on its own. So unless we have another 5.2.x to do before releasing 5.3, I am in favor of merging this into 5.3.