### PR TITLE
Add cross join support for Hql and Linq query provider

### DIFF
--- a/src/NHibernate.Test/Async/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/Async/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -948,6 +948,11 @@ namespace NHibernate.Test.FetchLazyProperties
 		[Test]
 		public async Task TestHqlCrossJoinFetchFormulaAsync()
 		{
+			if (!Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
+
 			var persons = new List<Person>();
 			var bestFriends = new List<Person>();
 			using (var sqlSpy = new SqlLogSpy())

--- a/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
@@ -274,6 +274,27 @@ namespace NHibernate.Test.Hql
 			}
 		}
 
+		[Test]
+		public async Task CrossJoinAndWhereClauseAsync()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				var result = await (session.CreateQuery(
+					"SELECT s " +
+					"FROM EntityComplex s cross join EntityComplex q " +
+					"where s.SameTypeChild.Id = q.SameTypeChild.Id"
+				).ListAsync());
+
+				Assert.That(result, Has.Count.EqualTo(1));
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+				if (Dialect.SupportsCrossJoin)
+				{
+					Assert.That(sqlLog.GetWholeLog(), Does.Contain("cross join"), "A cross join is expected in the SQL select");
+				}
+			}
+		}
+
 		#region Test Setup
 
 		protected override HbmMapping GetMappings()

--- a/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
@@ -31,5 +31,31 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.That(orders.Count, Is.EqualTo(828));
 			Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
 		}
+
+		[Test]
+		public async Task CrossJoinWithPredicateInOnStatementAsync()
+		{
+			var result =
+				await ((from o in db.Orders
+				from p in db.Products
+				join d in db.OrderLines
+					on new { o.OrderId, p.ProductId } equals new { d.Order.OrderId, d.Product.ProductId }
+					into details
+				from d in details
+				select new { o.OrderId, p.ProductId, d.UnitPrice }).Take(10).ToListAsync());
+
+			Assert.That(result.Count, Is.EqualTo(10));
+		}
+
+		[Test]
+		public async Task CrossJoinWithPredicateInWhereStatementAsync()
+		{
+			var result = await ((from o in db.Orders
+						from o2 in db.Orders.Where(x => x.Freight > 50)
+						where (o.OrderId == o2.OrderId + 1) || (o.OrderId == o2.OrderId - 1)
+						select new { o.OrderId, OrderId2 = o2.OrderId }).ToListAsync());
+
+			Assert.That(result.Count, Is.EqualTo(720));
+		}
 	}
 }

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -1065,8 +1065,8 @@ namespace NHibernate.Test.Linq
 				await (ObjectDumper.WriteAsync(q));
 
 				var sql = sqlSpy.GetWholeLog();
-				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
-				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(0));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -1026,7 +1026,9 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
-				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(0));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 1 : 2));
+				Assert.That(GetTotalOccurrences(sql, "cross join"), Is.EqualTo(useCrossJoin ? 1 : 0));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -9,9 +9,11 @@
 
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
+using NSubstitute;
 using NUnit.Framework;
 using NHibernate.Linq;
 
@@ -757,7 +759,13 @@ namespace NHibernate.Test.Linq
 				where c.Address.City == "London"
 				select o;
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
 		}
 
 		[Category("JOIN")]
@@ -863,7 +871,13 @@ namespace NHibernate.Test.Linq
 				where p.Supplier.Address.Country == "USA" && p.UnitsInStock == 0
 				select p;
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
 		}
 
 		[Category("JOIN")]
@@ -879,7 +893,16 @@ namespace NHibernate.Test.Linq
 				where e.Address.City == "Seattle"
 				select new {e.FirstName, e.LastName, et.Region.Description};
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				// EmployeeTerritories and Territories
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
+				// Region
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
 		}
 
 		[Category("JOIN")]
@@ -903,7 +926,13 @@ namespace NHibernate.Test.Linq
 							   e1.Address.City
 						   };
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
 		}
 
 		[Category("JOIN")]
@@ -918,7 +947,13 @@ namespace NHibernate.Test.Linq
 				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId into orders
 				select new {c.ContactName, OrderCount = orders.Average(x => x.Freight)};
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "join"), Is.EqualTo(0));
+			}
 		}
 
 		[Category("JOIN")]
@@ -959,15 +994,32 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
-		[Test(Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
-		public async Task DLinqJoin5dAsync()
+		[TestCase(true, Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
+		[TestCase(false, Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
+		public async Task DLinqJoin5dAsync(bool useCrossJoin)
 		{
+			if (useCrossJoin && !Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
+
 			var q =
 				from c in db.Customers
 				join o in db.Orders on new {c.CustomerId, HasContractTitle = c.ContactTitle != null} equals new {o.Customer.CustomerId, HasContractTitle = o.Customer.ContactTitle != null }
 				select new { c.ContactName, o.OrderId };
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var substitute = SubstituteDialect())
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ClearQueryPlanCache();
+				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
+
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
 		}
 
 		[Category("JOIN")]
@@ -983,7 +1035,13 @@ namespace NHibernate.Test.Linq
 				join e in db.Employees on c.Address.City equals e.Address.City into emps
 				select new {c.ContactName, ords = ords.Count(), emps = emps.Count()};
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "join"), Is.EqualTo(0));
+			}
 		}
 
 		[Category("JOIN")]
@@ -997,14 +1055,27 @@ namespace NHibernate.Test.Linq
 				from o in ords
 				select new {c.ContactName, o.OrderId, z};
 
-			await (ObjectDumper.WriteAsync(q));
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
 		}
 
 		[Category("JOIN")]
-		[Test(Description = "This sample shows a group join with a composite key.")]
-		public async Task DLinqJoin9Async()
+		[TestCase(true, Description = "This sample shows a group join with a composite key.")]
+		[TestCase(false, Description = "This sample shows a group join with a composite key.")]
+		public async Task DLinqJoin9Async(bool useCrossJoin)
 		{
-			var expected =
+			if (useCrossJoin && !Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
+
+			ICollection expected, actual;
+			expected =
 				(from o in db.Orders.ToList()
 				 from p in db.Products.ToList()
 				 join d in db.OrderLines.ToList()
@@ -1013,14 +1084,26 @@ namespace NHibernate.Test.Linq
 				 from d in details
 				 select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
 
-			var actual =
-				await ((from o in db.Orders
-				 from p in db.Products
-				 join d in db.OrderLines
-					on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
-					into details
-				 from d in details
-				 select new {o.OrderId, p.ProductId, d.UnitPrice}).ToListAsync());
+			using (var substitute = SubstituteDialect())
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ClearQueryPlanCache();
+				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
+
+				actual =
+					await ((from o in db.Orders
+					from p in db.Products
+					join d in db.OrderLines
+						on new { o.OrderId, p.ProductId } equals new { d.Order.OrderId, d.Product.ProductId }
+						into details
+					from d in details
+					select new { o.OrderId, p.ProductId, d.UnitPrice }).ToListAsync());
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(actual.Count, Is.EqualTo(2155));
+				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 1 : 2));
+			}
 
 			Assert.AreEqual(expected.Count, actual.Count);
 		}

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -1023,6 +1023,25 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample joins two tables and projects results from the first table.")]
+		public async Task DLinqJoin5eAsync()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId
+				where c.ContactName != null
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample explictly joins three tables and projects results from each of them.")]
 		public async Task DLinqJoin6Async()
 		{

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -1124,15 +1124,15 @@ namespace NHibernate.Test.Linq
 				Assert.Ignore("Dialect does not support cross join.");
 			}
 
-			ICollection expected, actual;
-			expected =
-				(from o in db.Orders.ToList()
-				 from p in db.Products.ToList()
-				 join d in db.OrderLines.ToList()
-					on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
-					into details
-				 from d in details
-				 select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
+			// The expected collection can be obtained from the below Linq to Objects query.
+			//var expected =
+			//	(from o in db.Orders.ToList()
+			//	 from p in db.Products.ToList()
+			//	 join d in db.OrderLines.ToList()
+			//		on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
+			//		into details
+			//	 from d in details
+			//	 select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
 
 			using (var substitute = SubstituteDialect())
 			using (var sqlSpy = new SqlLogSpy())
@@ -1140,7 +1140,7 @@ namespace NHibernate.Test.Linq
 				ClearQueryPlanCache();
 				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
 
-				actual =
+				var actual =
 					await ((from o in db.Orders
 					from p in db.Products
 					join d in db.OrderLines
@@ -1154,8 +1154,6 @@ namespace NHibernate.Test.Linq
 				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 1 : 2));
 			}
-
-			Assert.AreEqual(expected.Count, actual.Count);
 		}
 
 		[Category("JOIN")]

--- a/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cache;
 using NHibernate.Cfg;
 using NHibernate.Hql.Ast.ANTLR;
 using NHibernate.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Test.FetchLazyProperties
@@ -930,6 +932,37 @@ namespace NHibernate.Test.FetchLazyProperties
 			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Image"), Is.True);
 			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Address"), Is.True);
 			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Formula"), Is.True);
+		}
+
+		[Test]
+		public void TestHqlCrossJoinFetchFormula()
+		{
+			var persons = new List<Person>();
+			var bestFriends = new List<Person>();
+			using (var sqlSpy = new SqlLogSpy())
+			using (var s = OpenSession())
+			{
+				var list = s.CreateQuery("select p, bf from Person p cross join Person bf fetch bf.Formula where bf.Id = p.BestFriend.Id").List<object[]>();
+				foreach (var arr in list)
+				{
+					persons.Add((Person) arr[0]);
+					bestFriends.Add((Person) arr[1]);
+				}
+			}
+
+			AssertPersons(persons, false);
+			AssertPersons(bestFriends, true);
+
+			void AssertPersons(List<Person> results, bool fetched)
+			{
+				foreach (var person in results)
+				{
+					Assert.That(person, Is.Not.Null);
+					Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Image"), Is.False);
+					Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Address"), Is.False);
+					Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Formula"), fetched ? Is.True : (IResolveConstraint) Is.False);
+				}
+			}
 		}
 
 		private static Person GeneratePerson(int i, Person bestFriend)

--- a/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -937,6 +937,11 @@ namespace NHibernate.Test.FetchLazyProperties
 		[Test]
 		public void TestHqlCrossJoinFetchFormula()
 		{
+			if (!Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
+
 			var persons = new List<Person>();
 			var bestFriends = new List<Person>();
 			using (var sqlSpy = new SqlLogSpy())

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -264,7 +264,7 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test, Ignore("Failing for unrelated reasons")]
-		public void CrossJoinAndWithClause()
+		public void ImplicitJoinAndWithClause()
 		{
 			//This is about complex theta style join fix that was implemented in hibernate along with entity join functionality
 			//https://hibernate.atlassian.net/browse/HHH-7321
@@ -276,6 +276,27 @@ namespace NHibernate.Test.Hql
 				"FROM EntityComplex s, EntityComplex q " +
 				"LEFT JOIN s.SameTypeChild AS sa WITH sa.SameTypeChild.Id = q.SameTypeChild.Id"
 				).List();
+			}
+		}
+
+		[Test]
+		public void CrossJoinAndWhereClause()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				var result = session.CreateQuery(
+					"SELECT s " +
+					"FROM EntityComplex s cross join EntityComplex q " +
+					"where s.SameTypeChild.Id = q.SameTypeChild.Id"
+				).List();
+
+				Assert.That(result, Has.Count.EqualTo(1));
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+				if (Dialect.SupportsCrossJoin)
+				{
+					Assert.That(sqlLog.GetWholeLog(), Does.Contain("cross join"), "A cross join is expected in the SQL select");
+				}
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -1,4 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using NHibernate.Cfg;
+using NHibernate.Engine.Query;
+using NHibernate.Util;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq.ByMethod
@@ -20,30 +26,31 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
 		}
 
-		[Test]
-		public void CrossJoinWithPredicateInOnStatement()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void CrossJoinWithPredicateInWhereStatement(bool useCrossJoin)
 		{
-			var result =
-				(from o in db.Orders
-				from p in db.Products
-				join d in db.OrderLines
-					on new { o.OrderId, p.ProductId } equals new { d.Order.OrderId, d.Product.ProductId }
-					into details
-				from d in details
-				select new { o.OrderId, p.ProductId, d.UnitPrice }).Take(10).ToList();
+			if (useCrossJoin && !Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
 
-			Assert.That(result.Count, Is.EqualTo(10));
-		}
+			using (var substitute = SubstituteDialect())
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ClearQueryPlanCache();
+				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
 
-		[Test]
-		public void CrossJoinWithPredicateInWhereStatement()
-		{
-			var result = (from o in db.Orders
-						from o2 in db.Orders.Where(x => x.Freight > 50)
-						where (o.OrderId == o2.OrderId + 1) || (o.OrderId == o2.OrderId - 1)
-						select new { o.OrderId, OrderId2 = o2.OrderId }).ToList();
+				var result = (from o in db.Orders
+							from o2 in db.Orders.Where(x => x.Freight > 50)
+							where (o.OrderId == o2.OrderId + 1) || (o.OrderId == o2.OrderId - 1)
+							select new { o.OrderId, OrderId2 = o2.OrderId }).ToList();
 
-			Assert.That(result.Count, Is.EqualTo(720));
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(result.Count, Is.EqualTo(720));
+				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 0 : 1));
+			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -19,5 +19,31 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.That(orders.Count, Is.EqualTo(828));
 			Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
 		}
+
+		[Test]
+		public void CrossJoinWithPredicateInOnStatement()
+		{
+			var result =
+				(from o in db.Orders
+				from p in db.Products
+				join d in db.OrderLines
+					on new { o.OrderId, p.ProductId } equals new { d.Order.OrderId, d.Product.ProductId }
+					into details
+				from d in details
+				select new { o.OrderId, p.ProductId, d.UnitPrice }).Take(10).ToList();
+
+			Assert.That(result.Count, Is.EqualTo(10));
+		}
+
+		[Test]
+		public void CrossJoinWithPredicateInWhereStatement()
+		{
+			var result = (from o in db.Orders
+						from o2 in db.Orders.Where(x => x.Freight > 50)
+						where (o.OrderId == o2.OrderId + 1) || (o.OrderId == o2.OrderId - 1)
+						select new { o.OrderId, OrderId2 = o2.OrderId }).ToList();
+
+			Assert.That(result.Count, Is.EqualTo(720));
+		}
 	}
 }

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1570,7 +1570,9 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
-				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(0));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 1 : 2));
+				Assert.That(GetTotalOccurrences(sql, "cross join"), Is.EqualTo(useCrossJoin ? 1 : 0));
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1567,6 +1567,25 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample joins two tables and projects results from the first table.")]
+		public void DLinqJoin5e()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId
+				where c.ContactName != null
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ObjectDumper.Write(q);
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample explictly joins three tables and projects results from each of them.")]
 		public void DLinqJoin6()
 		{

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1609,8 +1609,8 @@ namespace NHibernate.Test.Linq
 				ObjectDumper.Write(q);
 
 				var sql = sqlSpy.GetWholeLog();
-				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
-				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(0));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1691,15 +1691,15 @@ namespace NHibernate.Test.Linq
 				Assert.Ignore("Dialect does not support cross join.");
 			}
 
-			ICollection expected, actual;
-			expected =
-				(from o in db.Orders.ToList()
-				 from p in db.Products.ToList()
-				 join d in db.OrderLines.ToList()
-					on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
-					into details
-				 from d in details
-				 select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
+			// The expected collection can be obtained from the below Linq to Objects query.
+			//var expected =
+			//	(from o in db.Orders.ToList()
+			//	 from p in db.Products.ToList()
+			//	 join d in db.OrderLines.ToList()
+			//		on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
+			//		into details
+			//	 from d in details
+			//	 select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
 
 			using (var substitute = SubstituteDialect())
 			using (var sqlSpy = new SqlLogSpy())
@@ -1707,7 +1707,7 @@ namespace NHibernate.Test.Linq
 				ClearQueryPlanCache();
 				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
 
-				actual =
+				var actual =
 					(from o in db.Orders
 					from p in db.Products
 					join d in db.OrderLines
@@ -1721,8 +1721,6 @@ namespace NHibernate.Test.Linq
 				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 1 : 2));
 			}
-
-			Assert.AreEqual(expected.Count, actual.Count);
 		}
 
 		[Category("JOIN")]

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -16,6 +16,9 @@ using NUnit.Framework.Interfaces;
 using System.Text;
 using NHibernate.Dialect;
 using NHibernate.Driver;
+using NHibernate.Engine.Query;
+using NHibernate.Util;
+using NSubstitute;
 
 namespace NHibernate.Test
 {
@@ -475,6 +478,72 @@ namespace NHibernate.Test
 				dialects,
 				Does.Not.Contain(Dialect.GetType()),
 				$"{Dialect} doesn't support {functionName} standard function.");
+		}
+
+		protected void ClearQueryPlanCache()
+		{
+			var planCacheField = typeof(QueryPlanCache)
+									.GetField("planCache", BindingFlags.NonPublic | BindingFlags.Instance)
+								?? throw new InvalidOperationException("planCache field does not exist in QueryPlanCache.");
+
+			var planCache = (SoftLimitMRUCache) planCacheField.GetValue(Sfi.QueryPlanCache);
+			planCache.Clear();
+		}
+
+		protected Substitute<Dialect.Dialect> SubstituteDialect()
+		{
+			var origDialect = Sfi.Settings.Dialect;
+			var dialectProperty = (PropertyInfo) ReflectHelper.GetProperty<Settings, Dialect.Dialect>(o => o.Dialect);
+			var forPartsOfMethod = ReflectHelper.GetMethodDefinition(() => Substitute.ForPartsOf<object>());
+			var substitute = (Dialect.Dialect) forPartsOfMethod.MakeGenericMethod(origDialect.GetType())
+																.Invoke(null, new object[] { new object[0] });
+
+			dialectProperty.SetValue(Sfi.Settings, substitute);
+
+			return new Substitute<Dialect.Dialect>(substitute, Dispose);
+
+			void Dispose()
+			{
+				dialectProperty.SetValue(Sfi.Settings, origDialect);
+			}
+		}
+
+		protected static int GetTotalOccurrences(string content, string substring)
+		{
+			if (string.IsNullOrEmpty(substring))
+			{
+				throw new ArgumentNullException(nameof(substring));
+			}
+
+			int occurrences = 0;
+			for (var index = 0; ; index += substring.Length)
+			{
+				index = content.IndexOf(substring, index);
+				if (index == -1)
+				{
+					return occurrences;
+				}
+
+				occurrences++;
+			}
+		}
+
+		protected struct Substitute<TType> : IDisposable
+		{
+			private readonly System.Action _disposeAction;
+
+			public Substitute(TType value, System.Action disposeAction)
+			{
+				Value = value;
+				_disposeAction = disposeAction;
+			}
+
+			public TType Value { get; }
+
+			public void Dispose()
+			{
+				_disposeAction();
+			}
 		}
 
 		#endregion

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -515,17 +515,14 @@ namespace NHibernate.Test
 				throw new ArgumentNullException(nameof(substring));
 			}
 
-			int occurrences = 0;
-			for (var index = 0; ; index += substring.Length)
+			int occurrences = 0, index = 0;
+			while ((index = content.IndexOf(substring, index)) >= 0)
 			{
-				index = content.IndexOf(substring, index);
-				if (index == -1)
-				{
-					return occurrences;
-				}
-
 				occurrences++;
+				index += substring.Length;
 			}
+
+			return occurrences;
 		}
 
 		protected struct Substitute<TType> : IDisposable

--- a/src/NHibernate/AdoNet/Util/BasicFormatter.cs
+++ b/src/NHibernate/AdoNet/Util/BasicFormatter.cs
@@ -20,6 +20,7 @@ namespace NHibernate.AdoNet.Util
 		{
 			beginClauses.Add("left");
 			beginClauses.Add("right");
+			beginClauses.Add("cross");
 			beginClauses.Add("inner");
 			beginClauses.Add("outer");
 			beginClauses.Add("group");

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -300,6 +300,9 @@ namespace NHibernate.Dialect
 
 		public override bool SupportsResultSetPositionQueryMethodsOnForwardOnlyCursor => false;
 
+		/// <inheritdoc />
+		public override bool SupportsCrossJoin => false; // DB2 v9.1 doesn't support 'cross join' syntax
+
 		public override bool SupportsLobValueChangePropogation => false;
 
 		public override bool SupportsExistsInSelect => false;

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -1337,6 +1337,11 @@ namespace NHibernate.Dialect
 			return new ANSIJoinFragment();
 		}
 
+		/// <summary>
+		/// Does this dialect support CROSS JOIN?
+		/// </summary>
+		public virtual bool SupportsCrossJoin => true;
+
 		/// <summary> 
 		/// Create a <see cref="CaseFragment"/> strategy responsible
 		/// for handling this dialect's variations in how CASE statements are

--- a/src/NHibernate/Dialect/InformixDialect0940.cs
+++ b/src/NHibernate/Dialect/InformixDialect0940.cs
@@ -126,7 +126,10 @@ namespace NHibernate.Dialect
             return new ANSIJoinFragment();
         }
 
-        /// <summary>
+		/// <inheritdoc />
+		public override bool SupportsCrossJoin => false;
+
+		/// <summary>
         /// Does this Dialect have some kind of <c>LIMIT</c> syntax?
         /// </summary>
         /// <value>False, unless overridden.</value>

--- a/src/NHibernate/Dialect/Oracle10gDialect.cs
+++ b/src/NHibernate/Dialect/Oracle10gDialect.cs
@@ -15,5 +15,8 @@ namespace NHibernate.Dialect
 		{
 			return new ANSIJoinFragment();
 		}
+
+		/// <inheritdoc />
+		public override bool SupportsCrossJoin => true;
 	}
 }

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -328,6 +328,9 @@ namespace NHibernate.Dialect
 			return new OracleJoinFragment();
 		}
 
+		/// <inheritdoc />
+		public override bool SupportsCrossJoin => false;
+
 		/// <summary> 
 		/// Map case support to the Oracle DECODE function.  Oracle did not
 		/// add support for CASE until 9i. 

--- a/src/NHibernate/Dialect/SybaseASA9Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASA9Dialect.cs
@@ -97,6 +97,9 @@ namespace NHibernate.Dialect
 			get { return true; }
 		}
 
+		/// <inheritdoc />
+		public override bool SupportsCrossJoin => false;
+
 		public override SqlString GetLimitString(SqlString queryString, SqlString offset, SqlString limit)
 		{
 			int intSelectInsertPoint = GetAfterSelectInsertPoint(queryString);

--- a/src/NHibernate/Dialect/SybaseASE15Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseASE15Dialect.cs
@@ -247,7 +247,10 @@ namespace NHibernate.Dialect
 		{
 			get { return false; }
 		}
-		
+
+		/// <inheritdoc />
+		public override bool SupportsCrossJoin => false;
+
 		public override char OpenQuote
 		{
 			get { return '['; }

--- a/src/NHibernate/Hql/Ast/ANTLR/Hql.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/Hql.g
@@ -256,7 +256,7 @@ fromClause
 fromJoin
 	: ( ( ( LEFT | RIGHT ) (OUTER)? ) | FULL | INNER )? JOIN^ (FETCH)? path (asAlias)? (propertyFetch)? (withClause)?
 	| ( ( ( LEFT | RIGHT ) (OUTER)? ) | FULL | INNER )? JOIN^ (FETCH)? ELEMENTS! OPEN! path CLOSE! (asAlias)? (propertyFetch)? (withClause)?
-	| CROSS JOIN^ { WeakKeywords(); } path (asAlias)?
+	| CROSS JOIN^ { WeakKeywords(); } path (asAlias)? (propertyFetch)?
 	;
 
 withClause

--- a/src/NHibernate/Hql/Ast/ANTLR/Hql.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/Hql.g
@@ -19,6 +19,7 @@ tokens
 	BETWEEN='between';
 	CLASS='class';
 	COUNT='count';
+	CROSS='cross';
 	DELETE='delete';
 	DESCENDING='desc';
 	DOT;
@@ -255,6 +256,7 @@ fromClause
 fromJoin
 	: ( ( ( LEFT | RIGHT ) (OUTER)? ) | FULL | INNER )? JOIN^ (FETCH)? path (asAlias)? (propertyFetch)? (withClause)?
 	| ( ( ( LEFT | RIGHT ) (OUTER)? ) | FULL | INNER )? JOIN^ (FETCH)? ELEMENTS! OPEN! path CLOSE! (asAlias)? (propertyFetch)? (withClause)?
+	| CROSS JOIN^ { WeakKeywords(); } path (asAlias)?
 	;
 
 withClause

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.g
@@ -306,6 +306,9 @@ joinType returns [int j]
 	| INNER {
 		$j = INNER;
 	}
+	| CROSS {
+		$j = CROSS;
+	}
 	;
 
 // Matches a path and returns the normalized string for the path (usually

--- a/src/NHibernate/Hql/Ast/ANTLR/Util/JoinProcessor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Util/JoinProcessor.cs
@@ -48,6 +48,8 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 					return JoinType.RightOuterJoin;
 				case HqlSqlWalker.FULL:
 					return JoinType.FullJoin;
+				case HqlSqlWalker.CROSS:
+					return JoinType.CrossJoin;
 				default:
 					throw new AssertionFailure("undefined join type " + astJoinType);
 			}

--- a/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
@@ -478,6 +478,11 @@ namespace NHibernate.Hql.Ast
 			return new HqlIn(_factory, itemExpression, source);
 		}
 
+		public HqlInnerJoin InnerJoin(HqlExpression expression, HqlAlias @alias)
+		{
+			return new HqlInnerJoin(_factory, expression, @alias);
+		}
+
 		public HqlLeftJoin LeftJoin(HqlExpression expression, HqlAlias @alias)
 		{
 			return new HqlLeftJoin(_factory, expression, @alias);

--- a/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeBuilder.cs
@@ -483,6 +483,11 @@ namespace NHibernate.Hql.Ast
 			return new HqlLeftJoin(_factory, expression, @alias);
 		}
 
+		public HqlCrossJoin CrossJoin(HqlExpression expression, HqlAlias @alias)
+		{
+			return new HqlCrossJoin(_factory, expression, @alias);
+		}
+
 		public HqlFetchJoin FetchJoin(HqlExpression expression, HqlAlias @alias)
 		{
 			return new HqlFetchJoin(_factory, expression, @alias);

--- a/src/NHibernate/Hql/Ast/HqlTreeNode.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeNode.cs
@@ -851,6 +851,13 @@ namespace NHibernate.Hql.Ast
 		}
 	}
 
+	public class HqlCrossJoin : HqlTreeNode
+	{
+		public HqlCrossJoin(IASTFactory factory, HqlExpression expression, HqlAlias @alias) : base(HqlSqlWalker.JOIN, "join", factory, new HqlCross(factory), expression, @alias)
+		{
+		}
+	}
+
 	public class HqlFetchJoin : HqlTreeNode
 	{
 		public HqlFetchJoin(IASTFactory factory, HqlExpression expression, HqlAlias @alias)
@@ -902,6 +909,14 @@ namespace NHibernate.Hql.Ast
 	{
 		public HqlLeft(IASTFactory factory)
 			: base(HqlSqlWalker.LEFT, "left", factory)
+		{
+		}
+	}
+
+	public class HqlCross : HqlTreeNode
+	{
+		public HqlCross(IASTFactory factory)
+			: base(HqlSqlWalker.CROSS, "cross", factory)
 		{
 		}
 	}

--- a/src/NHibernate/Hql/Ast/HqlTreeNode.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeNode.cs
@@ -844,6 +844,14 @@ namespace NHibernate.Hql.Ast
 		}
 	}
 
+	public class HqlInnerJoin : HqlTreeNode
+	{
+		public HqlInnerJoin(IASTFactory factory, HqlExpression expression, HqlAlias alias)
+			: base(HqlSqlWalker.JOIN, "join", factory, new HqlInner(factory), expression, alias)
+		{
+		}
+	}
+
 	public class HqlLeftJoin : HqlTreeNode
 	{
 		public HqlLeftJoin(IASTFactory factory, HqlExpression expression, HqlAlias @alias) : base(HqlSqlWalker.JOIN, "join", factory, new HqlLeft(factory), expression, @alias)
@@ -901,6 +909,14 @@ namespace NHibernate.Hql.Ast
 	{
 		public HqlBitwiseAnd(IASTFactory factory, HqlExpression lhs, HqlExpression rhs)
 			: base(HqlSqlWalker.BAND, "band", factory, lhs, rhs)
+		{
+		}
+	}
+
+	public class HqlInner : HqlTreeNode
+	{
+		public HqlInner(IASTFactory factory)
+			: base(HqlSqlWalker.INNER, "inner", factory)
 		{
 		}
 	}

--- a/src/NHibernate/Linq/Clauses/NhJoinClause.cs
+++ b/src/NHibernate/Linq/Clauses/NhJoinClause.cs
@@ -54,6 +54,8 @@ namespace NHibernate.Linq.Clauses
 
 		public bool IsInner { get; private set; }
 
+		internal IBodyClause RelatedBodyClause { get; set; }
+
 		public void TransformExpressions(Func<Expression, Expression> transformation)
 		{
 			if (transformation == null) throw new ArgumentNullException(nameof(transformation));

--- a/src/NHibernate/Linq/Clauses/NhJoinClause.cs
+++ b/src/NHibernate/Linq/Clauses/NhJoinClause.cs
@@ -54,7 +54,7 @@ namespace NHibernate.Linq.Clauses
 
 		public bool IsInner { get; private set; }
 
-		internal IBodyClause RelatedBodyClause { get; set; }
+		internal JoinClause ParentJoinClause { get; set; }
 
 		public void TransformExpressions(Func<Expression, Expression> transformation)
 		{

--- a/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
+++ b/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
@@ -63,11 +63,6 @@ namespace NHibernate.Linq.ReWriters
 
 		public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)
 		{
-			VisitJoinClause(joinClause, queryModel, joinClause);
-		}
-
-		private void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, IBodyClause bodyClause)
-		{
 			joinClause.InnerSequence = _whereJoinDetector.Transform(joinClause.InnerSequence);
 
 			// When associations are located in the outer key (e.g. from a in A join b in B b on a.C.D.Id equals b.Id),

--- a/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
+++ b/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
@@ -96,6 +96,12 @@ namespace NHibernate.Linq.ReWriters
 		private void AddJoin(QueryModel queryModel, NhJoinClause joinClause)
 		{
 			joinClause.ParentJoinClause = _currentJoin;
+			if (_currentJoin != null)
+			{
+				// Match the parent join type
+				joinClause.MakeInner();
+			}
+
 			queryModel.BodyClauses.Add(joinClause);
 		}
 	}

--- a/src/NHibernate/Linq/Visitors/JoinBuilder.cs
+++ b/src/NHibernate/Linq/Visitors/JoinBuilder.cs
@@ -21,11 +21,20 @@ namespace NHibernate.Linq.Visitors
 		private readonly NameGenerator _nameGenerator;
 		private readonly QueryModel _queryModel;
 
+		internal Joiner(QueryModel queryModel, System.Action<QueryModel, NhJoinClause> addJoinMethod)
+			: this(queryModel)
+		{
+			AddJoinMethod = addJoinMethod;
+		}
+
 		internal Joiner(QueryModel queryModel)
 		{
 			_nameGenerator = new NameGenerator(queryModel);
 			_queryModel = queryModel;
+			AddJoinMethod = AddJoin;
 		}
+		
+		internal System.Action<QueryModel, NhJoinClause> AddJoinMethod { get; }
 
 		public IEnumerable<NhJoinClause> Joins
 		{
@@ -39,7 +48,7 @@ namespace NHibernate.Linq.Visitors
 			if (!_joins.TryGetValue(key, out join))
 			{
 				join = new NhJoinClause(_nameGenerator.GetNewName(), expression.Type, expression);
-				_queryModel.BodyClauses.Add(join);
+				AddJoinMethod(_queryModel, join);
 				_joins.Add(key, join);
 			}
 
@@ -70,6 +79,11 @@ namespace NHibernate.Linq.Visitors
 
 			var resultOperatorBase = source as ResultOperatorBase;
 			return resultOperatorBase != null && _queryModel.ResultOperators.Contains(resultOperatorBase);
+		}
+
+		private void AddJoin(QueryModel queryModel, NhJoinClause joinClause)
+		{
+			queryModel.BodyClauses.Add(joinClause);
 		}
 
 		private class QuerySourceExtractor : RelinqExpressionVisitor

--- a/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
@@ -518,10 +518,9 @@ namespace NHibernate.Linq.Visitors
 			var alias = _hqlTree.TreeBuilder.Alias(VisitorParameters.QuerySourceNamer.GetName(joinClause));
 			var joinExpression = HqlGeneratorExpressionVisitor.Visit(joinClause.InnerSequence, VisitorParameters);
 			HqlTreeNode join;
-			// When there are association navigations inside an on clause:
-			// from c in db.Customers join o in db.Orders on c.ContactTitle equals o.Customer.ContactTitle
-			// we have to use a cross join instead of inner join and add the condition in the where statement.
-			if (queryModel.BodyClauses.OfType<NhJoinClause>().Any(o => o.RelatedBodyClause == joinClause))
+			// When associations are located inside the inner key selector we have to use a cross join instead of an inner
+			// join and add the condition in the where statement.
+			if (queryModel.BodyClauses.OfType<NhJoinClause>().Any(o => o.ParentJoinClause == joinClause))
 			{
 				_hqlTree.AddWhereClause(withClause);
 				join = CreateCrossJoin(joinExpression, alias);

--- a/src/NHibernate/Linq/Visitors/WhereJoinDetector.cs
+++ b/src/NHibernate/Linq/Visitors/WhereJoinDetector.cs
@@ -77,10 +77,21 @@ namespace NHibernate.Linq.Visitors
 			_joiner = joiner;
 		}
 
+		public Expression Transform(Expression expression)
+		{
+			var result = Visit(expression);
+			PostTransform();
+			return result;
+		}
+
 		public void Transform(IClause whereClause)
 		{
 			whereClause.TransformExpressions(Visit);
+			PostTransform();
+		}
 
+		private void PostTransform()
+		{
 			var values = _values.Pop();
 
 			foreach (var memberExpression in values.MemberExpressions)

--- a/src/NHibernate/SqlCommand/ANSIJoinFragment.cs
+++ b/src/NHibernate/SqlCommand/ANSIJoinFragment.cs
@@ -33,12 +33,21 @@ namespace NHibernate.SqlCommand
 				case JoinType.FullJoin:
 					joinString = " full outer join ";
 					break;
+				case JoinType.CrossJoin:
+					joinString = " cross join ";
+					break;
 				default:
 					throw new AssertionFailure("undefined join type");
 			}
 
-			_fromFragment.Add(joinString + tableName + ' ' + alias + " on ");
+			_fromFragment.Add(joinString).Add(tableName).Add(" ").Add(alias).Add(" ");
+			if (joinType == JoinType.CrossJoin)
+			{
+				// Cross join does not have an 'on' statement
+				return;
+			}
 
+			_fromFragment.Add("on ");
 			if (fkColumns.Length == 0)
 			{
 				AddBareCondition(_fromFragment, on);

--- a/src/NHibernate/SqlCommand/JoinFragment.cs
+++ b/src/NHibernate/SqlCommand/JoinFragment.cs
@@ -10,7 +10,8 @@ namespace NHibernate.SqlCommand
 		InnerJoin = 0,
 		FullJoin = 4,
 		LeftOuterJoin = 1,
-		RightOuterJoin = 2
+		RightOuterJoin = 2,
+		CrossJoin = 8
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes: #1128
Closes #1060

Hql example:
```Sql
select s from EntityComplex s cross join EntityComplex q where s.SameTypeChild.Id = q.SameTypeChild.Id
```

Linq example:
```C#
from o in db.Orders
from o2 in db.Orders
where (o.OrderId == o2.OrderId + 1) || (o.OrderId == o2.OrderId - 1)
select new { o.OrderId, OrderId2 = o2.OrderId }
```
Linq query provider will use cross join when using multiple `from` statements and will fallback to an inner join with `on 1=1`, when the dialect does not support it.

 Possible breaking change:
- Custom dialects used for databases that do not support cross join, will have to override `SupportsCrossJoin` property and set it to `false`.