### PR TITLE
Remove most RemoveAsAliasesFromSql usages

### DIFF
--- a/src/NHibernate.Test/Async/CompositeId/ClassWithCompositeIdFixture.cs
+++ b/src/NHibernate.Test/Async/CompositeId/ClassWithCompositeIdFixture.cs
@@ -395,6 +395,18 @@ namespace NHibernate.Test.CompositeId
 		}
 
 		[Test]
+		public async Task CriteriaGroupProjectionAsync()
+		{
+			using (ISession s = OpenSession())
+			{
+				await (s.CreateCriteria<ClassWithCompositeId>()
+				.SetProjection(Projections.GroupProperty(Projections.Id()))
+				.Add(Restrictions.Eq(Projections.Id(), id))
+				.ListAsync<Id>());
+			}
+		}
+
+		[Test]
 		public async Task QueryOverInClauseAsync()
 		{
 			// insert the new objects

--- a/src/NHibernate.Test/CompositeId/ClassWithCompositeIdFixture.cs
+++ b/src/NHibernate.Test/CompositeId/ClassWithCompositeIdFixture.cs
@@ -384,6 +384,18 @@ namespace NHibernate.Test.CompositeId
 		}
 
 		[Test]
+		public void CriteriaGroupProjection()
+		{
+			using (ISession s = OpenSession())
+			{
+				s.CreateCriteria<ClassWithCompositeId>()
+				.SetProjection(Projections.GroupProperty(Projections.Id()))
+				.Add(Restrictions.Eq(Projections.Id(), id))
+				.List<Id>();
+			}
+		}
+
+		[Test]
 		public void QueryOverInClause()
 		{
 			// insert the new objects

--- a/src/NHibernate/Criterion/AggregateProjection.cs
+++ b/src/NHibernate/Criterion/AggregateProjection.cs
@@ -2,7 +2,6 @@ using System;
 using NHibernate.SqlCommand;
 using NHibernate.Engine;
 using NHibernate.Type;
-using NHibernate.Util;
 
 namespace NHibernate.Criterion
 {
@@ -49,19 +48,12 @@ namespace NHibernate.Criterion
 
 		public override SqlString ToSqlString(ICriteria criteria, int loc, ICriteriaQuery criteriaQuery)
 		{
-			if (projection == null)
-			{
-				return new SqlString(aggregate, "(", criteriaQuery.GetColumn(criteria, propertyName), ") as y", loc.ToString(), "_");
-			}
+			var column = CriterionUtil.GetColumnNameAsSqlStringPart(propertyName, projection, criteriaQuery, criteria);
 
 			return new SqlString(
 				aggregate,
 				"(",
-				SqlStringHelper.RemoveAsAliasesFromSql(
-					projection.ToSqlString(
-						criteria,
-						loc,
-						criteriaQuery)),
+				column,
 				") as y",
 				loc.ToString(),
 				"_");

--- a/src/NHibernate/Criterion/AvgProjection.cs
+++ b/src/NHibernate/Criterion/AvgProjection.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Criterion
 			sql.Add("cast(");
 			if (projection != null)
 			{
-				sql.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(null, projection, criteriaQuery, criteria));
+				sql.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(projection, criteriaQuery, criteria));
 			}
 			else
 			{

--- a/src/NHibernate/Criterion/AvgProjection.cs
+++ b/src/NHibernate/Criterion/AvgProjection.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Criterion
 			sql.Add("cast(");
 			if (projection != null)
 			{
-				sql.Add(SqlStringHelper.RemoveAsAliasesFromSql(projection.ToSqlString(criteria, loc, criteriaQuery)));
+				sql.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(null, projection, criteriaQuery, criteria));
 			}
 			else
 			{

--- a/src/NHibernate/Criterion/BetweenExpression.cs
+++ b/src/NHibernate/Criterion/BetweenExpression.cs
@@ -53,13 +53,13 @@ namespace NHibernate.Criterion
 			var parametersTypes = GetTypedValues(criteria, criteriaQuery).ToArray();
 			var lowType = parametersTypes[0];
 			var highType = parametersTypes[1];
-			SqlString[] columnNames =
-				CriterionUtil.GetColumnNames(_propertyName, _projection, criteriaQuery, criteria);
+			var columnNames =
+				CriterionUtil.GetColumnNamesAsSqlStringParts(_propertyName, _projection, criteriaQuery, criteria);
 
 			if (columnNames.Length == 1)
 			{
 				sqlBuilder
-					.Add(columnNames[0])
+					.AddObject(columnNames[0])
 					.Add(" between ")
 					.Add(criteriaQuery.NewQueryParameter(lowType).Single())
 					.Add(" and ")
@@ -78,7 +78,7 @@ namespace NHibernate.Criterion
 					}
 					andNeeded = true;
 
-					sqlBuilder.Add(columnNames[i])
+					sqlBuilder.AddObject(columnNames[i])
 						.Add(" >= ")
 						.Add(lowParameters[i]);
 				}
@@ -87,7 +87,7 @@ namespace NHibernate.Criterion
 				for (int i = 0; i < columnNames.Length; i++)
 				{
 					sqlBuilder.Add(" AND ")
-						.Add(columnNames[i])
+						.AddObject(columnNames[i])
 						.Add(" <= ")
 						.Add(highParameters[i]);
 				}

--- a/src/NHibernate/Criterion/CastProjection.cs
+++ b/src/NHibernate/Criterion/CastProjection.cs
@@ -37,9 +37,7 @@ namespace NHibernate.Criterion
 				throw new QueryException("invalid Hibernate type for CastProjection");
 			}
 			string sqlType = factory.Dialect.GetCastTypeName(sqlTypeCodes[0]);
-			int loc = position*GetHashCode();
-			SqlString val = projection.ToSqlString(criteria, loc, criteriaQuery);
-			val = SqlStringHelper.RemoveAsAliasesFromSql(val);
+			var val = CriterionUtil.GetColumnNameAsSqlStringPart(null, projection, criteriaQuery, criteria);
 
 			return new SqlString("cast( ", val, " as ", sqlType, ") as ", GetColumnAliases(position, criteria, criteriaQuery)[0]);
 		}

--- a/src/NHibernate/Criterion/CastProjection.cs
+++ b/src/NHibernate/Criterion/CastProjection.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Criterion
 				throw new QueryException("invalid Hibernate type for CastProjection");
 			}
 			string sqlType = factory.Dialect.GetCastTypeName(sqlTypeCodes[0]);
-			var val = CriterionUtil.GetColumnNameAsSqlStringPart(null, projection, criteriaQuery, criteria);
+			var val = CriterionUtil.GetColumnNameAsSqlStringPart(projection, criteriaQuery, criteria);
 
 			return new SqlString("cast( ", val, " as ", sqlType, ") as ", GetColumnAliases(position, criteria, criteriaQuery)[0]);
 		}

--- a/src/NHibernate/Criterion/ConditionalProjection.cs
+++ b/src/NHibernate/Criterion/ConditionalProjection.cs
@@ -45,8 +45,8 @@ namespace NHibernate.Criterion
 		public override SqlString ToSqlString(ICriteria criteria, int position, ICriteriaQuery criteriaQuery)
 		{
 			SqlString condition = criterion.ToSqlString(criteria, criteriaQuery);
-			var ifTrue = CriterionUtil.GetColumnNameAsSqlStringPart(null, whenTrue, criteriaQuery, criteria);
-			var ifFalse = CriterionUtil.GetColumnNameAsSqlStringPart(null, whenFalse, criteriaQuery, criteria);
+			var ifTrue = CriterionUtil.GetColumnNameAsSqlStringPart(whenTrue, criteriaQuery, criteria);
+			var ifFalse = CriterionUtil.GetColumnNameAsSqlStringPart(whenFalse, criteriaQuery, criteria);
 			return new SqlString("(case when ", condition, " then ", ifTrue, " else ", ifFalse, " end) as ",
 			                     GetColumnAliases(position, criteria, criteriaQuery)[0]);
 		}

--- a/src/NHibernate/Criterion/ConditionalProjection.cs
+++ b/src/NHibernate/Criterion/ConditionalProjection.cs
@@ -45,10 +45,8 @@ namespace NHibernate.Criterion
 		public override SqlString ToSqlString(ICriteria criteria, int position, ICriteriaQuery criteriaQuery)
 		{
 			SqlString condition = criterion.ToSqlString(criteria, criteriaQuery);
-			SqlString ifTrue = whenTrue.ToSqlString(criteria, position + GetHashCode() + 1, criteriaQuery);
-			ifTrue = SqlStringHelper.RemoveAsAliasesFromSql(ifTrue);
-			SqlString ifFalse = whenFalse.ToSqlString(criteria, position + GetHashCode() + 2, criteriaQuery);
-			ifFalse = SqlStringHelper.RemoveAsAliasesFromSql(ifFalse);
+			var ifTrue = CriterionUtil.GetColumnNameAsSqlStringPart(null, whenTrue, criteriaQuery, criteria);
+			var ifFalse = CriterionUtil.GetColumnNameAsSqlStringPart(null, whenFalse, criteriaQuery, criteria);
 			return new SqlString("(case when ", condition, " then ", ifTrue, " else ", ifFalse, " end) as ",
 			                     GetColumnAliases(position, criteria, criteriaQuery)[0]);
 		}

--- a/src/NHibernate/Criterion/CountProjection.cs
+++ b/src/NHibernate/Criterion/CountProjection.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Criterion
 			}
 			if (projection != null)
 			{
-				buf.Add(SqlStringHelper.RemoveAsAliasesFromSql(projection.ToSqlString(criteria, position, criteriaQuery)));
+				buf.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(null, projection, criteriaQuery, criteria));
 			}
 			else
 			{

--- a/src/NHibernate/Criterion/CountProjection.cs
+++ b/src/NHibernate/Criterion/CountProjection.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Criterion
 			}
 			if (projection != null)
 			{
-				buf.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(null, projection, criteriaQuery, criteria));
+				buf.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(projection, criteriaQuery, criteria));
 			}
 			else
 			{

--- a/src/NHibernate/Criterion/CriterionUtil.cs
+++ b/src/NHibernate/Criterion/CriterionUtil.cs
@@ -168,12 +168,8 @@ namespace NHibernate.Criterion
 			string propertyName,
 			object value)
 		{
-			var propertyProjection = projection as IPropertyProjection;
-			if (projection == null || propertyProjection != null)
-			{
-				var pn = propertyProjection != null ? propertyProjection.PropertyName : propertyName;
-				return criteriaQuery.GetTypedValue(criteria, pn, value);
-			}
+			if (propertyName != null || (propertyName = (projection as IPropertyProjection)?.PropertyName) != null)
+				return criteriaQuery.GetTypedValue(criteria, propertyName, value);
 
 			return new TypedValue(NHibernateUtil.GuessType(value), value);
 		}

--- a/src/NHibernate/Criterion/CriterionUtil.cs
+++ b/src/NHibernate/Criterion/CriterionUtil.cs
@@ -5,7 +5,6 @@ namespace NHibernate.Criterion
 	using Engine;
 	using SqlCommand;
 	using Type;
-	using Util;
 
 	public static class CriterionUtil
 	{
@@ -51,7 +50,36 @@ namespace NHibernate.Criterion
 				return GetColumnNamesUsingPropertyName(criteriaQuery, criteria, propertyProjection.PropertyName);
 			}
 
-			SqlString sqlString = projection.ToSqlString(criteria, 
+			return GetProjectionColumns(projection, criteriaQuery, criteria);
+		}
+
+		internal static object[] GetColumnNamesAsSqlStringParts(string propertyName, IProjection projection, ICriteriaQuery criteriaQuery, ICriteria criteria)
+		{
+			if (propertyName != null)
+				return criteriaQuery.GetColumnsUsingProjection(criteria, propertyName);
+
+			if (projection is IPropertyProjection propertyProjection)
+			{
+				return criteriaQuery.GetColumnsUsingProjection(criteria, propertyProjection.PropertyName);
+			}
+
+			return GetProjectionColumns(projection, criteriaQuery, criteria);
+		}
+
+		internal static object GetColumnNameAsSqlStringPart(string propertyName, IProjection projection, ICriteriaQuery criteriaQuery, ICriteria criteria)
+		{
+			var columnNames = GetColumnNamesAsSqlStringParts(propertyName, projection, criteriaQuery, criteria);
+			if (columnNames.Length != 1)
+			{
+				throw new QueryException("property or projection does not map to a single column: " + (propertyName ?? projection.ToString()));
+			}
+
+			return columnNames[0];
+		}
+
+		private static SqlString[] GetProjectionColumns(IProjection projection, ICriteriaQuery criteriaQuery, ICriteria criteria)
+		{
+			SqlString sqlString = projection.ToSqlString(criteria,
 				criteriaQuery.GetIndexForAlias(),
 				criteriaQuery);
 			return new SqlString[]

--- a/src/NHibernate/Criterion/GroupedProjection.cs
+++ b/src/NHibernate/Criterion/GroupedProjection.cs
@@ -9,7 +9,6 @@ namespace NHibernate.Criterion
 	public class GroupedProjection : IProjection
 	{
 		private readonly IProjection projection;
-		private SqlString renderedProjection;
 
 		public GroupedProjection(IProjection projection)
 		{
@@ -18,13 +17,12 @@ namespace NHibernate.Criterion
 
 		public virtual SqlString ToSqlString(ICriteria criteria, int position, ICriteriaQuery criteriaQuery)
 		{
-			return renderedProjection = projection.ToSqlString(criteria, position, criteriaQuery);
+			return projection.ToSqlString(criteria, position, criteriaQuery);
 		}
 
 		public virtual SqlString ToGroupSqlString(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
-			//This is kind of a hack. The hack is based on the fact that ToGroupSqlString always called after ToSqlString.
-			return SqlStringHelper.RemoveAsAliasesFromSql(renderedProjection);
+			return SqlStringHelper.Join(new SqlString(","), CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria));
 		}
 
 		public virtual IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/IdentifierEqExpression.cs
+++ b/src/NHibernate/Criterion/IdentifierEqExpression.cs
@@ -69,8 +69,7 @@ namespace NHibernate.Criterion
 			}
 			else
 			{
-				SqlString sql = _projection.ToSqlString(criteria, GetHashCode(), criteriaQuery);
-				result.Add(SqlStringHelper.RemoveAsAliasesFromSql(sql));
+				result.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(null, _projection, criteriaQuery, criteria));
 			}
 		}
 

--- a/src/NHibernate/Criterion/IdentifierEqExpression.cs
+++ b/src/NHibernate/Criterion/IdentifierEqExpression.cs
@@ -69,7 +69,7 @@ namespace NHibernate.Criterion
 			}
 			else
 			{
-				result.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(null, _projection, criteriaQuery, criteria));
+				result.AddObject(CriterionUtil.GetColumnNameAsSqlStringPart(_projection, criteriaQuery, criteria));
 			}
 		}
 

--- a/src/NHibernate/Criterion/InsensitiveLikeExpression.cs
+++ b/src/NHibernate/Criterion/InsensitiveLikeExpression.cs
@@ -63,8 +63,8 @@ namespace NHibernate.Criterion
 		{
 			//TODO: add default capacity
 			SqlStringBuilder sqlBuilder = new SqlStringBuilder();
-			SqlString[] columnNames =
-				CriterionUtil.GetColumnNames(propertyName, projection, criteriaQuery, criteria);
+			var columnNames =
+				CriterionUtil.GetColumnNamesAsSqlStringParts(propertyName, projection, criteriaQuery, criteria);
 
 			if (columnNames.Length != 1)
 			{
@@ -73,14 +73,14 @@ namespace NHibernate.Criterion
 
 			if (criteriaQuery.Factory.Dialect is PostgreSQLDialect)
 			{
-				sqlBuilder.Add(columnNames[0]);
+				sqlBuilder.AddObject(columnNames[0]);
 				sqlBuilder.Add(" ilike ");
 			}
 			else
 			{
 				sqlBuilder.Add(criteriaQuery.Factory.Dialect.LowercaseFunction)
 					.Add("(")
-					.Add(columnNames[0])
+					.AddObject(columnNames[0])
 					.Add(")")
 					.Add(" like ");
 			}

--- a/src/NHibernate/Criterion/InsensitiveLikeExpression.cs
+++ b/src/NHibernate/Criterion/InsensitiveLikeExpression.cs
@@ -106,11 +106,7 @@ namespace NHibernate.Criterion
 		public TypedValue GetParameterTypedValue(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
 			var matchValue = value.ToString().ToLower();
-			if (projection != null)
-			{
-				return CriterionUtil.GetTypedValues(criteriaQuery, criteria, projection, null, matchValue).Single();
-			}
-			return criteriaQuery.GetTypedValue(criteria, propertyName, matchValue);
+			return CriterionUtil.GetTypedValue(criteriaQuery, criteria, projection, propertyName, matchValue);
 		}
 
 		public override IProjection[] GetProjections()

--- a/src/NHibernate/Criterion/LikeExpression.cs
+++ b/src/NHibernate/Criterion/LikeExpression.cs
@@ -59,7 +59,7 @@ namespace NHibernate.Criterion
 
 		public override SqlString ToSqlString(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
-			SqlString[] columns = CriterionUtil.GetColumnNamesUsingProjection(projection, criteriaQuery, criteria);
+			var columns = CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria);
 			if (columns.Length != 1)
 				throw new HibernateException("Like may only be used with single-column properties / projections.");
 
@@ -70,11 +70,11 @@ namespace NHibernate.Criterion
 				Dialect.Dialect dialect = criteriaQuery.Factory.Dialect;
 				lhs.Add(dialect.LowercaseFunction)
 					.Add(StringHelper.OpenParen)
-					.Add(columns[0])
+					.AddObject(columns[0])
 					.Add(StringHelper.ClosedParen);
 			}
 			else
-				lhs.Add(columns[0]);
+				lhs.AddObject(columns[0]);
 
 			if (ignoreCase)
 			{

--- a/src/NHibernate/Criterion/LikeExpression.cs
+++ b/src/NHibernate/Criterion/LikeExpression.cs
@@ -59,7 +59,7 @@ namespace NHibernate.Criterion
 
 		public override SqlString ToSqlString(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
-			var columns = CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria);
+			var columns = CriterionUtil.GetColumnNamesAsSqlStringParts(projection, criteriaQuery, criteria);
 			if (columns.Length != 1)
 				throw new HibernateException("Like may only be used with single-column properties / projections.");
 

--- a/src/NHibernate/Criterion/NotNullExpression.cs
+++ b/src/NHibernate/Criterion/NotNullExpression.cs
@@ -39,8 +39,8 @@ namespace NHibernate.Criterion
 			//TODO: add default capacity
 			SqlStringBuilder sqlBuilder = new SqlStringBuilder();
 
-			SqlString[] columnNames =
-				CriterionUtil.GetColumnNames(_propertyName, _projection, criteriaQuery, criteria);
+			var columnNames =
+				CriterionUtil.GetColumnNamesAsSqlStringParts(_propertyName, _projection, criteriaQuery, criteria);
 
 			bool opNeeded = false;
 
@@ -52,7 +52,7 @@ namespace NHibernate.Criterion
 				}
 				opNeeded = true;
 
-				sqlBuilder.Add(columnNames[i])
+				sqlBuilder.AddObject(columnNames[i])
 					.Add(" is not null");
 			}
 

--- a/src/NHibernate/Criterion/NullExpression.cs
+++ b/src/NHibernate/Criterion/NullExpression.cs
@@ -38,8 +38,8 @@ namespace NHibernate.Criterion
 			//TODO: add default capacity
 			SqlStringBuilder sqlBuilder = new SqlStringBuilder();
 
-			SqlString[] columnNames =
-				CriterionUtil.GetColumnNames(_propertyName, _projection, criteriaQuery, criteria);
+			var columnNames =
+				CriterionUtil.GetColumnNamesAsSqlStringParts(_propertyName, _projection, criteriaQuery, criteria);
 
 			for (int i = 0; i < columnNames.Length; i++)
 			{
@@ -48,7 +48,7 @@ namespace NHibernate.Criterion
 					sqlBuilder.Add(" and ");
 				}
 
-				sqlBuilder.Add(columnNames[i])
+				sqlBuilder.AddObject(columnNames[i])
 					.Add(" is null");
 			}
 

--- a/src/NHibernate/Criterion/Order.cs
+++ b/src/NHibernate/Criterion/Order.cs
@@ -75,7 +75,7 @@ namespace NHibernate.Criterion
 			var propName = propertyName ?? (projection as IPropertyProjection)?.PropertyName;
 			return propName != null
 				? criteriaQuery.GetColumnAliasesUsingProjection(criteria, propName)
-				: CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria);
+				: CriterionUtil.GetColumnNamesAsSqlStringParts(projection, criteriaQuery, criteria);
 		}
 
 		private SqlType[] SqlTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/Order.cs
+++ b/src/NHibernate/Criterion/Order.cs
@@ -75,7 +75,7 @@ namespace NHibernate.Criterion
 			var propName = propertyName ?? (projection as IPropertyProjection)?.PropertyName;
 			return propName != null
 				? criteriaQuery.GetColumnAliasesUsingProjection(criteria, propName)
-				: (object[]) CriterionUtil.GetColumnNamesUsingProjection(projection, criteriaQuery, criteria);
+				: CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria);
 		}
 
 		private SqlType[] SqlTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/PropertyExpression.cs
+++ b/src/NHibernate/Criterion/PropertyExpression.cs
@@ -75,10 +75,13 @@ namespace NHibernate.Criterion
 			var otherColumnNames =
 				CriterionUtil.GetColumnNamesAsSqlStringParts(_rhsPropertyName, _rhsProjection, criteriaQuery, criteria);
 
-			if (columnNames.Length == 0)
-				return SqlString.Empty;
-			if (columnNames.Length == 1)
-				return new SqlString(columnNames[0], Op, otherColumnNames[0]);
+			switch (columnNames.Length)
+			{
+				case 1:
+					return new SqlString(columnNames[0], Op, otherColumnNames[0]);
+				case 0:
+					return SqlString.Empty;
+			}
 
 			var sb = new SqlStringBuilder();
 			sb.Add(StringHelper.OpenParen);

--- a/src/NHibernate/Criterion/PropertyExpression.cs
+++ b/src/NHibernate/Criterion/PropertyExpression.cs
@@ -75,22 +75,17 @@ namespace NHibernate.Criterion
 			var otherColumnNames =
 				CriterionUtil.GetColumnNamesAsSqlStringParts(_rhsPropertyName, _rhsProjection, criteriaQuery, criteria);
 
-			switch (columnNames.Length)
-			{
-				case 1:
-					return new SqlString(columnNames[0], Op, otherColumnNames[0]);
-				case 0:
-					return SqlString.Empty;
-			}
+			if (columnNames.Length == 0)
+				return SqlString.Empty;
+			if (columnNames.Length == 1)
+				return new SqlString(columnNames[0], Op, otherColumnNames[0]);
 
 			var sb = new SqlStringBuilder();
 			sb.Add(StringHelper.OpenParen);
-
-			for (var i = 0; i < columnNames.Length; i++)
+			sb.AddObject(columnNames[0]).Add(Op).AddObject(otherColumnNames[0]);
+			for (var i = 1; i < columnNames.Length; i++)
 			{
-				if (i != 0)
-					sb.Add(" and ");
-
+				sb.Add(" and ");
 				sb.AddObject(columnNames[i]).Add(Op).AddObject(otherColumnNames[i]);
 			}
 			sb.Add(StringHelper.ClosedParen);

--- a/src/NHibernate/Criterion/PropertyExpression.cs
+++ b/src/NHibernate/Criterion/PropertyExpression.cs
@@ -70,10 +70,10 @@ namespace NHibernate.Criterion
 
 		public override SqlString ToSqlString(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
-			SqlString[] columnNames =
-				CriterionUtil.GetColumnNames(_lhsPropertyName, _lhsProjection, criteriaQuery, criteria);
-			SqlString[] otherColumnNames =
-				CriterionUtil.GetColumnNames(_rhsPropertyName, _rhsProjection, criteriaQuery, criteria);
+			var columnNames =
+				CriterionUtil.GetColumnNamesAsSqlStringParts(_lhsPropertyName, _lhsProjection, criteriaQuery, criteria);
+			var otherColumnNames =
+				CriterionUtil.GetColumnNamesAsSqlStringParts(_rhsPropertyName, _rhsProjection, criteriaQuery, criteria);
 
 			SqlStringBuilder sb = new SqlStringBuilder();
 			if (columnNames.Length > 1)
@@ -81,14 +81,14 @@ namespace NHibernate.Criterion
 				sb.Add(StringHelper.OpenParen);
 			}
 			bool first = true;
-			foreach (SqlString sqlString in SqlStringHelper.Add(columnNames, Op, otherColumnNames))
+			for (var i = 0; i < columnNames.Length; i++)
 			{
 				if (first == false)
 				{
 					sb.Add(" and ");
 				}
 				first = false;
-				sb.Add(sqlString);
+				sb.AddObject(columnNames[i]).Add(Op).AddObject(otherColumnNames[i]);
 			}
 
 			if (columnNames.Length > 1)

--- a/src/NHibernate/Criterion/PropertyExpression.cs
+++ b/src/NHibernate/Criterion/PropertyExpression.cs
@@ -75,26 +75,25 @@ namespace NHibernate.Criterion
 			var otherColumnNames =
 				CriterionUtil.GetColumnNamesAsSqlStringParts(_rhsPropertyName, _rhsProjection, criteriaQuery, criteria);
 
-			SqlStringBuilder sb = new SqlStringBuilder();
-			if (columnNames.Length > 1)
+			switch (columnNames.Length)
 			{
-				sb.Add(StringHelper.OpenParen);
-			}
-			bool first = true;
-			for (var i = 0; i < columnNames.Length; i++)
-			{
-				if (first == false)
-				{
-					sb.Add(" and ");
-				}
-				first = false;
-				sb.AddObject(columnNames[i]).Add(Op).AddObject(otherColumnNames[i]);
+				case 1:
+					return new SqlString(columnNames[0], Op, otherColumnNames[0]);
+				case 0:
+					return SqlString.Empty;
 			}
 
-			if (columnNames.Length > 1)
+			var sb = new SqlStringBuilder();
+			sb.Add(StringHelper.OpenParen);
+
+			for (var i = 0; i < columnNames.Length; i++)
 			{
-				sb.Add(StringHelper.ClosedParen);
+				if (i != 0)
+					sb.Add(" and ");
+
+				sb.AddObject(columnNames[i]).Add(Op).AddObject(otherColumnNames[i]);
 			}
+			sb.Add(StringHelper.ClosedParen);
 
 			return sb.ToSqlString();
 		}

--- a/src/NHibernate/Criterion/SimpleExpression.cs
+++ b/src/NHibernate/Criterion/SimpleExpression.cs
@@ -156,11 +156,7 @@ namespace NHibernate.Criterion
 		public TypedValue GetParameterTypedValue(ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
 			object icvalue = ignoreCase ? value.ToString().ToLower() : value;
-			if (_projection != null)
-			{
-				return CriterionUtil.GetTypedValues(criteriaQuery, criteria, _projection, null, icvalue).Single();
-			}
-			return criteriaQuery.GetTypedValue(criteria, propertyName, icvalue);
+			return CriterionUtil.GetTypedValue(criteriaQuery, criteria, _projection, propertyName, icvalue);
 		}
 
 		public override IProjection[] GetProjections()

--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -109,7 +109,7 @@ namespace NHibernate.Criterion
 
 		private static object[] GetProjectionArguments(ICriteriaQuery criteriaQuery, ICriteria criteria, IProjection projection)
 		{
-			return CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria);
+			return CriterionUtil.GetColumnNamesAsSqlStringParts(projection, criteriaQuery, criteria);
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -82,8 +82,8 @@ namespace NHibernate.Criterion
 			var arguments = new List<object>();
 			for (int i = 0; i < args.Length; i++)
 			{
-				SqlString projectArg = GetProjectionArgument(criteriaQuery, criteria, args[i], 0); // The loc parameter is unused.
-				arguments.Add(projectArg);
+				var projectArg = GetProjectionArguments(criteriaQuery, criteria, args[i]);
+				arguments.AddRange(projectArg);
 			}
 
 			return new SqlString(
@@ -107,10 +107,9 @@ namespace NHibernate.Criterion
 			return dialectFunction;
 		}
 
-		private static SqlString GetProjectionArgument(ICriteriaQuery criteriaQuery, ICriteria criteria, IProjection projection, int loc)
+		private static object[] GetProjectionArguments(ICriteriaQuery criteriaQuery, ICriteria criteria, IProjection projection)
 		{
-			SqlString sql = projection.ToSqlString(criteria, loc, criteriaQuery);
-			return SqlStringHelper.RemoveAsAliasesFromSql(sql);
+			return CriterionUtil.GetColumnNamesAsSqlStringParts(null, projection, criteriaQuery, criteria);
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/SqlCommand/SqlStringHelper.cs
+++ b/src/NHibernate/SqlCommand/SqlStringHelper.cs
@@ -59,8 +59,12 @@ namespace NHibernate.SqlCommand
 			return result;
 		}
 
-
-		//Consider using CriterionUtil.GetColumn... methods instead
+		/// <summary>
+		/// Removes the <c>as someColumnAlias</c> clause from a <c>SqlString</c> representing a column expression.
+		/// Consider using <c>CriterionUtil.GetColumn...</c> methods instead.
+		/// </summary>
+		/// <param name="sql">The <c>SqlString</c> representing a column expression which might be aliased.</param>
+		/// <returns><paramref name="sql" /> if it was not aliased, otherwise an un-aliased <c>SqlString</c> representing the column.</returns>
 		public static SqlString RemoveAsAliasesFromSql(SqlString sql)
 		{
 			int index = sql.LastIndexOfCaseInsensitive(" as ");

--- a/src/NHibernate/SqlCommand/SqlStringHelper.cs
+++ b/src/NHibernate/SqlCommand/SqlStringHelper.cs
@@ -59,6 +59,8 @@ namespace NHibernate.SqlCommand
 			return result;
 		}
 
+
+		//Consider using CriterionUtil.GetColumn... methods instead
 		public static SqlString RemoveAsAliasesFromSql(SqlString sql)
 		{
 			int index = sql.LastIndexOfCaseInsensitive(" as ");


### PR DESCRIPTION
As CriterionUtil handles better property projections and it's one step further to properly support multi-column projections.

Added optimized versions of CriterionUtil.GetColumn methods that don't create SqlString for property projections

Related to #846