### PR TITLE
Fix transaction leak

### DIFF
--- a/src/NHibernate.Test/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/BatcherFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NUnit.Framework;
@@ -44,11 +43,11 @@ namespace NHibernate.Test.Ado
 		private void Cleanup()
 		{
 			using (ISession s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.CreateQuery("delete from VerySimple").ExecuteUpdate();
 				s.CreateQuery("delete from AlmostSimple").ExecuteUpdate();
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Ado/GenericBatchingBatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/GenericBatchingBatcherFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using NHibernate.AdoNet;
@@ -229,10 +228,10 @@ namespace NHibernate.Test.Ado
 		private void Cleanup()
 		{
 			using (var s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.CreateQuery("delete from VerySimple").ExecuteUpdate();
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Any/AnyTypeTest.cs
+++ b/src/NHibernate.Test/Any/AnyTypeTest.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Any
@@ -24,30 +23,36 @@ namespace NHibernate.Test.Any
 		[Test]
 		public void FlushProcessing()
 		{
+			var person = new Person();
+			var address = new Address();
 			//http://opensource.atlassian.com/projects/hibernate/browse/HHH-1663
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			Person person = new Person();
-			Address address = new Address();
-			person.Data = address;
-			session.SaveOrUpdate(person);
-			session.SaveOrUpdate(address);
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				person.Data = address;
+				session.SaveOrUpdate(person);
+				session.SaveOrUpdate(address);
+				tran.Commit();
+				session.Close();
+			}
 
-			session = OpenSession();
-			session.BeginTransaction();
-			person = (Person) session.Load(typeof (Person), person.Id);
-			person.Name = "makingpersondirty";
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				person = (Person) session.Load(typeof(Person), person.Id);
+				person.Name = "makingpersondirty";
+				tran.Commit();
+				session.Close();
+			}
 
-			session = OpenSession();
-			session.BeginTransaction();
-			session.Delete(person);
-			session.Delete(address);
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Delete(person);
+				session.Delete(address);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NUnit.Framework;
@@ -56,11 +55,11 @@ namespace NHibernate.Test.Ado
 		private async Task CleanupAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			using (ISession s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.CreateQuery("delete from VerySimple").ExecuteUpdateAsync(cancellationToken));
 				await (s.CreateQuery("delete from AlmostSimple").ExecuteUpdateAsync(cancellationToken));
-				await (s.Transaction.CommitAsync(cancellationToken));
+				await (t.CommitAsync(cancellationToken));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Ado/GenericBatchingBatcherFixture.cs
+++ b/src/NHibernate.Test/Async/Ado/GenericBatchingBatcherFixture.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using NHibernate.AdoNet;
@@ -241,10 +240,10 @@ namespace NHibernate.Test.Ado
 		private async Task CleanupAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			using (var s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.CreateQuery("delete from VerySimple").ExecuteUpdateAsync(cancellationToken));
-				await (s.Transaction.CommitAsync(cancellationToken));
+				await (t.CommitAsync(cancellationToken));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Any/AnyTypeTest.cs
+++ b/src/NHibernate.Test/Async/Any/AnyTypeTest.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Any
@@ -35,30 +34,36 @@ namespace NHibernate.Test.Any
 		[Test]
 		public async Task FlushProcessingAsync()
 		{
+			var person = new Person();
+			var address = new Address();
 			//http://opensource.atlassian.com/projects/hibernate/browse/HHH-1663
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			Person person = new Person();
-			Address address = new Address();
-			person.Data = address;
-			await (session.SaveOrUpdateAsync(person));
-			await (session.SaveOrUpdateAsync(address));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				person.Data = address;
+				await (session.SaveOrUpdateAsync(person));
+				await (session.SaveOrUpdateAsync(address));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
-			session = OpenSession();
-			session.BeginTransaction();
-			person = (Person) await (session.LoadAsync(typeof (Person), person.Id));
-			person.Name = "makingpersondirty";
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				person = (Person) await (session.LoadAsync(typeof(Person), person.Id));
+				person.Name = "makingpersondirty";
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
-			session = OpenSession();
-			session.BeginTransaction();
-			await (session.DeleteAsync(person));
-			await (session.DeleteAsync(address));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				await (session.DeleteAsync(person));
+				await (session.DeleteAsync(address));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Cascade/Circle/MultiPathCircleCascadeTest.cs
+++ b/src/NHibernate.Test/Async/Cascade/Circle/MultiPathCircleCascadeTest.cs
@@ -166,21 +166,21 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.MergeAsync(route));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(1);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = await (s.GetAsync<Route>(route.RouteId));
 				CheckResults(route, true);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 
@@ -192,23 +192,23 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Node pickupNode = route.Nodes.First(n => n.Name == "pickupNodeB");
 				pickupNode = (Node) await (s.MergeAsync(pickupNode));
 
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = await (s.GetAsync<Route>(route.RouteId));
 				CheckResults(route, false);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 
@@ -220,22 +220,22 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Node deliveryNode = route.Nodes.First(n => n.Name == "deliveryNodeB");
 				deliveryNode = (Node) await (s.MergeAsync(deliveryNode));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = await (s.GetAsync<Route>(route.RouteId));
 				CheckResults(route, false);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 
@@ -247,21 +247,21 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Tour tour = await (s.MergeAsync(route.Nodes.First().Tour));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = await (s.GetAsync<Route>(route.RouteId));
 				CheckResults(route, false);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 		
@@ -273,7 +273,7 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Node node = route.Nodes.First();
 				Transport transport = null;
@@ -285,18 +285,18 @@ namespace NHibernate.Test.Cascade.Circle
 
 				transport = (Transport) await (s.MergeAsync(transport));
 
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 	
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = await (s.GetAsync<Route>(route.RouteId));
 				CheckResults(route, false);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 
@@ -304,12 +304,12 @@ namespace NHibernate.Test.Cascade.Circle
 		{
 			Route route = new Route();
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route.Name = "routeA";
 
 				await (s.SaveAsync(route, cancellationToken));
-				await (s.Transaction.CommitAsync(cancellationToken));
+				await (t.CommitAsync(cancellationToken));
 			}
 			route.Name = "new routeA";
 			route.TransientField = "sfnaouisrbn";

--- a/src/NHibernate.Test/Async/Cascade/MultiPathCascadeTest.cs
+++ b/src/NHibernate.Test/Async/Cascade/MultiPathCascadeTest.cs
@@ -36,20 +36,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = await (s.MergeAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 	
 			await (this.VerifyModificationsAsync(a.Id));
@@ -61,22 +61,22 @@ namespace NHibernate.Test.Cascade
 			// persist a simple A in the database
 			A a = new A();
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				A aLoaded = await (s.LoadAsync<A>(a.Id));
 				Assert.That(aLoaded, Is.InstanceOf<INHibernateProxy>());
 				Assert.That(await (s.MergeAsync(a)), Is.SameAs(aLoaded));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 	
 			await (this.VerifyModificationsAsync(a.Id));
@@ -89,21 +89,21 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 	
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.UpdateAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			await (this.VerifyModificationsAsync(a.Id));
 		}
@@ -115,20 +115,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				// retrieve the previously saved instance from the database, and update it
 				a = await (s.GetAsync<A>(a.Id));
 				this.ModifyEntity(a);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			await (this.VerifyModificationsAsync(a.Id));
 		}
@@ -140,20 +140,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}	
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = await (s.MergeAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			await (this.VerifyModificationsAsync(a.Id));
 	
@@ -167,7 +167,7 @@ namespace NHibernate.Test.Cascade
 			h.Gs.Add(gNew);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				try
 				{
@@ -189,20 +189,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = (A) await (s.MergeAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			await (this.VerifyModificationsAsync(a.Id));
 	
@@ -238,20 +238,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				await (s.SaveAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = (A) await (s.MergeAsync(a));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			await (this.VerifyModificationsAsync(a.Id));
 	
@@ -317,7 +317,7 @@ namespace NHibernate.Test.Cascade
 		private async Task VerifyModificationsAsync(long aId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				// retrieve the A object and check it
 				A a = await (s.GetAsync<A>(aId, cancellationToken));
@@ -344,7 +344,7 @@ namespace NHibernate.Test.Cascade
 				Assert.That(hFromA.Gs.Count, Is.EqualTo(1));
 				Assert.That(hFromA.Gs.First(), Is.SameAs(gFromA));
 
-				await (s.Transaction.CommitAsync(cancellationToken));
+				await (t.CommitAsync(cancellationToken));
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/Cascade/RefreshFixture.cs
+++ b/src/NHibernate.Test/Async/Cascade/RefreshFixture.cs
@@ -9,9 +9,7 @@
 
 
 using System;
-using System.Collections;
 using System.Data;
-using System.Data.Common;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Cascade
@@ -70,7 +68,7 @@ namespace NHibernate.Test.Cascade
 				var cmd = conn.CreateCommand();
 				cmd.CommandText = "UPDATE T_JOB SET JOB_STATUS = 1";
 				cmd.CommandType = CommandType.Text;
-				session.Transaction.Enlist(cmd);
+				session.GetSessionImplementation().ConnectionManager.EnlistInTransaction(cmd);
 				return cmd.ExecuteNonQueryAsync(cancellationToken);
 			}
 			catch (Exception ex)

--- a/src/NHibernate.Test/Async/DynamicEntity/Interceptor/InterceptorDynamicEntity.cs
+++ b/src/NHibernate.Test/Async/DynamicEntity/Interceptor/InterceptorDynamicEntity.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Collections;
 using NHibernate.Cfg;
 using NUnit.Framework;
 
@@ -38,68 +37,78 @@ namespace NHibernate.Test.DynamicEntity.Interceptor
 		[Test]
 		public async Task ItAsync()
 		{
+			var company = ProxyHelper.NewCompanyProxy();
+			var customer = ProxyHelper.NewCustomerProxy();
 			// Test saving these dyna-proxies
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			Company company = ProxyHelper.NewCompanyProxy();
-			company.Name = "acme";
-			await (session.SaveAsync(company));
-			Customer customer = ProxyHelper.NewCustomerProxy();
-			customer.Name = "Steve";
-			customer.Company = company;
-			await (session.SaveAsync(customer));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				company.Name = "acme";
+				await (session.SaveAsync(company));
+				customer.Name = "Steve";
+				customer.Company = company;
+				await (session.SaveAsync(customer));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			Assert.IsNotNull(company.Id, "company id not assigned");
 			Assert.IsNotNull(customer.Id, "customer id not assigned");
 
 			// Test loading these dyna-proxies, along with flush processing
-			session = OpenSession();
-			session.BeginTransaction();
-			customer = await (session.LoadAsync<Customer>(customer.Id));
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				customer = await (session.LoadAsync<Customer>(customer.Id));
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
 
-			customer.Name = "other";
-			await (session.FlushAsync());
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
+				customer.Name = "other";
+				await (session.FlushAsync());
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
 
-			await (session.RefreshAsync(customer));
-			Assert.AreEqual("other", customer.Name, "name not updated");
-			Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
+				await (session.RefreshAsync(customer));
+				Assert.AreEqual("other", customer.Name, "name not updated");
+				Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
 
-			await (session.Transaction.CommitAsync());
-			session.Close();
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			// Test detached entity re-attachment with these dyna-proxies
 			customer.Name = "Steve";
-			session = OpenSession();
-			session.BeginTransaction();
-			await (session.UpdateAsync(customer));
-			await (session.FlushAsync());
-			await (session.RefreshAsync(customer));
-			Assert.AreEqual("Steve", customer.Name, "name not updated");
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				await (session.UpdateAsync(customer));
+				await (session.FlushAsync());
+				await (session.RefreshAsync(customer));
+				Assert.AreEqual("Steve", customer.Name, "name not updated");
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			// Test querying
-			session = OpenSession();
-			session.BeginTransaction();
-			int count = (await (session.CreateQuery("from Customer").ListAsync())).Count;
-			Assert.AreEqual(1, count, "querying dynamic entity");
-			session.Clear();
-			count = (await (session.CreateQuery("from Person").ListAsync())).Count;
-			Assert.AreEqual(1, count, "querying dynamic entity");
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				int count = (await (session.CreateQuery("from Customer").ListAsync())).Count;
+				Assert.AreEqual(1, count, "querying dynamic entity");
+				session.Clear();
+				count = (await (session.CreateQuery("from Person").ListAsync())).Count;
+				Assert.AreEqual(1, count, "querying dynamic entity");
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			// test deleteing
-			session = OpenSession();
-			session.BeginTransaction();
-			await (session.DeleteAsync(company));
-			await (session.DeleteAsync(customer));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				await (session.DeleteAsync(company));
+				await (session.DeleteAsync(customer));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/DynamicEntity/Tuplizer/TuplizerDynamicEntity.cs
+++ b/src/NHibernate.Test/Async/DynamicEntity/Tuplizer/TuplizerDynamicEntity.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Cfg;
 using NUnit.Framework;
@@ -39,30 +38,33 @@ namespace NHibernate.Test.DynamicEntity.Tuplizer
 		[Test]
 		public async Task ItAsync()
 		{
+			var company = ProxyHelper.NewCompanyProxy();
+			var customer = ProxyHelper.NewCustomerProxy();
+			var address = ProxyHelper.NewAddressProxy();
+			var son = ProxyHelper.NewPersonProxy();
+			var wife = ProxyHelper.NewPersonProxy();
+
 			// Test saving these dyna-proxies
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			Company company = ProxyHelper.NewCompanyProxy();
-			company.Name = "acme";
-			await (session.SaveAsync(company));
-			Customer customer = ProxyHelper.NewCustomerProxy();
-			customer.Name = "Steve";
-			customer.Company = company;
-			Address address = ProxyHelper.NewAddressProxy();
-			address.Street = "somewhere over the rainbow";
-			address.City = "lawerence, kansas";
-			address.PostalCode = "toto";
-			customer.Address = address;
-			customer.Family = new HashSet<Person>();
-			Person son = ProxyHelper.NewPersonProxy();
-			son.Name = "son";
-			customer.Family.Add(son);
-			Person wife = ProxyHelper.NewPersonProxy();
-			wife.Name = "wife";
-			customer.Family.Add(wife);
-			await (session.SaveAsync(customer));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				company.Name = "acme";
+				await (session.SaveAsync(company));
+				customer.Name = "Steve";
+				customer.Company = company;
+				address.Street = "somewhere over the rainbow";
+				address.City = "lawerence, kansas";
+				address.PostalCode = "toto";
+				customer.Address = address;
+				customer.Family = new HashSet<Person>();
+				son.Name = "son";
+				customer.Family.Add(son);
+				wife.Name = "wife";
+				customer.Family.Add(wife);
+				await (session.SaveAsync(customer));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			Assert.IsNotNull(company.Id, "company id not assigned");
 			Assert.IsNotNull(customer.Id, "customer id not assigned");
@@ -71,51 +73,59 @@ namespace NHibernate.Test.DynamicEntity.Tuplizer
 			Assert.IsNotNull(wife.Id, "wife:Person id not assigned");
 
 			// Test loading these dyna-proxies, along with flush processing
-			session = OpenSession();
-			session.BeginTransaction();
-			customer = await (session.LoadAsync<Customer>(customer.Id));
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				customer = await (session.LoadAsync<Customer>(customer.Id));
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
 
-			customer.Name = "other";
-			await (session.FlushAsync());
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
+				customer.Name = "other";
+				await (session.FlushAsync());
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
 
-			await (session.RefreshAsync(customer));
-			Assert.AreEqual("other", customer.Name, "name not updated");
-			Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
+				await (session.RefreshAsync(customer));
+				Assert.AreEqual("other", customer.Name, "name not updated");
+				Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
 
-			await (session.Transaction.CommitAsync());
-			session.Close();
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			// Test detached entity re-attachment with these dyna-proxies
 			customer.Name = "Steve";
-			session = OpenSession();
-			session.BeginTransaction();
-			await (session.UpdateAsync(customer));
-			await (session.FlushAsync());
-			await (session.RefreshAsync(customer));
-			Assert.AreEqual("Steve", customer.Name, "name not updated");
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				await (session.UpdateAsync(customer));
+				await (session.FlushAsync());
+				await (session.RefreshAsync(customer));
+				Assert.AreEqual("Steve", customer.Name, "name not updated");
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			// Test querying
-			session = OpenSession();
-			session.BeginTransaction();
-			int count = (await (session.CreateQuery("from Customer").ListAsync())).Count;
-			Assert.AreEqual(1, count, "querying dynamic entity");
-			session.Clear();
-			count = (await (session.CreateQuery("from Person").ListAsync())).Count;
-			Assert.AreEqual(3, count, "querying dynamic entity");
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				int count = (await (session.CreateQuery("from Customer").ListAsync())).Count;
+				Assert.AreEqual(1, count, "querying dynamic entity");
+				session.Clear();
+				count = (await (session.CreateQuery("from Person").ListAsync())).Count;
+				Assert.AreEqual(3, count, "querying dynamic entity");
+				await (tran.CommitAsync());
+				session.Close();
+			}
 
 			// test deleteing
-			session = OpenSession();
-			session.BeginTransaction();
-			await (session.DeleteAsync(company));
-			await (session.DeleteAsync(customer));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				await (session.DeleteAsync(company));
+				await (session.DeleteAsync(customer));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/ExceptionsTest/SQLExceptionConversionTest.cs
+++ b/src/NHibernate.Test/Async/ExceptionsTest/SQLExceptionConversionTest.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Collections;
 using System.Data;
 using System.Data.Common;
 using NHibernate.Dialect;
@@ -83,61 +82,65 @@ namespace NHibernate.Test.ExceptionsTest
 			//ISQLExceptionConverter converter = Dialect.BuildSQLExceptionConverter();
 			ISQLExceptionConverter converter = Sfi.Settings.SqlExceptionConverter;
 
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			var connection = session.Connection;
-
-			// Attempt to insert some bad values into the T_MEMBERSHIP table that should
-			// result in a constraint violation
-			DbCommand ps = null;
-			try
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				ps = connection.CreateCommand();
-				ps.CommandType = CommandType.Text;
-				ps.CommandText = "INSERT INTO T_MEMBERSHIP (user_id, group_id) VALUES (@p1, @p2)";
-				var pr = ps.CreateParameter();
-				pr.ParameterName = "p1";
-				pr.DbType = DbType.Int64;
-				pr.Value = 52134241L; // Non-existent user_id
-				ps.Parameters.Add(pr);
+				var connection = session.Connection;
 
-				pr = ps.CreateParameter();
-				pr.ParameterName = "p2";
-				pr.DbType = DbType.Int64;
-				pr.Value = 5342L; // Non-existent group_id
-				ps.Parameters.Add(pr);
-
-				session.Transaction.Enlist(ps);
-				await (ps.ExecuteNonQueryAsync());
-
-				Assert.Fail("INSERT should have failed");
-			}
-			catch (Exception sqle)
-			{
-				ADOExceptionReporter.LogExceptions(sqle, "Just output!!!!");
-				Exception adoException = converter.Convert(new AdoExceptionContextInfo{SqlException  = sqle});
-				Assert.AreEqual(typeof(ConstraintViolationException), adoException.GetType(),
-												"Bad conversion [" + sqle.Message + "]");
-				ConstraintViolationException ex = (ConstraintViolationException)adoException;
-				Console.WriteLine("Violated constraint name: " + ex.ConstraintName);
-			}
-			finally
-			{
-				if (ps != null)
+				// Attempt to insert some bad values into the T_MEMBERSHIP table that should
+				// result in a constraint violation
+				DbCommand ps = null;
+				try
 				{
-					try
+					ps = connection.CreateCommand();
+					ps.CommandType = CommandType.Text;
+					ps.CommandText = "INSERT INTO T_MEMBERSHIP (user_id, group_id) VALUES (@p1, @p2)";
+					var pr = ps.CreateParameter();
+					pr.ParameterName = "p1";
+					pr.DbType = DbType.Int64;
+					pr.Value = 52134241L; // Non-existent user_id
+					ps.Parameters.Add(pr);
+
+					pr = ps.CreateParameter();
+					pr.ParameterName = "p2";
+					pr.DbType = DbType.Int64;
+					pr.Value = 5342L; // Non-existent group_id
+					ps.Parameters.Add(pr);
+
+					tran.Enlist(ps);
+					await (ps.ExecuteNonQueryAsync());
+
+					Assert.Fail("INSERT should have failed");
+				}
+				catch (Exception sqle)
+				{
+					ADOExceptionReporter.LogExceptions(sqle, "Just output!!!!");
+					Exception adoException = converter.Convert(new AdoExceptionContextInfo { SqlException = sqle });
+					Assert.AreEqual(
+						typeof(ConstraintViolationException),
+						adoException.GetType(),
+						"Bad conversion [" + sqle.Message + "]");
+					ConstraintViolationException ex = (ConstraintViolationException) adoException;
+					Console.WriteLine("Violated constraint name: " + ex.ConstraintName);
+				}
+				finally
+				{
+					if (ps != null)
 					{
-						ps.Dispose();
-					}
-					catch (Exception)
-					{
-						// ignore...
+						try
+						{
+							ps.Dispose();
+						}
+						catch (Exception)
+						{
+							// ignore...
+						}
 					}
 				}
-			}
 
-			await (session.Transaction.RollbackAsync());
-			session.Close();
+				await (tran.RollbackAsync());
+				session.Close();
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Async/GeneratedTest/PartiallyGeneratedComponentTest.cs
+++ b/src/NHibernate.Test/Async/GeneratedTest/PartiallyGeneratedComponentTest.cs
@@ -8,10 +8,7 @@
 //------------------------------------------------------------------------------
 
 
-using System;
-
 using NHibernate.Dialect;
-
 using NUnit.Framework;
 
 namespace NHibernate.Test.GeneratedTest
@@ -27,7 +24,7 @@ namespace NHibernate.Test.GeneratedTest
 
 		protected override string[] Mappings
 		{
-			get { return new string[] { "GeneratedTest.ComponentOwner.hbm.xml" }; }
+			get { return new [] { "GeneratedTest.ComponentOwner.hbm.xml" }; }
 		}
 
 		protected override bool AppliesTo(Dialect.Dialect dialect)
@@ -39,34 +36,40 @@ namespace NHibernate.Test.GeneratedTest
 		public async Task PartialComponentGenerationAsync()
 		{
 			ComponentOwner owner = new ComponentOwner("initial");
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			await (s.SaveAsync(owner));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				await (s.SaveAsync(owner));
+				await (t.CommitAsync());
+				s.Close();
+			}
 
 			Assert.IsNotNull(owner.Component, "expecting insert value generation");
 			int previousValue = owner.Component.Generated;
 			Assert.AreNotEqual(0, previousValue, "expecting insert value generation");
 
-			s = OpenSession();
-			s.BeginTransaction();
-			owner = (ComponentOwner) await (s.GetAsync(typeof(ComponentOwner), owner.Id));
-			Assert.AreEqual(previousValue, owner.Component.Generated, "expecting insert value generation");
-			owner.Name = "subsequent";
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				owner = (ComponentOwner) await (s.GetAsync(typeof(ComponentOwner), owner.Id));
+				Assert.AreEqual(previousValue, owner.Component.Generated, "expecting insert value generation");
+				owner.Name = "subsequent";
+				await (t.CommitAsync());
+				s.Close();
+			}
 
 			Assert.IsNotNull(owner.Component);
 			previousValue = owner.Component.Generated;
 
-			s = OpenSession();
-			s.BeginTransaction();
-			owner = (ComponentOwner) await (s.GetAsync(typeof(ComponentOwner), owner.Id));
-			Assert.AreEqual(previousValue, owner.Component.Generated, "expecting update value generation");
-			await (s.DeleteAsync(owner));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				owner = (ComponentOwner) await (s.GetAsync(typeof(ComponentOwner), owner.Id));
+				Assert.AreEqual(previousValue, owner.Component.Generated, "expecting update value generation");
+				await (s.DeleteAsync(owner));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
+++ b/src/NHibernate.Test/Async/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NHibernate.Cfg;
 using NUnit.Framework;
 
@@ -42,15 +41,17 @@ namespace NHibernate.Test.Generatedkeys.Identity
 		[Test]
 		public async Task IdentityColumnGeneratedIdsAsync()
 		{
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			MyEntity myEntity = new MyEntity("test");
-			long id = (long)await (s.SaveAsync(myEntity));
-			Assert.IsNotNull(id,"identity column did not force immediate insert");
-			Assert.AreEqual(id, myEntity.Id);
-			await (s.DeleteAsync(myEntity));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				MyEntity myEntity = new MyEntity("test");
+				long id = (long) await (s.SaveAsync(myEntity));
+				Assert.IsNotNull(id, "identity column did not force immediate insert");
+				Assert.AreEqual(id, myEntity.Id);
+				await (s.DeleteAsync(myEntity));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Generatedkeys/Identity/SimpleIdentityGeneratedFixture.cs
+++ b/src/NHibernate.Test/Async/Generatedkeys/Identity/SimpleIdentityGeneratedFixture.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Identity
@@ -33,18 +32,19 @@ namespace NHibernate.Test.Generatedkeys.Identity
 		[Test]
 		public async Task SequenceIdentityGeneratorAsync()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntityIdentity { Name = "entity-1" };
+				await (session.SaveAsync(e));
 
-			var e = new MyEntityIdentity { Name = "entity-1" };
-			await (session.SaveAsync(e));
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			await (session.DeleteAsync(e));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+				await (session.DeleteAsync(e));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Generatedkeys/Select/SelectGeneratorTest.cs
+++ b/src/NHibernate.Test/Async/Generatedkeys/Select/SelectGeneratorTest.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Select
@@ -35,18 +34,19 @@ namespace NHibernate.Test.Generatedkeys.Select
 		[Test]
 		public async Task GetGeneratedKeysSupportAsync()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				MyEntity e = new MyEntity("entity-1");
+				await (session.SaveAsync(e));
 
-			MyEntity e = new MyEntity("entity-1");
-			await (session.SaveAsync(e));
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			await (session.DeleteAsync(e));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+				await (session.DeleteAsync(e));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Generatedkeys/Seqidentity/SequenceIdentityFixture.cs
+++ b/src/NHibernate.Test/Async/Generatedkeys/Seqidentity/SequenceIdentityFixture.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Seqidentity
@@ -41,18 +40,19 @@ namespace NHibernate.Test.Generatedkeys.Seqidentity
 		[Test]
 		public async Task SequenceIdentityGeneratorAsync()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntity { Name = "entity-1" };
+				await (session.SaveAsync(e));
 
-			var e = new MyEntity{Name="entity-1"};
-			await (session.SaveAsync(e));
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			await (session.DeleteAsync(e));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+				await (session.DeleteAsync(e));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/HqlFixture.cs
@@ -82,10 +82,10 @@ namespace NHibernate.Test.Hql.Ast
 		{
 			// NH-322
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.SaveAsync(new Animal {BodyWeight = 12, Description = "Polliwog"}));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		
 			using (ISession s = OpenSession())
@@ -101,10 +101,10 @@ namespace NHibernate.Test.Hql.Ast
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 
@@ -112,10 +112,10 @@ namespace NHibernate.Test.Hql.Ast
 		public async Task MultipleParametersInCaseStatementAsync()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.SaveAsync(new Animal { BodyWeight = 12, Description = "Polliwog" }));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			try
@@ -133,10 +133,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
-					await (s.Transaction.CommitAsync());
+					await (t.CommitAsync());
 				}
 			}
 		}
@@ -145,10 +145,10 @@ namespace NHibernate.Test.Hql.Ast
 		public async Task ParameterInCaseThenClauseAsync()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.SaveAsync(new Animal { BodyWeight = 12, Description = "Polliwog" }));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			try
@@ -164,10 +164,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
-					await (s.Transaction.CommitAsync());
+					await (t.CommitAsync());
 				}
 			}
 		}
@@ -176,10 +176,10 @@ namespace NHibernate.Test.Hql.Ast
 		public async Task ParameterInCaseThenAndElseClausesWithCastAsync()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.SaveAsync(new Animal { BodyWeight = 12, Description = "Polliwog" }));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			try
@@ -196,10 +196,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
-					await (s.Transaction.CommitAsync());
+					await (t.CommitAsync());
 				}
 			}
 		}
@@ -208,10 +208,10 @@ namespace NHibernate.Test.Hql.Ast
 		public async Task SubselectAdditionAsync()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.SaveAsync(new Animal { BodyWeight = 12, Description = "Polliwog" }));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			try
@@ -226,10 +226,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
-					await (s.Transaction.CommitAsync());
+					await (t.CommitAsync());
 				}
 			}
 		}
@@ -267,25 +267,23 @@ namespace NHibernate.Test.Hql.Ast
 		public async Task InsertIntoFromSelect_WithSelectClauseParametersAsync()
 		{
 			using (ISession s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
-					// arrange
-					await (s.SaveAsync(new Animal() {Description = "cat1", BodyWeight = 2.1f}));
-					await (s.SaveAsync(new Animal() {Description = "cat2", BodyWeight = 2.5f}));
-					await (s.SaveAsync(new Animal() {Description = "cat3", BodyWeight = 2.7f}));
+				// arrange
+				await (s.SaveAsync(new Animal() {Description = "cat1", BodyWeight = 2.1f}));
+				await (s.SaveAsync(new Animal() {Description = "cat2", BodyWeight = 2.5f}));
+				await (s.SaveAsync(new Animal() {Description = "cat3", BodyWeight = 2.7f}));
 
-					// act
-					await (s.CreateQuery("insert into Animal (description, bodyWeight) select a.description, :weight from Animal a where a.bodyWeight < :weight")
-						.SetParameter<float>("weight", 5.7f).ExecuteUpdateAsync());
+				// act
+				await (s.CreateQuery("insert into Animal (description, bodyWeight) select a.description, :weight from Animal a where a.bodyWeight < :weight")
+					.SetParameter<float>("weight", 5.7f).ExecuteUpdateAsync());
 
-					// assert
-					Assert.AreEqual(3, await (s.CreateCriteria<Animal>().SetProjection(Projections.RowCount())
-					                    .Add(Restrictions.Gt("bodyWeight", 5.5f)).UniqueResultAsync<int>()));
+				// assert
+				Assert.AreEqual(3, await (s.CreateCriteria<Animal>().SetProjection(Projections.RowCount())
+				                    .Add(Restrictions.Gt("bodyWeight", 5.5f)).UniqueResultAsync<int>()));
 
-					await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
-					await (s.Transaction.CommitAsync());
-				}
+				await (s.CreateQuery("delete from Animal").ExecuteUpdateAsync());
+				await (t.CommitAsync());
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Insertordering/InsertOrderingFixture.cs
+++ b/src/NHibernate.Test/Async/Insertordering/InsertOrderingFixture.cs
@@ -87,8 +87,8 @@ namespace NHibernate.Test.Insertordering
 		[Test]
 		public async System.Threading.Tasks.Task BatchOrderingAsync()
 		{
-			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var  s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				for (int i = 0; i < instancesPerEach; i++)
 				{
@@ -99,7 +99,7 @@ namespace NHibernate.Test.Insertordering
 					user.AddMembership(group);
 				}
 				StatsBatcher.Reset();
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			int expectedBatchesPerEntity = (instancesPerEach / batchSize) + ((instancesPerEach % batchSize) == 0 ? 0 : 1);
@@ -675,11 +675,16 @@ namespace NHibernate.Test.Insertordering
 
 		#endregion
 	}
+
 	public partial class InsertOrderingFixture : TestCase
 	{
 		public partial class StatsBatcher : SqlClientBatchingBatcher
 		{
-			public override async System.Threading.Tasks.Task<DbCommand> PrepareBatchCommandAsync(CommandType type, SqlString sql, SqlType[] parameterTypes, CancellationToken cancellationToken)
+			public override async System.Threading.Tasks.Task<DbCommand> PrepareBatchCommandAsync(
+				CommandType type,
+				SqlString sql,
+				SqlType[] parameterTypes,
+				CancellationToken cancellationToken)
 			{
 				var result = await (base.PrepareBatchCommandAsync(type, sql, parameterTypes, cancellationToken));
 
@@ -688,7 +693,9 @@ namespace NHibernate.Test.Insertordering
 				return result;
 			}
 
-			public override System.Threading.Tasks.Task AddToBatchAsync(IExpectation expectation, CancellationToken cancellationToken)
+			public override System.Threading.Tasks.Task AddToBatchAsync(
+				IExpectation expectation,
+				CancellationToken cancellationToken)
 			{
 				try
 				{
@@ -701,7 +708,9 @@ namespace NHibernate.Test.Insertordering
 				}
 			}
 
-			protected override System.Threading.Tasks.Task DoExecuteBatchAsync(DbCommand ps, CancellationToken cancellationToken)
+			protected override System.Threading.Tasks.Task DoExecuteBatchAsync(
+				DbCommand ps,
+				CancellationToken cancellationToken)
 			{
 				try
 				{
@@ -715,5 +724,5 @@ namespace NHibernate.Test.Insertordering
 			}
 		}
 
-			}
+	}
 }

--- a/src/NHibernate.Test/Async/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Async/Legacy/FooBarTest.cs
@@ -2837,7 +2837,7 @@ namespace NHibernate.Test.Legacy
 			await (s.DeleteAsync(baz.TopGlarchez['H']));
 
 			var cmd = s.Connection.CreateCommand();
-			s.Transaction.Enlist(cmd);
+			txn.Enlist(cmd);
 			cmd.CommandText = "update " + Dialect.QuoteForTableName("glarchez") + " set baz_map_id=null where baz_map_index='a'";
 			int rows = await (cmd.ExecuteNonQueryAsync());
 			Assert.AreEqual(1, rows);

--- a/src/NHibernate.Test/Async/LinqBulkManipulation/Fixture.cs
+++ b/src/NHibernate.Test/Async/LinqBulkManipulation/Fixture.cs
@@ -467,9 +467,8 @@ namespace NHibernate.Test.LinqBulkManipulation
 
 			// this is just checking parsing and syntax...
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
-
 				Assert.DoesNotThrowAsync(() =>
 				{
 					return s
@@ -477,7 +476,7 @@ namespace NHibernate.Test.LinqBulkManipulation
 						.InsertIntoAsync(x => new Animal { Description = x.Description, BodyWeight = x.BodyWeight });
 				});
 
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 
@@ -983,11 +982,11 @@ namespace NHibernate.Test.LinqBulkManipulation
 			}
 
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				var count = await (s.Query<SimpleEntityWithAssociation>().Where(x => x.AssociatedEntities.Count == 0 && x.Name.Contains("myEntity")).DeleteAsync());
 				Assert.That(count, Is.EqualTo(1), "Incorrect delete count");
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/BagWithLazyExtraAndFilter/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/BagWithLazyExtraAndFilter/Fixture.cs
@@ -21,8 +21,8 @@ namespace NHibernate.Test.NHSpecificTest.BagWithLazyExtraAndFilter
 		public async Task CanUseFilterForLazyExtraAsync()
 		{
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				var machineRequest = new MachineRequest { EnvId = 1L, Id = 2L };
 				await (s.SaveAsync(new Env
 				{
@@ -33,7 +33,7 @@ namespace NHibernate.Test.NHSpecificTest.BagWithLazyExtraAndFilter
 					}
 				}));
 				await (s.SaveAsync(machineRequest));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			using (var s = OpenSession())
@@ -50,11 +50,11 @@ namespace NHibernate.Test.NHSpecificTest.BagWithLazyExtraAndFilter
 			}
 
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.DeleteAsync(await (s.LoadAsync<MachineRequest>(2L))));
 				await (s.DeleteAsync(await (s.LoadAsync<Env>(1L))));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/CriteriaQueryOnComponentCollection/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/CriteriaQueryOnComponentCollection/Fixture.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Cfg;
 using NHibernate.Criterion;
@@ -30,7 +29,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 		protected override void OnSetUp()
 		{
 			using (var s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				var parent = new Employee
 				{
@@ -56,18 +55,18 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 				s.Save(parent);
 				s.Save(emp);
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
 		protected override void OnTearDown()
 		{
 			using (var s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Delete("from System.Object");
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/ElementsEnums/AbstractIntEnumsBagFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/ElementsEnums/AbstractIntEnumsBagFixture.cs
@@ -28,25 +28,25 @@ namespace NHibernate.Test.NHSpecificTest.ElementsEnums
 		{
 			object savedId;
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				savedId = await (s.SaveAsync(new SimpleWithEnums { Things = new List<Something> { Something.B, Something.C, Something.D, Something.E } }));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				var swe = await (s.GetAsync<SimpleWithEnums>(savedId));
 				Assert.That(swe.Things, Is.EqualTo(new[] { Something.B, Something.C, Something.D, Something.E }));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.DeleteAsync("from SimpleWithEnums"));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1093/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1093/Fixture.cs
@@ -34,13 +34,11 @@ namespace NHibernate.Test.NHSpecificTest.NH1093
 
 		private async Task CleanupAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
-					await (s.CreateQuery("delete from SimpleCached").ExecuteUpdateAsync(cancellationToken));
-					await (s.Transaction.CommitAsync(cancellationToken));
-				}
+				await (s.CreateQuery("delete from SimpleCached").ExecuteUpdateAsync(cancellationToken));
+				await (t.CommitAsync(cancellationToken));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1323/CheckViability.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1323/CheckViability.cs
@@ -29,24 +29,24 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				this.factory = factory;
 				object savedId;
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var entity = new MyClass();
 					entity.Children.Add(new MyChild { Parent = entity });
 					entity.Components.Add(new MyComponent { Something = "something" });
 					entity.Elements.Add("somethingelse");
 					savedId = session.Save(entity);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					entity = session.Get<MyClass>(savedId);
 					NHibernateUtil.Initialize(entity.Children);
 					NHibernateUtil.Initialize(entity.Components);
 					NHibernateUtil.Initialize(entity.Elements);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 
@@ -76,13 +76,13 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 
 				// When I reassociate the collections the Owner has value
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var merged = (MyClass)await (session.MergeAsync(scenario.Entity));
 					Assert.That(((IPersistentCollection)merged.Children).Owner, Is.Not.Null);
 					Assert.That(((IPersistentCollection)merged.Components).Owner, Is.Not.Null);
 					Assert.That(((IPersistentCollection)merged.Elements).Owner, Is.Not.Null);
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 			}
 		}
@@ -97,7 +97,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					// When I reassociate the collections the Owner is null
 					await (session.LockAsync(scenario.Entity, LockMode.None));
@@ -105,17 +105,17 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 					scenario.Entity.Children.Add(new MyChild { Parent = scenario.Entity });
 					scenario.Entity.Components.Add(new MyComponent { Something = "something" });
 					scenario.Entity.Elements.Add("somethingelse");
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = await (session.GetAsync<MyClass>(scenario.Entity.Id));
 					Assert.That(fresh.Children, Has.Count.EqualTo(2));
 					Assert.That(fresh.Components, Has.Count.EqualTo(2));
 					Assert.That(fresh.Elements, Has.Count.EqualTo(2));
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 			}
 		}
@@ -130,24 +130,24 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					scenario.Entity.Children.Add(new MyChild { Parent = scenario.Entity });
 					scenario.Entity.Components.Add(new MyComponent { Something = "something" });
 					scenario.Entity.Elements.Add("somethingelse");
 					// When I reassociate the collections the Owner is null
 					await (session.UpdateAsync(scenario.Entity));
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = await (session.GetAsync<MyClass>(scenario.Entity.Id));
 					Assert.That(fresh.Children, Has.Count.EqualTo(2));
 					Assert.That(fresh.Components, Has.Count.EqualTo(2));
 					Assert.That(fresh.Elements, Has.Count.EqualTo(2));
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 			}
 		}
@@ -162,24 +162,24 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					scenario.Entity.Children.Add(new MyChild { Parent = scenario.Entity });
 					scenario.Entity.Components.Add(new MyComponent { Something = "something" });
 					scenario.Entity.Elements.Add("somethingelse");
 					// When I reassociate the collections the Owner is null
 					await (session.SaveOrUpdateAsync(scenario.Entity));
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = await (session.GetAsync<MyClass>(scenario.Entity.Id));
 					Assert.That(fresh.Children, Has.Count.EqualTo(2));
 					Assert.That(fresh.Components, Has.Count.EqualTo(2));
 					Assert.That(fresh.Elements, Has.Count.EqualTo(2));
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 			}
 		}
@@ -194,18 +194,18 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					await (session.DeleteAsync(scenario.Entity));
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = await (session.GetAsync<MyClass>(scenario.Entity.Id));
 					Assert.That(fresh, Is.Null);
-					await (session.Transaction.CommitAsync());
+					await (tran.CommitAsync());
 				}
 			}
 		}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1388/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1388/Fixture.cs
@@ -95,9 +95,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1388
 		protected override void OnTearDown()
 		{
 			// clean up the database
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				session.BeginTransaction();
 				foreach (var student in session.CreateCriteria(typeof (Student)).List<Student>())
 				{
 					session.Delete(student);
@@ -106,7 +106,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1388
 				{
 					session.Delete(subject);
 				}
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1665/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1665/Fixture.cs
@@ -24,16 +24,17 @@ namespace NHibernate.Test.NHSpecificTest.NH1665
 		[Test]
 		public async Task SupportsHibernateQuotingSequenceNameAsync()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntity { Name = "entity-1" };
+				await (session.SaveAsync(e));
+				Assert.AreEqual(1, (int) session.GetIdentifier(e));
 
-			var e = new MyEntity { Name = "entity-1" };
-			await (session.SaveAsync(e));
-			Assert.AreEqual(1, (int)session.GetIdentifier(e));
-
-			await (session.DeleteAsync(e));
-			await (session.Transaction.CommitAsync());
-			session.Close();
+				await (session.DeleteAsync(e));
+				await (tran.CommitAsync());
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
@@ -123,29 +123,29 @@ namespace NHibernate.Test.NHSpecificTest.NH1882
 			Assert.False(listener.FoundAny);
 
 			using (var s1 = OpenSession())
+			using (var t1 = s1.BeginTransaction())
 			{
-				s1.BeginTransaction();
 				var publisher = new Publisher("acme");
 				var author = new Author("john");
 				author.Publisher = publisher;
 				publisher.Authors.Add(author);
 				author.Books.Add(new Book("Reflections on a Wimpy Kid", author));
 				await (s1.SaveAsync(author));
-				await (s1.Transaction.CommitAsync());
+				await (t1.CommitAsync());
 				s1.Clear();
 				using (var s2 = OpenSession())
+				using (var t2 = s2.BeginTransaction())
 				{
-					s2.BeginTransaction();
 					publisher = await (s2.GetAsync<Publisher>(publisher.Id));
 					publisher.Name = "random nally";
 					await (s2.FlushAsync());
-					await (s2.Transaction.CommitAsync());
+					await (t2.CommitAsync());
 					s2.Clear();
 					using (var s3 = OpenSession())
+					using (var t3 = s3.BeginTransaction())
 					{
-						s3.BeginTransaction();
 						await (s3.DeleteAsync(author));
-						await (s3.Transaction.CommitAsync());
+						await (t3.CommitAsync());
 						s3.Clear();
 						s3.Close();
 					}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2065/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2065/Fixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2065
         protected override void OnSetUp()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 var person = new Person
                 {
@@ -31,17 +31,17 @@ namespace NHibernate.Test.NHSpecificTest.NH2065
                 s.Save(child);
                 person.Children.Add(child);
 
-                s.Transaction.Commit();
+                t.Commit();
             }
         }
 
         protected override void OnTearDown()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 s.Delete("from Person");
-                s.Transaction.Commit();
+                t.Commit();
             }
         }
 
@@ -50,17 +50,17 @@ namespace NHibernate.Test.NHSpecificTest.NH2065
 		{
 			Person person;
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				person = await (s.GetAsync<Person>(1));
 				await (NHibernateUtil.InitializeAsync(person.Children));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			person.Children.Clear();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Assert.That(
 					() =>

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2069/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2069/Fixture.cs
@@ -8,13 +8,7 @@
 //------------------------------------------------------------------------------
 
 
-using System;
-using System.Collections.Generic;
-using System.Transactions;
-using NHibernate;
-using NHibernate.Impl;
 using NHibernate.Proxy;
-using NHibernate.Criterion;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH2069
@@ -26,7 +20,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2069
         protected override void OnSetUp()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 var test2 = new Test2();
                 test2.Cid = 5;
@@ -40,19 +34,19 @@ namespace NHibernate.Test.NHSpecificTest.NH2069
                 s.Save(test2);
                 s.Save(test);
 
-                s.Transaction.Commit();
-            }            
+                t.Commit();
+            }
         }
 
         protected override void OnTearDown()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 s.Delete("from Test");
                 s.Delete("from Test2");
-                s.Transaction.Commit();
-            }            
+                t.Commit();
+            }
          }
 
         [Test]

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2510/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2510/Fixture.cs
@@ -10,7 +10,6 @@
 
 using System;
 using NHibernate.Cache;
-using NHibernate.Cfg;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
@@ -48,21 +47,21 @@ namespace NHibernate.Test.NHSpecificTest.NH2510
 			{
 				this.factory = factory;
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					session.Persist(new Image { Id = 1 });
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 
 			public void Dispose()
 			{
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					session.CreateQuery("delete from Image").ExecuteUpdate();
-					session.Transaction.Commit();
-				}				
+					tran.Commit();
+				}
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2691/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2691/Fixture.cs
@@ -10,9 +10,9 @@
 
 using System.Linq;
 using NHibernate.Cfg.MappingSchema;
-using NHibernate.Linq;
 using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.NHSpecificTest.NH2691
 {
@@ -33,11 +33,11 @@ namespace NHibernate.Test.NHSpecificTest.NH2691
 		public async Task WhenUseCountWithOrderThenCutTheOrderAsync()
 		{
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (var tran = session.BeginTransaction())
 			{
 				var baseQuery = from cat in session.Query<Cat>() orderby cat.BirthDate select cat;
 				Assert.That(() => baseQuery.CountAsync(), Throws.Nothing);
-				await (session.Transaction.CommitAsync());
+				await (tran.CommitAsync());
 			}
 		}
 
@@ -45,11 +45,11 @@ namespace NHibernate.Test.NHSpecificTest.NH2691
 		public async Task WhenUseLongCountWithOrderThenCutTheOrderAsync()
 		{
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (var tran = session.BeginTransaction())
 			{
 				var baseQuery = from cat in session.Query<Cat>() orderby cat.BirthDate select cat;
 				Assert.That(() => baseQuery.LongCountAsync(), Throws.Nothing);
-				await (session.Transaction.CommitAsync());
+				await (tran.CommitAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3567/NH3567Tests.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3567/NH3567Tests.cs
@@ -21,9 +21,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3567
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			using (ISession session = this.OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				session.BeginTransaction();
 				var id = 0;
 
 				var site1 = new Site { Id = ++id, Name = "Site 1" };
@@ -42,7 +42,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3567
 				session.Save(new Comment { Id = ++id, Content = "Comment 2.1", Post = p2 });
 				session.Save(new Comment { Id = ++id, Content = "Comment 2.2", Post = p2 });
 				session.Flush();
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH734/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH734/Fixture.cs
@@ -20,25 +20,14 @@ namespace NHibernate.Test.NHSpecificTest.NH734
 		[TestAttribute]
 		public async Task LimitProblemAsync()
 		{
-			using (ISession session = Sfi.OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
 				ICriteria criteria = session.CreateCriteria(typeof(MyClass));
 				criteria.SetMaxResults(100);
 				criteria.SetFirstResult(0);
-				try
-				{
-					session.BeginTransaction();
-					IList result = await (criteria.ListAsync());
-					await (session.Transaction.CommitAsync());
-				}
-				catch
-				{
-					if (session.Transaction != null)
-					{
-						await (session.Transaction.RollbackAsync());
-					}
-					throw;
-				}
+				IList result = await (criteria.ListAsync());
+				await (tran.CommitAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/Operations/MergeFixture.cs
+++ b/src/NHibernate.Test/Async/Operations/MergeFixture.cs
@@ -85,23 +85,31 @@ namespace NHibernate.Test.Operations
 		[Test]
 		public async Task DeleteAndMergeAsync()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				s.BeginTransaction();
-				var jboss = new Employer();
-				await (s.PersistAsync(jboss));
-				await (s.Transaction.CommitAsync());
-				s.Clear();
+				Employer jboss;
+				using (var t = s.BeginTransaction())
+				{
+					jboss = new Employer();
+					await (s.PersistAsync(jboss));
+					await (t.CommitAsync());
+					s.Clear();
+				}
 
-				s.BeginTransaction();
-				var otherJboss = await (s.GetAsync<Employer>(jboss.Id));
-				await (s.DeleteAsync(otherJboss));
-				await (s.Transaction.CommitAsync());
-				s.Clear();
+				using (var t = s.BeginTransaction())
+				{
+					var otherJboss = await (s.GetAsync<Employer>(jboss.Id));
+					await (s.DeleteAsync(otherJboss));
+					await (t.CommitAsync());
+					s.Clear();
+				}
+
 				jboss.Vers = 1;
-				s.BeginTransaction();
-				await (s.MergeAsync(jboss));
-				await (s.Transaction.CommitAsync());
+				using (var t = s.BeginTransaction())
+				{
+					await (s.MergeAsync(jboss));
+					await (t.CommitAsync());
+				}
 			}
 		}
 
@@ -126,13 +134,11 @@ namespace NHibernate.Test.Operations
 
 			p.Address.StreetAddress = "321 Main";
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
-					p = (Person) await (s.MergeAsync(p));
-					await (s.Transaction.CommitAsync());
-				}
+				p = (Person) await (s.MergeAsync(p));
+				await (t.CommitAsync());
 			}
 
 			AssertInsertCount(0);
@@ -417,44 +423,41 @@ namespace NHibernate.Test.Operations
 		{
 			var entity = new VersionedEntity {Id = "entity", Name = "entity"};
 			using(ISession s = OpenSession())
-			using(s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.PersistAsync(entity));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			// make the detached 'entity' reference stale...
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				var entity2 = await (s.GetAsync<VersionedEntity>(entity.Id));
 				entity2.Name = "entity-name";
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
-			// now try to reattch it
-			ISession s2 = null;
-			try
+			// now try to reattach it
+			using (var s2 = OpenSession())
+			using (var t = s2.BeginTransaction())
 			{
-				s2 = OpenSession();
-				s2.BeginTransaction();
-
-				await (s2.MergeAsync(entity));
-				await (s2.Transaction.CommitAsync());
-				Assert.Fail("was expecting staleness error");
-			}
-			catch (StaleObjectStateException)
-			{
-				// expected outcome...
-			}
-			finally
-			{
-				if (s2 != null)
+				try
 				{
-					await (s2.Transaction.RollbackAsync());
-					s2.Close();
+					await (s2.MergeAsync(entity));
+					await (t.CommitAsync());
+					Assert.Fail("was expecting staleness error");
 				}
-				await (CleanupAsync());
+				catch (StaleObjectStateException)
+				{
+					// expected outcome...
+				}
+				finally
+				{
+					await (t.RollbackAsync());
+					s2.Close();
+					await (CleanupAsync());
+				}
 			}
 		}
 
@@ -551,10 +554,10 @@ namespace NHibernate.Test.Operations
 				Name = "test"
 			};
 			using(ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.PersistAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -562,10 +565,10 @@ namespace NHibernate.Test.Operations
 			// node is now detached, but we have made no changes.  so attempt to merge it
 			// into this new session; this should cause no updates...
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				node = (Node) await (s.MergeAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -576,10 +579,10 @@ namespace NHibernate.Test.Operations
 			// make sure we get an update as a result...
 			node.Description = "new description";
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				node = (Node) await (s.MergeAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
@@ -591,10 +594,10 @@ namespace NHibernate.Test.Operations
 		{
 			var entity = new VersionedEntity {Id = "entity", Name = "entity"};
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.PersistAsync(entity));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -603,10 +606,10 @@ namespace NHibernate.Test.Operations
 			// into this new session; this should cause no updates...
 			VersionedEntity mergedEntity;
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				mergedEntity = (VersionedEntity) await (s.MergeAsync(entity));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -618,10 +621,10 @@ namespace NHibernate.Test.Operations
 			// make sure we get an update as a result...
 			entity.Name = "new name";
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				entity = (VersionedEntity) await (s.MergeAsync(entity));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
@@ -635,12 +638,12 @@ namespace NHibernate.Test.Operations
 			var child = new VersionedEntity {Id = "child", Name = "child"};
 
 			using(ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				parent.Children.Add(child);
 				child.Parent = parent;
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -649,10 +652,10 @@ namespace NHibernate.Test.Operations
 			// into this new session; this should cause no updates...
 			VersionedEntity mergedParent;
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				mergedParent = (VersionedEntity) await (s.MergeAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -669,10 +672,10 @@ namespace NHibernate.Test.Operations
 			mergedParent.Name = "new name";
 			mergedParent.Children.Add(new VersionedEntity {Id = "child2", Name = "new child"});
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				parent = (VersionedEntity) await (s.MergeAsync(mergedParent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
@@ -688,7 +691,7 @@ namespace NHibernate.Test.Operations
 				Name = "parent"
 			};
 			using(ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				var child = new Node
 				{
@@ -698,7 +701,7 @@ namespace NHibernate.Test.Operations
 				parent.Children.Add(child);
 				child.Parent = parent;
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -706,10 +709,10 @@ namespace NHibernate.Test.Operations
 			// parent is now detached, but we have made no changes.  so attempt to merge it
 			// into this new session; this should cause no updates...
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				parent = (Node) await (s.MergeAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -728,10 +731,10 @@ namespace NHibernate.Test.Operations
 					Name = "second child"
 				});
 			using(var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				parent = (Node) await (s.MergeAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 			AssertUpdateCount(1);
 			AssertInsertCount(1);

--- a/src/NHibernate.Test/Async/ReadOnly/ReadOnlyProxyTest.cs
+++ b/src/NHibernate.Test/Async/ReadOnly/ReadOnlyProxyTest.cs
@@ -9,17 +9,8 @@
 
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using NHibernate.Cfg;
-using NHibernate.Dialect;
-using NHibernate.Criterion;
 using NHibernate.Engine;
 using NHibernate.Proxy;
-using NHibernate.SqlCommand;
-using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ReadOnly
@@ -34,10 +25,10 @@ namespace NHibernate.Test.ReadOnly
 			get
 			{
 				return new string[]
-					{
-						"ReadOnly.DataPoint.hbm.xml",
-						//"ReadOnly.TextHolder.hbm.xml"
-					};
+				{
+					"ReadOnly.DataPoint.hbm.xml",
+					//"ReadOnly.TextHolder.hbm.xml"
+				};
 			}
 		}
 
@@ -45,1627 +36,1811 @@ namespace NHibernate.Test.ReadOnly
 		public async Task ReadOnlyViaSessionDoesNotInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.SetReadOnly(dp, false);
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (s.FlushAsync());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (s.Transaction.CommitAsync());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.SetReadOnly(dp, false);
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (s.FlushAsync());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (t.CommitAsync());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyViaLazyInitializerDoesNotInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dpLI.ReadOnly = true;
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dpLI.ReadOnly = false;
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (s.FlushAsync());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (s.Transaction.CommitAsync());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dpLI.ReadOnly = true;
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dpLI.ReadOnly = false;
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (s.FlushAsync());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (t.CommitAsync());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyViaSessionNoChangeAfterInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.SetReadOnly(dp, false);
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (CheckReadOnlyAsync(s, dp, true));
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.SetReadOnly(dp, false);
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyViaLazyInitializerNoChangeAfterInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(dpLI.IsUninitialized);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			dpLI.ReadOnly = true;
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(dpLI.IsUninitialized);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			dpLI.ReadOnly = true;
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(dpLI.IsUninitialized);
-			dpLI.ReadOnly = false;
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(dpLI.IsUninitialized);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(dpLI.IsUninitialized);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				var dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				dpLI.ReadOnly = true;
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(dpLI.IsUninitialized);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				await (CheckReadOnlyAsync(s, dp, true));
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				var dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				dpLI.ReadOnly = true;
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(dpLI.IsUninitialized);
+				dpLI.ReadOnly = false;
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(dpLI.IsUninitialized);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ReadOnlyViaSessionBeforeInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			s.SetReadOnly(dp, true);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				s.SetReadOnly(dp, true);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ModifiableViaSessionBeforeInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyViaSessionBeforeInitByModifiableQueryAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where id = " + dpOrig.Id).SetReadOnly(false).UniqueResultAsync<DataPoint>());
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where id = " + dpOrig.Id).SetReadOnly(false)
+				                         .UniqueResultAsync<DataPoint>());
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				await (CheckReadOnlyAsync(s, dp, true));
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ReadOnlyViaSessionBeforeInitByReadOnlyQueryAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			DataPoint dpFromQuery = await (s.CreateQuery( "from DataPoint where Id = " + dpOrig.Id).SetReadOnly(true).UniqueResultAsync<DataPoint>());
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where Id = " + dpOrig.Id).SetReadOnly(true)
+				                         .UniqueResultAsync<DataPoint>());
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				await (CheckReadOnlyAsync(s, dp, true));
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ModifiableViaSessionBeforeInitByModifiableQueryAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where Id = " + dpOrig.Id).SetReadOnly(false).UniqueResultAsync<DataPoint>());
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where Id = " + dpOrig.Id).SetReadOnly(false)
+				                         .UniqueResultAsync<DataPoint>());
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ModifiableViaSessionBeforeInitByReadOnlyQueryAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where id=" + dpOrig.Id).SetReadOnly(true).UniqueResultAsync<DataPoint>());
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				DataPoint dpFromQuery = await (s.CreateQuery("from DataPoint where id=" + dpOrig.Id).SetReadOnly(true)
+				                         .UniqueResultAsync<DataPoint>());
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ReadOnlyViaLazyInitializerBeforeInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dpLI.IsUninitialized);
-			await (CheckReadOnlyAsync(s, dp, false));
-			dpLI.ReadOnly = true;
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dpLI.IsUninitialized);
+				await (CheckReadOnlyAsync(s, dp, false));
+				dpLI.ReadOnly = true;
+				await (CheckReadOnlyAsync(s, dp, true));
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ModifiableViaLazyInitializerBeforeInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(dpLI.IsUninitialized);
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(dpLI.IsUninitialized);
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyViaLazyInitializerAfterInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dpLI.IsUninitialized);
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, false));
-			dpLI.ReadOnly = true;
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dpLI.IsUninitialized);
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, false));
+				dpLI.ReadOnly = true;
+				await (CheckReadOnlyAsync(s, dp, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ModifiableViaLazyInitializerAfterInitAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dpLI.IsUninitialized);
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dpLI.IsUninitialized);
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ReadOnlyChangedEvictedUpdateAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.EvictAsync(dp));
-			Assert.That(s.Contains(dp), Is.False);
-			await (s.UpdateAsync(dp));
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.EvictAsync(dp));
+				Assert.That(s.Contains(dp), Is.False);
+				await (s.UpdateAsync(dp));
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyToModifiableInitWhenModifiedIsUpdatedAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			s.SetReadOnly(dp, false);
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				s.SetReadOnly(dp, false);
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyInitToModifiableModifiedIsUpdatedAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (CheckReadOnlyAsync(s, dp, true));
-			s.SetReadOnly(dp, false);
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (CheckReadOnlyAsync(s, dp, true));
+				s.SetReadOnly(dp, false);
+				await (CheckReadOnlyAsync(s, dp, false));
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyModifiedUpdateAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.UpdateAsync(dp));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dp, true));
+				await (s.UpdateAsync(dp));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyDeleteAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (s.DeleteAsync(dp));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.Null);
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (s.DeleteAsync(dp));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.Null);
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
 
 		[Test]
 		public async Task ReadOnlyRefreshAsync()
 		{
 			DataPoint dp = await (this.CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			ITransaction t = s.BeginTransaction();
-			dp = await (s.LoadAsync<DataPoint>(dp.Id));
-			s.SetReadOnly(dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (s.RefreshAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(s.IsReadOnly(dp), Is.True);
-			Assert.That(s.IsReadOnly(await (((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None))), Is.True);
-			await (s.RefreshAsync(dp));
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(s.IsReadOnly(dp), Is.True);
-			Assert.That(s.IsReadOnly(await (((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None))), Is.True);
-			await (t.CommitAsync());
-	
-			s.Clear();
-			t = s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dp.Id));
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			await (s.DeleteAsync(dp));
-			await (t.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.LoadAsync<DataPoint>(dp.Id));
+					s.SetReadOnly(dp, true);
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (s.RefreshAsync(dp));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					dp.Description = "changed";
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					Assert.That(s.IsReadOnly(dp), Is.True);
+					Assert.That(
+						s.IsReadOnly(await (((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None))),
+						Is.True);
+					await (s.RefreshAsync(dp));
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					dp.Description = "changed";
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					Assert.That(s.IsReadOnly(dp), Is.True);
+					Assert.That(
+						s.IsReadOnly(await (((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None))),
+						Is.True);
+					await (t.CommitAsync());
+				}
+
+				s.Clear();
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.GetAsync<DataPoint>(dp.Id));
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyRefreshDeletedAsync()
 		{
 			DataPoint dp = await (this.CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			ITransaction t = s.BeginTransaction();
-			INHibernateProxy dpProxy = (INHibernateProxy)await (s.LoadAsync<DataPoint>(dp.Id));
-			Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
-			await (t.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			t = s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dp.Id));
-			await (s.DeleteAsync(dp));
-			await (s.FlushAsync());
-			
-			try
+			INHibernateProxy dpProxy;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				await (s.RefreshAsync(dp));
-				Assert.Fail("should have thrown UnresolvableObjectException" );
-			}
-			catch (UnresolvableObjectException)
-			{
-				// expected
-			}
-			finally
-			{
-				await (t.RollbackAsync());
+				s.CacheMode = CacheMode.Ignore;
+				dpProxy = (INHibernateProxy) await (s.LoadAsync<DataPoint>(dp.Id));
+				Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
+				await (t.CommitAsync());
 				s.Close();
 			}
-	
-			s = OpenSession();
-			t = s.BeginTransaction();
-			s.CacheMode = CacheMode.Ignore;
-			DataPoint dpProxyInit = await (s.LoadAsync<DataPoint>(dp.Id));
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			await (s.DeleteAsync(dpProxyInit));
-			await (t.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			t = s.BeginTransaction();
-			Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dpProxyInit), Is.True);
 
 			try
 			{
-				await (s.RefreshAsync(dpProxyInit));
-				Assert.Fail("should have thrown UnresolvableObjectException");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+					dp = await (s.GetAsync<DataPoint>(dp.Id));
+					await (s.DeleteAsync(dp));
+					await (s.FlushAsync());
+
+					await (s.RefreshAsync(dp));
+					Assert.Fail("should have thrown UnresolvableObjectException");
+				}
 			}
 			catch (UnresolvableObjectException)
 			{
 				// expected
 			}
-			finally
+
+			DataPoint dpProxyInit;
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				await (t.RollbackAsync());
+				s.CacheMode = CacheMode.Ignore;
+				dpProxyInit = await (s.LoadAsync<DataPoint>(dp.Id));
+				Assert.That(dp.Description, Is.EqualTo("original"));
+				await (s.DeleteAsync(dpProxyInit));
+				await (t.CommitAsync());
 				s.Close();
 			}
-	
-			s = OpenSession();
-			t = s.BeginTransaction();
-			Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
-			
+
 			try
 			{
-				await (s.RefreshAsync(dpProxy));
-				Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
-				await (NHibernateUtil.InitializeAsync(dpProxy));
-				Assert.Fail("should have thrown UnresolvableObjectException");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dpProxyInit), Is.True);
+
+					await (s.RefreshAsync(dpProxyInit));
+					Assert.Fail("should have thrown UnresolvableObjectException");
+				}
 			}
 			catch (UnresolvableObjectException)
 			{
 				// expected
 			}
-			finally
+
+			try
 			{
-				await (t.RollbackAsync());
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
+
+					await (s.RefreshAsync(dpProxy));
+					Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
+					await (NHibernateUtil.InitializeAsync(dpProxy));
+					Assert.Fail("should have thrown UnresolvableObjectException");
+				}
+			}
+			catch (UnresolvableObjectException)
+			{
+				// expected
 			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyRefreshDetachedAsync()
 		{
 			DataPoint dp = await (this.CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			ITransaction t = s.BeginTransaction();
-			dp = await (s.LoadAsync<DataPoint>(dp.Id));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			Assert.That(s.IsReadOnly(dp), Is.False);
-			s.SetReadOnly(dp, true);
-			Assert.That(s.IsReadOnly(dp), Is.True);
-			await (s.EvictAsync(dp));
-			await (s.RefreshAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			Assert.That(s.IsReadOnly(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.SetReadOnly(dp, true);
-			await (s.EvictAsync(dp));
-			await (s.RefreshAsync(dp));
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			Assert.That(s.IsReadOnly(dp), Is.False);
-			await (t.CommitAsync());
-	
-			s.Clear();
-			t = s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dp.Id));
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			await (s.DeleteAsync(dp));
-			await (t.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.LoadAsync<DataPoint>(dp.Id));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					Assert.That(s.IsReadOnly(dp), Is.False);
+					s.SetReadOnly(dp, true);
+					Assert.That(s.IsReadOnly(dp), Is.True);
+					await (s.EvictAsync(dp));
+					await (s.RefreshAsync(dp));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					Assert.That(s.IsReadOnly(dp), Is.False);
+					dp.Description = "changed";
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					s.SetReadOnly(dp, true);
+					await (s.EvictAsync(dp));
+					await (s.RefreshAsync(dp));
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					Assert.That(s.IsReadOnly(dp), Is.False);
+					await (t.CommitAsync());
+				}
+
+				s.Clear();
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.GetAsync<DataPoint>(dp.Id));
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyProxyMergeDetachedProxyWithChangeAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (t.CommitAsync());
+				s.Close();
+			}
+
 			// modify detached proxy
 			dp.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dpLoaded, false));
-			s.SetReadOnly(dpLoaded, true);
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			DataPoint dpMerged = (DataPoint)await (s.MergeAsync(dp));
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dpLoaded, false));
+				s.SetReadOnly(dpLoaded, true);
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				DataPoint dpMerged = (DataPoint) await (s.MergeAsync(dp));
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyProxyInitMergeDetachedProxyWithChangeAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (t.CommitAsync());
+				s.Close();
+			}
+
 			// modify detached proxy
 			dp.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			await (NHibernateUtil.InitializeAsync(dpLoaded));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			await (CheckReadOnlyAsync(s, dpLoaded, false));
-			s.SetReadOnly(dpLoaded, true);
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			DataPoint dpMerged = (DataPoint)await (s.MergeAsync(dp));
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				await (NHibernateUtil.InitializeAsync(dpLoaded));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				await (CheckReadOnlyAsync(s, dpLoaded, false));
+				s.SetReadOnly(dpLoaded, true);
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				DataPoint dpMerged = (DataPoint) await (s.MergeAsync(dp));
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyProxyMergeDetachedEntityWithChangeAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (t.CommitAsync());
+				s.Close();
+			}
+
 			// modify detached proxy target
-			DataPoint dpEntity = (DataPoint)await (((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None));
+			DataPoint dpEntity = (DataPoint) await (((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None));
 			dpEntity.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dpLoaded, false));
-			s.SetReadOnly(dpLoaded, true);
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			DataPoint dpMerged = (DataPoint)await (s.MergeAsync(dpEntity));
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dpLoaded, false));
+				s.SetReadOnly(dpLoaded, true);
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				DataPoint dpMerged = (DataPoint) await (s.MergeAsync(dpEntity));
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyProxyInitMergeDetachedEntityWithChangeAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (t.CommitAsync());
+				s.Close();
+			}
+
 			// modify detached proxy target
-			DataPoint dpEntity = (DataPoint)await (((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None));
+			DataPoint dpEntity = (DataPoint) await (((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementationAsync(CancellationToken.None));
 			dpEntity.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			await (NHibernateUtil.InitializeAsync(dpLoaded));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			await (CheckReadOnlyAsync(s, dpLoaded, false));
-			s.SetReadOnly(dpLoaded, true);
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			DataPoint dpMerged = (DataPoint)await (s.MergeAsync(dpEntity));
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dpLoaded, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				await (NHibernateUtil.InitializeAsync(dpLoaded));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				await (CheckReadOnlyAsync(s, dpLoaded, false));
+				s.SetReadOnly(dpLoaded, true);
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				DataPoint dpMerged = (DataPoint) await (s.MergeAsync(dpEntity));
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				await (CheckReadOnlyAsync(s, dpLoaded, true));
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task ReadOnlyEntityMergeDetachedProxyWithChangeAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (NHibernateUtil.InitializeAsync(dp));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (NHibernateUtil.InitializeAsync(dp));
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				await (t.CommitAsync());
+				s.Close();
+			}
+
 			// modify detached proxy
 			dp.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpEntity = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dpEntity, Is.Not.InstanceOf<INHibernateProxy>());
-			Assert.That(s.IsReadOnly(dpEntity), Is.False);
-			s.SetReadOnly(dpEntity, true);
-			Assert.That(s.IsReadOnly(dpEntity), Is.True);
-			DataPoint dpMerged = (DataPoint)await (s.MergeAsync(dp));
-			Assert.That(dpMerged, Is.SameAs(dpEntity));
-			Assert.That(dpEntity.Description, Is.EqualTo("changed"));
-			Assert.That(s.IsReadOnly(dpEntity), Is.True);
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpEntity = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dpEntity, Is.Not.InstanceOf<INHibernateProxy>());
+				Assert.That(s.IsReadOnly(dpEntity), Is.False);
+				s.SetReadOnly(dpEntity, true);
+				Assert.That(s.IsReadOnly(dpEntity), Is.True);
+				DataPoint dpMerged = (DataPoint) await (s.MergeAsync(dp));
+				Assert.That(dpMerged, Is.SameAs(dpEntity));
+				Assert.That(dpEntity.Description, Is.EqualTo("changed"));
+				Assert.That(s.IsReadOnly(dpEntity), Is.True);
+				await (s.FlushAsync());
+				await (t.CommitAsync());
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task SetReadOnlyInTwoTransactionsSameSessionAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-	
-			await (CheckReadOnlyAsync(s, dp, true));
-	
-			s.BeginTransaction();
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed again";
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-	
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (CheckReadOnlyAsync(s, dp, false));
+					s.SetReadOnly(dp, true);
+					await (CheckReadOnlyAsync(s, dp, true));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					dp.Description = "changed";
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					await (s.FlushAsync());
+					await (t.CommitAsync());
+				}
+
+				await (CheckReadOnlyAsync(s, dp, true));
+
+				using (var t = s.BeginTransaction())
+				{
+					await (CheckReadOnlyAsync(s, dp, true));
+					dp.Description = "changed again";
+					Assert.That(dp.Description, Is.EqualTo("changed again"));
+					await (s.FlushAsync());
+					await (t.CommitAsync());
+				}
+
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task SetReadOnlyBetweenTwoTransactionsSameSessionAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-	
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-	
-			s.BeginTransaction();
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed again";
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-	
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (CheckReadOnlyAsync(s, dp, false));
+					dp.Description = "changed";
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					await (CheckReadOnlyAsync(s, dp, false));
+					await (s.FlushAsync());
+					await (t.CommitAsync());
+				}
+
+				await (CheckReadOnlyAsync(s, dp, false));
+				s.SetReadOnly(dp, true);
+				await (CheckReadOnlyAsync(s, dp, true));
+
+				using (var t = s.BeginTransaction())
+				{
+					await (CheckReadOnlyAsync(s, dp, true));
+					dp.Description = "changed again";
+					Assert.That(dp.Description, Is.EqualTo("changed again"));
+					await (s.FlushAsync());
+					await (t.CommitAsync());
+				}
+
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task SetModifiableBetweenTwoTransactionsSameSessionAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			s.SetReadOnly(dp, true);
-			await (CheckReadOnlyAsync(s, dp, true));
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (CheckReadOnlyAsync(s, dp, true));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-	
-			await (CheckReadOnlyAsync(s, dp, true));
-			s.SetReadOnly(dp, false);
-			await (CheckReadOnlyAsync(s, dp, false));
-	
-			s.BeginTransaction();
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			await (s.RefreshAsync(dp));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			await (CheckReadOnlyAsync(s, dp, false));
-			dp.Description = "changed again";
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			await (s.FlushAsync());
-			await (s.Transaction.CommitAsync());
-	
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			await (s.DeleteAsync(dp));
-			await (s.Transaction.CommitAsync());
-			s.Close();
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (CheckReadOnlyAsync(s, dp, false));
+					s.SetReadOnly(dp, true);
+					await (CheckReadOnlyAsync(s, dp, true));
+					dp.Description = "changed";
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					await (CheckReadOnlyAsync(s, dp, true));
+					await (s.FlushAsync());
+					await (t.CommitAsync());
+				}
+
+				await (CheckReadOnlyAsync(s, dp, true));
+				s.SetReadOnly(dp, false);
+				await (CheckReadOnlyAsync(s, dp, false));
+
+				using (var t = s.BeginTransaction())
+				{
+					await (CheckReadOnlyAsync(s, dp, false));
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					await (s.RefreshAsync(dp));
+					Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+					await (CheckReadOnlyAsync(s, dp, false));
+					dp.Description = "changed again";
+					Assert.That(dp.Description, Is.EqualTo("changed again"));
+					await (s.FlushAsync());
+					await (t.CommitAsync());
+				}
+
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = await (s.GetAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed again"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				await (s.DeleteAsync(dp));
+				await (t.CommitAsync());
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public async Task IsReadOnlyAfterSessionClosedAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp = null;
+
 			try
 			{
-	 			s.IsReadOnly(dp);
-				Assert.Fail("should have failed because session was closed");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+
+					dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (CheckReadOnlyAsync(s, dp, false));
+					await (t.CommitAsync());
+					s.Close();
+					s.IsReadOnly(dp);
+					Assert.Fail("should have failed because session was closed");
+				}
 			}
 			catch (ObjectDisposedException) // SessionException in Hibernate
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task IsReadOnlyAfterSessionClosedViaLazyInitializerAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			Assert.That(s.Contains(dp), Is.True);
-			s.Close();
-	
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (t.CommitAsync());
+				Assert.That(s.Contains(dp), Is.True);
+				s.Close();
+			}
+
+			Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
 			try
 			{
-	 			var value = ((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly;
+				var value = ((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly;
 				Assert.Fail("should have failed because session was detached");
 			}
 			catch (TransientObjectException)
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task DetachedIsReadOnlyAfterEvictViaSessionAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(s.Contains(dp), Is.True);
-			await (s.EvictAsync(dp));
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-	
-			try
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-	 			s.IsReadOnly(dp);
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				s.CacheMode = CacheMode.Ignore;
+
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(s.Contains(dp), Is.True);
+				await (s.EvictAsync(dp));
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+
+				try
+				{
+					s.IsReadOnly(dp);
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task DetachedIsReadOnlyAfterEvictViaLazyInitializerAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.EvictAsync(dp));
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-			try
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-	 			var value = ((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly;
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				s.CacheMode = CacheMode.Ignore;
+
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (s.EvictAsync(dp));
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+				try
+				{
+					var value = ((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly;
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task SetReadOnlyAfterSessionClosedAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			s.Close();
-	
+			DataPoint dp = null;
+
 			try
 			{
-	 			s.SetReadOnly(dp, true);
-				Assert.Fail("should have failed because session was closed");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+
+					dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (CheckReadOnlyAsync(s, dp, false));
+					await (t.CommitAsync());
+					s.Close();
+					s.SetReadOnly(dp, true);
+					Assert.Fail("should have failed because session was closed");
+				}
 			}
 			catch (ObjectDisposedException) // SessionException in Hibernate
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task SetReadOnlyAfterSessionClosedViaLazyInitializerAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			Assert.That(s.Contains(dp), Is.True);
-			s.Close();
-	
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+
+				dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (t.CommitAsync());
+				Assert.That(s.Contains(dp), Is.True);
+				s.Close();
+			}
+
+			Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
 			try
 			{
-	 			((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly = true;
+				((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly = true;
 				Assert.Fail("should have failed because session was detached");
 			}
 			catch (TransientObjectException)
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task SetClosedSessionInLazyInitializerAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.Transaction.CommitAsync());
-			Assert.That(s.Contains(dp), Is.True);
-			s.Close();
-	
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-			Assert.That(((ISessionImplementor)s).IsClosed, Is.True);
-			
+			DataPoint dp = null;
+
 			try
 			{
-				((INHibernateProxy)dp).HibernateLazyInitializer.SetSession((ISessionImplementor)s);
-				Assert.Fail("should have failed because session was closed");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+
+					dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					await (CheckReadOnlyAsync(s, dp, false));
+					await (t.CommitAsync());
+					Assert.That(s.Contains(dp), Is.True);
+					s.Close();
+
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+					Assert.That(((ISessionImplementor) s).IsClosed, Is.True);
+
+					((INHibernateProxy) dp).HibernateLazyInitializer.SetSession((ISessionImplementor) s);
+					Assert.Fail("should have failed because session was closed");
+				}
 			}
 			catch (ObjectDisposedException) // SessionException in Hibernate
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-		
+
 		[Test]
 		public async Task DetachedSetReadOnlyAfterEvictViaSessionAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			Assert.That(s.Contains(dp), Is.True);
-			await (s.EvictAsync(dp));
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-	
-			try
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-	 			s.SetReadOnly(dp, true);
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
+				s.CacheMode = CacheMode.Ignore;
+
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				Assert.That(s.Contains(dp), Is.True);
+				await (s.EvictAsync(dp));
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+
+				try
+				{
+					s.SetReadOnly(dp, true);
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public async Task DetachedSetReadOnlyAfterEvictViaLazyInitializerAsync()
 		{
 			DataPoint dpOrig = await (CreateDataPointAsync(CacheMode.Ignore));
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			await (CheckReadOnlyAsync(s, dp, false));
-			await (s.EvictAsync(dp));
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-			
-			try
-			{
-	 			((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly = true;
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				s.BeginTransaction();
-				await (s.DeleteAsync(dp));
-				await (s.Transaction.CommitAsync());
-				s.Close();
-			}
-		}
-		
-		private async Task<DataPoint> CreateDataPointAsync(CacheMode mode, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			DataPoint dp = null;
-			
-			using (ISession s = OpenSession())
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				
-				using (ITransaction t = s.BeginTransaction())
+
+				DataPoint dp = await (s.LoadAsync<DataPoint>(dpOrig.Id));
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				await (CheckReadOnlyAsync(s, dp, false));
+				await (s.EvictAsync(dp));
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+
+				try
 				{
-					dp = new DataPoint();
-					dp.X = 0.1M;
-					dp.Y = (decimal)System.Math.Cos((double)dp.X);
-					dp.Description = "original";
-					await (s.SaveAsync(dp, cancellationToken));
-					await (t.CommitAsync(cancellationToken));
+					((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly = true;
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					await (s.DeleteAsync(dp));
+					await (t.CommitAsync());
+					s.Close();
 				}
 			}
-			
-			return dp;
 		}
-	
+
+		private async Task<DataPoint> CreateDataPointAsync(CacheMode mode, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+
+				var dp = new DataPoint();
+				dp.X = 0.1M;
+				dp.Y = (decimal) System.Math.Cos((double) dp.X);
+				dp.Description = "original";
+				await (s.SaveAsync(dp, cancellationToken));
+				await (t.CommitAsync(cancellationToken));
+				return dp;
+			}
+		}
+
 		private async Task CheckReadOnlyAsync(ISession s, object proxy, bool expectedReadOnly, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			Assert.That(proxy, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer li = ((INHibernateProxy)proxy).HibernateLazyInitializer;
+			ILazyInitializer li = ((INHibernateProxy) proxy).HibernateLazyInitializer;
 			Assert.That(s, Is.SameAs(li.Session));
 			Assert.That(s.IsReadOnly(proxy), Is.EqualTo(expectedReadOnly));
 			Assert.That(li.ReadOnly, Is.EqualTo(expectedReadOnly));

--- a/src/NHibernate.Test/Async/ReadOnly/ReadOnlySessionTest.cs
+++ b/src/NHibernate.Test/Async/ReadOnly/ReadOnlySessionTest.cs
@@ -10,15 +10,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using NHibernate.Cfg;
-using NHibernate.Criterion;
-using NHibernate.Dialect;
-using NHibernate.Engine;
 using NHibernate.Proxy;
-using NHibernate.SqlCommand;
-using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ReadOnly
@@ -52,10 +44,10 @@ namespace NHibernate.Test.ReadOnly
 			DataPoint dp = null;
 			long dpId = -1;
 			
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 			
 				dp = new DataPoint();
 				dp.X = 0.1M;
@@ -63,13 +55,13 @@ namespace NHibernate.Test.ReadOnly
 				dp.Description = "original";
 				await (s.SaveAsync(dp));
 				dpId = dp.Id;
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				s.DefaultReadOnly = true;
 				Assert.That(s.DefaultReadOnly, Is.True);
 				dp = (DataPoint)await (s.LoadAsync<DataPoint>(dpId));
@@ -81,16 +73,16 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True, "was not initialized during mod");
 				Assert.That(dp.Description, Is.EqualTo("changed"), "desc not changed in memory");
 				await (s.FlushAsync());
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
-	
-			using (ISession s = OpenSession())
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				IList list = await (s.CreateQuery("from DataPoint where description = 'changed'").ListAsync());
 				Assert.That(list.Count, Is.EqualTo(0), "change written to database");
 				await (s.CreateQuery("delete from DataPoint").ExecuteUpdateAsync());
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 		

--- a/src/NHibernate.Test/Async/ReadOnly/ReadOnlyVersionedNodes.cs
+++ b/src/NHibernate.Test/Async/ReadOnly/ReadOnlyVersionedNodes.cs
@@ -8,18 +8,7 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using NHibernate.Cfg;
-using NHibernate.Criterion;
-using NHibernate.Dialect;
-using NHibernate.Engine;
-using NHibernate.Proxy;
-using NHibernate.SqlCommand;
-using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ReadOnly
@@ -42,22 +31,23 @@ namespace NHibernate.Test.ReadOnly
 		public async Task SetReadOnlyTrueAndFalseAsync()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				s.BeginTransaction();
-				node = await (s.GetAsync<VersionedNode>(node.Id));
-				s.SetReadOnly(node, true);
-				node.Name = "node-name";
-				await (s.Transaction.CommitAsync());
+				using (var t = s.BeginTransaction())
+				{
+					node = await (s.GetAsync<VersionedNode>(node.Id));
+					s.SetReadOnly(node, true);
+					node.Name = "node-name";
+					await (t.CommitAsync());
+				}
 
 				AssertUpdateCount(0);
 				AssertInsertCount(0);
@@ -65,24 +55,25 @@ namespace NHibernate.Test.ReadOnly
 				// the changed name is still in node
 				Assert.That(node.Name, Is.EqualTo("node-name"));
 
-				s.BeginTransaction();
-				node = await (s.GetAsync<VersionedNode>(node.Id));
-				// the changed name is still in the session
-				Assert.That(node.Name, Is.EqualTo("node-name"));
-				await (s.RefreshAsync(node));
-				// after refresh, the name reverts to the original value
-				Assert.That(node.Name, Is.EqualTo("node"));
-				node = await (s.GetAsync<VersionedNode>(node.Id));
-				Assert.That(node.Name, Is.EqualTo("node"));
-				await (s.Transaction.CommitAsync());
+				using (var t = s.BeginTransaction())
+				{
+					node = await (s.GetAsync<VersionedNode>(node.Id));
+					// the changed name is still in the session
+					Assert.That(node.Name, Is.EqualTo("node-name"));
+					await (s.RefreshAsync(node));
+					// after refresh, the name reverts to the original value
+					Assert.That(node.Name, Is.EqualTo("node"));
+					node = await (s.GetAsync<VersionedNode>(node.Id));
+					Assert.That(node.Name, Is.EqualTo("node"));
+					await (t.CommitAsync());
+				}
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = await (s.GetAsync<VersionedNode>(node.Id));
 				Assert.That(node.Name, Is.EqualTo("node"));
 				s.SetReadOnly(node, true);
@@ -93,22 +84,21 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(node.Name, Is.EqualTo("node"));
 				s.SetReadOnly(node, false);
 				node.Name = "diff-node-name";
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = await (s.GetAsync<VersionedNode>(node.Id));
 				Assert.That(node.Name, Is.EqualTo("diff-node-name"));
 				Assert.That(node.Version, Is.EqualTo(2));
 				s.SetReadOnly(node, true);
 				await (s.DeleteAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -119,37 +109,35 @@ namespace NHibernate.Test.ReadOnly
 		public async Task UpdateSetReadOnlyTwiceAsync()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = await (s.GetAsync<VersionedNode>(node.Id));
 				node.Name = "node-name";
 				s.SetReadOnly(node, true);
 				s.SetReadOnly(node, true);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = await (s.GetAsync<VersionedNode>(node.Id));
 				Assert.That(node.Name, Is.EqualTo("node"));
 				Assert.That(node.Version, Is.EqualTo(1));
 				s.SetReadOnly(node, true);
 				await (s.DeleteAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -160,37 +148,35 @@ namespace NHibernate.Test.ReadOnly
 		public async Task UpdateSetModifiableAsync()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = await (s.GetAsync<VersionedNode>(node.Id));
 				node.Name = "node-name";
 				s.SetReadOnly(node, false);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = await (s.GetAsync<VersionedNode>(node.Id));
 				Assert.That(node.Name, Is.EqualTo("node-name"));
 				Assert.That(node.Version, Is.EqualTo(2));
 				//s.SetReadOnly(node, true);
 				await (s.DeleteAsync(node));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -201,36 +187,36 @@ namespace NHibernate.Test.ReadOnly
 		public async Task AddNewChildToReadOnlyParentAsync()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
 
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				VersionedNode parentManaged = await (s.GetAsync<VersionedNode>(parent.Id));
 				s.SetReadOnly(parentManaged, true);
 				parentManaged.Name = "new parent name";
 				parentManaged.AddChild(child);
 				await (s.SaveAsync(parentManaged));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				Assert.That(parent.Name, Is.EqualTo("parent"));
 				Assert.That(parent.Children.Count, Is.EqualTo(1));
@@ -238,7 +224,7 @@ namespace NHibernate.Test.ReadOnly
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(child, Is.Not.Null);
 				await (s.DeleteAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 		}
 	
@@ -246,11 +232,11 @@ namespace NHibernate.Test.ReadOnly
 		public async Task UpdateParentWithNewChildCommitWithReadOnlyParentAsync()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -258,22 +244,20 @@ namespace NHibernate.Test.ReadOnly
 			parent.Name = "new parent name";
 			VersionedNode child = new VersionedNode("child", "child");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.UpdateAsync(parent));
 				s.SetReadOnly(parent, true);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -286,7 +270,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -297,11 +281,11 @@ namespace NHibernate.Test.ReadOnly
 		public async Task MergeDetachedParentWithNewChildCommitWithReadOnlyParentAsync()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -309,22 +293,20 @@ namespace NHibernate.Test.ReadOnly
 			parent.Name = "new parent name";
 			VersionedNode child = new VersionedNode("child", "child");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = (VersionedNode) await (s.MergeAsync(parent));
 				s.SetReadOnly(parent, true);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -337,7 +319,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -348,11 +330,11 @@ namespace NHibernate.Test.ReadOnly
 		public async Task GetParentMakeReadOnlyThenMergeDetachedParentWithNewChildCAsync()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -360,24 +342,22 @@ namespace NHibernate.Test.ReadOnly
 			parent.Name = "new parent name";
 			VersionedNode child = new VersionedNode("child", "child");
 			parent.AddChild(child);
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode parentManaged = await (s.GetAsync<VersionedNode>(parent.Id));
 				s.SetReadOnly(parentManaged, true);
 				VersionedNode parentMerged = (VersionedNode) await (s.MergeAsync(parent));
 				Assert.That(parentManaged, Is.SameAs(parentMerged));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -388,7 +368,7 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(child.Version, Is.EqualTo(1));
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -400,55 +380,50 @@ namespace NHibernate.Test.ReadOnly
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			VersionedNode child = new VersionedNode("child", "child");
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent.AddChild(child);
 				await (s.PersistAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = (VersionedNode) await (s.MergeAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode parentGet = await (s.GetAsync<VersionedNode>(parent.Id));
 				await (s.MergeAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode parentLoad = await (s.LoadAsync<VersionedNode>(parent.Id));
 				await (s.MergeAsync(parent));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -459,7 +434,7 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(child.Version, Is.EqualTo(1));
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -470,32 +445,31 @@ namespace NHibernate.Test.ReadOnly
 		public async Task AddNewParentToReadOnlyChildAsync()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
 
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode childManaged = await (s.GetAsync<VersionedNode>(child.Id));
 				s.SetReadOnly(childManaged, true);
 				childManaged.Name = "new child name";
 				parent.AddChild(childManaged);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(1);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(child.Name, Is.EqualTo("child"));
 				Assert.That(child.Parent, Is.Null);
@@ -504,7 +478,7 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(parent, Is.Not.Null);
 				s.SetReadOnly(child, true);
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -515,11 +489,11 @@ namespace NHibernate.Test.ReadOnly
 		public async Task UpdateChildWithNewParentCommitWithReadOnlyChildAsync()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -527,22 +501,20 @@ namespace NHibernate.Test.ReadOnly
 			child.Name = "new child name";
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.UpdateAsync(child));
 				s.SetReadOnly(child, true);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(child.Name, Is.EqualTo("child"));
@@ -555,7 +527,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -566,11 +538,11 @@ namespace NHibernate.Test.ReadOnly
 		public async Task MergeDetachedChildWithNewParentCommitWithReadOnlyChildAsync()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -578,22 +550,20 @@ namespace NHibernate.Test.ReadOnly
 			child.Name = "new child name";
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				child = (VersionedNode) await (s.MergeAsync(child));
 				s.SetReadOnly(child, true);
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0); // NH-specific: Hibernate issues a separate UPDATE for the version number
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(child.Name, Is.EqualTo("child"));
@@ -606,7 +576,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -617,11 +587,11 @@ namespace NHibernate.Test.ReadOnly
 		public async Task GetChildMakeReadOnlyThenMergeDetachedChildWithNewParentAsync()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				await (s.PersistAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			ClearCounts();
@@ -629,24 +599,22 @@ namespace NHibernate.Test.ReadOnly
 			child.Name = "new child name";
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode childManaged = await (s.GetAsync<VersionedNode>(child.Id));
 				s.SetReadOnly(childManaged, true);
 				VersionedNode childMerged = (VersionedNode) await (s.MergeAsync(child));
 				Assert.That(childManaged, Is.SameAs(childMerged));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0); // NH-specific: Hibernate issues a separate UPDATE for the version number
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = await (s.GetAsync<VersionedNode>(parent.Id));
 				child = await (s.GetAsync<VersionedNode>(child.Id));
 				Assert.That(child.Name, Is.EqualTo("child"));
@@ -660,7 +628,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				await (s.DeleteAsync(parent));
 				await (s.DeleteAsync(child));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 			}
 
 			AssertUpdateCount(0);
@@ -669,14 +637,13 @@ namespace NHibernate.Test.ReadOnly
 	
 		protected override void OnTearDown()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
-
 				s.CreateQuery("delete from VersionedNode where parent is not null").ExecuteUpdate();
 				s.CreateQuery("delete from VersionedNode").ExecuteUpdate();
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			base.OnTearDown();

--- a/src/NHibernate.Test/Async/SqlTest/Query/NativeSQLQueriesFixture.cs
+++ b/src/NHibernate.Test/Async/SqlTest/Query/NativeSQLQueriesFixture.cs
@@ -720,7 +720,7 @@ namespace NHibernate.Test.SqlTest.Query
 		public async Task HandlesManualSynchronizationAsync()
 		{
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.SessionFactory.Statistics.IsStatisticsEnabled = true;
 				s.SessionFactory.Statistics.Clear();
@@ -739,7 +739,7 @@ namespace NHibernate.Test.SqlTest.Query
 
 				// clean up
 				await (s.DeleteAsync(jboss));
-				await (s.Transaction.CommitAsync());
+				await (t.CommitAsync());
 				s.Close();
 			}
 		}

--- a/src/NHibernate.Test/Async/TransactionTest/TransactionFixture.cs
+++ b/src/NHibernate.Test/Async/TransactionTest/TransactionFixture.cs
@@ -9,11 +9,10 @@
 
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using NHibernate.Linq;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.TransactionTest
 {
@@ -96,41 +95,30 @@ namespace NHibernate.Test.TransactionTest
 			{
 				using (ITransaction t = s.BeginTransaction())
 				{
-					Assert.AreSame(t, s.Transaction);
-					Assert.IsFalse(s.Transaction.WasCommitted);
-					Assert.IsFalse(s.Transaction.WasRolledBack);
+					Assert.AreSame(t, s.GetCurrentTransaction());
+					Assert.IsFalse(s.GetCurrentTransaction().WasCommitted);
+					Assert.IsFalse(s.GetCurrentTransaction().WasRolledBack);
 					await (t.CommitAsync());
 
-					// ISession.Transaction returns a new transaction
-					// if the previous one completed!
-					Assert.IsNotNull(s.Transaction);
-					Assert.IsFalse(t == s.Transaction);
+					// ISession.GetCurrentTransaction() returns null if the transaction is completed.
+					Assert.IsNull(s.GetCurrentTransaction());
 
 					Assert.IsTrue(t.WasCommitted);
 					Assert.IsFalse(t.WasRolledBack);
-					Assert.IsFalse(s.Transaction.WasCommitted);
-					Assert.IsFalse(s.Transaction.WasRolledBack);
 					Assert.IsFalse(t.IsActive);
-					Assert.IsFalse(s.Transaction.IsActive);
 				}
 
 				using (ITransaction t = s.BeginTransaction())
 				{
 					await (t.RollbackAsync());
 
-					// ISession.Transaction returns a new transaction
-					// if the previous one completed!
-					Assert.IsNotNull(s.Transaction);
-					Assert.IsFalse(t == s.Transaction);
+					// ISession.GetCurrentTransaction() returns null if the transaction is completed.
+					Assert.IsNull(s.GetCurrentTransaction());
 
 					Assert.IsTrue(t.WasRolledBack);
 					Assert.IsFalse(t.WasCommitted);
 
-					Assert.IsFalse(s.Transaction.WasCommitted);
-					Assert.IsFalse(s.Transaction.WasRolledBack);
-
 					Assert.IsFalse(t.IsActive);
-					Assert.IsFalse(s.Transaction.IsActive);
 				}
 			}
 		}

--- a/src/NHibernate.Test/Async/TransformTests/AliasToBeanResultTransformerFixture.cs
+++ b/src/NHibernate.Test/Async/TransformTests/AliasToBeanResultTransformerFixture.cs
@@ -142,25 +142,21 @@ namespace NHibernate.Test.TransformTests
 		protected override void OnSetUp()
 		{
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
 					s.Save(new Simple { Name = "Name1" });
 					s.Save(new Simple { Name = "Name2" });
-					s.Transaction.Commit();
+					t.Commit();
 				}
-			}
 		}
 
 		protected override void OnTearDown()
 		{
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
 					s.Delete("from Simple");
-					s.Transaction.Commit();
-				}
+					t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Async/VersionTest/Db/MsSQL/ComplexDomainFixture.cs
+++ b/src/NHibernate.Test/Async/VersionTest/Db/MsSQL/ComplexDomainFixture.cs
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 
-using System.Collections;
 using NHibernate.Dialect;
 using NUnit.Framework;
 
@@ -62,11 +61,11 @@ namespace NHibernate.Test.VersionTest.Db.MsSQL
 				Assert.IsTrue(BinaryTimestamp.Equals(bar.Timestamp, retrievedBar.Timestamp), "Timestamps are different!");
 			}
 
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				session.BeginTransaction();
 				await (session.DeleteAsync("from Bar"));
-				await (session.Transaction.CommitAsync());
+				await (tran.CommitAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Cascade/Circle/MultiPathCircleCascadeTest.cs
+++ b/src/NHibernate.Test/Cascade/Circle/MultiPathCircleCascadeTest.cs
@@ -153,21 +153,21 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Merge(route);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(1);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = s.Get<Route>(route.RouteId);
 				CheckResults(route, true);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -179,23 +179,23 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Node pickupNode = route.Nodes.First(n => n.Name == "pickupNodeB");
 				pickupNode = (Node) s.Merge(pickupNode);
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = s.Get<Route>(route.RouteId);
 				CheckResults(route, false);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -207,22 +207,22 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Node deliveryNode = route.Nodes.First(n => n.Name == "deliveryNodeB");
 				deliveryNode = (Node) s.Merge(deliveryNode);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = s.Get<Route>(route.RouteId);
 				CheckResults(route, false);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -234,21 +234,21 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Tour tour = s.Merge(route.Nodes.First().Tour);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = s.Get<Route>(route.RouteId);
 				CheckResults(route, false);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 		
@@ -260,7 +260,7 @@ namespace NHibernate.Test.Cascade.Circle
 			ClearCounts();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Node node = route.Nodes.First();
 				Transport transport = null;
@@ -272,18 +272,18 @@ namespace NHibernate.Test.Cascade.Circle
 
 				transport = (Transport) s.Merge(transport);
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 	
 			AssertInsertCount(4);
 			AssertUpdateCount(0);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route = s.Get<Route>(route.RouteId);
 				CheckResults(route, false);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -291,12 +291,12 @@ namespace NHibernate.Test.Cascade.Circle
 		{
 			Route route = new Route();
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				route.Name = "routeA";
 
 				s.Save(route);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			route.Name = "new routeA";
 			route.TransientField = "sfnaouisrbn";

--- a/src/NHibernate.Test/Cascade/MultiPathCascadeTest.cs
+++ b/src/NHibernate.Test/Cascade/MultiPathCascadeTest.cs
@@ -24,20 +24,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = s.Merge(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 	
 			this.VerifyModifications(a.Id);
@@ -49,22 +49,22 @@ namespace NHibernate.Test.Cascade
 			// persist a simple A in the database
 			A a = new A();
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				A aLoaded = s.Load<A>(a.Id);
 				Assert.That(aLoaded, Is.InstanceOf<INHibernateProxy>());
 				Assert.That(s.Merge(a), Is.SameAs(aLoaded));
-				s.Transaction.Commit();
+				t.Commit();
 			}
 	
 			this.VerifyModifications(a.Id);
@@ -77,21 +77,21 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 	
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Update(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			this.VerifyModifications(a.Id);
 		}
@@ -103,20 +103,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				// retrieve the previously saved instance from the database, and update it
 				a = s.Get<A>(a.Id);
 				this.ModifyEntity(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			this.VerifyModifications(a.Id);
 		}
@@ -128,20 +128,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}	
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = s.Merge(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			this.VerifyModifications(a.Id);
 	
@@ -155,7 +155,7 @@ namespace NHibernate.Test.Cascade
 			h.Gs.Add(gNew);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				try
 				{
@@ -177,20 +177,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = (A) s.Merge(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			this.VerifyModifications(a.Id);
 	
@@ -226,20 +226,20 @@ namespace NHibernate.Test.Cascade
 			A a = new A();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a.Data = "Anna";
 				s.Save(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			// modify detached entity
 			this.ModifyEntity(a);
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				a = (A) s.Merge(a);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 			this.VerifyModifications(a.Id);
 	
@@ -305,7 +305,7 @@ namespace NHibernate.Test.Cascade
 		private void VerifyModifications(long aId)
 		{
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				// retrieve the A object and check it
 				A a = s.Get<A>(aId);
@@ -332,7 +332,7 @@ namespace NHibernate.Test.Cascade
 				Assert.That(hFromA.Gs.Count, Is.EqualTo(1));
 				Assert.That(hFromA.Gs.First(), Is.SameAs(gFromA));
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/Cascade/RefreshFixture.cs
+++ b/src/NHibernate.Test/Cascade/RefreshFixture.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Data;
-using System.Data.Common;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Cascade
@@ -56,7 +54,7 @@ namespace NHibernate.Test.Cascade
 			var cmd = conn.CreateCommand();
 			cmd.CommandText = "UPDATE T_JOB SET JOB_STATUS = 1";
 			cmd.CommandType = CommandType.Text;
-			session.Transaction.Enlist(cmd);
+			session.GetSessionImplementation().ConnectionManager.EnlistInTransaction(cmd);
 			cmd.ExecuteNonQuery();
 		}
 

--- a/src/NHibernate.Test/ConnectionTest/AggressiveReleaseTest.cs
+++ b/src/NHibernate.Test/ConnectionTest/AggressiveReleaseTest.cs
@@ -218,30 +218,31 @@ namespace NHibernate.Test.ConnectionTest
 		{
 			Prepare();
 			ISession s = GetSessionUnderTest();
-			s.BeginTransaction();
-
-			IList<Silly> entities = new List<Silly>();
-			for (int i = 0; i < 10; i++)
+			using (var t = s.BeginTransaction())
 			{
-				Other other = new Other("other-" + i);
-				Silly silly = new Silly("silly-" + i, other);
-				entities.Add(silly);
-				s.Save(silly);
-			}
-			s.Flush();
+				IList<Silly> entities = new List<Silly>();
+				for (int i = 0; i < 10; i++)
+				{
+					Other other = new Other("other-" + i);
+					Silly silly = new Silly("silly-" + i, other);
+					entities.Add(silly);
+					s.Save(silly);
+				}
+				s.Flush();
 
-			foreach (Silly silly in entities)
-			{
-				silly.Name = "new-" + silly.Name;
-				silly.Other.Name = "new-" + silly.Other.Name;
-			}
-//			long initialCount = sessions.Statistics.getConnectCount();
-			s.Flush();
-//			Assert.AreEqual(initialCount + 1, sessions.Statistics.getConnectCount(), "connection not maintained through Flush");
+				foreach (Silly silly in entities)
+				{
+					silly.Name = "new-" + silly.Name;
+					silly.Other.Name = "new-" + silly.Other.Name;
+				}
+				// long initialCount = sessions.Statistics.getConnectCount();
+				s.Flush();
+				//Assert.AreEqual(initialCount + 1, sessions.Statistics.getConnectCount(), "connection not maintained through Flush");
 
-			s.Delete("from Silly");
-			s.Delete("from Other");
-			s.Transaction.Commit();
+				s.Delete("from Silly");
+				s.Delete("from Other");
+				t.Commit();
+			}
 			Release(s);
 			Done();
 		}

--- a/src/NHibernate.Test/ConnectionTest/ThreadLocalCurrentSessionTest.cs
+++ b/src/NHibernate.Test/ConnectionTest/ThreadLocalCurrentSessionTest.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Test.ConnectionTest
 		protected override void Release(ISession session)
 		{
 			long initialCount = Sfi.Statistics.SessionCloseCount;
-			session.Transaction.Commit();
+			session.GetCurrentTransaction()?.Commit();
 			long subsequentCount = Sfi.Statistics.SessionCloseCount;
 			Assert.AreEqual(initialCount + 1, subsequentCount, "Session still open after commit");
 			// also make sure it was cleaned up from the internal ThreadLocal...
@@ -37,8 +37,8 @@ namespace NHibernate.Test.ConnectionTest
 		public void ContextCleanup()
 		{
 			ISession session = Sfi.OpenSession();
-			session.BeginTransaction();
-			session.Transaction.Commit();
+			using(var t = session.BeginTransaction())
+				t.Commit();
 			Assert.IsFalse(session.IsOpen, "session open after txn completion");
 			Assert.IsFalse(TestableThreadLocalContext.IsSessionBound(session), "session still bound after txn completion");
 			

--- a/src/NHibernate.Test/DynamicEntity/Interceptor/InterceptorDynamicEntity.cs
+++ b/src/NHibernate.Test/DynamicEntity/Interceptor/InterceptorDynamicEntity.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using NHibernate.Cfg;
 using NUnit.Framework;
 
@@ -27,68 +26,78 @@ namespace NHibernate.Test.DynamicEntity.Interceptor
 		[Test]
 		public void It()
 		{
+			var company = ProxyHelper.NewCompanyProxy();
+			var customer = ProxyHelper.NewCustomerProxy();
 			// Test saving these dyna-proxies
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			Company company = ProxyHelper.NewCompanyProxy();
-			company.Name = "acme";
-			session.Save(company);
-			Customer customer = ProxyHelper.NewCustomerProxy();
-			customer.Name = "Steve";
-			customer.Company = company;
-			session.Save(customer);
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				company.Name = "acme";
+				session.Save(company);
+				customer.Name = "Steve";
+				customer.Company = company;
+				session.Save(customer);
+				tran.Commit();
+				session.Close();
+			}
 
 			Assert.IsNotNull(company.Id, "company id not assigned");
 			Assert.IsNotNull(customer.Id, "customer id not assigned");
 
 			// Test loading these dyna-proxies, along with flush processing
-			session = OpenSession();
-			session.BeginTransaction();
-			customer = session.Load<Customer>(customer.Id);
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				customer = session.Load<Customer>(customer.Id);
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
 
-			customer.Name = "other";
-			session.Flush();
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
+				customer.Name = "other";
+				session.Flush();
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
 
-			session.Refresh(customer);
-			Assert.AreEqual("other", customer.Name, "name not updated");
-			Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
+				session.Refresh(customer);
+				Assert.AreEqual("other", customer.Name, "name not updated");
+				Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
 
-			session.Transaction.Commit();
-			session.Close();
+				tran.Commit();
+				session.Close();
+			}
 
 			// Test detached entity re-attachment with these dyna-proxies
 			customer.Name = "Steve";
-			session = OpenSession();
-			session.BeginTransaction();
-			session.Update(customer);
-			session.Flush();
-			session.Refresh(customer);
-			Assert.AreEqual("Steve", customer.Name, "name not updated");
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Update(customer);
+				session.Flush();
+				session.Refresh(customer);
+				Assert.AreEqual("Steve", customer.Name, "name not updated");
+				tran.Commit();
+				session.Close();
+			}
 
 			// Test querying
-			session = OpenSession();
-			session.BeginTransaction();
-			int count = session.CreateQuery("from Customer").List().Count;
-			Assert.AreEqual(1, count, "querying dynamic entity");
-			session.Clear();
-			count = session.CreateQuery("from Person").List().Count;
-			Assert.AreEqual(1, count, "querying dynamic entity");
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				int count = session.CreateQuery("from Customer").List().Count;
+				Assert.AreEqual(1, count, "querying dynamic entity");
+				session.Clear();
+				count = session.CreateQuery("from Person").List().Count;
+				Assert.AreEqual(1, count, "querying dynamic entity");
+				tran.Commit();
+				session.Close();
+			}
 
 			// test deleteing
-			session = OpenSession();
-			session.BeginTransaction();
-			session.Delete(company);
-			session.Delete(customer);
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Delete(company);
+				session.Delete(customer);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/DynamicEntity/Tuplizer/TuplizerDynamicEntity.cs
+++ b/src/NHibernate.Test/DynamicEntity/Tuplizer/TuplizerDynamicEntity.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Cfg;
 using NUnit.Framework;
@@ -28,30 +27,33 @@ namespace NHibernate.Test.DynamicEntity.Tuplizer
 		[Test]
 		public void It()
 		{
+			var company = ProxyHelper.NewCompanyProxy();
+			var customer = ProxyHelper.NewCustomerProxy();
+			var address = ProxyHelper.NewAddressProxy();
+			var son = ProxyHelper.NewPersonProxy();
+			var wife = ProxyHelper.NewPersonProxy();
+
 			// Test saving these dyna-proxies
-			ISession session = OpenSession();
-			session.BeginTransaction();
-			Company company = ProxyHelper.NewCompanyProxy();
-			company.Name = "acme";
-			session.Save(company);
-			Customer customer = ProxyHelper.NewCustomerProxy();
-			customer.Name = "Steve";
-			customer.Company = company;
-			Address address = ProxyHelper.NewAddressProxy();
-			address.Street = "somewhere over the rainbow";
-			address.City = "lawerence, kansas";
-			address.PostalCode = "toto";
-			customer.Address = address;
-			customer.Family = new HashSet<Person>();
-			Person son = ProxyHelper.NewPersonProxy();
-			son.Name = "son";
-			customer.Family.Add(son);
-			Person wife = ProxyHelper.NewPersonProxy();
-			wife.Name = "wife";
-			customer.Family.Add(wife);
-			session.Save(customer);
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				company.Name = "acme";
+				session.Save(company);
+				customer.Name = "Steve";
+				customer.Company = company;
+				address.Street = "somewhere over the rainbow";
+				address.City = "lawerence, kansas";
+				address.PostalCode = "toto";
+				customer.Address = address;
+				customer.Family = new HashSet<Person>();
+				son.Name = "son";
+				customer.Family.Add(son);
+				wife.Name = "wife";
+				customer.Family.Add(wife);
+				session.Save(customer);
+				tran.Commit();
+				session.Close();
+			}
 
 			Assert.IsNotNull(company.Id, "company id not assigned");
 			Assert.IsNotNull(customer.Id, "customer id not assigned");
@@ -60,51 +62,59 @@ namespace NHibernate.Test.DynamicEntity.Tuplizer
 			Assert.IsNotNull(wife.Id, "wife:Person id not assigned");
 
 			// Test loading these dyna-proxies, along with flush processing
-			session = OpenSession();
-			session.BeginTransaction();
-			customer = session.Load<Customer>(customer.Id);
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				customer = session.Load<Customer>(customer.Id);
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer), "should-be-proxy was initialized");
 
-			customer.Name = "other";
-			session.Flush();
-			Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
+				customer.Name = "other";
+				session.Flush();
+				Assert.IsFalse(NHibernateUtil.IsInitialized(customer.Company), "should-be-proxy was initialized");
 
-			session.Refresh(customer);
-			Assert.AreEqual("other", customer.Name, "name not updated");
-			Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
+				session.Refresh(customer);
+				Assert.AreEqual("other", customer.Name, "name not updated");
+				Assert.AreEqual("acme", customer.Company.Name, "company association not correct");
 
-			session.Transaction.Commit();
-			session.Close();
+				tran.Commit();
+				session.Close();
+			}
 
 			// Test detached entity re-attachment with these dyna-proxies
 			customer.Name = "Steve";
-			session = OpenSession();
-			session.BeginTransaction();
-			session.Update(customer);
-			session.Flush();
-			session.Refresh(customer);
-			Assert.AreEqual("Steve", customer.Name, "name not updated");
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Update(customer);
+				session.Flush();
+				session.Refresh(customer);
+				Assert.AreEqual("Steve", customer.Name, "name not updated");
+				tran.Commit();
+				session.Close();
+			}
 
 			// Test querying
-			session = OpenSession();
-			session.BeginTransaction();
-			int count = session.CreateQuery("from Customer").List().Count;
-			Assert.AreEqual(1, count, "querying dynamic entity");
-			session.Clear();
-			count = session.CreateQuery("from Person").List().Count;
-			Assert.AreEqual(3, count, "querying dynamic entity");
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				int count = session.CreateQuery("from Customer").List().Count;
+				Assert.AreEqual(1, count, "querying dynamic entity");
+				session.Clear();
+				count = session.CreateQuery("from Person").List().Count;
+				Assert.AreEqual(3, count, "querying dynamic entity");
+				tran.Commit();
+				session.Close();
+			}
 
 			// test deleteing
-			session = OpenSession();
-			session.BeginTransaction();
-			session.Delete(company);
-			session.Delete(customer);
-			session.Transaction.Commit();
-			session.Close();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				session.Delete(company);
+				session.Delete(customer);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/GeneratedTest/PartiallyGeneratedComponentTest.cs
+++ b/src/NHibernate.Test/GeneratedTest/PartiallyGeneratedComponentTest.cs
@@ -1,7 +1,4 @@
-using System;
-
 using NHibernate.Dialect;
-
 using NUnit.Framework;
 
 namespace NHibernate.Test.GeneratedTest
@@ -16,7 +13,7 @@ namespace NHibernate.Test.GeneratedTest
 
 		protected override string[] Mappings
 		{
-			get { return new string[] { "GeneratedTest.ComponentOwner.hbm.xml" }; }
+			get { return new [] { "GeneratedTest.ComponentOwner.hbm.xml" }; }
 		}
 
 		protected override bool AppliesTo(Dialect.Dialect dialect)
@@ -28,34 +25,40 @@ namespace NHibernate.Test.GeneratedTest
 		public void PartialComponentGeneration()
 		{
 			ComponentOwner owner = new ComponentOwner("initial");
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			s.Save(owner);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Save(owner);
+				t.Commit();
+				s.Close();
+			}
 
 			Assert.IsNotNull(owner.Component, "expecting insert value generation");
 			int previousValue = owner.Component.Generated;
 			Assert.AreNotEqual(0, previousValue, "expecting insert value generation");
 
-			s = OpenSession();
-			s.BeginTransaction();
-			owner = (ComponentOwner) s.Get(typeof(ComponentOwner), owner.Id);
-			Assert.AreEqual(previousValue, owner.Component.Generated, "expecting insert value generation");
-			owner.Name = "subsequent";
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				owner = (ComponentOwner) s.Get(typeof(ComponentOwner), owner.Id);
+				Assert.AreEqual(previousValue, owner.Component.Generated, "expecting insert value generation");
+				owner.Name = "subsequent";
+				t.Commit();
+				s.Close();
+			}
 
 			Assert.IsNotNull(owner.Component);
 			previousValue = owner.Component.Generated;
 
-			s = OpenSession();
-			s.BeginTransaction();
-			owner = (ComponentOwner) s.Get(typeof(ComponentOwner), owner.Id);
-			Assert.AreEqual(previousValue, owner.Component.Generated, "expecting update value generation");
-			s.Delete(owner);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				owner = (ComponentOwner) s.Get(typeof(ComponentOwner), owner.Id);
+				Assert.AreEqual(previousValue, owner.Component.Generated, "expecting update value generation");
+				s.Delete(owner);
+				t.Commit();
+				s.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Generatedkeys/ByTrigger/GeneratedIdentityFixture.cs
+++ b/src/NHibernate.Test/Generatedkeys/ByTrigger/GeneratedIdentityFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.ByTrigger
@@ -24,18 +23,19 @@ namespace NHibernate.Test.Generatedkeys.ByTrigger
 		[Test]
 		public void GetGeneratedKeysSupport()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntity { Name = "entity-1" };
+				session.Save(e);
 
-			var e = new MyEntity { Name = "entity-1" };
-			session.Save(e);
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			session.Delete(e);
-			session.Transaction.Commit();
-			session.Close();
+				session.Delete(e);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
+++ b/src/NHibernate.Test/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NHibernate.Cfg;
 using NUnit.Framework;
 
@@ -31,137 +30,188 @@ namespace NHibernate.Test.Generatedkeys.Identity
 		[Test]
 		public void IdentityColumnGeneratedIds()
 		{
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			MyEntity myEntity = new MyEntity("test");
-			long id = (long)s.Save(myEntity);
-			Assert.IsNotNull(id,"identity column did not force immediate insert");
-			Assert.AreEqual(id, myEntity.Id);
-			s.Delete(myEntity);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				MyEntity myEntity = new MyEntity("test");
+				long id = (long) s.Save(myEntity);
+				Assert.IsNotNull(id, "identity column did not force immediate insert");
+				Assert.AreEqual(id, myEntity.Id);
+				s.Delete(myEntity);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test, Ignore("Not supported yet.")]
 		public void PersistOutsideTransaction()
 		{
-			ISession s = OpenSession();
+			var myEntity1 = new MyEntity("test-save");
+			var myEntity2 = new MyEntity("test-persist");
+			using (var s = OpenSession())
+			{
+				// first test save() which should force an immediate insert...
+				long id = (long) s.Save(myEntity1);
+				Assert.IsNotNull(id, "identity column did not force immediate insert");
+				Assert.AreEqual(id, myEntity1.Id);
 
-			// first test save() which should force an immediate insert...
-			MyEntity myEntity1 = new MyEntity("test-save");
-			long id = (long)s.Save(myEntity1);
-			Assert.IsNotNull(id, "identity column did not force immediate insert");
-			Assert.AreEqual(id, myEntity1.Id);
+				// next test persist() which should cause a delayed insert...
+				long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+				s.Persist(myEntity2);
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity2.Id);
 
-			// next test persist() which should cause a delayed insert...
-			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
-			MyEntity myEntity2 = new MyEntity("test-persist");
-			s.Persist(myEntity2);
-			Assert.AreEqual(initialInsertCount, Sfi.Statistics.EntityInsertCount, "persist on identity column not delayed");
-			Assert.AreEqual(0,myEntity2.Id);
+				// an explicit flush should cause execution of the delayed insertion
+				s.Flush();
+				Assert.AreEqual(
+					initialInsertCount + 1,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
 
-			// an explicit flush should cause execution of the delayed insertion
-			s.Flush();
-			Assert.AreEqual(initialInsertCount + 1, Sfi.Statistics.EntityInsertCount, "delayed persist insert not executed on flush");
-			s.Close();
-
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete(myEntity1);
-			s.Delete(myEntity2);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete(myEntity1);
+				s.Delete(myEntity2);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test, Ignore("Not supported yet.")]
 		public void PersistOutsideTransactionCascadedToNonInverseCollection()
 		{
 			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
-			ISession s = OpenSession();
-			MyEntity myEntity = new MyEntity("test-persist");
-			myEntity.NonInverseChildren.Add(new MyChild("test-child-persist-non-inverse"));
-			s.Persist(myEntity);
-			Assert.AreEqual(initialInsertCount, Sfi.Statistics.EntityInsertCount, "persist on identity column not delayed");
-			Assert.AreEqual(0, myEntity.Id);
-			s.Flush();
-			Assert.AreEqual(initialInsertCount + 2, Sfi.Statistics.EntityInsertCount,"delayed persist insert not executed on flush");
-			s.Close();
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity = new MyEntity("test-persist");
+				myEntity.NonInverseChildren.Add(new MyChild("test-child-persist-non-inverse"));
+				s.Persist(myEntity);
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity.Id);
+				s.Flush();
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete("from MyChild");
-			s.Delete("from MyEntity");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from MyChild");
+				s.Delete("from MyEntity");
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test, Ignore("Not supported yet.")]
 		public void PersistOutsideTransactionCascadedToInverseCollection()
 		{
 			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
-			ISession s = OpenSession();
-			MyEntity myEntity2 = new MyEntity("test-persist-2");
-			MyChild child = new MyChild("test-child-persist-inverse");
-			myEntity2.InverseChildren.Add(child);
-			child.InverseParent= myEntity2;
-			s.Persist(myEntity2);
-			Assert.AreEqual(initialInsertCount, Sfi.Statistics.EntityInsertCount,"persist on identity column not delayed");
-			Assert.AreEqual(0, myEntity2.Id);
-			s.Flush();
-			Assert.AreEqual(initialInsertCount + 2, Sfi.Statistics.EntityInsertCount,"delayed persist insert not executed on flush");
-			s.Close();
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity2 = new MyEntity("test-persist-2");
+				MyChild child = new MyChild("test-child-persist-inverse");
+				myEntity2.InverseChildren.Add(child);
+				child.InverseParent = myEntity2;
+				s.Persist(myEntity2);
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity2.Id);
+				s.Flush();
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete("from MyChild");
-			s.Delete("from MyEntity");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from MyChild");
+				s.Delete("from MyEntity");
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test, Ignore("Not supported yet.")]
 		public void PersistOutsideTransactionCascadedToManyToOne()
 		{
 			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
-			ISession s = OpenSession();
-			MyEntity myEntity = new MyEntity("test-persist");
-			myEntity.Sibling=new MySibling("test-persist-sibling-out");
-			s.Persist(myEntity);
-			Assert.AreEqual(initialInsertCount, Sfi.Statistics.EntityInsertCount, "persist on identity column not delayed");
-			Assert.AreEqual(0, myEntity.Id);
-			s.Flush();
-			Assert.AreEqual(initialInsertCount + 2, Sfi.Statistics.EntityInsertCount, "delayed persist insert not executed on flush");
-			s.Close();
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity = new MyEntity("test-persist");
+				myEntity.Sibling = new MySibling("test-persist-sibling-out");
+				s.Persist(myEntity);
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity.Id);
+				s.Flush();
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete("from MyEntity");
-			s.Delete("from MySibling");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from MyEntity");
+				s.Delete("from MySibling");
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test, Ignore("Not supported yet.")]
 		public void PersistOutsideTransactionCascadedFromManyToOne()
 		{
 			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
-			ISession s = OpenSession();
-			MyEntity myEntity2 = new MyEntity("test-persist-2");
-			MySibling sibling = new MySibling("test-persist-sibling-in");
-			sibling.Entity= myEntity2;
-			s.Persist(sibling);
-			Assert.AreEqual(initialInsertCount, Sfi.Statistics.EntityInsertCount, "persist on identity column not delayed");
-			Assert.AreEqual(0, myEntity2.Id);
-			s.Flush();
-			Assert.AreEqual(initialInsertCount + 2, Sfi.Statistics.EntityInsertCount, "delayed persist insert not executed on flush");
-			s.Close();
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity2 = new MyEntity("test-persist-2");
+				MySibling sibling = new MySibling("test-persist-sibling-in");
+				sibling.Entity = myEntity2;
+				s.Persist(sibling);
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity2.Id);
+				s.Flush();
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete("from MySibling");
-			s.Delete("from MyEntity");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from MySibling");
+				s.Delete("from MyEntity");
+				t.Commit();
+				s.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Generatedkeys/Identity/SimpleIdentityGeneratedFixture.cs
+++ b/src/NHibernate.Test/Generatedkeys/Identity/SimpleIdentityGeneratedFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Identity
@@ -22,18 +21,19 @@ namespace NHibernate.Test.Generatedkeys.Identity
 		[Test]
 		public void SequenceIdentityGenerator()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntityIdentity { Name = "entity-1" };
+				session.Save(e);
 
-			var e = new MyEntityIdentity { Name = "entity-1" };
-			session.Save(e);
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			session.Delete(e);
-			session.Transaction.Commit();
-			session.Close();
+				session.Delete(e);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Generatedkeys/Select/SelectGeneratorTest.cs
+++ b/src/NHibernate.Test/Generatedkeys/Select/SelectGeneratorTest.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Select
@@ -24,18 +23,19 @@ namespace NHibernate.Test.Generatedkeys.Select
 		[Test]
 		public void GetGeneratedKeysSupport()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				MyEntity e = new MyEntity("entity-1");
+				session.Save(e);
 
-			MyEntity e = new MyEntity("entity-1");
-			session.Save(e);
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			session.Delete(e);
-			session.Transaction.Commit();
-			session.Close();
+				session.Delete(e);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Generatedkeys/Seqidentity/SequenceIdentityFixture.cs
+++ b/src/NHibernate.Test/Generatedkeys/Seqidentity/SequenceIdentityFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Seqidentity
@@ -30,18 +29,19 @@ namespace NHibernate.Test.Generatedkeys.Seqidentity
 		[Test]
 		public void SequenceIdentityGenerator()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntity { Name = "entity-1" };
+				session.Save(e);
 
-			var e = new MyEntity{Name="entity-1"};
-			session.Save(e);
+				// this insert should happen immediately!
+				Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
 
-			// this insert should happen immediately!
-			Assert.AreEqual(1, e.Id, "id not generated through forced insertion");
-
-			session.Delete(e);
-			session.Transaction.Commit();
-			session.Close();
+				session.Delete(e);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
+++ b/src/NHibernate.Test/Hql/Ast/BulkManipulation.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Threading;
-using NHibernate.Dialect;
 using NHibernate.Hql.Ast.ANTLR;
 using NHibernate.Id;
 using NHibernate.Persister.Entity;
@@ -362,14 +361,16 @@ namespace NHibernate.Test.Hql.Ast
 		public void InsertWithSelectListUsingJoins()
 		{
 			// this is just checking parsing and syntax...
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			s.CreateQuery(
-				"insert into Animal (description, bodyWeight) select h.description, h.bodyWeight from Human h where h.mother.mother is not null")
-				.ExecuteUpdate();
-			s.CreateQuery("delete from Animal").ExecuteUpdate();
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CreateQuery(
+					 "insert into Animal (description, bodyWeight) select h.description, h.bodyWeight from Human h where h.mother.mother is not null")
+				 .ExecuteUpdate();
+				s.CreateQuery("delete from Animal").ExecuteUpdate();
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		#endregion
@@ -833,41 +834,48 @@ namespace NHibernate.Test.Hql.Ast
 		public void DeleteWithSubquery()
 		{
 			// setup the test data...
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			var owner = new SimpleEntityWithAssociation {Name = "myEntity-1"};
-			owner.AddAssociation("assoc-1");
-			owner.AddAssociation("assoc-2");
-			owner.AddAssociation("assoc-3");
-			s.Save(owner);
-			var owner2 = new SimpleEntityWithAssociation {Name = "myEntity-2"};
-			owner2.AddAssociation("assoc-1");
-			owner2.AddAssociation("assoc-2");
-			owner2.AddAssociation("assoc-3");
-			owner2.AddAssociation("assoc-4");
-			s.Save(owner2);
-			var owner3 = new SimpleEntityWithAssociation {Name = "myEntity-3"};
-			s.Save(owner3);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var owner = new SimpleEntityWithAssociation { Name = "myEntity-1" };
+				owner.AddAssociation("assoc-1");
+				owner.AddAssociation("assoc-2");
+				owner.AddAssociation("assoc-3");
+				s.Save(owner);
+				var owner2 = new SimpleEntityWithAssociation { Name = "myEntity-2" };
+				owner2.AddAssociation("assoc-1");
+				owner2.AddAssociation("assoc-2");
+				owner2.AddAssociation("assoc-3");
+				owner2.AddAssociation("assoc-4");
+				s.Save(owner2);
+				var owner3 = new SimpleEntityWithAssociation { Name = "myEntity-3" };
+				s.Save(owner3);
+				t.Commit();
+				s.Close();
+			}
 
 			// now try the bulk delete
-			s = OpenSession();
-			s.BeginTransaction();
-			int count =
-				s.CreateQuery("delete SimpleEntityWithAssociation e where size(e.AssociatedEntities ) = 0 and e.Name like '%'").
-					ExecuteUpdate();
-			Assert.That(count, Is.EqualTo(1), "Incorrect delete count");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				int count =
+					s.CreateQuery(
+						 "delete SimpleEntityWithAssociation e where size(e.AssociatedEntities ) = 0 and e.Name like '%'")
+					 .ExecuteUpdate();
+				Assert.That(count, Is.EqualTo(1), "Incorrect delete count");
+				t.Commit();
+				s.Close();
+			}
 
 			// finally, clean up
-			s = OpenSession();
-			s.BeginTransaction();
-			s.CreateQuery("delete SimpleAssociatedEntity").ExecuteUpdate();
-			s.CreateQuery("delete SimpleEntityWithAssociation").ExecuteUpdate();
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CreateQuery("delete SimpleAssociatedEntity").ExecuteUpdate();
+				s.CreateQuery("delete SimpleEntityWithAssociation").ExecuteUpdate();
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
@@ -88,10 +88,10 @@ namespace NHibernate.Test.Hql.Ast
 		{
 			// NH-322
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(new Animal {BodyWeight = 12, Description = "Polliwog"});
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		
 			using (ISession s = OpenSession())
@@ -107,10 +107,10 @@ namespace NHibernate.Test.Hql.Ast
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.CreateQuery("delete from Animal").ExecuteUpdate();
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -118,10 +118,10 @@ namespace NHibernate.Test.Hql.Ast
 		public void MultipleParametersInCaseStatement()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(new Animal { BodyWeight = 12, Description = "Polliwog" });
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			try
@@ -139,10 +139,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					s.CreateQuery("delete from Animal").ExecuteUpdate();
-					s.Transaction.Commit();
+					t.Commit();
 				}
 			}
 		}
@@ -151,10 +151,10 @@ namespace NHibernate.Test.Hql.Ast
 		public void ParameterInCaseThenClause()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(new Animal { BodyWeight = 12, Description = "Polliwog" });
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			try
@@ -170,10 +170,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					s.CreateQuery("delete from Animal").ExecuteUpdate();
-					s.Transaction.Commit();
+					t.Commit();
 				}
 			}
 		}
@@ -182,10 +182,10 @@ namespace NHibernate.Test.Hql.Ast
 		public void ParameterInCaseThenAndElseClausesWithCast()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(new Animal { BodyWeight = 12, Description = "Polliwog" });
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			try
@@ -202,10 +202,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					s.CreateQuery("delete from Animal").ExecuteUpdate();
-					s.Transaction.Commit();
+					t.Commit();
 				}
 			}
 		}
@@ -214,10 +214,10 @@ namespace NHibernate.Test.Hql.Ast
 		public void SubselectAddition()
 		{
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(new Animal { BodyWeight = 12, Description = "Polliwog" });
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			try
@@ -232,10 +232,10 @@ namespace NHibernate.Test.Hql.Ast
 			finally
 			{
 				using (ISession s = OpenSession())
-				using (s.BeginTransaction())
+				using (var t = s.BeginTransaction())
 				{
 					s.CreateQuery("delete from Animal").ExecuteUpdate();
-					s.Transaction.Commit();
+					t.Commit();
 				}
 			}
 		}
@@ -245,10 +245,10 @@ namespace NHibernate.Test.Hql.Ast
 		{
 			// NH-1734
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Save(new Human{ IntValue = 11, BodyWeight = 12.5f, Description = "Polliwog" });
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			using (ISession s = OpenSession())
@@ -258,10 +258,10 @@ namespace NHibernate.Test.Hql.Ast
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.CreateQuery("delete from Animal").ExecuteUpdate();
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -298,25 +298,23 @@ namespace NHibernate.Test.Hql.Ast
 		public void InsertIntoFromSelect_WithSelectClauseParameters()
 		{
 			using (ISession s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
-					// arrange
-					s.Save(new Animal() {Description = "cat1", BodyWeight = 2.1f});
-					s.Save(new Animal() {Description = "cat2", BodyWeight = 2.5f});
-					s.Save(new Animal() {Description = "cat3", BodyWeight = 2.7f});
+				// arrange
+				s.Save(new Animal() {Description = "cat1", BodyWeight = 2.1f});
+				s.Save(new Animal() {Description = "cat2", BodyWeight = 2.5f});
+				s.Save(new Animal() {Description = "cat3", BodyWeight = 2.7f});
 
-					// act
-					s.CreateQuery("insert into Animal (description, bodyWeight) select a.description, :weight from Animal a where a.bodyWeight < :weight")
-						.SetParameter<float>("weight", 5.7f).ExecuteUpdate();
+				// act
+				s.CreateQuery("insert into Animal (description, bodyWeight) select a.description, :weight from Animal a where a.bodyWeight < :weight")
+					.SetParameter<float>("weight", 5.7f).ExecuteUpdate();
 
-					// assert
-					Assert.AreEqual(3, s.CreateCriteria<Animal>().SetProjection(Projections.RowCount())
-					                    .Add(Restrictions.Gt("bodyWeight", 5.5f)).UniqueResult<int>());
+				// assert
+				Assert.AreEqual(3, s.CreateCriteria<Animal>().SetProjection(Projections.RowCount())
+				                    .Add(Restrictions.Gt("bodyWeight", 5.5f)).UniqueResult<int>());
 
-					s.CreateQuery("delete from Animal").ExecuteUpdate();
-					s.Transaction.Commit();
-				}
+				s.CreateQuery("delete from Animal").ExecuteUpdate();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Insertordering/InsertOrderingFixture.cs
+++ b/src/NHibernate.Test/Insertordering/InsertOrderingFixture.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using System.Threading;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NHibernate.Dialect;
@@ -78,8 +76,8 @@ namespace NHibernate.Test.Insertordering
 		[Test]
 		public void BatchOrdering()
 		{
-			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				for (int i = 0; i < instancesPerEach; i++)
 				{
@@ -90,7 +88,7 @@ namespace NHibernate.Test.Insertordering
 					user.AddMembership(group);
 				}
 				StatsBatcher.Reset();
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			int expectedBatchesPerEntity = (instancesPerEach / batchSize) + ((instancesPerEach % batchSize) == 0 ? 0 : 1);

--- a/src/NHibernate.Test/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Legacy/FooBarTest.cs
@@ -2825,7 +2825,7 @@ namespace NHibernate.Test.Legacy
 			s.Delete(baz.TopGlarchez['H']);
 
 			var cmd = s.Connection.CreateCommand();
-			s.Transaction.Enlist(cmd);
+			txn.Enlist(cmd);
 			cmd.CommandText = "update " + Dialect.QuoteForTableName("glarchez") + " set baz_map_id=null where baz_map_index='a'";
 			int rows = cmd.ExecuteNonQuery();
 			Assert.AreEqual(1, rows);

--- a/src/NHibernate.Test/LinqBulkManipulation/Fixture.cs
+++ b/src/NHibernate.Test/LinqBulkManipulation/Fixture.cs
@@ -456,9 +456,8 @@ namespace NHibernate.Test.LinqBulkManipulation
 
 			// this is just checking parsing and syntax...
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
-
 				Assert.DoesNotThrow(() =>
 				{
 					s
@@ -466,7 +465,7 @@ namespace NHibernate.Test.LinqBulkManipulation
 						.InsertInto(x => new Animal { Description = x.Description, BodyWeight = x.BodyWeight });
 				});
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
@@ -972,11 +971,11 @@ namespace NHibernate.Test.LinqBulkManipulation
 			}
 
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				var count = s.Query<SimpleEntityWithAssociation>().Where(x => x.AssociatedEntities.Count == 0 && x.Name.Contains("myEntity")).Delete();
 				Assert.That(count, Is.EqualTo(1), "Incorrect delete count");
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/BagWithLazyExtraAndFilter/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/BagWithLazyExtraAndFilter/Fixture.cs
@@ -10,8 +10,8 @@ namespace NHibernate.Test.NHSpecificTest.BagWithLazyExtraAndFilter
 		public void CanUseFilterForLazyExtra()
 		{
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				var machineRequest = new MachineRequest { EnvId = 1L, Id = 2L };
 				s.Save(new Env
 				{
@@ -22,7 +22,7 @@ namespace NHibernate.Test.NHSpecificTest.BagWithLazyExtraAndFilter
 					}
 				});
 				s.Save(machineRequest);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			using (var s = OpenSession())
@@ -39,11 +39,11 @@ namespace NHibernate.Test.NHSpecificTest.BagWithLazyExtraAndFilter
 			}
 
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Delete(s.Load<MachineRequest>(2L));
 				s.Delete(s.Load<Env>(1L));
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/CriteriaQueryOnComponentCollection/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/CriteriaQueryOnComponentCollection/Fixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Cfg;
 using NHibernate.Criterion;
@@ -19,7 +18,7 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 		protected override void OnSetUp()
 		{
 			using (var s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				var parent = new Employee
 				{
@@ -45,18 +44,18 @@ namespace NHibernate.Test.NHSpecificTest.CriteriaQueryOnComponentCollection
 				s.Save(parent);
 				s.Save(emp);
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 
 		protected override void OnTearDown()
 		{
 			using (var s = Sfi.OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Delete("from System.Object");
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/ElementsEnums/AbstractIntEnumsBagFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/ElementsEnums/AbstractIntEnumsBagFixture.cs
@@ -17,25 +17,25 @@ namespace NHibernate.Test.NHSpecificTest.ElementsEnums
 		{
 			object savedId;
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				savedId = s.Save(new SimpleWithEnums { Things = new List<Something> { Something.B, Something.C, Something.D, Something.E } });
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				var swe = s.Get<SimpleWithEnums>(savedId);
 				Assert.That(swe.Things, Is.EqualTo(new[] { Something.B, Something.C, Something.D, Something.E }));
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			using (ISession s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.Delete("from SimpleWithEnums");
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1093/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1093/Fixture.cs
@@ -22,13 +22,11 @@ namespace NHibernate.Test.NHSpecificTest.NH1093
 
 		private void Cleanup()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
-					s.CreateQuery("delete from SimpleCached").ExecuteUpdate();
-					s.Transaction.Commit();
-				}
+				s.CreateQuery("delete from SimpleCached").ExecuteUpdate();
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH1323/CheckViability.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1323/CheckViability.cs
@@ -18,24 +18,24 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				this.factory = factory;
 				object savedId;
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var entity = new MyClass();
 					entity.Children.Add(new MyChild { Parent = entity });
 					entity.Components.Add(new MyComponent { Something = "something" });
 					entity.Elements.Add("somethingelse");
 					savedId = session.Save(entity);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					entity = session.Get<MyClass>(savedId);
 					NHibernateUtil.Initialize(entity.Children);
 					NHibernateUtil.Initialize(entity.Components);
 					NHibernateUtil.Initialize(entity.Elements);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 
@@ -65,13 +65,13 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 
 				// When I reassociate the collections the Owner has value
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var merged = (MyClass)session.Merge(scenario.Entity);
 					Assert.That(((IPersistentCollection)merged.Children).Owner, Is.Not.Null);
 					Assert.That(((IPersistentCollection)merged.Components).Owner, Is.Not.Null);
 					Assert.That(((IPersistentCollection)merged.Elements).Owner, Is.Not.Null);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 		}
@@ -86,7 +86,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					// When I reassociate the collections the Owner is null
 					session.Lock(scenario.Entity, LockMode.None);
@@ -94,17 +94,17 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 					scenario.Entity.Children.Add(new MyChild { Parent = scenario.Entity });
 					scenario.Entity.Components.Add(new MyComponent { Something = "something" });
 					scenario.Entity.Elements.Add("somethingelse");
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = session.Get<MyClass>(scenario.Entity.Id);
 					Assert.That(fresh.Children, Has.Count.EqualTo(2));
 					Assert.That(fresh.Components, Has.Count.EqualTo(2));
 					Assert.That(fresh.Elements, Has.Count.EqualTo(2));
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 		}
@@ -119,24 +119,24 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					scenario.Entity.Children.Add(new MyChild { Parent = scenario.Entity });
 					scenario.Entity.Components.Add(new MyComponent { Something = "something" });
 					scenario.Entity.Elements.Add("somethingelse");
 					// When I reassociate the collections the Owner is null
 					session.Update(scenario.Entity);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = session.Get<MyClass>(scenario.Entity.Id);
 					Assert.That(fresh.Children, Has.Count.EqualTo(2));
 					Assert.That(fresh.Components, Has.Count.EqualTo(2));
 					Assert.That(fresh.Elements, Has.Count.EqualTo(2));
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 		}
@@ -151,24 +151,24 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					scenario.Entity.Children.Add(new MyChild { Parent = scenario.Entity });
 					scenario.Entity.Components.Add(new MyComponent { Something = "something" });
 					scenario.Entity.Elements.Add("somethingelse");
 					// When I reassociate the collections the Owner is null
 					session.SaveOrUpdate(scenario.Entity);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = session.Get<MyClass>(scenario.Entity.Id);
 					Assert.That(fresh.Children, Has.Count.EqualTo(2));
 					Assert.That(fresh.Components, Has.Count.EqualTo(2));
 					Assert.That(fresh.Elements, Has.Count.EqualTo(2));
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 		}
@@ -183,18 +183,18 @@ namespace NHibernate.Test.NHSpecificTest.NH1323
 				((IPersistentCollection)scenario.Entity.Elements).Owner = null;
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					session.Delete(scenario.Entity);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 
 				using (var session = OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					var fresh = session.Get<MyClass>(scenario.Entity.Id);
 					Assert.That(fresh, Is.Null);
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 		}

--- a/src/NHibernate.Test/NHSpecificTest/NH1388/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1388/Fixture.cs
@@ -114,9 +114,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1388
 		protected override void OnTearDown()
 		{
 			// clean up the database
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				session.BeginTransaction();
 				foreach (var student in session.CreateCriteria(typeof (Student)).List<Student>())
 				{
 					session.Delete(student);
@@ -125,7 +125,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1388
 				{
 					session.Delete(subject);
 				}
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH1665/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1665/Fixture.cs
@@ -13,16 +13,17 @@ namespace NHibernate.Test.NHSpecificTest.NH1665
 		[Test]
 		public void SupportsHibernateQuotingSequenceName()
 		{
-			ISession session = OpenSession();
-			session.BeginTransaction();
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
+			{
+				var e = new MyEntity { Name = "entity-1" };
+				session.Save(e);
+				Assert.AreEqual(1, (int) session.GetIdentifier(e));
 
-			var e = new MyEntity { Name = "entity-1" };
-			session.Save(e);
-			Assert.AreEqual(1, (int)session.GetIdentifier(e));
-
-			session.Delete(e);
-			session.Transaction.Commit();
-			session.Close();
+				session.Delete(e);
+				tran.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1882/TestCollectionInitializingDuringFlush.cs
@@ -89,29 +89,29 @@ namespace NHibernate.Test.NHSpecificTest.NH1882
 			Assert.False(listener.FoundAny);
 
 			using (var s1 = OpenSession())
+			using (var t1 = s1.BeginTransaction())
 			{
-				s1.BeginTransaction();
 				var publisher = new Publisher("acme");
 				var author = new Author("john");
 				author.Publisher = publisher;
 				publisher.Authors.Add(author);
 				author.Books.Add(new Book("Reflections on a Wimpy Kid", author));
 				s1.Save(author);
-				s1.Transaction.Commit();
+				t1.Commit();
 				s1.Clear();
 				using (var s2 = OpenSession())
+				using (var t2 = s2.BeginTransaction())
 				{
-					s2.BeginTransaction();
 					publisher = s2.Get<Publisher>(publisher.Id);
 					publisher.Name = "random nally";
 					s2.Flush();
-					s2.Transaction.Commit();
+					t2.Commit();
 					s2.Clear();
 					using (var s3 = OpenSession())
+					using (var t3 = s3.BeginTransaction())
 					{
-						s3.BeginTransaction();
 						s3.Delete(author);
-						s3.Transaction.Commit();
+						t3.Commit();
 						s3.Clear();
 						s3.Close();
 					}

--- a/src/NHibernate.Test/NHSpecificTest/NH1965/ReattachWithCollectionTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1965/ReattachWithCollectionTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
@@ -41,10 +40,10 @@ namespace NHibernate.Test.NHSpecificTest.NH1965
 		{
 			var cat = new Cat();
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (var tran = session.BeginTransaction())
 			{
 				session.Save(cat);
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 
 			using (var session = OpenSession())
@@ -53,10 +52,10 @@ namespace NHibernate.Test.NHSpecificTest.NH1965
 			}
 
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (var tran = session.BeginTransaction())
 			{
 				session.Delete(cat);
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH2065/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2065/Fixture.cs
@@ -9,7 +9,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2065
         protected override void OnSetUp()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 var person = new Person
                 {
@@ -20,17 +20,17 @@ namespace NHibernate.Test.NHSpecificTest.NH2065
                 s.Save(child);
                 person.Children.Add(child);
 
-                s.Transaction.Commit();
+                t.Commit();
             }
         }
 
         protected override void OnTearDown()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 s.Delete("from Person");
-                s.Transaction.Commit();
+                t.Commit();
             }
         }
 
@@ -39,17 +39,17 @@ namespace NHibernate.Test.NHSpecificTest.NH2065
 		{
 			Person person;
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				person = s.Get<Person>(1);
 				NHibernateUtil.Initialize(person.Children);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			person.Children.Clear();
 
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				Assert.That(
 					() =>

--- a/src/NHibernate.Test/NHSpecificTest/NH2069/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2069/Fixture.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Transactions;
-using NHibernate;
-using NHibernate.Impl;
 using NHibernate.Proxy;
-using NHibernate.Criterion;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH2069
@@ -15,7 +9,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2069
         protected override void OnSetUp()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 var test2 = new Test2();
                 test2.Cid = 5;
@@ -29,19 +23,19 @@ namespace NHibernate.Test.NHSpecificTest.NH2069
                 s.Save(test2);
                 s.Save(test);
 
-                s.Transaction.Commit();
-            }            
+                t.Commit();
+            }
         }
 
         protected override void OnTearDown()
         {
             using (var s = OpenSession())
-            using (s.BeginTransaction())
+            using (var t = s.BeginTransaction())
             {
                 s.Delete("from Test");
                 s.Delete("from Test2");
-                s.Transaction.Commit();
-            }            
+                t.Commit();
+            }
          }
 
         [Test]

--- a/src/NHibernate.Test/NHSpecificTest/NH2477/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2477/Fixture.cs
@@ -31,23 +31,23 @@ namespace NHibernate.Test.NHSpecificTest.NH2477
 			{
 				this.factory = factory;
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					for (int i = 0; i < 5; i++)
 					{
 						session.Persist(new Something { Name = i.ToString() });
 					}
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 
 			public void Dispose()
 			{
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					session.CreateQuery("delete from Something").ExecuteUpdate();
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 		}
@@ -58,7 +58,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2477
 			using (new Scenario(Sfi))
 			{
 				using (var session = Sfi.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					// This is another case where we have to work with subqueries and we have to write a specific query rewriter for Skip/Take instead flat the query in QueryReferenceExpressionFlattener
 					//var actual = session.CreateQuery("select count(s) from Something s where s in (from Something take 3)").UniqueResult<long>();

--- a/src/NHibernate.Test/NHSpecificTest/NH2510/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2510/Fixture.cs
@@ -1,6 +1,5 @@
 using System;
 using NHibernate.Cache;
-using NHibernate.Cfg;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
@@ -42,21 +41,21 @@ namespace NHibernate.Test.NHSpecificTest.NH2510
 			{
 				this.factory = factory;
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					session.Persist(new Image { Id = 1 });
-					session.Transaction.Commit();
+					tran.Commit();
 				}
 			}
 
 			public void Dispose()
 			{
 				using (var session = factory.OpenSession())
-				using (session.BeginTransaction())
+				using (var tran = session.BeginTransaction())
 				{
 					session.CreateQuery("delete from Image").ExecuteUpdate();
-					session.Transaction.Commit();
-				}				
+					tran.Commit();
+				}
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2583/AbstractMassTestingFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2583/AbstractMassTestingFixture.cs
@@ -1,5 +1,4 @@
 using NHibernate.Cfg;
-using NHibernate.Linq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -235,9 +234,9 @@ namespace NHibernate.Test.NHSpecificTest.NH2583
 							}
 							if ((i%BatchSize) == 0)
 							{
-								if (session.Transaction.IsActive)
+								if (session.GetCurrentTransaction()?.IsActive == true)
 								{
-									session.Transaction.Commit();
+									session.GetCurrentTransaction().Commit();
 									session.Clear();
 								}
 								session.BeginTransaction();
@@ -251,9 +250,9 @@ namespace NHibernate.Test.NHSpecificTest.NH2583
 							// emulating the outer-join logic for exceptional cases in Lin2Objects is IMO very hard.
 						}
 					}
-					if (session.Transaction.IsActive)
+					if (session.GetCurrentTransaction()?.IsActive == true)
 					{
-						session.Transaction.Commit();
+						session.GetCurrentTransaction().Commit();
 						session.Clear();
 					}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2691/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2691/Fixture.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using NHibernate.Cfg.MappingSchema;
-using NHibernate.Linq;
 using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
 
@@ -22,11 +21,11 @@ namespace NHibernate.Test.NHSpecificTest.NH2691
 		public void WhenUseCountWithOrderThenCutTheOrder()
 		{
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (var tran = session.BeginTransaction())
 			{
 				var baseQuery = from cat in session.Query<Cat>() orderby cat.BirthDate select cat;
 				Assert.That(() => baseQuery.Count(), Throws.Nothing);
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 
@@ -34,11 +33,11 @@ namespace NHibernate.Test.NHSpecificTest.NH2691
 		public void WhenUseLongCountWithOrderThenCutTheOrder()
 		{
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (var tran = session.BeginTransaction())
 			{
 				var baseQuery = from cat in session.Query<Cat>() orderby cat.BirthDate select cat;
 				Assert.That(() => baseQuery.LongCount(), Throws.Nothing);
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH295/SubclassFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH295/SubclassFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NHibernate.Criterion;
 using NUnit.Framework;
 
@@ -21,29 +20,35 @@ namespace NHibernate.Test.NHSpecificTest.NH295
 		public void LoadByIDFailureSameSession()
 		{
 			User ui1 = new User("User1");
+			object uid1;
 
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			object uid1 = s.Save(ui1);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				uid1 = s.Save(ui1);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				Assert.IsNotNull(s.Get(typeof(User), uid1));
 
-			Assert.IsNotNull(s.Get(typeof(User), uid1));
+				UserGroup ug = (UserGroup) s.Get(typeof(UserGroup), uid1);
+				Assert.IsNull(ug);
 
-			UserGroup ug = (UserGroup) s.Get(typeof(UserGroup), uid1);
-			Assert.IsNull(ug);
+				t.Commit();
+				s.Close();
+			}
 
-			s.Transaction.Commit();
-			s.Close();
-
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete("from Party");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from Party");
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
@@ -52,79 +57,98 @@ namespace NHibernate.Test.NHSpecificTest.NH295
 			UserGroup ug1 = new UserGroup();
 			ug1.Name = "Group1";
 			User ui1 = new User("User1");
+			object gid1, uid1;
 
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			object gid1 = s.Save(ug1);
-			object uid1 = s.Save(ui1);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				gid1 = s.Save(ug1);
+				uid1 = s.Save(ui1);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			//Load user with USER NAME: 
-			ICriteria criteria1 = s.CreateCriteria(typeof(User));
-			criteria1.Add(Expression.Eq("Name", "User1"));
-			Assert.AreEqual(1, criteria1.List().Count);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				//Load user with USER NAME: 
+				ICriteria criteria1 = s.CreateCriteria(typeof(User));
+				criteria1.Add(Expression.Eq("Name", "User1"));
+				Assert.AreEqual(1, criteria1.List().Count);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			//Load group with USER NAME: 
-			ICriteria criteria2 = s.CreateCriteria(typeof(UserGroup));
-			criteria2.Add(Expression.Eq("Name", "User1"));
-			Assert.AreEqual(0, criteria2.List().Count);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				//Load group with USER NAME: 
+				ICriteria criteria2 = s.CreateCriteria(typeof(UserGroup));
+				criteria2.Add(Expression.Eq("Name", "User1"));
+				Assert.AreEqual(0, criteria2.List().Count);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			//Load group with GROUP NAME
-			ICriteria criteria3 = s.CreateCriteria(typeof(UserGroup));
-			criteria3.Add(Expression.Eq("Name", "Group1"));
-			Assert.AreEqual(1, criteria3.List().Count);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				//Load group with GROUP NAME
+				ICriteria criteria3 = s.CreateCriteria(typeof(UserGroup));
+				criteria3.Add(Expression.Eq("Name", "Group1"));
+				Assert.AreEqual(1, criteria3.List().Count);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			//Load user with GROUP NAME
-			ICriteria criteria4 = s.CreateCriteria(typeof(User));
-			criteria4.Add(Expression.Eq("Name", "Group1"));
-			Assert.AreEqual(0, criteria4.List().Count);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				//Load user with GROUP NAME
+				ICriteria criteria4 = s.CreateCriteria(typeof(User));
+				criteria4.Add(Expression.Eq("Name", "Group1"));
+				Assert.AreEqual(0, criteria4.List().Count);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			//Load group with USER IDENTITY
-			ug1 = (UserGroup) s.Get(typeof(UserGroup), uid1);
-			Assert.IsNull(ug1);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				//Load group with USER IDENTITY
+				ug1 = (UserGroup) s.Get(typeof(UserGroup), uid1);
+				Assert.IsNull(ug1);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			ui1 = (User) s.Get(typeof(User), gid1);
-			Assert.IsNull(ui1);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				ui1 = (User) s.Get(typeof(User), gid1);
+				Assert.IsNull(ui1);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			Party p = (Party) s.Get(typeof(Party), uid1);
-			Assert.IsTrue(p is User);
-			p = (Party) s.Get(typeof(Party), gid1);
-			Assert.IsTrue(p is UserGroup);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				Party p = (Party) s.Get(typeof(Party), uid1);
+				Assert.IsTrue(p is User);
+				p = (Party) s.Get(typeof(Party), gid1);
+				Assert.IsTrue(p is UserGroup);
+				t.Commit();
+				s.Close();
+			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete("from Party");
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete("from Party");
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/NHSpecificTest/NH3567/NH3567Tests.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3567/NH3567Tests.cs
@@ -10,9 +10,9 @@ namespace NHibernate.Test.NHSpecificTest.NH3567
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			using (ISession session = this.OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				session.BeginTransaction();
 				var id = 0;
 
 				var site1 = new Site { Id = ++id, Name = "Site 1" };
@@ -31,7 +31,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3567
 				session.Save(new Comment { Id = ++id, Content = "Comment 2.1", Post = p2 });
 				session.Save(new Comment { Id = ++id, Content = "Comment 2.2", Post = p2 });
 				session.Flush();
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH734/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH734/Fixture.cs
@@ -9,25 +9,14 @@ namespace NHibernate.Test.NHSpecificTest.NH734
 		[TestAttribute]
 		public void LimitProblem()
 		{
-			using (ISession session = Sfi.OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
 				ICriteria criteria = session.CreateCriteria(typeof(MyClass));
 				criteria.SetMaxResults(100);
 				criteria.SetFirstResult(0);
-				try
-				{
-					session.BeginTransaction();
-					IList result = criteria.List();
-					session.Transaction.Commit();
-				}
-				catch
-				{
-					if (session.Transaction != null)
-					{
-						session.Transaction.Rollback();
-					}
-					throw;
-				}
+				IList result = criteria.List();
+				tran.Commit();
 			}
 		}
 	}

--- a/src/NHibernate.Test/Naturalid/Mutable/MutableNaturalIdFixture.cs
+++ b/src/NHibernate.Test/Naturalid/Mutable/MutableNaturalIdFixture.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections;
 using System.Reflection;
 using NHibernate.Cfg;
 using NHibernate.Criterion;
@@ -31,41 +29,33 @@ namespace NHibernate.Test.Naturalid.Mutable
 		[Test]
 		public void ReattachmentNaturalIdCheck()
 		{
-			ISession s = OpenSession();
-			s.BeginTransaction();
-			User u = new User("gavin", "hb", "secret");
-			s.Persist(u);
-			s.Transaction.Commit();
-			s.Close();
+			User u;
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				u = new User("gavin", "hb", "secret");
+				s.Persist(u);
+				t.Commit();
+				s.Close();
+			}
 
 			FieldInfo name = u.GetType().GetField("name",
 			                                      BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
 			name.SetValue(u, "Gavin");
-			s = OpenSession();
-			s.BeginTransaction();
-			try
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.Update(u);
-				s.Transaction.Commit();
-			}
-			catch (HibernateException)
-			{
-				s.Transaction.Rollback();
-			}
-			catch (Exception)
-			{
-					s.Transaction.Rollback();
-			}
-			finally
-			{
-				s.Close();
+				t.Commit();
 			}
 
-			s = OpenSession();
-			s.BeginTransaction();
-			s.Delete(u);
-			s.Transaction.Commit();
-			s.Close();
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Delete(u);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/ReadOnly/ReadOnlyProxyTest.cs
+++ b/src/NHibernate.Test/ReadOnly/ReadOnlyProxyTest.cs
@@ -1,15 +1,6 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using NHibernate.Cfg;
-using NHibernate.Dialect;
-using NHibernate.Criterion;
 using NHibernate.Engine;
 using NHibernate.Proxy;
-using NHibernate.SqlCommand;
-using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ReadOnly
@@ -22,10 +13,10 @@ namespace NHibernate.Test.ReadOnly
 			get
 			{
 				return new string[]
-					{
-						"ReadOnly.DataPoint.hbm.xml",
-						//"ReadOnly.TextHolder.hbm.xml"
-					};
+				{
+					"ReadOnly.DataPoint.hbm.xml",
+					//"ReadOnly.TextHolder.hbm.xml"
+				};
 			}
 		}
 
@@ -33,544 +24,612 @@ namespace NHibernate.Test.ReadOnly
 		public void ReadOnlyViaSessionDoesNotInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Flush();
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Transaction.Commit();
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Flush();
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				t.Commit();
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyViaLazyInitializerDoesNotInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dpLI.ReadOnly = true;
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dpLI.ReadOnly = false;
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Flush();
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Transaction.Commit();
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dpLI.ReadOnly = true;
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dpLI.ReadOnly = false;
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Flush();
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				t.Commit();
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyViaSessionNoChangeAfterInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			CheckReadOnly(s, dp, true);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				CheckReadOnly(s, dp, false);
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				CheckReadOnly(s, dp, true);
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				CheckReadOnly(s, dp, false);
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyViaLazyInitializerNoChangeAfterInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			CheckReadOnly(s, dp, false);
-			Assert.That(dpLI.IsUninitialized);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			dpLI.ReadOnly = true;
-			CheckReadOnly(s, dp, true);
-			Assert.That(dpLI.IsUninitialized);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			CheckReadOnly(s, dp, true);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			dpLI.ReadOnly = true;
-			CheckReadOnly(s, dp, true);
-			Assert.That(dpLI.IsUninitialized);
-			dpLI.ReadOnly = false;
-			CheckReadOnly(s, dp, false);
-			Assert.That(dpLI.IsUninitialized);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				CheckReadOnly(s, dp, false);
+				Assert.That(dpLI.IsUninitialized);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				CheckReadOnly(s, dp, false);
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				var dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				dpLI.ReadOnly = true;
+				CheckReadOnly(s, dp, true);
+				Assert.That(dpLI.IsUninitialized);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				CheckReadOnly(s, dp, true);
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				var dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				var dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				dpLI.ReadOnly = true;
+				CheckReadOnly(s, dp, true);
+				Assert.That(dpLI.IsUninitialized);
+				dpLI.ReadOnly = false;
+				CheckReadOnly(s, dp, false);
+				Assert.That(dpLI.IsUninitialized);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				CheckReadOnly(s, dp, false);
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
 		public void ReadOnlyViaSessionBeforeInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			s.SetReadOnly(dp, true);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				s.SetReadOnly(dp, true);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
 		public void ModifiableViaSessionBeforeInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, false);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, false);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyViaSessionBeforeInitByModifiableQuery()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			DataPoint dpFromQuery = s.CreateQuery("from DataPoint where id = " + dpOrig.Id).SetReadOnly(false).UniqueResult<DataPoint>();
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				DataPoint dpFromQuery = s.CreateQuery("from DataPoint where id = " + dpOrig.Id).SetReadOnly(false)
+				                         .UniqueResult<DataPoint>();
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				CheckReadOnly(s, dp, true);
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
 		public void ReadOnlyViaSessionBeforeInitByReadOnlyQuery()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			DataPoint dpFromQuery = s.CreateQuery( "from DataPoint where Id = " + dpOrig.Id).SetReadOnly(true).UniqueResult<DataPoint>();
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				DataPoint dpFromQuery = s.CreateQuery("from DataPoint where Id = " + dpOrig.Id).SetReadOnly(true)
+				                         .UniqueResult<DataPoint>();
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				CheckReadOnly(s, dp, true);
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ModifiableViaSessionBeforeInitByModifiableQuery()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			DataPoint dpFromQuery = s.CreateQuery("from DataPoint where Id = " + dpOrig.Id).SetReadOnly(false).UniqueResult<DataPoint>();
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				DataPoint dpFromQuery = s.CreateQuery("from DataPoint where Id = " + dpOrig.Id).SetReadOnly(false)
+				                         .UniqueResult<DataPoint>();
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ModifiableViaSessionBeforeInitByReadOnlyQuery()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			DataPoint dpFromQuery = s.CreateQuery("from DataPoint where id=" + dpOrig.Id).SetReadOnly(true).UniqueResult<DataPoint>();
-			Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
-			Assert.That(dpFromQuery, Is.SameAs(dp));
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				DataPoint dpFromQuery = s.CreateQuery("from DataPoint where id=" + dpOrig.Id).SetReadOnly(true)
+				                         .UniqueResult<DataPoint>();
+				Assert.That(NHibernateUtil.IsInitialized(dpFromQuery), Is.True);
+				Assert.That(dpFromQuery, Is.SameAs(dp));
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
 		public void ReadOnlyViaLazyInitializerBeforeInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dpLI.IsUninitialized);
-			CheckReadOnly(s, dp, false);
-			dpLI.ReadOnly = true;
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dpLI.IsUninitialized);
+				CheckReadOnly(s, dp, false);
+				dpLI.ReadOnly = true;
+				CheckReadOnly(s, dp, true);
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
 		public void ModifiableViaLazyInitializerBeforeInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(dpLI.IsUninitialized);
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, false);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(dpLI.IsUninitialized);
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, false);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyViaLazyInitializerAfterInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dpLI.IsUninitialized);
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, false);
-			dpLI.ReadOnly = true;
-			CheckReadOnly(s, dp, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dpLI.IsUninitialized);
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, false);
+				dpLI.ReadOnly = true;
+				CheckReadOnly(s, dp, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ModifiableViaLazyInitializerAfterInit()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer dpLI = ((INHibernateProxy)dp).HibernateLazyInitializer;
-			Assert.That(dpLI.IsUninitialized);
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(dpLI.IsUninitialized, Is.False);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, false);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				ILazyInitializer dpLI = ((INHibernateProxy) dp).HibernateLazyInitializer;
+				Assert.That(dpLI.IsUninitialized);
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(dpLI.IsUninitialized, Is.False);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, false);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
@@ -578,98 +637,108 @@ namespace NHibernate.Test.ReadOnly
 		public void ModifyToReadOnlyToModifiableIsUpdatedFailureExpected()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
 			try
 			{
-				Assert.That(dp.Description, Is.EqualTo("changed"));
-				// should fail due to HHH-4642
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Get<DataPoint>(dpOrig.Id);
+					Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+					Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+					Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+					Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					// should fail due to HHH-4642
+				}
 			}
 			finally
 			{
-				s.Transaction.Rollback();
-				s.Close();
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		[Ignore("Failing test. See HHH-4642")]
 		public void ReadOnlyModifiedToModifiableIsUpdatedFailureExpected()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
 			try
 			{
-				Assert.That(dp.Description, Is.EqualTo("changed"));
-				// should fail due to HHH-4642
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Get<DataPoint>(dpOrig.Id);
+					Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+					Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+					Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+					Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					// should fail due to HHH-4642
+				}
 			}
 			finally
 			{
-				s.Transaction.Rollback();
-				s.Close();
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
 
@@ -677,1083 +746,1199 @@ namespace NHibernate.Test.ReadOnly
 		public void ReadOnlyChangedEvictedUpdate()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Evict(dp);
-			Assert.That(s.Contains(dp), Is.False);
-			s.Update(dp);
-			CheckReadOnly(s, dp, false);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Evict(dp);
+				Assert.That(s.Contains(dp), Is.False);
+				s.Update(dp);
+				CheckReadOnly(s, dp, false);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyToModifiableInitWhenModifiedIsUpdated()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyInitToModifiableModifiedIsUpdated()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			CheckReadOnly(s, dp, true);
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				CheckReadOnly(s, dp, true);
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyModifiedUpdate()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, true);
-			s.Update(dp);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				dp.Description = "changed";
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dp, true);
+				s.Update(dp);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyDelete()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Delete(dp);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.Null);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				s.Delete(dp);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				var dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.Null);
+				t.Commit();
+				s.Close();
+			}
 		}
 
 		[Test]
 		public void ReadOnlyRefresh()
 		{
 			DataPoint dp = this.CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			ITransaction t = s.BeginTransaction();
-			dp = s.Load<DataPoint>(dp.Id);
-			s.SetReadOnly(dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			s.Refresh(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(s.IsReadOnly(dp), Is.True);
-			Assert.That(s.IsReadOnly(((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementation()), Is.True);
-			s.Refresh(dp);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(s.IsReadOnly(dp), Is.True);
-			Assert.That(s.IsReadOnly(((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementation()), Is.True);
-			t.Commit();
-	
-			s.Clear();
-			t = s.BeginTransaction();
-			dp = s.Get<DataPoint>(dp.Id);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			s.Delete(dp);
-			t.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Load<DataPoint>(dp.Id);
+					s.SetReadOnly(dp, true);
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					s.Refresh(dp);
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					dp.Description = "changed";
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					Assert.That(s.IsReadOnly(dp), Is.True);
+					Assert.That(
+						s.IsReadOnly(((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementation()),
+						Is.True);
+					s.Refresh(dp);
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					dp.Description = "changed";
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					Assert.That(s.IsReadOnly(dp), Is.True);
+					Assert.That(
+						s.IsReadOnly(((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementation()),
+						Is.True);
+					t.Commit();
+				}
+
+				s.Clear();
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Get<DataPoint>(dp.Id);
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyRefreshDeleted()
 		{
 			DataPoint dp = this.CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			ITransaction t = s.BeginTransaction();
-			INHibernateProxy dpProxy = (INHibernateProxy)s.Load<DataPoint>(dp.Id);
-			Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
-			t.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			t = s.BeginTransaction();
-			dp = s.Get<DataPoint>(dp.Id);
-			s.Delete(dp);
-			s.Flush();
-			
-			try
+			INHibernateProxy dpProxy;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.Refresh(dp);
-				Assert.Fail("should have thrown UnresolvableObjectException" );
-			}
-			catch (UnresolvableObjectException)
-			{
-				// expected
-			}
-			finally
-			{
-				t.Rollback();
+				s.CacheMode = CacheMode.Ignore;
+				dpProxy = (INHibernateProxy) s.Load<DataPoint>(dp.Id);
+				Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
+				t.Commit();
 				s.Close();
 			}
-	
-			s = OpenSession();
-			t = s.BeginTransaction();
-			s.CacheMode = CacheMode.Ignore;
-			DataPoint dpProxyInit = s.Load<DataPoint>(dp.Id);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			s.Delete(dpProxyInit);
-			t.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			t = s.BeginTransaction();
-			Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dpProxyInit), Is.True);
 
 			try
 			{
-				s.Refresh(dpProxyInit);
-				Assert.Fail("should have thrown UnresolvableObjectException");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+					dp = s.Get<DataPoint>(dp.Id);
+					s.Delete(dp);
+					s.Flush();
+
+					s.Refresh(dp);
+					Assert.Fail("should have thrown UnresolvableObjectException");
+				}
 			}
 			catch (UnresolvableObjectException)
 			{
 				// expected
 			}
-			finally
+
+			DataPoint dpProxyInit;
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				t.Rollback();
+				s.CacheMode = CacheMode.Ignore;
+				dpProxyInit = s.Load<DataPoint>(dp.Id);
+				Assert.That(dp.Description, Is.EqualTo("original"));
+				s.Delete(dpProxyInit);
+				t.Commit();
 				s.Close();
 			}
-	
-			s = OpenSession();
-			t = s.BeginTransaction();
-			Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
-			
+
 			try
 			{
-				s.Refresh(dpProxy);
-				Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
-				NHibernateUtil.Initialize(dpProxy);
-				Assert.Fail("should have thrown UnresolvableObjectException");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dpProxyInit), Is.True);
+
+					s.Refresh(dpProxyInit);
+					Assert.Fail("should have thrown UnresolvableObjectException");
+				}
 			}
 			catch (UnresolvableObjectException)
 			{
 				// expected
 			}
-			finally
+
+			try
 			{
-				t.Rollback();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					Assert.That(dpProxyInit, Is.InstanceOf<INHibernateProxy>());
+
+					s.Refresh(dpProxy);
+					Assert.That(NHibernateUtil.IsInitialized(dpProxy), Is.False);
+					NHibernateUtil.Initialize(dpProxy);
+					Assert.Fail("should have thrown UnresolvableObjectException");
+				}
+			}
+			catch (UnresolvableObjectException)
+			{
+				// expected
 			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyRefreshDetached()
 		{
 			DataPoint dp = this.CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			ITransaction t = s.BeginTransaction();
-			dp = s.Load<DataPoint>(dp.Id);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			Assert.That(s.IsReadOnly(dp), Is.False);
-			s.SetReadOnly(dp, true);
-			Assert.That(s.IsReadOnly(dp), Is.True);
-			s.Evict(dp);
-			s.Refresh(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			Assert.That(s.IsReadOnly(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.SetReadOnly(dp, true);
-			s.Evict(dp);
-			s.Refresh(dp);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			Assert.That(s.IsReadOnly(dp), Is.False);
-			t.Commit();
-	
-			s.Clear();
-			t = s.BeginTransaction();
-			dp = s.Get<DataPoint>(dp.Id);
-			Assert.That(dp.Description, Is.EqualTo("original"));
-			s.Delete(dp);
-			t.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Load<DataPoint>(dp.Id);
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					Assert.That(s.IsReadOnly(dp), Is.False);
+					s.SetReadOnly(dp, true);
+					Assert.That(s.IsReadOnly(dp), Is.True);
+					s.Evict(dp);
+					s.Refresh(dp);
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					Assert.That(s.IsReadOnly(dp), Is.False);
+					dp.Description = "changed";
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					s.SetReadOnly(dp, true);
+					s.Evict(dp);
+					s.Refresh(dp);
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					Assert.That(s.IsReadOnly(dp), Is.False);
+					t.Commit();
+				}
+
+				s.Clear();
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Get<DataPoint>(dp.Id);
+					Assert.That(dp.Description, Is.EqualTo("original"));
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyProxyMergeDetachedProxyWithChange()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				t.Commit();
+				s.Close();
+			}
+
 			// modify detached proxy
 			dp.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dpLoaded, false);
-			s.SetReadOnly(dpLoaded, true);
-			CheckReadOnly(s, dpLoaded, true);
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			DataPoint dpMerged = (DataPoint)s.Merge(dp);
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dpLoaded, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dpLoaded, false);
+				s.SetReadOnly(dpLoaded, true);
+				CheckReadOnly(s, dpLoaded, true);
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				DataPoint dpMerged = (DataPoint) s.Merge(dp);
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dpLoaded, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyProxyInitMergeDetachedProxyWithChange()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				t.Commit();
+				s.Close();
+			}
+
 			// modify detached proxy
 			dp.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			NHibernateUtil.Initialize(dpLoaded);
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			CheckReadOnly(s, dpLoaded, false);
-			s.SetReadOnly(dpLoaded, true);
-			CheckReadOnly(s, dpLoaded, true);
-			DataPoint dpMerged = (DataPoint)s.Merge(dp);
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dpLoaded, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				NHibernateUtil.Initialize(dpLoaded);
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				CheckReadOnly(s, dpLoaded, false);
+				s.SetReadOnly(dpLoaded, true);
+				CheckReadOnly(s, dpLoaded, true);
+				DataPoint dpMerged = (DataPoint) s.Merge(dp);
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dpLoaded, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyProxyMergeDetachedEntityWithChange()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				t.Commit();
+				s.Close();
+			}
+
 			// modify detached proxy target
-			DataPoint dpEntity = (DataPoint)((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementation();
+			DataPoint dpEntity = (DataPoint) ((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementation();
 			dpEntity.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dpLoaded, false);
-			s.SetReadOnly(dpLoaded, true);
-			CheckReadOnly(s, dpLoaded, true);
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			DataPoint dpMerged = (DataPoint)s.Merge(dpEntity);
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dpLoaded, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dpLoaded, false);
+				s.SetReadOnly(dpLoaded, true);
+				CheckReadOnly(s, dpLoaded, true);
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				DataPoint dpMerged = (DataPoint) s.Merge(dpEntity);
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dpLoaded, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyProxyInitMergeDetachedEntityWithChange()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				t.Commit();
+				s.Close();
+			}
+
 			// modify detached proxy target
-			DataPoint dpEntity = (DataPoint)((INHibernateProxy)dp).HibernateLazyInitializer.GetImplementation();
+			DataPoint dpEntity = (DataPoint) ((INHibernateProxy) dp).HibernateLazyInitializer.GetImplementation();
 			dpEntity.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
-			NHibernateUtil.Initialize(dpLoaded);
-			Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
-			CheckReadOnly(s, dpLoaded, false);
-			s.SetReadOnly(dpLoaded, true);
-			CheckReadOnly(s, dpLoaded, true);
-			DataPoint dpMerged = (DataPoint)s.Merge(dpEntity);
-			Assert.That(dpMerged, Is.SameAs(dpLoaded));
-			Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dpLoaded, true);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpLoaded = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dpLoaded, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.False);
+				NHibernateUtil.Initialize(dpLoaded);
+				Assert.That(NHibernateUtil.IsInitialized(dpLoaded), Is.True);
+				CheckReadOnly(s, dpLoaded, false);
+				s.SetReadOnly(dpLoaded, true);
+				CheckReadOnly(s, dpLoaded, true);
+				DataPoint dpMerged = (DataPoint) s.Merge(dpEntity);
+				Assert.That(dpMerged, Is.SameAs(dpLoaded));
+				Assert.That(dpLoaded.Description, Is.EqualTo("changed"));
+				CheckReadOnly(s, dpLoaded, true);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void ReadOnlyEntityMergeDetachedProxyWithChange()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			CheckReadOnly(s, dp, false);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			NHibernateUtil.Initialize(dp);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				CheckReadOnly(s, dp, false);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				NHibernateUtil.Initialize(dp);
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+				t.Commit();
+				s.Close();
+			}
+
 			// modify detached proxy
 			dp.Description = "changed";
-	
-			s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-			s.BeginTransaction();
-			DataPoint dpEntity = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dpEntity, Is.Not.InstanceOf<INHibernateProxy>());
-			Assert.That(s.IsReadOnly(dpEntity), Is.False);
-			s.SetReadOnly(dpEntity, true);
-			Assert.That(s.IsReadOnly(dpEntity), Is.True);
-			DataPoint dpMerged = (DataPoint)s.Merge(dp);
-			Assert.That(dpMerged, Is.SameAs(dpEntity));
-			Assert.That(dpEntity.Description, Is.EqualTo("changed"));
-			Assert.That(s.IsReadOnly(dpEntity), Is.True);
-			s.Flush();
-			s.Transaction.Commit();
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				DataPoint dpEntity = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dpEntity, Is.Not.InstanceOf<INHibernateProxy>());
+				Assert.That(s.IsReadOnly(dpEntity), Is.False);
+				s.SetReadOnly(dpEntity, true);
+				Assert.That(s.IsReadOnly(dpEntity), Is.True);
+				DataPoint dpMerged = (DataPoint) s.Merge(dp);
+				Assert.That(dpMerged, Is.SameAs(dpEntity));
+				Assert.That(dpEntity.Description, Is.EqualTo("changed"));
+				Assert.That(s.IsReadOnly(dpEntity), Is.True);
+				s.Flush();
+				t.Commit();
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void SetReadOnlyInTwoTransactionsSameSession()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Flush();
-			s.Transaction.Commit();
-	
-			CheckReadOnly(s, dp, true);
-	
-			s.BeginTransaction();
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed again";
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			s.Flush();
-			s.Transaction.Commit();
-	
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Load<DataPoint>(dpOrig.Id);
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					CheckReadOnly(s, dp, false);
+					s.SetReadOnly(dp, true);
+					CheckReadOnly(s, dp, true);
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					dp.Description = "changed";
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					s.Flush();
+					t.Commit();
+				}
+
+				CheckReadOnly(s, dp, true);
+
+				using (var t = s.BeginTransaction())
+				{
+					CheckReadOnly(s, dp, true);
+					dp.Description = "changed again";
+					Assert.That(dp.Description, Is.EqualTo("changed again"));
+					s.Flush();
+					t.Commit();
+				}
+
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void SetReadOnlyBetweenTwoTransactionsSameSession()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, false);
-			s.Flush();
-			s.Transaction.Commit();
-	
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-	
-			s.BeginTransaction();
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed again";
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			s.Flush();
-			s.Transaction.Commit();
-	
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Load<DataPoint>(dpOrig.Id);
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					CheckReadOnly(s, dp, false);
+					dp.Description = "changed";
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					CheckReadOnly(s, dp, false);
+					s.Flush();
+					t.Commit();
+				}
+
+				CheckReadOnly(s, dp, false);
+				s.SetReadOnly(dp, true);
+				CheckReadOnly(s, dp, true);
+
+				using (var t = s.BeginTransaction())
+				{
+					CheckReadOnly(s, dp, true);
+					dp.Description = "changed again";
+					Assert.That(dp.Description, Is.EqualTo("changed again"));
+					s.Flush();
+					t.Commit();
+				}
+
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void SetModifiableBetweenTwoTransactionsSameSession()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.SetReadOnly(dp, true);
-			CheckReadOnly(s, dp, true);
-			dp.Description = "changed";
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			CheckReadOnly(s, dp, true);
-			s.Flush();
-			s.Transaction.Commit();
-	
-			CheckReadOnly(s, dp, true);
-			s.SetReadOnly(dp, false);
-			CheckReadOnly(s, dp, false);
-	
-			s.BeginTransaction();
-			CheckReadOnly(s, dp, false);
-			Assert.That(dp.Description, Is.EqualTo("changed"));
-			s.Refresh(dp);
-			Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
-			CheckReadOnly(s, dp, false);
-			dp.Description = "changed again";
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			s.Flush();
-			s.Transaction.Commit();
-	
-			s.Close();
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			dp = s.Get<DataPoint>(dpOrig.Id);
-			Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
-			Assert.That(dp.Description, Is.EqualTo("changed again"));
-			Assert.That(dp.X, Is.EqualTo(dpOrig.X));
-			Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
-			s.Delete(dp);
-			s.Transaction.Commit();
-			s.Close();
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			{
+				s.CacheMode = CacheMode.Ignore;
+				using (var t = s.BeginTransaction())
+				{
+					dp = s.Load<DataPoint>(dpOrig.Id);
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					CheckReadOnly(s, dp, false);
+					s.SetReadOnly(dp, true);
+					CheckReadOnly(s, dp, true);
+					dp.Description = "changed";
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.True);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					CheckReadOnly(s, dp, true);
+					s.Flush();
+					t.Commit();
+				}
+
+				CheckReadOnly(s, dp, true);
+				s.SetReadOnly(dp, false);
+				CheckReadOnly(s, dp, false);
+
+				using (var t = s.BeginTransaction())
+				{
+					CheckReadOnly(s, dp, false);
+					Assert.That(dp.Description, Is.EqualTo("changed"));
+					s.Refresh(dp);
+					Assert.That(dp.Description, Is.EqualTo(dpOrig.Description));
+					CheckReadOnly(s, dp, false);
+					dp.Description = "changed again";
+					Assert.That(dp.Description, Is.EqualTo("changed again"));
+					s.Flush();
+					t.Commit();
+				}
+
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				dp = s.Get<DataPoint>(dpOrig.Id);
+				Assert.That(dp.Id, Is.EqualTo(dpOrig.Id));
+				Assert.That(dp.Description, Is.EqualTo("changed again"));
+				Assert.That(dp.X, Is.EqualTo(dpOrig.X));
+				Assert.That(dp.Y, Is.EqualTo(dpOrig.Y));
+				s.Delete(dp);
+				t.Commit();
+				s.Close();
+			}
 		}
-	
+
 		[Test]
 		public void IsReadOnlyAfterSessionClosed()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp = null;
+
 			try
 			{
-	 			s.IsReadOnly(dp);
-				Assert.Fail("should have failed because session was closed");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+
+					dp = s.Load<DataPoint>(dpOrig.Id);
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					CheckReadOnly(s, dp, false);
+					t.Commit();
+					s.Close();
+					s.IsReadOnly(dp);
+					Assert.Fail("should have failed because session was closed");
+				}
 			}
 			catch (ObjectDisposedException) // SessionException in Hibernate
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void IsReadOnlyAfterSessionClosedViaLazyInitializer()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			Assert.That(s.Contains(dp), Is.True);
-			s.Close();
-	
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				t.Commit();
+				Assert.That(s.Contains(dp), Is.True);
+				s.Close();
+			}
+
+			Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
 			try
 			{
-	 			var value = ((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly;
+				var value = ((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly;
 				Assert.Fail("should have failed because session was detached");
 			}
 			catch (TransientObjectException)
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void DetachedIsReadOnlyAfterEvictViaSession()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			Assert.That(s.Contains(dp), Is.True);
-			s.Evict(dp);
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-	
-			try
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-	 			s.IsReadOnly(dp);
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				s.CacheMode = CacheMode.Ignore;
+
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				Assert.That(s.Contains(dp), Is.True);
+				s.Evict(dp);
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+
+				try
+				{
+					s.IsReadOnly(dp);
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void DetachedIsReadOnlyAfterEvictViaLazyInitializer()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Evict(dp);
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-			try
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-	 			var value = ((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly;
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				s.CacheMode = CacheMode.Ignore;
+
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				s.Evict(dp);
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+				try
+				{
+					var value = ((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly;
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void SetReadOnlyAfterSessionClosed()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			s.Close();
-	
+			DataPoint dp = null;
+
 			try
 			{
-	 			s.SetReadOnly(dp, true);
-				Assert.Fail("should have failed because session was closed");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+
+					dp = s.Load<DataPoint>(dpOrig.Id);
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					CheckReadOnly(s, dp, false);
+					t.Commit();
+					s.Close();
+					s.SetReadOnly(dp, true);
+					Assert.Fail("should have failed because session was closed");
+				}
 			}
 			catch (ObjectDisposedException) // SessionException in Hibernate
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void SetReadOnlyAfterSessionClosedViaLazyInitializer()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			Assert.That(s.Contains(dp), Is.True);
-			s.Close();
-	
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
+			DataPoint dp;
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+
+				dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				t.Commit();
+				Assert.That(s.Contains(dp), Is.True);
+				s.Close();
+			}
+
+			Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
 			try
 			{
-	 			((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly = true;
+				((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly = true;
 				Assert.Fail("should have failed because session was detached");
 			}
 			catch (TransientObjectException)
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void SetClosedSessionInLazyInitializer()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Transaction.Commit();
-			Assert.That(s.Contains(dp), Is.True);
-			s.Close();
-	
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-			Assert.That(((ISessionImplementor)s).IsClosed, Is.True);
-			
+			DataPoint dp = null;
+
 			try
 			{
-				((INHibernateProxy)dp).HibernateLazyInitializer.SetSession((ISessionImplementor)s);
-				Assert.Fail("should have failed because session was closed");
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.CacheMode = CacheMode.Ignore;
+
+					dp = s.Load<DataPoint>(dpOrig.Id);
+					Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+					Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+					CheckReadOnly(s, dp, false);
+					t.Commit();
+					Assert.That(s.Contains(dp), Is.True);
+					s.Close();
+
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+					Assert.That(((ISessionImplementor) s).IsClosed, Is.True);
+
+					((INHibernateProxy) dp).HibernateLazyInitializer.SetSession((ISessionImplementor) s);
+					Assert.Fail("should have failed because session was closed");
+				}
 			}
 			catch (ObjectDisposedException) // SessionException in Hibernate
 			{
 				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
 			}
 			finally
 			{
-				s = OpenSession();
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				using (var s = OpenSession())
+				using (var t = s.BeginTransaction())
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-		
+
 		[Test]
 		public void DetachedSetReadOnlyAfterEvictViaSession()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			Assert.That(s.Contains(dp), Is.True);
-			s.Evict(dp);
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-	
-			try
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-	 			s.SetReadOnly(dp, true);
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
+				s.CacheMode = CacheMode.Ignore;
+
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				Assert.That(s.Contains(dp), Is.True);
+				s.Evict(dp);
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+
+				try
+				{
+					s.SetReadOnly(dp, true);
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					s.Delete(dp);
+					t.Commit();
+					s.Close();
+				}
 			}
 		}
-	
+
 		[Test]
 		public void DetachedSetReadOnlyAfterEvictViaLazyInitializer()
 		{
 			DataPoint dpOrig = CreateDataPoint(CacheMode.Ignore);
-	
-			ISession s = OpenSession();
-			s.CacheMode = CacheMode.Ignore;
-	
-			s.BeginTransaction();
-			DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
-			Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
-			Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
-			CheckReadOnly(s, dp, false);
-			s.Evict(dp);
-			Assert.That(s.Contains(dp), Is.False);
-			Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.Session, Is.Null);
-			
-			try
-			{
-	 			((INHibernateProxy)dp).HibernateLazyInitializer.ReadOnly = true;
-				Assert.Fail("should have failed because proxy was detached");
-			}
-			catch (TransientObjectException)
-			{
-				// expected
-				Assert.That(((INHibernateProxy)dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
-			}
-			finally
-			{
-				s.BeginTransaction();
-				s.Delete(dp);
-				s.Transaction.Commit();
-				s.Close();
-			}
-		}
-		
-		private DataPoint CreateDataPoint(CacheMode mode)
-		{
-			DataPoint dp = null;
-			
-			using (ISession s = OpenSession())
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				
-				using (ITransaction t = s.BeginTransaction())
+
+				DataPoint dp = s.Load<DataPoint>(dpOrig.Id);
+				Assert.That(dp, Is.InstanceOf<INHibernateProxy>());
+				Assert.That(NHibernateUtil.IsInitialized(dp), Is.False);
+				CheckReadOnly(s, dp, false);
+				s.Evict(dp);
+				Assert.That(s.Contains(dp), Is.False);
+				Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.Session, Is.Null);
+
+				try
 				{
-					dp = new DataPoint();
-					dp.X = 0.1M;
-					dp.Y = (decimal)System.Math.Cos((double)dp.X);
-					dp.Description = "original";
-					s.Save(dp);
+					((INHibernateProxy) dp).HibernateLazyInitializer.ReadOnly = true;
+					Assert.Fail("should have failed because proxy was detached");
+				}
+				catch (TransientObjectException)
+				{
+					// expected
+					Assert.That(((INHibernateProxy) dp).HibernateLazyInitializer.IsReadOnlySettingAvailable, Is.False);
+				}
+				finally
+				{
+					s.Delete(dp);
 					t.Commit();
+					s.Close();
 				}
 			}
-			
-			return dp;
 		}
-	
+
+		private DataPoint CreateDataPoint(CacheMode mode)
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CacheMode = CacheMode.Ignore;
+
+				var dp = new DataPoint();
+				dp.X = 0.1M;
+				dp.Y = (decimal) System.Math.Cos((double) dp.X);
+				dp.Description = "original";
+				s.Save(dp);
+				t.Commit();
+				return dp;
+			}
+		}
+
 		private void CheckReadOnly(ISession s, object proxy, bool expectedReadOnly)
 		{
 			Assert.That(proxy, Is.InstanceOf<INHibernateProxy>());
-			ILazyInitializer li = ((INHibernateProxy)proxy).HibernateLazyInitializer;
+			ILazyInitializer li = ((INHibernateProxy) proxy).HibernateLazyInitializer;
 			Assert.That(s, Is.SameAs(li.Session));
 			Assert.That(s.IsReadOnly(proxy), Is.EqualTo(expectedReadOnly));
 			Assert.That(li.ReadOnly, Is.EqualTo(expectedReadOnly));

--- a/src/NHibernate.Test/ReadOnly/ReadOnlySessionTest.cs
+++ b/src/NHibernate.Test/ReadOnly/ReadOnlySessionTest.cs
@@ -1,14 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
-using NHibernate.Cfg;
-using NHibernate.Criterion;
-using NHibernate.Dialect;
-using NHibernate.Engine;
 using NHibernate.Proxy;
-using NHibernate.SqlCommand;
-using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ReadOnly
@@ -40,10 +32,10 @@ namespace NHibernate.Test.ReadOnly
 			DataPoint dp = null;
 			long dpId = -1;
 			
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 			
 				dp = new DataPoint();
 				dp.X = 0.1M;
@@ -51,13 +43,13 @@ namespace NHibernate.Test.ReadOnly
 				dp.Description = "original";
 				s.Save(dp);
 				dpId = dp.Id;
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				s.DefaultReadOnly = true;
 				Assert.That(s.DefaultReadOnly, Is.True);
 				dp = (DataPoint)s.Load<DataPoint>(dpId);
@@ -69,16 +61,16 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(NHibernateUtil.IsInitialized(dp), Is.True, "was not initialized during mod");
 				Assert.That(dp.Description, Is.EqualTo("changed"), "desc not changed in memory");
 				s.Flush();
-				s.Transaction.Commit();
+				t.Commit();
 			}
-	
-			using (ISession s = OpenSession())
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				IList list = s.CreateQuery("from DataPoint where description = 'changed'").List();
 				Assert.That(list.Count, Is.EqualTo(0), "change written to database");
 				s.CreateQuery("delete from DataPoint").ExecuteUpdate();
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 		

--- a/src/NHibernate.Test/ReadOnly/ReadOnlyVersionedNodes.cs
+++ b/src/NHibernate.Test/ReadOnly/ReadOnlyVersionedNodes.cs
@@ -1,15 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using NHibernate.Cfg;
-using NHibernate.Criterion;
-using NHibernate.Dialect;
-using NHibernate.Engine;
-using NHibernate.Proxy;
-using NHibernate.SqlCommand;
-using NHibernate.Transform;
-using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.ReadOnly
@@ -31,22 +20,23 @@ namespace NHibernate.Test.ReadOnly
 		public void SetReadOnlyTrueAndFalse()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
 			{
-				s.BeginTransaction();
-				node = s.Get<VersionedNode>(node.Id);
-				s.SetReadOnly(node, true);
-				node.Name = "node-name";
-				s.Transaction.Commit();
+				using (var t = s.BeginTransaction())
+				{
+					node = s.Get<VersionedNode>(node.Id);
+					s.SetReadOnly(node, true);
+					node.Name = "node-name";
+					t.Commit();
+				}
 
 				AssertUpdateCount(0);
 				AssertInsertCount(0);
@@ -54,24 +44,25 @@ namespace NHibernate.Test.ReadOnly
 				// the changed name is still in node
 				Assert.That(node.Name, Is.EqualTo("node-name"));
 
-				s.BeginTransaction();
-				node = s.Get<VersionedNode>(node.Id);
-				// the changed name is still in the session
-				Assert.That(node.Name, Is.EqualTo("node-name"));
-				s.Refresh(node);
-				// after refresh, the name reverts to the original value
-				Assert.That(node.Name, Is.EqualTo("node"));
-				node = s.Get<VersionedNode>(node.Id);
-				Assert.That(node.Name, Is.EqualTo("node"));
-				s.Transaction.Commit();
+				using (var t = s.BeginTransaction())
+				{
+					node = s.Get<VersionedNode>(node.Id);
+					// the changed name is still in the session
+					Assert.That(node.Name, Is.EqualTo("node-name"));
+					s.Refresh(node);
+					// after refresh, the name reverts to the original value
+					Assert.That(node.Name, Is.EqualTo("node"));
+					node = s.Get<VersionedNode>(node.Id);
+					Assert.That(node.Name, Is.EqualTo("node"));
+					t.Commit();
+				}
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				Assert.That(node.Name, Is.EqualTo("node"));
 				s.SetReadOnly(node, true);
@@ -82,22 +73,21 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(node.Name, Is.EqualTo("node"));
 				s.SetReadOnly(node, false);
 				node.Name = "diff-node-name";
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				Assert.That(node.Name, Is.EqualTo("diff-node-name"));
 				Assert.That(node.Version, Is.EqualTo(2));
 				s.SetReadOnly(node, true);
 				s.Delete(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -108,37 +98,35 @@ namespace NHibernate.Test.ReadOnly
 		public void UpdateSetReadOnlyTwice()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				node.Name = "node-name";
 				s.SetReadOnly(node, true);
 				s.SetReadOnly(node, true);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				Assert.That(node.Name, Is.EqualTo("node"));
 				Assert.That(node.Version, Is.EqualTo(1));
 				s.SetReadOnly(node, true);
 				s.Delete(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -149,37 +137,35 @@ namespace NHibernate.Test.ReadOnly
 		public void UpdateSetModifiable()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				node.Name = "node-name";
 				s.SetReadOnly(node, false);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				Assert.That(node.Name, Is.EqualTo("node-name"));
 				Assert.That(node.Version, Is.EqualTo(2));
 				//s.SetReadOnly(node, true);
 				s.Delete(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -191,36 +177,34 @@ namespace NHibernate.Test.ReadOnly
 		public void UpdateSetReadOnlySetModifiableFailureExpected()
 		{
 			VersionedNode node = new VersionedNode("node", "node");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				node.Name = "node-name";
 				s.SetReadOnly(node, true);
 				s.SetReadOnly(node, false);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				node = s.Get<VersionedNode>(node.Id);
 				Assert.That(node.Name, Is.EqualTo("node-name"));
 				Assert.That(node.Version, Is.EqualTo(2));
 				s.Delete(node);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 	
@@ -228,72 +212,77 @@ namespace NHibernate.Test.ReadOnly
 		[Ignore("Failure expected")]
 		public void SetReadOnlyUpdateSetModifiableFailureExpected()
 		{
-			ISession s = OpenSession();
-			s.BeginTransaction();
 			VersionedNode node = new VersionedNode("node", "node");
-			s.Persist(node);
-			s.Transaction.Commit();
-			s.Close();
-	
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.Persist(node);
+				t.Commit();
+				s.Close();
+			}
+
 			ClearCounts();
-	
-			s = OpenSession();
-	
-			s.BeginTransaction();
-			node = s.Get<VersionedNode>(node.Id);
-			s.SetReadOnly(node, true);
-			node.Name = "node-name";
-			s.SetReadOnly(node, false);
-			s.Transaction.Commit();
-			s.Close();
-	
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				node = s.Get<VersionedNode>(node.Id);
+				s.SetReadOnly(node, true);
+				node.Name = "node-name";
+				s.SetReadOnly(node, false);
+				t.Commit();
+				s.Close();
+			}
+
 			AssertUpdateCount(1);
 			AssertInsertCount(0);
-	
-			s = OpenSession();
-			s.BeginTransaction();
-			node = s.Get<VersionedNode>(node.Id);
-			Assert.That(node.Name, Is.EqualTo("node-name"));
-			Assert.That(node.Version, Is.EqualTo(2));
-			s.Delete(node);
-			s.Transaction.Commit();
-			s.Close();
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				node = s.Get<VersionedNode>(node.Id);
+				Assert.That(node.Name, Is.EqualTo("node-name"));
+				Assert.That(node.Version, Is.EqualTo(2));
+				s.Delete(node);
+				t.Commit();
+				s.Close();
+			}
 		}
 	
 		[Test]
 		public void AddNewChildToReadOnlyParent()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				s.Persist(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
 
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				VersionedNode parentManaged = s.Get<VersionedNode>(parent.Id);
 				s.SetReadOnly(parentManaged, true);
 				parentManaged.Name = "new parent name";
 				parentManaged.AddChild(child);
 				s.Save(parentManaged);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.CacheMode = CacheMode.Ignore;
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				Assert.That(parent.Name, Is.EqualTo("parent"));
 				Assert.That(parent.Children.Count, Is.EqualTo(1));
@@ -301,7 +290,7 @@ namespace NHibernate.Test.ReadOnly
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(child, Is.Not.Null);
 				s.Delete(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 		}
 	
@@ -309,11 +298,11 @@ namespace NHibernate.Test.ReadOnly
 		public void UpdateParentWithNewChildCommitWithReadOnlyParent()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
@@ -321,22 +310,20 @@ namespace NHibernate.Test.ReadOnly
 			parent.Name = "new parent name";
 			VersionedNode child = new VersionedNode("child", "child");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Update(parent);
 				s.SetReadOnly(parent, true);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -349,7 +336,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -360,11 +347,11 @@ namespace NHibernate.Test.ReadOnly
 		public void MergeDetachedParentWithNewChildCommitWithReadOnlyParent()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
@@ -372,22 +359,20 @@ namespace NHibernate.Test.ReadOnly
 			parent.Name = "new parent name";
 			VersionedNode child = new VersionedNode("child", "child");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = (VersionedNode) s.Merge(parent);
 				s.SetReadOnly(parent, true);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -400,7 +385,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -411,11 +396,11 @@ namespace NHibernate.Test.ReadOnly
 		public void GetParentMakeReadOnlyThenMergeDetachedParentWithNewChildC()
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
@@ -423,24 +408,22 @@ namespace NHibernate.Test.ReadOnly
 			parent.Name = "new parent name";
 			VersionedNode child = new VersionedNode("child", "child");
 			parent.AddChild(child);
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode parentManaged = s.Get<VersionedNode>(parent.Id);
 				s.SetReadOnly(parentManaged, true);
 				VersionedNode parentMerged = (VersionedNode) s.Merge(parent);
 				Assert.That(parentManaged, Is.SameAs(parentMerged));
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(1);
 			AssertInsertCount(1);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -451,7 +434,7 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(child.Version, Is.EqualTo(1));
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -463,55 +446,50 @@ namespace NHibernate.Test.ReadOnly
 		{
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			VersionedNode child = new VersionedNode("child", "child");
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent.AddChild(child);
 				s.Persist(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = (VersionedNode) s.Merge(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode parentGet = s.Get<VersionedNode>(parent.Id);
 				s.Merge(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode parentLoad = s.Load<VersionedNode>(parent.Id);
 				s.Merge(parent);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(0);
 			ClearCounts();
-
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(parent.Name, Is.EqualTo("parent"));
@@ -522,7 +500,7 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(child.Version, Is.EqualTo(1));
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -533,32 +511,31 @@ namespace NHibernate.Test.ReadOnly
 		public void AddNewParentToReadOnlyChild()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
 
 			VersionedNode parent = new VersionedNode("parent", "parent");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode childManaged = s.Get<VersionedNode>(child.Id);
 				s.SetReadOnly(childManaged, true);
 				childManaged.Name = "new child name";
 				parent.AddChild(childManaged);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(1);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(child.Name, Is.EqualTo("child"));
 				Assert.That(child.Parent, Is.Null);
@@ -567,7 +544,7 @@ namespace NHibernate.Test.ReadOnly
 				Assert.That(parent, Is.Not.Null);
 				s.SetReadOnly(child, true);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -578,11 +555,11 @@ namespace NHibernate.Test.ReadOnly
 		public void UpdateChildWithNewParentCommitWithReadOnlyChild()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
@@ -590,22 +567,20 @@ namespace NHibernate.Test.ReadOnly
 			child.Name = "new child name";
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Update(child);
 				s.SetReadOnly(child, true);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(child.Name, Is.EqualTo("child"));
@@ -618,7 +593,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -629,11 +604,11 @@ namespace NHibernate.Test.ReadOnly
 		public void MergeDetachedChildWithNewParentCommitWithReadOnlyChild()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
@@ -641,22 +616,20 @@ namespace NHibernate.Test.ReadOnly
 			child.Name = "new child name";
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				child = (VersionedNode) s.Merge(child);
 				s.SetReadOnly(child, true);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0); // NH-specific: Hibernate issues a separate UPDATE for the version number
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(child.Name, Is.EqualTo("child"));
@@ -669,7 +642,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -680,11 +653,11 @@ namespace NHibernate.Test.ReadOnly
 		public void GetChildMakeReadOnlyThenMergeDetachedChildWithNewParent()
 		{
 			VersionedNode child = new VersionedNode("child", "child");
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				s.Persist(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			ClearCounts();
@@ -692,24 +665,22 @@ namespace NHibernate.Test.ReadOnly
 			child.Name = "new child name";
 			VersionedNode parent = new VersionedNode("parent", "parent");
 			parent.AddChild(child);
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				VersionedNode childManaged = s.Get<VersionedNode>(child.Id);
 				s.SetReadOnly(childManaged, true);
 				VersionedNode childMerged = (VersionedNode) s.Merge(child);
 				Assert.That(childManaged, Is.SameAs(childMerged));
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0); // NH-specific: Hibernate issues a separate UPDATE for the version number
 			AssertInsertCount(1);
 			ClearCounts();
-
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
 				parent = s.Get<VersionedNode>(parent.Id);
 				child = s.Get<VersionedNode>(child.Id);
 				Assert.That(child.Name, Is.EqualTo("child"));
@@ -723,7 +694,7 @@ namespace NHibernate.Test.ReadOnly
 				s.SetReadOnly(child, true);
 				s.Delete(parent);
 				s.Delete(child);
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			AssertUpdateCount(0);
@@ -732,14 +703,13 @@ namespace NHibernate.Test.ReadOnly
 	
 		protected override void OnTearDown()
 		{
-			using (ISession s = OpenSession())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				s.BeginTransaction();
-
 				s.CreateQuery("delete from VersionedNode where parent is not null").ExecuteUpdate();
 				s.CreateQuery("delete from VersionedNode").ExecuteUpdate();
 
-				s.Transaction.Commit();
+				t.Commit();
 			}
 
 			base.OnTearDown();

--- a/src/NHibernate.Test/SqlTest/Query/NativeSQLQueriesFixture.cs
+++ b/src/NHibernate.Test/SqlTest/Query/NativeSQLQueriesFixture.cs
@@ -783,7 +783,7 @@ namespace NHibernate.Test.SqlTest.Query
 		public void HandlesManualSynchronization()
 		{
 			using (var s = OpenSession())
-			using (s.BeginTransaction())
+			using (var t = s.BeginTransaction())
 			{
 				s.SessionFactory.Statistics.IsStatisticsEnabled = true;
 				s.SessionFactory.Statistics.Clear();
@@ -802,7 +802,7 @@ namespace NHibernate.Test.SqlTest.Query
 
 				// clean up
 				s.Delete(jboss);
-				s.Transaction.Commit();
+				t.Commit();
 				s.Close();
 			}
 		}

--- a/src/NHibernate.Test/TransactionTest/TransactionFixture.cs
+++ b/src/NHibernate.Test/TransactionTest/TransactionFixture.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using NHibernate.Linq;
 using NUnit.Framework;
 
 namespace NHibernate.Test.TransactionTest
@@ -99,41 +97,30 @@ namespace NHibernate.Test.TransactionTest
 			{
 				using (ITransaction t = s.BeginTransaction())
 				{
-					Assert.AreSame(t, s.Transaction);
-					Assert.IsFalse(s.Transaction.WasCommitted);
-					Assert.IsFalse(s.Transaction.WasRolledBack);
+					Assert.AreSame(t, s.GetCurrentTransaction());
+					Assert.IsFalse(s.GetCurrentTransaction().WasCommitted);
+					Assert.IsFalse(s.GetCurrentTransaction().WasRolledBack);
 					t.Commit();
 
-					// ISession.Transaction returns a new transaction
-					// if the previous one completed!
-					Assert.IsNotNull(s.Transaction);
-					Assert.IsFalse(t == s.Transaction);
+					// ISession.GetCurrentTransaction() returns null if the transaction is completed.
+					Assert.IsNull(s.GetCurrentTransaction());
 
 					Assert.IsTrue(t.WasCommitted);
 					Assert.IsFalse(t.WasRolledBack);
-					Assert.IsFalse(s.Transaction.WasCommitted);
-					Assert.IsFalse(s.Transaction.WasRolledBack);
 					Assert.IsFalse(t.IsActive);
-					Assert.IsFalse(s.Transaction.IsActive);
 				}
 
 				using (ITransaction t = s.BeginTransaction())
 				{
 					t.Rollback();
 
-					// ISession.Transaction returns a new transaction
-					// if the previous one completed!
-					Assert.IsNotNull(s.Transaction);
-					Assert.IsFalse(t == s.Transaction);
+					// ISession.GetCurrentTransaction() returns null if the transaction is completed.
+					Assert.IsNull(s.GetCurrentTransaction());
 
 					Assert.IsTrue(t.WasRolledBack);
 					Assert.IsFalse(t.WasCommitted);
 
-					Assert.IsFalse(s.Transaction.WasCommitted);
-					Assert.IsFalse(s.Transaction.WasRolledBack);
-
 					Assert.IsFalse(t.IsActive);
-					Assert.IsFalse(s.Transaction.IsActive);
 				}
 			}
 		}

--- a/src/NHibernate.Test/TransactionTest/TransactionNotificationFixture.cs
+++ b/src/NHibernate.Test/TransactionTest/TransactionNotificationFixture.cs
@@ -11,7 +11,7 @@ namespace NHibernate.Test.TransactionTest
 	{
 		protected override string[] Mappings => Array.Empty<string>();
 
-		[Test]
+		[Test, Obsolete]
 		public void NoTransaction()
 		{
 			var interceptor = new RecordingInterceptor();

--- a/src/NHibernate.Test/TransformTests/AliasToBeanResultTransformerFixture.cs
+++ b/src/NHibernate.Test/TransformTests/AliasToBeanResultTransformerFixture.cs
@@ -130,25 +130,21 @@ namespace NHibernate.Test.TransformTests
 		protected override void OnSetUp()
 		{
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
 					s.Save(new Simple { Name = "Name1" });
 					s.Save(new Simple { Name = "Name2" });
-					s.Transaction.Commit();
+					t.Commit();
 				}
-			}
 		}
 
 		protected override void OnTearDown()
 		{
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				using (s.BeginTransaction())
-				{
 					s.Delete("from Simple");
-					s.Transaction.Commit();
-				}
+					t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/Unconstrained/UnconstrainedNoLazyTest.cs
+++ b/src/NHibernate.Test/Unconstrained/UnconstrainedNoLazyTest.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-
 using log4net;
 using NHibernate.Criterion;
 using NUnit.Framework;
@@ -135,30 +132,39 @@ namespace NHibernate.Test.Unconstrained
 		[Test]
 		public void ManyToOneUpdateFalse()
 		{
-			ISession session = OpenSession();
-			ITransaction tx = session.BeginTransaction();
-			Person p = new Person("gavin");
-			p.EmployeeId = "123456";
-			p.Unrelated = 10;
-			session.Save(p);
-			tx.Commit();
+			using (var session = OpenSession())
+			{
+				Person p = new Person("gavin");
+				using (var tx = session.BeginTransaction())
+				{
+					p.EmployeeId = "123456";
+					p.Unrelated = 10;
+					session.Save(p);
+					tx.Commit();
+				}
 
-			session.BeginTransaction();
-			p.Employee = new Employee("456123");
-			p.Unrelated = 235; // Force update of the object
-			session.Save(p.Employee);
-			session.Transaction.Commit();
-			session.Close();
+				using (var tx = session.BeginTransaction())
+				{
+					p.Employee = new Employee("456123");
+					p.Unrelated = 235; // Force update of the object
+					session.Save(p.Employee);
+					tx.Commit();
+				}
 
-			session = OpenSession();
-			session.BeginTransaction();
-			p = (Person) session.Load(typeof (Person), "gavin");
-			// Should be null, not Employee#456123
-			Assert.IsNull(p.Employee);
-			session.Delete(p);
-			session.Delete("from Employee");
-			session.Transaction.Commit();
-			session.Close();
+				session.Close();
+			}
+
+			using (var session = OpenSession())
+			using (var tx = session.BeginTransaction())
+			{
+				var p = (Person) session.Load(typeof(Person), "gavin");
+				// Should be null, not Employee#456123
+				Assert.IsNull(p.Employee);
+				session.Delete(p);
+				session.Delete("from Employee");
+				tx.Commit();
+				session.Close();
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/VersionTest/Db/MsSQL/ComplexDomainFixture.cs
+++ b/src/NHibernate.Test/VersionTest/Db/MsSQL/ComplexDomainFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using NHibernate.Dialect;
 using NUnit.Framework;
 
@@ -52,11 +51,11 @@ namespace NHibernate.Test.VersionTest.Db.MsSQL
 				Assert.IsTrue(BinaryTimestamp.Equals(bar.Timestamp, retrievedBar.Timestamp), "Timestamps are different!");
 			}
 
-			using (ISession session = OpenSession())
+			using (var session = OpenSession())
+			using (var tran = session.BeginTransaction())
 			{
-				session.BeginTransaction();
 				session.Delete("from Bar");
-				session.Transaction.Commit();
+				tran.Commit();
 			}
 		}
 	}

--- a/src/NHibernate/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/AdoNet/AbstractBatcher.cs
@@ -130,7 +130,7 @@ namespace NHibernate.AdoNet
 					cmd.Connection = sessionConnection;
 				}
 
-				_connectionManager.Transaction.Enlist(cmd);
+				_connectionManager.EnlistInTransaction(cmd);
 				Driver.PrepareCommand(cmd);
 			}
 			catch (InvalidOperationException ioe)

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -406,6 +406,8 @@ namespace NHibernate.AdoNet
 			}
 		}
 
+		// Since v5.3
+		[Obsolete("Use CurrentTransaction instead, and check for null.")]
 		public ITransaction Transaction
 		{
 			get

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -386,27 +386,39 @@ namespace NHibernate.AdoNet
 
 		public ITransaction BeginTransaction(IsolationLevel isolationLevel)
 		{
-			Transaction.Begin(isolationLevel);
+			EnsureTransactionIsCreated();
+			_transaction.Begin(isolationLevel);
 			return _transaction;
 		}
 
 		public ITransaction BeginTransaction()
 		{
-			Transaction.Begin();
+			EnsureTransactionIsCreated();
+			_transaction.Begin();
 			return _transaction;
+		}
+
+		private void EnsureTransactionIsCreated()
+		{
+			if (_transaction == null)
+			{
+				_transaction = Factory.TransactionFactory.CreateTransaction(Session);
+			}
 		}
 
 		public ITransaction Transaction
 		{
 			get
 			{
-				if (_transaction == null)
-				{
-					_transaction = Factory.TransactionFactory.CreateTransaction(Session);
-				}
+				EnsureTransactionIsCreated();
 				return _transaction;
 			}
 		}
+
+		/// <summary>
+		/// The current transaction if any is ongoing, else <see langword="null" />.
+		/// </summary>
+		public ITransaction CurrentTransaction => _transaction;
 
 		public void AfterNonTransactionalQuery(bool success)
 		{
@@ -444,8 +456,30 @@ namespace NHibernate.AdoNet
 		public DbCommand CreateCommand()
 		{
 			var result = GetConnection().CreateCommand();
-			Transaction.Enlist(result);
+			EnlistInTransaction(result);
 			return result;
+		}
+
+		/// <summary>
+		/// Enlist a command in the current transaction, if any.
+		/// </summary>
+		/// <param name="command">The command to enlist.</param>
+		public void EnlistInTransaction(DbCommand command)
+		{
+			if (command == null)
+				throw new ArgumentNullException(nameof(command));
+
+			if (_transaction != null)
+			{
+				_transaction.Enlist(command);
+				return;
+			}
+
+			if (command.Transaction != null)
+			{
+				_log.Warn("set a nonnull DbCommand.Transaction to null because the Session had no Transaction");
+				command.Transaction = null;
+			}
 		}
 
 		/// <summary>

--- a/src/NHibernate/Async/AdoNet/AbstractBatcher.cs
+++ b/src/NHibernate/Async/AdoNet/AbstractBatcher.cs
@@ -58,7 +58,7 @@ namespace NHibernate.AdoNet
 					cmd.Connection = sessionConnection;
 				}
 
-				_connectionManager.Transaction.Enlist(cmd);
+				_connectionManager.EnlistInTransaction(cmd);
 				Driver.PrepareCommand(cmd);
 			}
 			catch (InvalidOperationException ioe)

--- a/src/NHibernate/Async/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/Async/AdoNet/ConnectionManager.cs
@@ -90,7 +90,7 @@ namespace NHibernate.AdoNet
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			var result = (await (GetConnectionAsync(cancellationToken)).ConfigureAwait(false)).CreateCommand();
-			Transaction.Enlist(result);
+			EnlistInTransaction(result);
 			return result;
 		}
 	}

--- a/src/NHibernate/Async/Context/ThreadLocalSessionContext.cs
+++ b/src/NHibernate/Async/Context/ThreadLocalSessionContext.cs
@@ -32,17 +32,16 @@ namespace NHibernate.Context
 
 				try
 				{
-					if (orphan.Transaction != null && orphan.Transaction.IsActive)
+					try
 					{
-						try
-						{
-							await (orphan.Transaction.RollbackAsync(cancellationToken)).ConfigureAwait(false);
-						}
-						catch (OperationCanceledException) { throw; }
-						catch (Exception ex)
-						{
-							log.Debug(ex, "Unable to rollback transaction for orphaned session");
-						}
+						var transaction = orphan.GetCurrentTransaction();
+						if (transaction?.IsActive == true)
+							await (transaction.RollbackAsync(cancellationToken)).ConfigureAwait(false);
+					}
+					catch (OperationCanceledException) { throw; }
+					catch (Exception ex)
+					{
+						log.Debug(ex, "Unable to rollback transaction for orphaned session");
 					}
 					orphan.Close();
 				}

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
@@ -68,9 +68,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			{
 				IIsolatedWork work = new TmpIdTableDropIsolatedWork(persister, log, session);
 
-				if (ShouldIsolateTemporaryTableDDL())
+				if (ShouldIsolateTemporaryTableDDL() && session.ConnectionManager.CurrentTransaction != null)
 				{
-					session.ConnectionManager.Transaction.RegisterSynchronization(
+					session.ConnectionManager.CurrentTransaction.RegisterSynchronization(
 						new IsolatedWorkAfterTransaction(work, session));
 				}
 				else

--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -164,6 +164,7 @@ namespace NHibernate.Transaction
 					// don't dispose of multiple times.
 					return;
 				}
+				_isAlreadyDisposed = true;
 
 				// free managed resources that are being managed by the AdoTransaction if we
 				// know this call came through Dispose()
@@ -186,8 +187,6 @@ namespace NHibernate.Transaction
 				}
 
 				// free unmanaged resources here
-
-				_isAlreadyDisposed = true;
 			}
 		}
 

--- a/src/NHibernate/Context/ThreadLocalSessionContext.cs
+++ b/src/NHibernate/Context/ThreadLocalSessionContext.cs
@@ -77,16 +77,15 @@ namespace NHibernate.Context
 
 				try
 				{
-					if (orphan.Transaction != null && orphan.Transaction.IsActive)
+					try
 					{
-						try
-						{
-							orphan.Transaction.Rollback();
-						}
-						catch (Exception ex)
-						{
-							log.Debug(ex, "Unable to rollback transaction for orphaned session");
-						}
+						var transaction = orphan.GetCurrentTransaction();
+						if (transaction?.IsActive == true)
+							transaction.Rollback();
+					}
+					catch (Exception ex)
+					{
+						log.Debug(ex, "Unable to rollback transaction for orphaned session");
 					}
 					orphan.Close();
 				}

--- a/src/NHibernate/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Exec/AbstractStatementExecutor.cs
@@ -188,9 +188,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Exec
 			{
 				IIsolatedWork work = new TmpIdTableDropIsolatedWork(persister, log, session);
 
-				if (ShouldIsolateTemporaryTableDDL())
+				if (ShouldIsolateTemporaryTableDDL() && session.ConnectionManager.CurrentTransaction != null)
 				{
-					session.ConnectionManager.Transaction.RegisterSynchronization(
+					session.ConnectionManager.CurrentTransaction.RegisterSynchronization(
 						new IsolatedWorkAfterTransaction(work, session));
 				}
 				else

--- a/src/NHibernate/ISession.cs
+++ b/src/NHibernate/ISession.cs
@@ -771,6 +771,8 @@ namespace NHibernate
 		/// <summary>
 		/// Get the current Unit of Work and return the associated <c>ITransaction</c> object.
 		/// </summary>
+		// Since v5.3
+		[Obsolete("Use GetCurrentTransaction extension method instead, and check for null.")]
 		ITransaction Transaction { get; }
 
 		/// <summary>

--- a/src/NHibernate/ISession.cs
+++ b/src/NHibernate/ISession.cs
@@ -14,7 +14,7 @@ using NHibernate.Util;
 
 namespace NHibernate
 {
-	// 6.0 TODO: Convert to interface methods
+	// 6.0 TODO: Convert most of these extensions to interface methods
 	public static class SessionExtensions
 	{
 		/// <summary>
@@ -39,6 +39,15 @@ namespace NHibernate
 		{
 			return ReflectHelper.CastOrThrow<AbstractSessionImpl>(session, "query batch").CreateQueryBatch();
 		}
+
+		// 6.0 TODO: consider if it should be added as a property on ISession then obsolete this, or if it should stay here as an extension method.
+		/// <summary>
+		/// Get the current transaction if any is ongoing, else <see langword="null" />.
+		/// </summary>
+		/// <param name="session">The session.</param>
+		/// <returns>The current transaction or <see langword="null" />..</returns>
+		public static ITransaction GetCurrentTransaction(this ISession session)
+			=> session.GetSessionImplementation().ConnectionManager.CurrentTransaction;
 	}
 
 	/// <summary>

--- a/src/NHibernate/IStatelessSession.cs
+++ b/src/NHibernate/IStatelessSession.cs
@@ -10,7 +10,7 @@ using NHibernate.Util;
 
 namespace NHibernate
 {
-	// 6.0 TODO: Convert to interface methods
+	// 6.0 TODO: Convert most of these extensions to interface methods
 	public static class StatelessSessionExtensions
 	{
 		/// <summary>
@@ -22,6 +22,15 @@ namespace NHibernate
 		{
 			return ReflectHelper.CastOrThrow<AbstractSessionImpl>(session, "query batch").CreateQueryBatch();
 		}
+
+		// 6.0 TODO: consider if it should be added as a property on IStatelessSession then obsolete this, or if it should stay here as an extension method.
+		/// <summary>
+		/// Get the current transaction if any is ongoing, else <see langword="null" />.
+		/// </summary>
+		/// <param name="session">The session.</param>
+		/// <returns>The current transaction or <see langword="null" />..</returns>
+		public static ITransaction GetCurrentTransaction(this IStatelessSession session)
+			=> session.GetSessionImplementation().ConnectionManager.CurrentTransaction;
 	}
 
 	/// <summary>

--- a/src/NHibernate/IStatelessSession.cs
+++ b/src/NHibernate/IStatelessSession.cs
@@ -63,6 +63,8 @@ namespace NHibernate
 		DbConnection Connection { get; }
 		
 		/// <summary>Get the current NHibernate transaction.</summary>
+		// Since v5.3
+		[Obsolete("Use GetCurrentTransaction extension method instead, and check for null.")]
 		ITransaction Transaction { get; }
 		
 		/// <summary>

--- a/src/NHibernate/Impl/AbstractSessionImpl.cs
+++ b/src/NHibernate/Impl/AbstractSessionImpl.cs
@@ -38,6 +38,8 @@ namespace NHibernate.Impl
 		private bool closed;
 
 		/// <summary>Get the current NHibernate transaction.</summary>
+		// Since v5.3
+		[Obsolete("Use GetCurrentTransaction extension method instead, and check for null.")]
 		public ITransaction Transaction => ConnectionManager.Transaction;
 
 		protected bool IsTransactionCoordinatorShared { get; }

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -370,6 +370,7 @@ namespace NHibernate.Transaction
 					// don't dispose of multiple times.
 					return;
 				}
+				_isAlreadyDisposed = true;
 
 				// free managed resources that are being managed by the AdoTransaction if we
 				// know this call came through Dispose()
@@ -392,8 +393,6 @@ namespace NHibernate.Transaction
 				}
 
 				// free unmanaged resources here
-
-				_isAlreadyDisposed = true;
 			}
 		}
 


### PR DESCRIPTION
Fixes #2144

Instead of disposing `ConnectionManager._transaction` in `AfterTransaction` as proposed in #2144, this obsoletes `ConnectionManager.Transaction` in favor of a new `ConnectionManager.CurrentTransaction` property which does not create a transaction when none are already created, but yields `null`.

So now any existing transaction should be the result of a call to `BeginTransaction`, and its disposal is always a responsibility of the caller.