### PR TITLE
Make persistent collection classes implement the IReadOnly* interfaces

### DIFF
--- a/src/NHibernate.Test/CollectionTest/PersistentCollectionsFixture.cs
+++ b/src/NHibernate.Test/CollectionTest/PersistentCollectionsFixture.cs
@@ -36,5 +36,22 @@ namespace NHibernate.Test.CollectionTest
 			
 			Assert.That(items, Is.EqualTo(new[] {"A", "B", "C", "D", "E"}));
 		}
+
+		[Test]
+		public void SelectManyWorksCorrectlyWithIReadOnlyCollection()
+		{
+			var bags = new IReadOnlyCollection<string>[]
+			{
+				new List<string> {"A"},
+				new PersistentGenericBag<string>(null, new[] {"B"}),
+				new PersistentIdentifierBag<string>(null, new[] {"C"}),
+				(IReadOnlyList<string>)new PersistentGenericList<string>(null, new[] {"D"}),
+				new PersistentGenericSet<string>(null, new HashSet<string> {"E"})
+			};
+			
+			var items = bags.SelectMany(b => b).ToArray();
+
+			Assert.That(items, Is.EqualTo(new[] {"A", "B", "C", "D", "E"}));
+		}
 	}
 }

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class PersistentGenericBag<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
+	public partial class PersistentGenericBag<T> : AbstractPersistentCollection, IList<T>, IReadOnlyList<T>, IList, IQueryable<T>
 	{
 
 		public override async Task<object> DisassembleAsync(ICollectionPersister persister, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericIdentifierBag.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericIdentifierBag.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class PersistentIdentifierBag<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
+	public partial class PersistentIdentifierBag<T> : AbstractPersistentCollection, IList<T>, IReadOnlyList<T>, IList, IQueryable<T>
 	{
 
 		/// <summary>

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericList.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class PersistentGenericList<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
+	public partial class PersistentGenericList<T> : AbstractPersistentCollection, IList<T>, IReadOnlyList<T>, IList, IQueryable<T>
 	{
 
 		//Since 5.3

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericMap.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class PersistentGenericMap<TKey, TValue> : AbstractPersistentCollection, IDictionary<TKey, TValue>, ICollection
+	public partial class PersistentGenericMap<TKey, TValue> : AbstractPersistentCollection, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, ICollection
 	{
 
 		//Since 5.3

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericSet.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericSet.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Collection.Generic
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class PersistentGenericSet<T> : AbstractPersistentCollection, ISet<T>, IQueryable<T>
+	public partial class PersistentGenericSet<T> : AbstractPersistentCollection, ISet<T>, IReadOnlyCollection<T>, IQueryable<T>
 	{
 
 		//Since 5.3

--- a/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Collection.Generic
 	/// <remarks>The underlying collection used is an <see cref="List{T}"/></remarks>
 	[Serializable]
 	[DebuggerTypeProxy(typeof (CollectionProxy<>))]
-	public partial class PersistentGenericBag<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
+	public partial class PersistentGenericBag<T> : AbstractPersistentCollection, IList<T>, IReadOnlyList<T>, IList, IQueryable<T>
 	{
 		// TODO NH: find a way to writeonce (no duplicated code from PersistentBag)
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericIdentifierBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericIdentifierBag.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Collection.Generic
 	/// </remarks>
 	[Serializable]
 	[DebuggerTypeProxy(typeof (CollectionProxy<>))]
-	public partial class PersistentIdentifierBag<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
+	public partial class PersistentIdentifierBag<T> : AbstractPersistentCollection, IList<T>, IReadOnlyList<T>, IList, IQueryable<T>
 	{
 		/* NH considerations:
 		 * For various reason we know that the underlining type will be a List<T> or a 

--- a/src/NHibernate/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericList.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Collection.Generic
 	/// <remarks>The underlying collection used is a <see cref="List{T}"/></remarks>
 	[Serializable]
 	[DebuggerTypeProxy(typeof (CollectionProxy<>))]
-	public partial class PersistentGenericList<T> : AbstractPersistentCollection, IList<T>, IList, IQueryable<T>
+	public partial class PersistentGenericList<T> : AbstractPersistentCollection, IList<T>, IReadOnlyList<T>, IList, IQueryable<T>
 	{
 		protected IList<T> WrappedList;
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
@@ -369,7 +369,6 @@ namespace NHibernate.Collection.Generic
 		{
 			get { return Values; }
 		}
-		
 
 		#endregion
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Collection.Generic
 	/// <typeparam name="TValue">The type of the elements in the IDictionary.</typeparam>
 	[Serializable]
 	[DebuggerTypeProxy(typeof(DictionaryProxy<,>))]
-	public partial class PersistentGenericMap<TKey, TValue> : AbstractPersistentCollection, IDictionary<TKey, TValue>, ICollection
+	public partial class PersistentGenericMap<TKey, TValue> : AbstractPersistentCollection, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, ICollection
 	{
 		protected IDictionary<TKey, TValue> WrappedMap;
 		private readonly ICollection<TValue> _wrappedValues;
@@ -359,6 +359,17 @@ namespace NHibernate.Collection.Generic
 				return _wrappedValues;
 			}
 		}
+
+		IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+		{
+			get { return Keys; }
+		}
+
+		IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+		{
+			get { return Values; }
+		}
+		
 
 		#endregion
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericSet.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericSet.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Collection.Generic
 	/// </summary>
 	[Serializable]
 	[DebuggerTypeProxy(typeof(CollectionProxy<>))]
-	public partial class PersistentGenericSet<T> : AbstractPersistentCollection, ISet<T>, IQueryable<T>
+	public partial class PersistentGenericSet<T> : AbstractPersistentCollection, ISet<T>, IReadOnlyCollection<T>, IQueryable<T>
 	{
 		/// <summary>
 		/// The <see cref="ISet{T}"/> that NHibernate is wrapping.

--- a/src/NHibernate/Collection/Generic/SetHelpers/ISetSnapshot.cs
+++ b/src/NHibernate/Collection/Generic/SetHelpers/ISetSnapshot.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace NHibernate.Collection.Generic.SetHelpers
 {
-	internal interface ISetSnapshot<T> : ICollection<T>, ICollection
+	internal interface ISetSnapshot<T> : ICollection<T>, IReadOnlyCollection<T>, ICollection
 	{
 		bool TryGetValue(T element, out T value);
 	}

--- a/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
+++ b/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
@@ -83,6 +83,11 @@ namespace NHibernate.Collection.Generic.SetHelpers
 			get { return _elements.Count; }
 		}
 
+		int IReadOnlyCollection<T>.Count
+		{
+			get { return _elements.Count; }
+		}
+
 		public bool IsReadOnly
 		{
 			get { return ((ICollection<T>)_elements).IsReadOnly; }


### PR DESCRIPTION
## Issue

Currently the `PersistentGenericBag`/List/etc. classes that NHibernate uses only implement the `IList<T>` or `ICollection<T>` interface, but not the readonly `IReadOnlyList<T>` / `IReadOnlyCollection<T>` interfaces. Unfortunately the read/write interfaces [do not inherit](https://stackoverflow.com/a/35940240/10614791) the readonly ones. This in turn makes using such properties in my model classes illegal.

Example code:
```
public virtual IReadOnlyCollection<ShippingAddress> ShippingAddresses { get; protected set; }
```
This throws at runtime:
> System.InvalidCastException: Unable to cast object of type 'NHibernate.Collection.Generic.PersistentGenericBag`1[MyProject.Domain.Entities.BillingAddress]' to type 'System.Collections.Generic.IReadOnlyCollection`1[MyProject.Domain.Entities.BillingAddress]'

## Solution

I made sure all of our custom persistent **collection classes implement the `IReadOnly*` counterpart** as well.

At most places I only had to add the the interface, all methods / properties were already implemented by the implementation for the mutable interface. Where there were missing properties I implemented them using an explicit interface implementation so **no change in the collection's public interface has been made** other than the added interface implementation.

## Remark

This is my first contribution to this repo. I tried to follow all the guidelines and existing coding style, but if there is anything I need to change, I welcome all feedback.