### PR TITLE
Add multiple arguments support for ISQLFunction

### DIFF
--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -125,7 +125,7 @@ namespace NHibernate.Criterion
 
 			var resultType = returnType ?? returnTypeProjection?.GetTypes(criteria, criteriaQuery).FirstOrDefault();
 
-			return sqlFunction.ReturnType(resultType, criteriaQuery.Factory);
+			return sqlFunction.GetReturnType(new[] {resultType}, criteriaQuery.Factory, true);
 		}
 
 		public override TypedValue[] GetTypedValues(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -131,7 +131,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("length", new StandardSQLFunction("length", NHibernateUtil.Int32));
 			RegisterFunction("ltrim", new StandardSQLFunction("ltrim"));
 
-			RegisterFunction("mod", new StandardSQLFunction("mod", NHibernateUtil.Int32));
+			RegisterFunction("mod", new ModulusFunction(true, false));
 
 			RegisterFunction("substring", new StandardSQLFunction("substr", NHibernateUtil.String));
 

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -94,7 +94,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("coalesce", new StandardSQLFunction("coalesce"));
 			RegisterFunction("nullif", new StandardSQLFunction("nullif"));
 			RegisterFunction("abs", new StandardSQLFunction("abs"));
-			RegisterFunction("mod", new StandardSQLFunction("mod", NHibernateUtil.Int32));
+			RegisterFunction("mod", new ModulusFunction(false, false));
 			RegisterFunction("sqrt", new StandardSQLFunction("sqrt", NHibernateUtil.Double));
 			RegisterFunction("upper", new StandardSQLFunction("upper"));
 			RegisterFunction("lower", new StandardSQLFunction("lower"));

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using NHibernate.Dialect.Function;
@@ -147,7 +148,7 @@ namespace NHibernate.Dialect
 
 			public override SqlString Render(IList args, ISessionFactoryImplementor factory)
 			{
-				return new SqlString("cast('", Name, "' as ", FunctionReturnType.SqlTypes(factory)[0].ToString(), ")");
+				return new SqlString("cast('", FunctionName, "' as ", FunctionReturnType.SqlTypes(factory)[0].ToString(), ")");
 			}
 		}
 
@@ -160,7 +161,7 @@ namespace NHibernate.Dialect
 
 			public override SqlString Render(IList args, ISessionFactoryImplementor factory)
 			{
-				return new SqlString(Name);
+				return new SqlString(FunctionName);
 			}
 		}
 
@@ -205,7 +206,7 @@ namespace NHibernate.Dialect
 		}
 
 		[Serializable]
-		private class PositionFunction : ISQLFunction
+		private class PositionFunction : ISQLFunction, ISQLFunctionExtended
 		{
 			// The cast is needed, at least in the case that ?3 is a named integer parameter, otherwise firebird will generate an error.  
 			// We have a unit test to cover this potential firebird bug.
@@ -214,10 +215,27 @@ namespace NHibernate.Dialect
 			private static readonly ISQLFunction LocateWith3Params = new SQLFunctionTemplate(NHibernateUtil.Int32,
 				"position(?1, ?2, cast(?3 as int))");
 
+			// Since v5.3
+			[Obsolete("Use GetReturnType method instead.")]
 			public IType ReturnType(IType columnType, IMapping mapping)
 			{
 				return NHibernateUtil.Int32;
 			}
+
+			/// <inheritdoc />
+			public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+			{
+				return NHibernateUtil.Int32;
+			}
+
+			/// <inheritdoc />
+			public IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+			{
+				return GetReturnType(argumentTypes, mapping, throwOnError);
+			}
+
+			/// <inheritdoc />
+			public string FunctionName => "position";
 
 			public bool HasArguments
 			{
@@ -418,7 +436,8 @@ namespace NHibernate.Dialect
 			RegisterFunction("nullif", new StandardSafeSQLFunction("nullif", 2));
 			RegisterFunction("lower", new StandardSafeSQLFunction("lower", NHibernateUtil.String, 1));
 			RegisterFunction("upper", new StandardSafeSQLFunction("upper", NHibernateUtil.String, 1));
-			RegisterFunction("mod", new StandardSafeSQLFunction("mod", NHibernateUtil.Double, 2));
+			// Modulo does not throw for decimal parameters but they are casted to int by Firebird, which produces unexpected results
+			RegisterFunction("mod", new ModulusFunction(false, false));
 			RegisterFunction("str", new SQLFunctionTemplate(NHibernateUtil.String, "cast(?1 as VARCHAR(255))"));
 			RegisterFunction("strguid", new StandardSQLFunction("uuid_to_char", NHibernateUtil.String));
 			RegisterFunction("sysdate", new CastedFunction("today", NHibernateUtil.Date));
@@ -437,7 +456,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("yesterday", new CastedFunction("yesterday", NHibernateUtil.Date));
 			RegisterFunction("tomorrow", new CastedFunction("tomorrow", NHibernateUtil.Date));
 			RegisterFunction("now", new CastedFunction("now", NHibernateUtil.DateTime));
-			RegisterFunction("iif", new StandardSafeSQLFunction("iif", 3));
+			RegisterFunction("iif", new IifSafeSQLFunction());
 			// New embedded functions in FB 2.0 (http://www.firebirdsql.org/rlsnotes20/rnfbtwo-str.html#str-string-func)
 			RegisterFunction("char_length", new StandardSafeSQLFunction("char_length", NHibernateUtil.Int64, 1));
 			RegisterFunction("bit_length", new StandardSafeSQLFunction("bit_length", NHibernateUtil.Int64, 1));

--- a/src/NHibernate/Dialect/Function/AnsiSubstringFunction.cs
+++ b/src/NHibernate/Dialect/Function/AnsiSubstringFunction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
@@ -22,14 +24,33 @@ namespace NHibernate.Dialect.Function
 	///]]>
 	/// </remarks>
 	[Serializable]
-	public class AnsiSubstringFunction : ISQLFunction
+	public class AnsiSubstringFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.String;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => "substring";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/AnsiTrimEmulationFunction.cs
+++ b/src/NHibernate/Dialect/Function/AnsiTrimEmulationFunction.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
@@ -17,7 +17,7 @@ namespace NHibernate.Dialect.Function
 	/// functionality.
 	/// </summary>
 	[Serializable]
-	public class AnsiTrimEmulationFunction : ISQLFunction, IFunctionGrammar
+	public class AnsiTrimEmulationFunction : ISQLFunction, IFunctionGrammar, ISQLFunctionExtended
 	{
 		private static readonly ISQLFunction LeadingSpaceTrim = new SQLFunctionTemplate(NHibernateUtil.String, "ltrim( ?1 )");
 		private static readonly ISQLFunction TrailingSpaceTrim = new SQLFunctionTemplate(NHibernateUtil.String, "rtrim( ?1 )");
@@ -76,10 +76,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.String;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => null;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/AvgQueryFunctionInfo.cs
+++ b/src/NHibernate/Dialect/Function/AvgQueryFunctionInfo.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Generic;
 using NHibernate.Engine;
-using NHibernate.SqlTypes;
 using NHibernate.Type;
 
 namespace NHibernate.Dialect.Function
@@ -10,26 +10,21 @@ namespace NHibernate.Dialect.Function
 	{
 		public AvgQueryFunctionInfo() : base("avg", false) { }
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public override IType ReturnType(IType columnType, IMapping mapping)
 		{
-			if (columnType == null)
+			return GetReturnType(new[] {columnType}, mapping, true);
+		}
+
+		/// <inheritdoc />
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			if (!TryGetArgumentType(argumentTypes, mapping, throwOnError, out _, out _))
 			{
-				throw new ArgumentNullException("columnType");
-			}
-			SqlType[] sqlTypes;
-			try
-			{
-				sqlTypes = columnType.SqlTypes(mapping);
-			}
-			catch (MappingException me)
-			{
-				throw new QueryException(me);
+				return null;
 			}
 
-			if (sqlTypes.Length != 1)
-			{
-				throw new QueryException("multi-column type can not be in avg()");
-			}
 			return NHibernateUtil.Double;
 		}
 	}

--- a/src/NHibernate/Dialect/Function/BitwiseFunctionOperation.cs
+++ b/src/NHibernate/Dialect/Function/BitwiseFunctionOperation.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
@@ -27,8 +29,9 @@ namespace NHibernate.Dialect.Function
 	/// Treats bitwise operations as SQL function calls.
 	/// </summary>
 	[Serializable]
-	public class BitwiseFunctionOperation : ISQLFunction
+	public class BitwiseFunctionOperation : ISQLFunction, ISQLFunctionExtended
 	{
+		// TODO 6.0: convert FunctionName to read-only auto-property
 		private readonly string _functionName;
 
 		/// <summary>
@@ -45,10 +48,29 @@ namespace NHibernate.Dialect.Function
 		#region ISQLFunction Members
 
 		/// <inheritdoc />
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.Int64;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => _functionName;
 
 		/// <inheritdoc />
 		public bool HasArguments => true;

--- a/src/NHibernate/Dialect/Function/BitwiseNativeOperation.cs
+++ b/src/NHibernate/Dialect/Function/BitwiseNativeOperation.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
@@ -32,7 +34,7 @@ namespace NHibernate.Dialect.Function
 	/// Treats bitwise operations as native operations.
 	/// </summary>
 	[Serializable]
-	public class BitwiseNativeOperation : ISQLFunction
+	public class BitwiseNativeOperation : ISQLFunction, ISQLFunctionExtended
 	{
 		private readonly string _sqlOpToken;
 		private readonly bool _isUnary;
@@ -65,10 +67,29 @@ namespace NHibernate.Dialect.Function
 		#region ISQLFunction Members
 
 		/// <inheritdoc />
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.Int64;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => null;
 
 		/// <inheritdoc />
 		public bool HasArguments => true;

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
@@ -12,16 +14,35 @@ namespace NHibernate.Dialect.Function
 	/// ANSI-SQL style cast(foo as type) where the type is a NHibernate type
 	/// </summary>
 	[Serializable]
-	public class CastFunction : ISQLFunction, IFunctionGrammar
+	public class CastFunction : ISQLFunction, IFunctionGrammar, ISQLFunctionExtended
 	{
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			//note there is a weird implementation in the client side
 			//TODO: cast that use only costant are not supported in SELECT. Ex: cast(5 as string)
 			return columnType;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => "cast";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/CharIndexFunction.cs
+++ b/src/NHibernate/Dialect/Function/CharIndexFunction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
@@ -11,7 +13,7 @@ namespace NHibernate.Dialect.Function
 	/// Emulation of locate() on Sybase
 	/// </summary>
 	[Serializable]
-	public class CharIndexFunction : ISQLFunction
+	public class CharIndexFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		public CharIndexFunction()
 		{
@@ -19,10 +21,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.Int32;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => "charindex";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/ClassicAvgFunction.cs
+++ b/src/NHibernate/Dialect/Function/ClassicAvgFunction.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using NHibernate.Engine;
-using NHibernate.SqlTypes;
 using NHibernate.Type;
 
 namespace NHibernate.Dialect.Function
@@ -16,28 +16,20 @@ namespace NHibernate.Dialect.Function
 		{
 		}
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public override IType ReturnType(IType columnType, IMapping mapping)
 		{
-			if (columnType == null)
-			{
-				throw new ArgumentNullException("columnType");
-			}
-			SqlType[] sqlTypes;
-			try
-			{
-				sqlTypes = columnType.SqlTypes(mapping);
-			}
-			catch (MappingException me)
-			{
-				throw new QueryException(me);
-			}
+			return GetReturnType(new[] {columnType}, mapping, true);
+		}
 
-			if (sqlTypes.Length != 1)
+		/// <inheritdoc />
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			if (!TryGetArgumentType(argumentTypes, mapping, throwOnError, out var argumentType, out var sqlType))
 			{
-				throw new QueryException("multi-column type can not be in avg()");
+				return null;
 			}
-
-			SqlType sqlType = sqlTypes[0];
 
 			if (sqlType.DbType == DbType.Int16 || sqlType.DbType == DbType.Int32 || sqlType.DbType == DbType.Int64)
 			{
@@ -45,7 +37,7 @@ namespace NHibernate.Dialect.Function
 			}
 			else
 			{
-				return columnType;
+				return argumentType;
 			}
 		}
 	}

--- a/src/NHibernate/Dialect/Function/ClassicCountFunction.cs
+++ b/src/NHibernate/Dialect/Function/ClassicCountFunction.cs
@@ -14,6 +14,8 @@ namespace NHibernate.Dialect.Function
 		{
 		}
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public override IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.Int32;

--- a/src/NHibernate/Dialect/Function/ClassicCountFunction.cs
+++ b/src/NHibernate/Dialect/Function/ClassicCountFunction.cs
@@ -20,5 +20,13 @@ namespace NHibernate.Dialect.Function
 		{
 			return NHibernateUtil.Int32;
 		}
+
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			// 6.0 TODO: return NHibernateUtil.Int32;
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
 	}
 }

--- a/src/NHibernate/Dialect/Function/ClassicCountFunction.cs
+++ b/src/NHibernate/Dialect/Function/ClassicCountFunction.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.Type;
 

--- a/src/NHibernate/Dialect/Function/CountQueryFunctionInfo.cs
+++ b/src/NHibernate/Dialect/Function/CountQueryFunctionInfo.cs
@@ -9,6 +9,8 @@ namespace NHibernate.Dialect.Function
 	{
 		public CountQueryFunctionInfo() : base("count", true) { }
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public override IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.Int64;

--- a/src/NHibernate/Dialect/Function/CountQueryFunctionInfo.cs
+++ b/src/NHibernate/Dialect/Function/CountQueryFunctionInfo.cs
@@ -15,5 +15,13 @@ namespace NHibernate.Dialect.Function
 		{
 			return NHibernateUtil.Int64;
 		}
+
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			// 6.0 TODO: return NHibernateUtil.Int64;
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
 	}
 }

--- a/src/NHibernate/Dialect/Function/CountQueryFunctionInfo.cs
+++ b/src/NHibernate/Dialect/Function/CountQueryFunctionInfo.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.Type;
 

--- a/src/NHibernate/Dialect/Function/ISQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/ISQLFunction.cs
@@ -68,7 +68,9 @@ namespace NHibernate.Dialect.Function
 			{
 				try
 				{
+#pragma warning disable 618
 					return sqlFunction.ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
 				}
 				catch (QueryException)
 				{

--- a/src/NHibernate/Dialect/Function/ISQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/ISQLFunction.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,6 +24,8 @@ namespace NHibernate.Dialect.Function
 		/// <param name="columnType">The type of the first argument</param>
 		/// <param name="mapping"></param>
 		/// <returns></returns>
+		// Since v5.3
+		[Obsolete("Use GetReturnType extension method instead.")]
 		IType ReturnType(IType columnType, IMapping mapping);
 
 		/// <summary>
@@ -45,7 +48,7 @@ namespace NHibernate.Dialect.Function
 	}
 
 	// 6.0 TODO: Remove
-	internal static class SQLFunctionExtensions
+	public static class SQLFunctionExtensions
 	{
 		/// <summary>
 		/// Get the type that will be effectively returned by the underlying database.
@@ -84,6 +87,43 @@ namespace NHibernate.Dialect.Function
 			}
 
 			return extendedSqlFunction.GetEffectiveReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <summary>
+		/// Get the function general return type, ignoring underlying database specifics.
+		/// </summary>
+		/// <param name="sqlFunction">The sql function.</param>
+		/// <param name="argumentTypes">The types of arguments.</param>
+		/// <param name="mapping">The mapping for retrieving the argument sql types.</param>
+		/// <param name="throwOnError">Whether to throw when the number of arguments is invalid or they are not supported.</param>
+		/// <returns>The type returned by the underlying database or <see langword="null"/> when the number of arguments
+		/// is invalid or they are not supported.</returns>
+		public static IType GetReturnType(
+			this ISQLFunction sqlFunction,
+			IEnumerable<IType> argumentTypes,
+			IMapping mapping,
+			bool throwOnError)
+		{
+			if (!(sqlFunction is ISQLFunctionExtended extendedSqlFunction))
+			{
+				try
+				{
+#pragma warning disable 618
+					return sqlFunction.ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+				}
+				catch (QueryException)
+				{
+					if (throwOnError)
+					{
+						throw;
+					}
+
+					return null;
+				}
+			}
+
+			return extendedSqlFunction.GetReturnType(argumentTypes, mapping, throwOnError);
 		}
 	}
 }

--- a/src/NHibernate/Dialect/Function/ISQLFunctionExtended.cs
+++ b/src/NHibernate/Dialect/Function/ISQLFunctionExtended.cs
@@ -13,6 +13,16 @@ namespace NHibernate.Dialect.Function
 		string FunctionName { get; }
 
 		/// <summary>
+		/// Get the function general return type, ignoring underlying database specifics.
+		/// </summary>
+		/// <param name="argumentTypes">The types of arguments.</param>
+		/// <param name="mapping">The mapping for retrieving the argument sql types.</param>
+		/// <param name="throwOnError">Whether to throw when the number of arguments is invalid or they are not supported.</param>
+		/// <returns>The type returned by the underlying database or <see langword="null"/> when the number of arguments
+		/// is invalid or they are not supported.</returns>
+		IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError);
+
+		/// <summary>
 		/// Get the type that will be effectively returned by the underlying database.
 		/// </summary>
 		/// <param name="argumentTypes">The types of arguments.</param>

--- a/src/NHibernate/Dialect/Function/IifSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/IifSQLFunction.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Engine;
+using NHibernate.Type;
+
+namespace NHibernate.Dialect.Function
+{
+	[Serializable]
+	internal class IifSQLFunction : SQLFunctionTemplate
+	{
+		public IifSQLFunction() : base(null, "case when ?1 then ?2 else ?3 end")
+		{
+		}
+
+		/// <inheritdoc />
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			var args = argumentTypes.ToList();
+			if (args.Count != 3)
+			{
+				if (throwOnError)
+				{
+					throw new QueryException($"Invalid number of arguments for iif()");
+				}
+
+				return null;
+			}
+
+			return args[1] ?? args[2];
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Function/IifSafeSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/IifSafeSQLFunction.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Engine;
+using NHibernate.Type;
+
+namespace NHibernate.Dialect.Function
+{
+	[Serializable]
+	internal class IifSafeSQLFunction : StandardSafeSQLFunction
+	{
+		public IifSafeSQLFunction() : base("iif", 3)
+		{
+		}
+
+		/// <inheritdoc />
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			var args = argumentTypes.ToList();
+			if (args.Count != 3)
+			{
+				return null; // Not enough information
+			}
+
+			return args[1] ?? args[2];
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Function/ModulusFunction.cs
+++ b/src/NHibernate/Dialect/Function/ModulusFunction.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using NHibernate.Engine;
+using NHibernate.Type;
+
+namespace NHibernate.Dialect.Function
+{
+	[Serializable]
+	internal class ModulusFunction : StandardSafeSQLFunction
+	{
+		private readonly ModulusFunctionTypeDetector _modulusFunctionTypeDetector;
+
+		public ModulusFunction(bool supportDecimals, bool supportFloatingNumbers)
+			: this(new ModulusFunctionTypeDetector(supportDecimals, supportFloatingNumbers))
+		{
+		}
+
+		public ModulusFunction(ModulusFunctionTypeDetector modulusFunction) : base("mod", NHibernateUtil.Int32, 2)
+		{
+			_modulusFunctionTypeDetector = modulusFunction;
+		}
+
+		/// <inheritdoc />
+		public override IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return _modulusFunctionTypeDetector.GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Function/ModulusFunctionTemplate.cs
+++ b/src/NHibernate/Dialect/Function/ModulusFunctionTemplate.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using NHibernate.Engine;
+using NHibernate.Type;
+
+namespace NHibernate.Dialect.Function
+{
+	[Serializable]
+	internal class ModulusFunctionTemplate : SQLFunctionTemplate
+	{
+		private readonly ModulusFunctionTypeDetector _modulusFunctionTypeDetector;
+
+		public ModulusFunctionTemplate(bool supportDecimals) : this(new ModulusFunctionTypeDetector(supportDecimals))
+		{
+		}
+
+		public ModulusFunctionTemplate(ModulusFunctionTypeDetector modulusFunction) : base(NHibernateUtil.Int32, "((?1) % (?2))")
+		{
+			_modulusFunctionTypeDetector = modulusFunction;
+		}
+
+		/// <inheritdoc />
+		public override IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return _modulusFunctionTypeDetector.GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Function/ModulusFunctionTypeDetector.cs
+++ b/src/NHibernate/Dialect/Function/ModulusFunctionTypeDetector.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+using NHibernate.Type;
+
+namespace NHibernate.Dialect.Function
+{
+	[Serializable]
+	internal class ModulusFunctionTypeDetector
+	{
+		// The supported DbTypes with their priorities in order to detect which is the
+		// returned type when mixing them
+		private readonly Lazy<Dictionary<DbType, KeyValuePair<int, IType>>> _supportedDbTypesLazy;
+		private readonly bool _supportDecimals;
+		private readonly bool _supportFloatingNumbers;
+
+		public ModulusFunctionTypeDetector(bool supportDecimals, bool supportFloatingNumbers)
+		{
+			_supportDecimals = supportDecimals;
+			_supportFloatingNumbers = supportFloatingNumbers;
+			_supportedDbTypesLazy = new Lazy<Dictionary<DbType, KeyValuePair<int, IType>>>(GetSupportedTypes);
+		}
+
+		public ModulusFunctionTypeDetector(bool supportDecimals) : this(supportDecimals, false)
+		{
+		}
+
+		protected virtual Dictionary<DbType, KeyValuePair<int, IType>> GetSupportedTypes()
+		{
+			var types = new Dictionary<DbType, KeyValuePair<int, IType>>()
+			{
+					{DbType.Int16, new KeyValuePair<int, IType>(1, NHibernateUtil.Int16)},
+					{DbType.Int32, new KeyValuePair<int, IType>(2, NHibernateUtil.Int32)},
+					{DbType.Int64, new KeyValuePair<int, IType>(3, NHibernateUtil.Int64)},
+			};
+
+			if (_supportDecimals)
+			{
+				types.Add(DbType.Currency, new KeyValuePair<int, IType>(4, NHibernateUtil.Decimal));
+				types.Add(DbType.Decimal, new KeyValuePair<int, IType>(4, NHibernateUtil.Decimal));
+			}
+
+			if (_supportFloatingNumbers)
+			{
+				types.Add(DbType.Single, new KeyValuePair<int, IType>(5, NHibernateUtil.Single));
+				types.Add(DbType.Double, new KeyValuePair<int, IType>(6, NHibernateUtil.Double));
+			}
+
+			return types;
+		}
+
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			KeyValuePair<int, IType> currentReturnType = default;
+			int totalArguments = 0;
+			foreach (var argumentType in argumentTypes)
+			{
+				if (argumentType == null)
+				{
+					return null;
+				}
+
+				SqlType[] sqlTypes;
+				try
+				{
+					sqlTypes = argumentType.SqlTypes(mapping);
+				}
+				catch (MappingException me)
+				{
+					if (throwOnError)
+					{
+						throw new QueryException(me);
+					}
+
+					return null;
+				}
+
+				if (sqlTypes.Length != 1)
+				{
+					return ThrowOrReturnDefault("Multi-column type can not be in mod()", throwOnError);
+				}
+
+				if (!_supportedDbTypesLazy.Value.TryGetValue(sqlTypes[0].DbType, out var returnType))
+				{
+					return ThrowOrReturnDefault($"DbType {sqlTypes[0].DbType} is not supported for mod()", throwOnError);
+				}
+
+				if (returnType.Key > currentReturnType.Key)
+				{
+					currentReturnType = returnType;
+				}
+
+				totalArguments++;
+			}
+
+			return totalArguments == 2
+				? currentReturnType.Value
+				: ThrowOrReturnDefault("Invalid number of arguments for mod()", throwOnError);
+		}
+
+		private IType ThrowOrReturnDefault(string error, bool throwOnError)
+		{
+			if (throwOnError)
+			{
+				throw new QueryException(error);
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Function/NoArgSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/NoArgSQLFunction.cs
@@ -3,6 +3,8 @@ using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Dialect.Function
 {
@@ -10,7 +12,7 @@ namespace NHibernate.Dialect.Function
 	/// Summary description for NoArgSQLFunction.
 	/// </summary>
 	[Serializable]
-	public class NoArgSQLFunction : ISQLFunction
+	public class NoArgSQLFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		public NoArgSQLFunction(string name, IType returnType)
 			: this(name, returnType, true)
@@ -19,21 +21,46 @@ namespace NHibernate.Dialect.Function
 
 		public NoArgSQLFunction(string name, IType returnType, bool hasParenthesesIfNoArguments)
 		{
+#pragma warning disable 618
 			Name = name;
+#pragma warning restore 618
 			FunctionReturnType = returnType;
 			HasParenthesesIfNoArguments = hasParenthesesIfNoArguments;
 		}
 
 		public IType FunctionReturnType { get; protected set; }
 
+		// Since v5.3
+		[Obsolete("Use FunctionName property instead.")]
 		public string Name { get; protected set; }
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return FunctionReturnType;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+#pragma warning disable 618
+		public string FunctionName => Name;
+#pragma warning restore 618
 
 		public bool HasArguments
 		{
@@ -46,15 +73,15 @@ namespace NHibernate.Dialect.Function
 		{
 			if (args.Count > 0)
 			{
-				throw new QueryException("function takes no arguments: " + Name);
+				throw new QueryException("function takes no arguments: " + FunctionName);
 			}
 
 			if (HasParenthesesIfNoArguments)
 			{
-				return new SqlString(Name + "()");
+				return new SqlString(FunctionName + "()");
 			}
 
-			return new SqlString(Name);
+			return new SqlString(FunctionName);
 		}
 
 		#endregion

--- a/src/NHibernate/Dialect/Function/NvlFunction.cs
+++ b/src/NHibernate/Dialect/Function/NvlFunction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
@@ -10,7 +12,7 @@ namespace NHibernate.Dialect.Function
 	/// Emulation of coalesce() on Oracle, using multiple nvl() calls
 	/// </summary>
 	[Serializable]
-	public class NvlFunction : ISQLFunction
+	public class NvlFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		public NvlFunction()
 		{
@@ -18,10 +20,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return columnType;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => "nvl";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/PositionSubstringFunction.cs
+++ b/src/NHibernate/Dialect/Function/PositionSubstringFunction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Antlr.Runtime;
 using NHibernate.Engine;
@@ -12,7 +14,7 @@ namespace NHibernate.Dialect.Function
 	/// Emulation of locate() on PostgreSQL
 	/// </summary>
 	[Serializable]
-	public class PositionSubstringFunction : ISQLFunction
+	public class PositionSubstringFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		public PositionSubstringFunction()
 		{
@@ -20,10 +22,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return NHibernateUtil.Int32;
 		}
+
+		/// <inheritdoc />
+		public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => "position";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
+++ b/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
@@ -6,6 +6,8 @@ using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Dialect.Function
 {
@@ -18,7 +20,7 @@ namespace NHibernate.Dialect.Function
 	/// parameters with '?' followed by parameter's index (first index is 1).
 	/// </summary>
 	[Serializable]
-	public class SQLFunctionTemplate : ISQLFunction
+	public class SQLFunctionTemplate : ISQLFunction, ISQLFunctionExtended
 	{
 		private const int InvalidArgumentIndex = -1;
 		private static readonly Regex SplitRegex = new Regex("(\\?[0-9]+)");
@@ -80,10 +82,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return (returnType == null) ? columnType : returnType;
 		}
+
+		/// <inheritdoc />
+		public virtual IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public virtual string FunctionName => null;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/StandardSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/StandardSQLFunction.cs
@@ -4,6 +4,8 @@ using NHibernate.Engine;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NHibernate.Dialect.Function
 {
@@ -16,7 +18,7 @@ namespace NHibernate.Dialect.Function
 	/// for processing of the associated function.
 	/// </remarks>
 	[Serializable]
-	public class StandardSQLFunction : ISQLFunction
+	public class StandardSQLFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		private IType returnType = null;
 		protected readonly string name;
@@ -43,10 +45,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public virtual IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return returnType ?? columnType;
 		}
+
+		/// <inheritdoc />
+		public virtual IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public string FunctionName => name;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/SumQueryFunctionInfo.cs
+++ b/src/NHibernate/Dialect/Function/SumQueryFunctionInfo.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using NHibernate.Engine;
-using NHibernate.SqlTypes;
 using NHibernate.Type;
 
 namespace NHibernate.Dialect.Function
@@ -12,28 +12,20 @@ namespace NHibernate.Dialect.Function
 		public SumQueryFunctionInfo() : base("sum", false) { }
 
 		//H3.2 behavior
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public override IType ReturnType(IType columnType, IMapping mapping)
 		{
-			if (columnType == null)
-			{
-				throw new ArgumentNullException("columnType");
-			}
-			SqlType[] sqlTypes;
-			try
-			{
-				sqlTypes = columnType.SqlTypes(mapping);
-			}
-			catch (MappingException me)
-			{
-				throw new QueryException(me);
-			}
+			return GetReturnType(new[] { columnType }, mapping, true);
+		}
 
-			if (sqlTypes.Length != 1)
+		/// <inheritdoc />
+		public override IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			if (!TryGetArgumentType(argumentTypes, mapping, throwOnError, out var argumentType, out var sqlType))
 			{
-				throw new QueryException("multi-column type can not be in sum()");
+				return null;
 			}
-
-			SqlType sqlType = sqlTypes[0];
 
 			// TODO: (H3.2 for nullable types) First allow the actual type to control the return value. (the actual underlying sqltype could actually be different)
 
@@ -57,7 +49,7 @@ namespace NHibernate.Dialect.Function
 					return NHibernateUtil.UInt64;
 
 				default:
-					return columnType;
+					return argumentType;
 			}
 		}
 	}

--- a/src/NHibernate/Dialect/Function/VarArgsSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/VarArgsSQLFunction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
@@ -12,7 +14,7 @@ namespace NHibernate.Dialect.Function
 	/// with an unlimited number of arguments.
 	/// </summary>
 	[Serializable]
-	public class VarArgsSQLFunction : ISQLFunction
+	public class VarArgsSQLFunction : ISQLFunction, ISQLFunctionExtended
 	{
 		private readonly string begin;
 		private readonly string sep;
@@ -34,10 +36,29 @@ namespace NHibernate.Dialect.Function
 
 		#region ISQLFunction Members
 
+		// Since v5.3
+		[Obsolete("Use GetReturnType method instead.")]
 		public virtual IType ReturnType(IType columnType, IMapping mapping)
 		{
 			return (returnType == null) ? columnType : returnType;
 		}
+
+		/// <inheritdoc />
+		public virtual IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+#pragma warning disable 618
+			return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+		}
+
+		/// <inheritdoc />
+		public virtual IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+		{
+			return GetReturnType(argumentTypes, mapping, throwOnError);
+		}
+
+		/// <inheritdoc />
+		public virtual string FunctionName => null;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -313,7 +313,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("ln", new StandardSQLFunction("ln", NHibernateUtil.Double));
 			RegisterFunction("log", new StandardSQLFunction("log", NHibernateUtil.Double));
 			RegisterFunction("log10", new StandardSQLFunction("log10", NHibernateUtil.Double));
-			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
+			RegisterFunction("mod", new ModulusFunctionTemplate(true));
 			RegisterFunction("radians", new StandardSQLFunction("radians", NHibernateUtil.Double));
 			RegisterFunction("rand", new NoArgSQLFunction("rand", NHibernateUtil.Double));
 			// SQL Server rand returns the same value for each row, unless hacking it with a random seed per row
@@ -351,7 +351,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("ltrim", new StandardSQLFunction("ltrim"));
 
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
-			RegisterFunction("iif", new SQLFunctionTemplate(null, "case when ?1 then ?2 else ?3 end"));
+			RegisterFunction("iif", new IifSQLFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));
 
 			// Casting to CHAR (without specified length) truncates to 30 characters. 

--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -53,7 +53,7 @@ namespace NHibernate.Dialect
 		protected override void RegisterFunctions()
 		{
 			base.RegisterFunctions();
-			RegisterFunction("iif", new StandardSafeSQLFunction("iif", 3));
+			RegisterFunction("iif", new IifSafeSQLFunction());
 		}
 
 		public override SqlString GetLimitString(SqlString querySqlString, SqlString offset, SqlString limit)

--- a/src/NHibernate/Dialect/MsSqlCeDialect.cs
+++ b/src/NHibernate/Dialect/MsSqlCeDialect.cs
@@ -191,10 +191,11 @@ namespace NHibernate.Dialect
 			RegisterFunction("lower", new StandardSQLFunction("lower"));
 
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
-			RegisterFunction("iif", new SQLFunctionTemplate(null, "case when ?1 then ?2 else ?3 end"));
+			RegisterFunction("iif", new IifSQLFunction());
 
 			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", "+", ")"));
-			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
+			// Modulo is not supported on real, float, money, and numeric data types
+			RegisterFunction("mod", new ModulusFunctionTemplate(false));
 
 			RegisterFunction("round", new StandardSQLFunctionWithRequiredParameters("round", new object[] {null, "0"}));
 			RegisterFunction("truncate", new StandardSQLFunctionWithRequiredParameters("round", new object[] {null, "0", "1"}));

--- a/src/NHibernate/Dialect/OracleLiteDialect.cs
+++ b/src/NHibernate/Dialect/OracleLiteDialect.cs
@@ -101,7 +101,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("translate", new StandardSQLFunction("translate", NHibernateUtil.String));
 
 			// Multi-param numeric dialect functions...
-			RegisterFunction("mod", new StandardSQLFunction("mod", NHibernateUtil.Int32));
+			RegisterFunction("mod", new ModulusFunction(true, false));
 			RegisterFunction("nvl", new StandardSQLFunction("nvl"));
 
 			// Multi-param date dialect functions...

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using NHibernate.Dialect.Function;
 using NHibernate.Dialect.Schema;
 using NHibernate.Engine;
@@ -63,10 +65,10 @@ namespace NHibernate.Dialect
 			RegisterFunction("current_timestamp", new NoArgSQLFunction("now", NHibernateUtil.LocalDateTime, true));
 			RegisterFunction("str", new SQLFunctionTemplate(NHibernateUtil.String, "cast(?1 as varchar)"));
 			RegisterFunction("locate", new PositionSubstringFunction());
-			RegisterFunction("iif", new SQLFunctionTemplate(null, "case when ?1 then ?2 else ?3 end"));
+			RegisterFunction("iif", new IifSQLFunction());
 			RegisterFunction("replace", new StandardSQLFunction("replace", NHibernateUtil.String));
 			RegisterFunction("left", new SQLFunctionTemplate(NHibernateUtil.String, "substr(?1,1,?2)"));
-			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
+			RegisterFunction("mod", new ModulusFunctionTemplate(true));
 
 			RegisterFunction("sign", new StandardSQLFunction("sign", NHibernateUtil.Int32));
 			RegisterFunction("round", new RoundFunction(false));
@@ -347,7 +349,7 @@ namespace NHibernate.Dialect
 		#endregion
 
 		[Serializable]
-		private class RoundFunction : ISQLFunction
+		private class RoundFunction : ISQLFunction, ISQLFunctionExtended
 		{
 			private static readonly ISQLFunction Round = new StandardSQLFunction("round");
 			private static readonly ISQLFunction Truncate = new StandardSQLFunction("trunc");
@@ -361,7 +363,7 @@ namespace NHibernate.Dialect
 
 			private readonly ISQLFunction _singleParamFunction;
 			private readonly ISQLFunction _twoParamFunction;
-			private readonly string _name;
+			private readonly string _name; // TODO 6.0: convert FunctionName to read-only auto property
 
 			public RoundFunction(bool truncate)
 			{
@@ -379,7 +381,26 @@ namespace NHibernate.Dialect
 				}
 			}
 
+			// Since v5.3
+			[Obsolete("Use GetReturnType method instead.")]
 			public IType ReturnType(IType columnType, IMapping mapping) => columnType;
+
+			/// <inheritdoc />
+			public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+			{
+#pragma warning disable 618
+				return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+			}
+
+			/// <inheritdoc />
+			public IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+			{
+				return GetReturnType(argumentTypes, mapping, throwOnError);
+			}
+
+			/// <inheritdoc />
+			public string FunctionName => _name;
 
 			public bool HasArguments => true;
 

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -110,9 +110,9 @@ namespace NHibernate.Dialect
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));
 			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
 
-			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "((?1) % (?2))"));
+			RegisterFunction("mod", new ModulusFunctionTemplate(false));
 
-			RegisterFunction("iif", new SQLFunctionTemplate(null, "case when ?1 then ?2 else ?3 end"));
+			RegisterFunction("iif", new IifSQLFunction());
 
 			RegisterFunction("round", new StandardSQLFunction("round"));
 
@@ -121,7 +121,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("bxor", new SQLFunctionTemplate(null, "((?1 | ?2) - (?1 & ?2))"));
 
 			// NH-3787: SQLite requires the cast in SQL too for not defaulting to string.
-			RegisterFunction("transparentcast", new CastFunction());
+			RegisterFunction("transparentcast", new SQLiteCastFunction());
 
 			if (_binaryGuid)
 				RegisterFunction("strguid", new SQLFunctionTemplate(NHibernateUtil.String, "substr(hex(?1), 7, 2) || substr(hex(?1), 5, 2) || substr(hex(?1), 3, 2) || substr(hex(?1), 1, 2) || '-' || substr(hex(?1), 11, 2) || substr(hex(?1), 9, 2) || '-' || substr(hex(?1), 15, 2) || substr(hex(?1), 13, 2) || '-' || substr(hex(?1), 17, 4) || '-' || substr(hex(?1), 21) "));

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -121,7 +121,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("bxor", new SQLFunctionTemplate(null, "((?1 | ?2) - (?1 & ?2))"));
 
 			// NH-3787: SQLite requires the cast in SQL too for not defaulting to string.
-			RegisterFunction("transparentcast", new SQLiteCastFunction());
+			RegisterFunction("transparentcast", new CastFunction());
 
 			if (_binaryGuid)
 				RegisterFunction("strguid", new SQLFunctionTemplate(NHibernateUtil.String, "substr(hex(?1), 7, 2) || substr(hex(?1), 5, 2) || substr(hex(?1), 3, 2) || substr(hex(?1), 1, 2) || '-' || substr(hex(?1), 11, 2) || substr(hex(?1), 9, 2) || '-' || substr(hex(?1), 15, 2) || substr(hex(?1), 13, 2) || '-' || substr(hex(?1), 17, 4) || '-' || substr(hex(?1), 21) "));

--- a/src/NHibernate/Dialect/SybaseASE15Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASE15Dialect.cs
@@ -93,7 +93,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("lower", new StandardSQLFunction("lower"));
 			RegisterFunction("ltrim", new StandardSQLFunction("ltrim"));
 			RegisterFunction("minute", new SQLFunctionTemplate(NHibernateUtil.Int32, "datepart(minute, ?1)"));
-			RegisterFunction("mod", new SQLFunctionTemplate(NHibernateUtil.Int32, "?1 % ?2"));
+			RegisterFunction("mod", new ModulusFunctionTemplate(false));
 			RegisterFunction("month", new StandardSQLFunction("month", NHibernateUtil.Int32));
 			RegisterFunction("pi", new NoArgSQLFunction("pi", NHibernateUtil.Double));
 			RegisterFunction("radians", new StandardSQLFunction("radians", NHibernateUtil.Double));

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -137,7 +137,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("floor", new StandardSQLFunction("floor", NHibernateUtil.Double));
 			RegisterFunction("log", new StandardSQLFunction("log", NHibernateUtil.Double));
 			RegisterFunction("log10", new StandardSQLFunction("log10", NHibernateUtil.Double));
-			RegisterFunction("mod", new StandardSQLFunction("mod"));
+			RegisterFunction("mod", new ModulusFunction(false, false));
 			RegisterFunction("pi", new NoArgSQLFunction("pi", NHibernateUtil.Double, true));
 			RegisterFunction("power", new StandardSQLFunction("power", NHibernateUtil.Double));
 			RegisterFunction("radians", new StandardSQLFunction("radians", NHibernateUtil.Double));
@@ -355,7 +355,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("transactsql", new StandardSQLFunction("transactsql", NHibernateUtil.String));
 			RegisterFunction("varexists", new StandardSQLFunction("varexists", NHibernateUtil.Int32));
 			RegisterFunction("watcomsql", new StandardSQLFunction("watcomsql", NHibernateUtil.String));
-			RegisterFunction("iif", new SQLFunctionTemplate(null, "case when ?1 then ?2 else ?3 end"));
+			RegisterFunction("iif", new IifSQLFunction());
 		}
 
 		#region private static readonly string[] DialectKeywords = { ... }

--- a/src/NHibernate/Hql/Ast/ANTLR/SessionFactoryHelperExtensions.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/SessionFactoryHelperExtensions.cs
@@ -133,7 +133,6 @@ namespace NHibernate.Hql.Ast.ANTLR
 			return extendedSqlFunction.GetReturnType(argumentTypes, _sfi, true);
 		}
 
-
 		/// <summary>
 		/// Given a (potentially unqualified) class name, locate its imported qualified name.
 		/// </summary>

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/AggregateNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/AggregateNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Antlr.Runtime;
 using NHibernate.Dialect.Function;
 using NHibernate.Type;
@@ -38,7 +39,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			get
 			{
 				// Get the function return value type, based on the type of the first argument.
-				return SessionFactoryHelper.FindFunctionReturnType(Text, GetChild(0));
+				return SessionFactoryHelper.FindFunctionReturnType(Text, (IEnumerable<IASTNode>) this);
 			}
 			set
 			{

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/CountNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/CountNode.cs
@@ -1,4 +1,5 @@
-﻿using Antlr.Runtime;
+﻿using System.Linq;
+using Antlr.Runtime;
 using NHibernate.Dialect.Function;
 using NHibernate.Hql.Ast.ANTLR.Util;
 using NHibernate.Type;
@@ -20,7 +21,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		{
 			get
 			{
-				return SessionFactoryHelper.FindFunctionReturnType(Text, null);
+				return SessionFactoryHelper.FindFunctionReturnType(Text, Enumerable.Empty<IASTNode>());
 			}
 			set
 			{

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/IdentNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/IdentNode.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Antlr.Runtime;
 using NHibernate.Dialect.Function;
 using NHibernate.Hql.Ast.ANTLR.Util;
 using NHibernate.Persister.Collection;
-using NHibernate.Persister.Entity;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
 using NHibernate.Util;
+using IQueryable = NHibernate.Persister.Entity.IQueryable;
 
 namespace NHibernate.Hql.Ast.ANTLR.Tree
 {
@@ -38,7 +39,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 					return fe.DataType;
 				}
 				ISQLFunction sf = Walker.SessionFactoryHelper.FindSQLFunction(Text);
-				return sf?.ReturnType(null, Walker.SessionFactoryHelper.Factory);
+				return sf?.GetReturnType(Enumerable.Empty<IType>(), Walker.SessionFactoryHelper.Factory, true);
 			}
 
 			set

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/MethodNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/MethodNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Antlr.Runtime;
 
 using NHibernate.Dialect.Function;
@@ -194,14 +195,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 
 			if (_function != null)
 			{
-				IASTNode child = null;
-
-				if (exprList != null)
-				{
-					child = _methodName == "iif" ? exprList.GetChild(1) : exprList.GetChild(0);
-				}
-
-				DataType = SessionFactoryHelper.FindFunctionReturnType(_methodName, child);
+				DataType = SessionFactoryHelper.FindFunctionReturnType(_methodName, (IEnumerable<IASTNode>) exprList);
 			}
 			//TODO:
 			/*else {


### PR DESCRIPTION
This is a continuation of #2061 where the code was extracted from #2079 in order to reduce the PR scope for easier review. Unfortunately, `ModulusFunctionTypeDetector` cannot be tested in this PR due to the current Linq behavior, which always executes `mod` on the client side, so tests were not ported from #2079.