### PR TITLE
Do not cache ExpandedQueryExpression query plan if it's based on not cacheable query expression 

### DIFF
--- a/src/NHibernate.Test/Linq/ConstantTest.cs
+++ b/src/NHibernate.Test/Linq/ConstantTest.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NHibernate.Criterion;
 using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Engine.Query;
+using NHibernate.Linq;
 using NHibernate.Linq.Visitors;
 using NHibernate.Util;
 using NUnit.Framework;
@@ -275,6 +277,63 @@ namespace NHibernate.Test.Linq
 				cache,
 				Has.Count.EqualTo(0),
 				"Query plan should not be cached.");
+		}
+
+		[Test]
+		public void PlansWithNonParameterizedConstantsAreNotCachedForExpandedQuery()
+		{
+			var queryPlanCacheType = typeof(QueryPlanCache);
+
+			var cache = (SoftLimitMRUCache)
+				queryPlanCacheType
+					.GetField("planCache", BindingFlags.Instance | BindingFlags.NonPublic)
+					.GetValue(Sfi.QueryPlanCache);
+			cache.Clear();
+
+			var ids = new[] {"ANATR", "UNKNOWN"}.ToList();
+			db.Customers.Where(x => ids.Contains(x.CustomerId)).Select(
+				c => new {c.CustomerId, c.ContactName, Constant = 1}).First();
+
+			Assert.That(
+				cache,
+				Has.Count.EqualTo(0),
+				"Query plan should not be cached.");
+		}
+
+		//GH-2298 - Different Update queries - same query cache plan
+		[Test]
+		public void DmlPlansForExpandedQuery()
+		{
+			var queryPlanCacheType = typeof(QueryPlanCache);
+
+			var cache = (SoftLimitMRUCache)
+				queryPlanCacheType
+					.GetField("planCache", BindingFlags.Instance | BindingFlags.NonPublic)
+					.GetValue(Sfi.QueryPlanCache);
+			cache.Clear();
+
+			using (session.BeginTransaction())
+			{
+				var list = new[] {"UNKNOWN", "UNKNOWN2"}.ToList();
+				db.Customers.Where(x => list.Contains(x.CustomerId)).Update(
+					x => new Customer
+					{
+						CompanyName = "Constant1"
+					});
+
+				db.Customers.Where(x => list.Contains(x.CustomerId))
+				.Update(
+					x => new Customer
+					{
+						ContactName = "Constant1"
+					});
+
+				Assert.That(
+					cache.Count,
+					//2 original queries + 2 expanded queries are expected in cache
+					Is.EqualTo(0).Or.EqualTo(4),
+					"Query plans should either be cached separately or not cached at all.");
+			}
 		}
 	}
 }

--- a/src/NHibernate/Engine/Query/QueryPlanCache.cs
+++ b/src/NHibernate/Engine/Query/QueryPlanCache.cs
@@ -62,7 +62,7 @@ namespace NHibernate.Engine.Query
 				}
 				plan = new QueryExpressionPlan(queryExpression, shallow, enabledFilters, factory);
 				// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
-				if (!(queryExpression is NhLinqExpression linqExpression) || linqExpression.CanCachePlan)
+				if (!(queryExpression is ICacheableQueryExpression linqExpression) || linqExpression.CanCachePlan)
 					planCache.Put(key, plan);
 				else
 					log.Debug("Query plan not cacheable");
@@ -117,7 +117,7 @@ namespace NHibernate.Engine.Query
 				log.Debug("unable to locate collection-filter query plan in cache; generating ({0} : {1})", collectionRole, queryExpression.Key);
 				plan = new FilterQueryPlan(queryExpression, collectionRole, shallow, enabledFilters, factory);
 				// 6.0 TODO: add "CanCachePlan { get; }" to IQueryExpression interface
-				if (!(queryExpression is NhLinqExpression linqExpression) || linqExpression.CanCachePlan)
+				if (!(queryExpression is ICacheableQueryExpression linqExpression) || linqExpression.CanCachePlan)
 					planCache.Put(key, plan);
 				else
 					log.Debug("Query plan not cacheable");

--- a/src/NHibernate/IQueryExpression.cs
+++ b/src/NHibernate/IQueryExpression.cs
@@ -5,6 +5,12 @@ using NHibernate.Hql.Ast.ANTLR.Tree;
 
 namespace NHibernate
 {
+	//TODO 6.0: Merge into IQueryExpression
+	internal interface ICacheableQueryExpression
+	{
+		bool CanCachePlan { get; }
+	}
+
 	public interface IQueryExpression
 	{
 		IASTNode Translate(ISessionFactoryImplementor sessionFactory, bool filter);

--- a/src/NHibernate/Impl/ExpressionQueryImpl.cs
+++ b/src/NHibernate/Impl/ExpressionQueryImpl.cs
@@ -150,9 +150,10 @@ namespace NHibernate.Impl
 		}
 	}
 
-	internal class ExpandedQueryExpression : IQueryExpression
+	internal class ExpandedQueryExpression : IQueryExpression, ICacheableQueryExpression
 	{
 		private readonly IASTNode _tree;
+		private ICacheableQueryExpression _cacheableExpression;
 
 		public ExpandedQueryExpression(IQueryExpression queryExpression, IASTNode tree, string key)
 		{
@@ -160,6 +161,7 @@ namespace NHibernate.Impl
 			Key = key;
 			Type = queryExpression.Type;
 			ParameterDescriptors = queryExpression.ParameterDescriptors;
+			 _cacheableExpression = queryExpression as ICacheableQueryExpression;
 		}
 
 		#region IQueryExpression Members
@@ -176,6 +178,8 @@ namespace NHibernate.Impl
 		public IList<NamedParameterDescriptor> ParameterDescriptors { get; private set; }
 
 		#endregion
+
+		public bool CanCachePlan => _cacheableExpression?.CanCachePlan ?? true;
 	}
 
 	internal class ParameterExpander

--- a/src/NHibernate/Linq/NhLinqExpression.cs
+++ b/src/NHibernate/Linq/NhLinqExpression.cs
@@ -11,7 +11,7 @@ using NHibernate.Type;
 
 namespace NHibernate.Linq
 {
-	public class NhLinqExpression : IQueryExpression
+	public class NhLinqExpression : IQueryExpression, ICacheableQueryExpression
 	{
 		public string Key { get; protected set; }
 


### PR DESCRIPTION
Fixes #2298. Do not cache `ExpandedQueryExpression` query plan  if it's based on not cacheable query expression

It fixes regression since 5.1 with possible execution of wrong DML query for queries with parameters list (details [here](https://github.com/nhibernate/nhibernate-core/issues/2298#issuecomment-571547485))

In master branch it depends on #2299 (already merged)

And async code should be re-genarated when merging to master (as test for UpdateAsync is not generated in  5.2)