### PR TITLE
Add logging for QueryBatch similar to Loader.DoQuery

### DIFF
--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -34,6 +34,7 @@ namespace NHibernate.Multi
 
 			var dialect = Session.Factory.Dialect;
 			var hydratedObjects = new List<object>[_queryInfos.Count];
+			var isDebugLog = Log.IsDebugEnabled();
 
 			using (Session.SwitchCacheMode(_cacheMode))
 			{
@@ -76,8 +77,15 @@ namespace NHibernate.Multi
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
 
-					for (var count = 0; count < maxRows && await (reader.ReadAsync(cancellationToken)).ConfigureAwait(false); count++)
+					if (isDebugLog)
+						Log.Debug("processing result set");
+
+					int count;
+					for (count = 0; count < maxRows && await (reader.ReadAsync(cancellationToken)).ConfigureAwait(false); count++)
 					{
+						if (isDebugLog)
+							Log.Debug("result set row: {0}", count);
+
 						rowCount++;
 
 						var o =
@@ -100,6 +108,9 @@ namespace NHibernate.Multi
 
 						tmpResults.Add(o);
 					}
+
+					if (isDebugLog)
+						Log.Debug("done processing result set ({0} rows)", count);
 
 					queryInfo.Result = tmpResults;
 					if (queryInfo.CanPutToCache)


### PR DESCRIPTION
Fixes #2296 
Added logging from [`Loader.DoQuery`](https://github.com/nhibernate/nhibernate-core/blob/df6cbbe12bb00f22fab1fc0ad024a1b1a2f13a8c/src/NHibernate/Loader/Loader.cs#L505-L534) to QueryBatch

We might also fix this one in 5.2.

It's not exactly a regression as debug logging is not a public API.  And this logging is not present for criteria `MultiCriteriaImpl` but only in `MultiQueryImpl`.
But I agree logging for `List()` and for `Future().List()`  should be the same if possible.
And this logging is missing for hql Future queries in 5.2 - so might be considered as regression.

What do you think?