### PR TITLE
Fix QueryOver Coalesce projection in Select

### DIFF
--- a/src/NHibernate.Test/Criteria/Lambda/RestrictionsFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/RestrictionsFixture.cs
@@ -287,9 +287,9 @@ namespace NHibernate.Test.Criteria.Lambda
 					.Add(Restrictions.Eq(Projections.SqlFunction("substring", NHibernateUtil.String, Projections.Property("Name"), Projections.Property("Age"), Projections.Constant(2)), "te"))
 					.Add(Restrictions.Eq(Projections.SqlFunction("locate", NHibernateUtil.String, Projections.Constant("e"), Projections.Property("Name"), Projections.Constant(1)), 2))
 					.Add(Restrictions.Eq(Projections.SqlFunction("locate", NHibernateUtil.String, Projections.Constant("e"), Projections.Property("Name"), Projections.Property("Age")), 2))
-					.Add(Restrictions.Eq(Projections.SqlFunction("coalesce", NHibernateUtil.Object, Projections.Property("Name"), Projections.Constant("not-null-val")), "test"))
-					.Add(Restrictions.Eq(Projections.SqlFunction("coalesce", NHibernateUtil.Object, Projections.Property("Name"), Projections.Property("Nickname")), "test"))
-					.Add(Restrictions.Eq(Projections.SqlFunction("coalesce", NHibernateUtil.Object, Projections.Property("NullableIsParent"), Projections.Constant(true)), true))
+					.Add(Restrictions.Eq(new SqlFunctionProjection("coalesce", Projections.Property("Name"), Projections.Property("Name"), Projections.Constant("not-null-val")), "test"))
+					.Add(Restrictions.Eq(new SqlFunctionProjection("coalesce", Projections.Property("Name"), Projections.Property("Name"), Projections.Property("Nickname")), "test"))
+					.Add(Restrictions.Eq(new SqlFunctionProjection("coalesce", Projections.Property("NullableIsParent"), Projections.Property("NullableIsParent"), Projections.Constant(true)), true))
 					.Add(Restrictions.Eq(Projections.SqlFunction("concat", NHibernateUtil.String, Projections.Property("Name"), Projections.Constant(", "), Projections.Property("Name")), "test, test"))
 					.Add(Restrictions.Eq(Projections.SqlFunction("mod", NHibernateUtil.Int32, Projections.Property("Height"), Projections.Constant(10)), 0))
 					.Add(Restrictions.Eq(Projections.SqlFunction("mod", NHibernateUtil.Int32, Projections.Property("Height"), Projections.Property("Age")), 0));

--- a/src/NHibernate/Criterion/ProjectionsExtensions.cs
+++ b/src/NHibernate/Criterion/ProjectionsExtensions.cs
@@ -316,7 +316,7 @@ namespace NHibernate.Criterion
 		{
 			IProjection property = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[0]).AsProjection();
 			var replaceValueIfIsNull = ExpressionProcessor.FindMemberProjection(methodCallExpression.Arguments[1]);
-			return Projections.SqlFunction("coalesce", NHibernateUtil.Object, property, replaceValueIfIsNull.AsProjection());
+			return new SqlFunctionProjection("coalesce", returnTypeProjection: property, property, replaceValueIfIsNull.AsProjection());
 		}
 
 		/// <summary>

--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -115,7 +115,8 @@ namespace NHibernate.Criterion
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
-			return new IType[] {GetReturnType(criteria, criteriaQuery)};
+			var type = GetReturnType(criteria, criteriaQuery);
+			return type != null ? new[] {type} : Array.Empty<IType>();
 		}
 
 		private IType GetReturnType(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Dialect.Function;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
-using NHibernate.Util;
 
 namespace NHibernate.Criterion
 {
@@ -16,6 +15,7 @@ namespace NHibernate.Criterion
 		private readonly ISQLFunction function;
 		private readonly string functionName;
 		private readonly IType returnType;
+		private readonly IProjection returnTypeProjection;
 
 		public SqlFunctionProjection(string functionName, IType returnType, params IProjection[] args)
 		{
@@ -28,6 +28,13 @@ namespace NHibernate.Criterion
 		{
 			this.function = function;
 			this.returnType = returnType;
+			this.args = args;
+		}
+
+		public SqlFunctionProjection(string functionName, IProjection returnTypeProjection, params IProjection[] args)
+		{
+			this.functionName = functionName;
+			this.returnTypeProjection = returnTypeProjection;
 			this.args = args;
 		}
 
@@ -108,9 +115,16 @@ namespace NHibernate.Criterion
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
+			return new IType[] {GetReturnType(criteria, criteriaQuery)};
+		}
+
+		private IType GetReturnType(ICriteria criteria, ICriteriaQuery criteriaQuery)
+		{
 			ISQLFunction sqlFunction = GetFunction(criteriaQuery);
-			IType type = sqlFunction.ReturnType(returnType, criteriaQuery.Factory);
-			return new IType[] {type};
+
+			var resultType = returnType ?? returnTypeProjection?.GetTypes(criteria, criteriaQuery).FirstOrDefault();
+
+			return sqlFunction.ReturnType(resultType, criteriaQuery.Factory);
 		}
 
 		public override TypedValue[] GetTypedValues(ICriteria criteria, ICriteriaQuery criteriaQuery)


### PR DESCRIPTION
Fixes #1107 

In fact simple `Select(x => x.Value.Coalesce(0))` was broken in QueryOver due to using `NHibernateUtil.Object` as return type for `coalesce` function which is something completely unrelated:
> Handles "any" mappings and the old deprecated "object" type.
