### PR TITLE
Proper query plan caching for DML LINQ queries

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ConstantTest.cs
+++ b/src/NHibernate.Test/Async/Linq/ConstantTest.cs
@@ -237,7 +237,6 @@ namespace NHibernate.Test.Linq
 			}
 		}
 
-		[KnownBug("GH-2222")]
 		[Test]
 		public async Task DmlPlansAreCachedAsync()
 		{
@@ -279,7 +278,7 @@ namespace NHibernate.Test.Linq
 								.And.Not.Contain("Constant1"),
 							"Unexpected constant parameter value");
 						Assert.That(
-							sqlEvents[1].RenderedMessage,
+							sqlEvents[2].RenderedMessage,
 							Does.Contain("UNKNOWN").And.Contain("Constant2").And.Contain("ContactName").IgnoreCase
 								.And.Not.Contain("Constant1"),
 							"Unexpected constant parameter value");

--- a/src/NHibernate.Test/Linq/ConstantTest.cs
+++ b/src/NHibernate.Test/Linq/ConstantTest.cs
@@ -258,7 +258,6 @@ namespace NHibernate.Test.Linq
 			}
 		}
 
-		[KnownBug("GH-2222")]
 		[Test]
 		public void DmlPlansAreCached()
 		{
@@ -300,7 +299,7 @@ namespace NHibernate.Test.Linq
 								.And.Not.Contain("Constant1"),
 							"Unexpected constant parameter value");
 						Assert.That(
-							sqlEvents[1].RenderedMessage,
+							sqlEvents[2].RenderedMessage,
 							Does.Contain("UNKNOWN").And.Contain("Constant2").And.Contain("ContactName").IgnoreCase
 								.And.Not.Contain("Constant1"),
 							"Unexpected constant parameter value");

--- a/src/NHibernate/Linq/NhLinqExpression.cs
+++ b/src/NHibernate/Linq/NhLinqExpression.cs
@@ -88,16 +88,13 @@ namespace NHibernate.Linq
 
 			ParameterDescriptors = requiredHqlParameters.AsReadOnly();
 
-			if (QueryMode == QueryMode.Select && CanCachePlan)
-			{
-				CanCachePlan =
-					// If some constants do not have matching HQL parameters, their values from first query will
-					// be embedded in the plan and reused for subsequent queries: do not cache the plan.
-					!ParameterValuesByName
+			CanCachePlan = CanCachePlan &&
+				// If some constants do not have matching HQL parameters, their values from first query will
+				// be embedded in the plan and reused for subsequent queries: do not cache the plan.
+				!ParameterValuesByName
 					.Keys
 					.Except(requiredHqlParameters.Select(p => p.Name))
 					.Any();
-			}
 
 			// The ast node may be altered by caller, duplicate it for preserving the original one.
 			return DuplicateTree(ExpressionToHqlTranslationResults.Statement.AstNode);


### PR DESCRIPTION
Properly fixes #2222  by including modified property names in to query key (see https://github.com/nhibernate/nhibernate-core/pull/2300#issuecomment-570933604 for details)