### PR TITLE
Update IIsEntityDecider to use ExpressionsHelper.TryGetMappedType

### DIFF
--- a/src/NHibernate.DomainModel/Northwind/Entities/Animal.cs
+++ b/src/NHibernate.DomainModel/Northwind/Entities/Animal.cs
@@ -12,7 +12,9 @@ namespace NHibernate.DomainModel.Northwind.Entities
         public virtual Animal Father { get; set; }
         public virtual IList<Animal> Children { get; set; }
         public virtual string SerialNumber { get; set; }
-    }
+
+		public virtual Animal FatherOrMother => Father ?? Mother;
+	}
 
     public abstract class Reptile : Animal
     {

--- a/src/NHibernate.Test/Async/Linq/SelectionTests.cs
+++ b/src/NHibernate.Test/Async/Linq/SelectionTests.cs
@@ -290,6 +290,14 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task CanSelectNotMappedEntityPropertyAsync()
+		{
+			var list = await (db.Animals.Where(o => o.Mother != null).Select(o => o.FatherOrMother.SerialNumber).ToListAsync());
+
+			Assert.That(list, Has.Count.GreaterThan(0));
+		}
+
+		[Test]
 		public async Task CanProjectWithCastAsync()
 		{
 			// NH-2463

--- a/src/NHibernate.Test/Linq/SelectionTests.cs
+++ b/src/NHibernate.Test/Linq/SelectionTests.cs
@@ -329,6 +329,14 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void CanSelectNotMappedEntityProperty()
+		{
+			var list = db.Animals.Where(o => o.Mother != null).Select(o => o.FatherOrMother.SerialNumber).ToList();
+
+			Assert.That(list, Has.Count.GreaterThan(0));
+		}
+
+		[Test]
 		public void CanProjectWithCast()
 		{
 			// NH-2463

--- a/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
+++ b/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
@@ -27,8 +27,8 @@ namespace NHibernate.Linq.ReWriters
 		{
 			_sessionFactory = sessionFactory;
 			var joiner = new Joiner(queryModel, AddJoin);
-			_memberExpressionJoinDetector = new MemberExpressionJoinDetector(this, joiner, _sessionFactory);
-			_whereJoinDetector = new WhereJoinDetector(this, joiner, _sessionFactory);
+			_memberExpressionJoinDetector = new MemberExpressionJoinDetector(this, joiner);
+			_whereJoinDetector = new WhereJoinDetector(this, joiner);
 		}
 
 		public static void ReWrite(QueryModel queryModel, VisitorParameters parameters)

--- a/src/NHibernate/Linq/Visitors/MemberExpressionJoinDetector.cs
+++ b/src/NHibernate/Linq/Visitors/MemberExpressionJoinDetector.cs
@@ -19,21 +19,16 @@ namespace NHibernate.Linq.Visitors
 	{
 		private readonly IIsEntityDecider _isEntityDecider;
 		private readonly IJoiner _joiner;
-		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		private bool _requiresJoinForNonIdentifier;
 		private bool _preventJoinsInConditionalTest;
 		private bool _hasIdentifier;
 		private int _memberExpressionDepth;
 
-		public MemberExpressionJoinDetector(
-			IIsEntityDecider isEntityDecider,
-			IJoiner joiner,
-			ISessionFactoryImplementor sessionFactory)
+		public MemberExpressionJoinDetector(IIsEntityDecider isEntityDecider, IJoiner joiner)
 		{
 			_isEntityDecider = isEntityDecider;
 			_joiner = joiner;
-			_sessionFactory = sessionFactory;
 		}
 
 		protected override Expression VisitMember(MemberExpression expression)

--- a/src/NHibernate/Linq/Visitors/MemberExpressionJoinDetector.cs
+++ b/src/NHibernate/Linq/Visitors/MemberExpressionJoinDetector.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using NHibernate.Engine;
 using NHibernate.Linq.Expressions;
 using NHibernate.Linq.ReWriters;
 using Remotion.Linq.Clauses;
@@ -18,16 +19,21 @@ namespace NHibernate.Linq.Visitors
 	{
 		private readonly IIsEntityDecider _isEntityDecider;
 		private readonly IJoiner _joiner;
+		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		private bool _requiresJoinForNonIdentifier;
 		private bool _preventJoinsInConditionalTest;
 		private bool _hasIdentifier;
 		private int _memberExpressionDepth;
 
-		public MemberExpressionJoinDetector(IIsEntityDecider isEntityDecider, IJoiner joiner)
+		public MemberExpressionJoinDetector(
+			IIsEntityDecider isEntityDecider,
+			IJoiner joiner,
+			ISessionFactoryImplementor sessionFactory)
 		{
 			_isEntityDecider = isEntityDecider;
 			_joiner = joiner;
+			_sessionFactory = sessionFactory;
 		}
 
 		protected override Expression VisitMember(MemberExpression expression)
@@ -39,7 +45,7 @@ namespace NHibernate.Linq.Visitors
 				return base.VisitMember(expression);
 			}
 
-			var isIdentifier = _isEntityDecider.IsIdentifier(expression.Expression.Type, expression.Member.Name);
+			var isEntity = _isEntityDecider.IsEntity(expression, out var isIdentifier);
 			if (isIdentifier)
 				_hasIdentifier = true;
 			if (!isIdentifier)
@@ -50,7 +56,7 @@ namespace NHibernate.Linq.Visitors
 			if (!isIdentifier)
 				_memberExpressionDepth--;
 
-			if (_isEntityDecider.IsEntity(expression.Type) &&
+			if (isEntity &&
 				((_requiresJoinForNonIdentifier && !_hasIdentifier) || _memberExpressionDepth > 0) &&
 				_joiner.CanAddJoin(expression))
 			{

--- a/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using NHibernate.Engine;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Expressions;
 using NHibernate.Util;
@@ -15,6 +16,7 @@ namespace NHibernate.Linq.Visitors
 	class SelectClauseHqlNominator : RelinqExpressionVisitor
 	{
 		private readonly ILinqToHqlGeneratorsRegistry _functionRegistry;
+		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		/// <summary>
 		/// The expression parts that can be converted to pure HQL.
@@ -35,6 +37,7 @@ namespace NHibernate.Linq.Visitors
 		public SelectClauseHqlNominator(VisitorParameters parameters)
 		{
 			_functionRegistry = parameters.SessionFactory.Settings.LinqToHqlGeneratorsRegistry;
+			_sessionFactory = parameters.SessionFactory;
 		}
 
 		internal Expression Nominate(Expression expression)
@@ -168,8 +171,10 @@ namespace NHibernate.Linq.Visitors
 				return projectConstantsInHql;
 			}
 
-			// Assume all is good
-			return true;
+			return !(expression is MemberExpression memberExpression) || // Assume all is good
+			       // Evaluate only expressions that represent a mapped property
+			       ExpressionsHelper.TryGetMappedType(_sessionFactory, expression, out _, out _, out _, out _) ||
+			       _functionRegistry.TryGetGenerator(memberExpression.Member, out _);
 		}
 
 		private static bool CanBeEvaluatedInHqlStatementShortcut(Expression expression)

--- a/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
@@ -172,7 +172,7 @@ namespace NHibernate.Linq.Visitors
 			}
 
 			return !(expression is MemberExpression memberExpression) || // Assume all is good
-			       // Evaluate only expressions that represent a mapped property
+			       // Nominate only expressions that represent a mapped property or a translatable method call
 			       ExpressionsHelper.TryGetMappedType(_sessionFactory, expression, out _, out _, out _, out _) ||
 			       _functionRegistry.TryGetGenerator(memberExpression.Member, out _);
 		}

--- a/src/NHibernate/Linq/Visitors/WhereJoinDetector.cs
+++ b/src/NHibernate/Linq/Visitors/WhereJoinDetector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using NHibernate.Engine;
 using NHibernate.Linq.ReWriters;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
@@ -61,6 +62,7 @@ namespace NHibernate.Linq.Visitors
 		// TODO: There are a number of types of expressions that we didn't handle here due to time constraints.  For example, the ?: operator could be checked easily.
 		private readonly IIsEntityDecider _isEntityDecider;
 		private readonly IJoiner _joiner;
+		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		private readonly Stack<bool> _handled = new Stack<bool>();
 		
@@ -70,10 +72,14 @@ namespace NHibernate.Linq.Visitors
 		// The following is used for member expressions traversal.
 		private int _memberExpressionDepth;
 
-		internal WhereJoinDetector(IIsEntityDecider isEntityDecider, IJoiner joiner)
+		internal WhereJoinDetector(
+			IIsEntityDecider isEntityDecider,
+			IJoiner joiner,
+			ISessionFactoryImplementor sessionFactory)
 		{
 			_isEntityDecider = isEntityDecider;
 			_joiner = joiner;
+			_sessionFactory = sessionFactory;
 		}
 
 		public Expression Transform(Expression expression)
@@ -314,10 +320,7 @@ namespace NHibernate.Linq.Visitors
 				return base.VisitMember(expression);
 			}
 
-			var isIdentifier = _isEntityDecider.IsIdentifier(
-				expression.Expression.Type,
-				expression.Member.Name);
-
+			var isEntity = _isEntityDecider.IsEntity(expression, out var isIdentifier);
 			if (!isIdentifier)
 				_memberExpressionDepth++;
 
@@ -327,7 +330,7 @@ namespace NHibernate.Linq.Visitors
 				_memberExpressionDepth--;
 
 			ExpressionValues values = _values.Pop().Operation(pvs => pvs.MemberAccess(expression.Type));
-			if (_isEntityDecider.IsEntity(expression.Type))
+			if (isEntity)
 			{
 				// Don't add joins for things like a.B == a.C where B and C are entities.
 				// We only need to join B when there's something like a.B.D.

--- a/src/NHibernate/Linq/Visitors/WhereJoinDetector.cs
+++ b/src/NHibernate/Linq/Visitors/WhereJoinDetector.cs
@@ -62,7 +62,6 @@ namespace NHibernate.Linq.Visitors
 		// TODO: There are a number of types of expressions that we didn't handle here due to time constraints.  For example, the ?: operator could be checked easily.
 		private readonly IIsEntityDecider _isEntityDecider;
 		private readonly IJoiner _joiner;
-		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		private readonly Stack<bool> _handled = new Stack<bool>();
 		
@@ -72,14 +71,10 @@ namespace NHibernate.Linq.Visitors
 		// The following is used for member expressions traversal.
 		private int _memberExpressionDepth;
 
-		internal WhereJoinDetector(
-			IIsEntityDecider isEntityDecider,
-			IJoiner joiner,
-			ISessionFactoryImplementor sessionFactory)
+		internal WhereJoinDetector(IIsEntityDecider isEntityDecider, IJoiner joiner)
 		{
 			_isEntityDecider = isEntityDecider;
 			_joiner = joiner;
-			_sessionFactory = sessionFactory;
 		}
 
 		public Expression Transform(Expression expression)


### PR DESCRIPTION
Extracted from #2316 and will allow the following query to work:
```C#
db.Query<Animal>().Select(o => o.FatherOrMother.SerialNumber).ToList();

// Not mapped property
public Animal FatherOrMother => Father ?? Mother;
```
The current logic detects `FatherOrMother` as a mapped property and a join is added, which prevents #2316 from support the above query. By using `ExpressionsHelper.TryGetMappedType` prevents `FatherOrMother` to be detected as a mapped property.


