### PR TITLE
Backport sqlite.binaryguid to configuration schema

### DIFF
--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -200,6 +200,18 @@
 												</xs:documentation>
 											</xs:annotation>
 										</xs:enumeration>
+										<xs:enumeration value="sqlite.binaryguid">
+											<xs:annotation>
+												<xs:documentation>
+													SQLite can store GUIDs in binary or text form, controlled by the BinaryGuid
+													connection string parameter (default is 'true'). The BinaryGuid setting will affect
+													how to cast GUID to string in SQL. NHibernate will attempt to detect this
+													setting automatically from the connection string, but if the connection
+													or connection string is being handled by the application instead of by NHibernate,
+													you can use the 'sqlite.binaryguid' NHibernate setting to override the behavior.
+												</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
 										<xs:enumeration value="sql_types.keep_datetime">
 											<xs:annotation>
 												<xs:documentation>


### PR DESCRIPTION
(cherry picked from commit 23df8cdd24ac73bf07d03d1c36e450e8a717b445)

Backport of this #2245 fix done in master for a incomplete 5.2x fix. This defect was not considered worth a release on its own. But now we have to release a fix for a regression (#2300), so why not back-porting it.