### PR TITLE
Allow customizing 'alias to bean' property not found behavior

### DIFF
--- a/src/NHibernate/Transform/AliasToBeanResultTransformer.cs
+++ b/src/NHibernate/Transform/AliasToBeanResultTransformer.cs
@@ -109,6 +109,11 @@ namespace NHibernate.Transform
 			return collection;
 		}
 
+		protected virtual void OnPropertyNotFound(string propertyName)
+		{
+			throw new PropertyNotFoundException(_resultClass.GetType(), propertyName, "setter");
+		}
+
 		#region Setter resolution
 
 		/// <summary>
@@ -136,7 +141,7 @@ namespace NHibernate.Transform
 			if (TrySet(alias, value, resultObj, _fieldsByNameCaseInsensitive))
 				return;
 
-			throw new PropertyNotFoundException(resultObj.GetType(), alias, "setter");
+			OnPropertyNotFound(alias);
 		}
 
 		private bool TrySet(string alias, object value, object resultObj, Dictionary<string, NamedMember<FieldInfo>> fieldsMap)


### PR DESCRIPTION
## Scenario
A developer updates a stored procedure to return an additional column; this is generally expected to be a safe change.

The default behavior of `AliasToBeanResultTransformer` is to throw an exception when a value is observed but there is no field/property on the target instance to accept the value.

This change retains the existing behavior, but allows for specialization.

Here was the temporary workaround that I came up with which can be greatly simplified.

### Before
```c#
        class PartialAliasToBeanResultTransformer<T> : AliasToBeanResultTransformer
        {
            readonly MethodInfo _setPropertyMethod;
            public PartialAliasToBeanResultTransformer() : base(typeof(T))
            {
                _setPropertyMethod = typeof(AliasToBeanResultTransformer).GetMethod("SetProperty", BindingFlags.NonPublic | BindingFlags.Instance);
            }

            public override object TransformTuple(object[] tuple, string[] aliases)
            {
                var result = ResultClass.IsClass
                    ? BeanConstructor.Invoke(null)
                    : Activator.CreateInstance(ResultClass, true);

                for (int i = 0; i < aliases.Length; i++)
                {
                    SetPropertyHelper(aliases[i], tuple[i], result);
                }

                return result;
            }

            static Type ResultClass => typeof(T);
            static ConstructorInfo BeanConstructor => ResultClass
                .GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                    null,
                    Type.EmptyTypes,
                    null);

            void SetPropertyHelper(string alias, object value, object resultObj)
            {
                try
                {
                    _setPropertyMethod.Invoke(this, new object[] {alias, value, resultObj});
                }
                catch (TargetInvocationException ex)
                {
                    if (!(ex.InnerException is PropertyNotFoundException))
                    {
                        throw;
                    }
                }
            }
        }
```

### After
```c#
        class PartialAliasToBeanResultTransformer<T> : AliasToBeanResultTransformer
        {
            protected override void OnPropertyNotFound(string propertyName)
            {
            }
        }
```