### PR TITLE
Add missing options to QueryOver

### DIFF
--- a/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/QueryOverFixture.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Collections;
-
 using NUnit.Framework;
-
 using NHibernate.Criterion;
 using NHibernate.SqlCommand;
 using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 
 namespace NHibernate.Test.Criteria.Lambda
 {
@@ -924,6 +919,48 @@ namespace NHibernate.Test.Criteria.Lambda
 			IQueryOver<Person> actual =
 				CreateTestQueryOver<Person>()
 					.ReadOnly();
+
+			AssertCriteriaAreEqual(expected, actual);
+		}
+
+		[Test]
+		public void SetTimeout()
+		{
+			var expected =
+				CreateTestCriteria(typeof(Person))
+					.SetTimeout(3);
+
+			var actual =
+				CreateTestQueryOver<Person>()
+					.SetTimeout(3);
+
+			AssertCriteriaAreEqual(expected, actual);
+		}
+
+		[Test]
+		public void SetFetchSize()
+		{
+			var expected =
+				CreateTestCriteria(typeof(Person))
+					.SetFetchSize(3);
+
+			var actual =
+				CreateTestQueryOver<Person>()
+					.SetFetchSize(3);
+
+			AssertCriteriaAreEqual(expected, actual);
+		}
+
+		[Test]
+		public void SetComment()
+		{
+			var expected =
+				CreateTestCriteria(typeof(Person))
+					.SetComment("blah");
+
+			var actual =
+				CreateTestQueryOver<Person>()
+					.SetComment("blah");
 
 			AssertCriteriaAreEqual(expected, actual);
 		}

--- a/src/NHibernate/QueryOverExtensions.cs
+++ b/src/NHibernate/QueryOverExtensions.cs
@@ -1,0 +1,42 @@
+namespace NHibernate
+{
+	// 6.0 TODO: merge into IQueryOver<TRoot>
+	public static class QueryOverExtensions
+	{
+		/// <summary>
+		/// Set a timeout for the underlying ADO.NET query.
+		/// </summary>
+		/// <param name="queryOver">The query on which to set the timeout.</param>
+		/// <param name="timeout">The timeout in seconds.</param>
+		/// <returns><see langword="this" /> (for method chaining).</returns>
+		public static IQueryOver<TRoot> SetTimeout<TRoot>(this IQueryOver<TRoot> queryOver, int timeout)
+		{
+			queryOver.RootCriteria.SetTimeout(timeout);
+			return queryOver;
+		}
+		
+		/// <summary>
+		/// Set a fetch size for the underlying ADO query.
+		/// </summary>
+		/// <param name="queryOver">The query on which to set the timeout.</param>
+		/// <param name="fetchSize">The fetch size.</param>
+		/// <returns><see langword="this" /> (for method chaining).</returns>
+		public static IQueryOver<TRoot> SetFetchSize<TRoot>(this IQueryOver<TRoot> queryOver, int fetchSize)
+		{
+			queryOver.RootCriteria.SetFetchSize(fetchSize);
+			return queryOver;
+		}
+
+		/// <summary>
+		/// Add a comment to the generated SQL.
+		/// </summary>
+		/// <param name="queryOver">The query on which to set the timeout.</param>
+		/// <param name="comment">A human-readable string.</param>
+		/// <returns><see langword="this" /> (for method chaining).</returns>
+		public static IQueryOver<TRoot> SetComment<TRoot>(this IQueryOver<TRoot> queryOver, string comment)
+		{
+			queryOver.RootCriteria.SetComment(comment);
+			return queryOver;
+		}
+	}
+}

--- a/src/NHibernate/QueryOverExtensions.cs
+++ b/src/NHibernate/QueryOverExtensions.cs
@@ -9,7 +9,7 @@ namespace NHibernate
 		/// <param name="queryOver">The query on which to set the timeout.</param>
 		/// <param name="timeout">The timeout in seconds.</param>
 		/// <returns><see langword="this" /> (for method chaining).</returns>
-		public static IQueryOver<TRoot> SetTimeout<TRoot>(this IQueryOver<TRoot> queryOver, int timeout)
+		public static TQueryOver SetTimeout<TQueryOver>(this TQueryOver queryOver, int timeout) where TQueryOver: IQueryOver
 		{
 			queryOver.RootCriteria.SetTimeout(timeout);
 			return queryOver;
@@ -21,7 +21,7 @@ namespace NHibernate
 		/// <param name="queryOver">The query on which to set the timeout.</param>
 		/// <param name="fetchSize">The fetch size.</param>
 		/// <returns><see langword="this" /> (for method chaining).</returns>
-		public static IQueryOver<TRoot> SetFetchSize<TRoot>(this IQueryOver<TRoot> queryOver, int fetchSize)
+		public static TQueryOver SetFetchSize<TQueryOver>(this TQueryOver queryOver, int fetchSize) where TQueryOver: IQueryOver
 		{
 			queryOver.RootCriteria.SetFetchSize(fetchSize);
 			return queryOver;
@@ -33,7 +33,7 @@ namespace NHibernate
 		/// <param name="queryOver">The query on which to set the timeout.</param>
 		/// <param name="comment">A human-readable string.</param>
 		/// <returns><see langword="this" /> (for method chaining).</returns>
-		public static IQueryOver<TRoot> SetComment<TRoot>(this IQueryOver<TRoot> queryOver, string comment)
+		public static TQueryOver SetComment<TQueryOver>(this TQueryOver queryOver, string comment) where TQueryOver: IQueryOver
 		{
 			queryOver.RootCriteria.SetComment(comment);
 			return queryOver;

--- a/src/NHibernate/QueryOverExtensions.cs
+++ b/src/NHibernate/QueryOverExtensions.cs
@@ -1,6 +1,7 @@
 namespace NHibernate
 {
-	// 6.0 TODO: merge into IQueryOver<TRoot>
+	// 6.0 TODO: consider moving other criteria delegated methods to extension methods.
+	// It may allow better return typing for chaining, and it is slightly less code.
 	public static class QueryOverExtensions
 	{
 		/// <summary>


### PR DESCRIPTION
Fix #2270

Fix it by adding the missing options as extension methods, rather than documenting getting them through the underlying criteria. If that is accepted, then #2270 should be rewritten a bit.

Adds `SetTimeout`, `SetFetchSize`, `SetComment`.

It seems the `IQueryOver` interface tends to drop the `Set` prefix. Should theses extension methods do the same? It does not look to me as a proper convention, since methods are supposed to start with a verb. But if it is preferred to keep dropping the verb for the interface consistency, I will do.