### PR TITLE
Add left join support for Linq query provider

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
@@ -13,10 +13,10 @@ using System.Linq;
 using System.Reflection;
 using NHibernate.Cfg;
 using NHibernate.Engine.Query;
+using NHibernate.Linq;
 using NHibernate.Util;
 using NSubstitute;
 using NUnit.Framework;
-using NHibernate.Linq;
 
 namespace NHibernate.Test.Linq.ByMethod
 {
@@ -27,15 +27,70 @@ namespace NHibernate.Test.Linq.ByMethod
 		[Test]
 		public async Task MultipleLinqJoinsWithSameProjectionNamesAsync()
 		{
-			var orders = await (db.Orders
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = await (db.Orders
 						   .Join(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
 						   .Select(x => new { First = x.order, Second = x.order1 })
 						   .Join(db.Orders, x => x.First.OrderId, x => x.OrderId - 2, (order, order1) => new { order, order1 })
 						   .Select(x => new { FirstId = x.order.First.OrderId, SecondId = x.order.Second.OrderId, ThirdId = x.order1.OrderId })
 						   .ToListAsync());
 
-			Assert.That(orders.Count, Is.EqualTo(828));
-			Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(828));
+				Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
+			}
+		}
+
+		[Test]
+		public async Task MultipleLinqJoinsWithSameProjectionNamesWithLeftJoinAsync()
+		{
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = await (db.Orders
+								.GroupJoin(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
+								.SelectMany(x => x.order1.DefaultIfEmpty(), (x, order1) => new { First = x.order, Second = order1 })
+								.GroupJoin(db.Orders, x => x.First.OrderId, x => x.OrderId - 2, (order, order1) => new { order, order1 })
+								.SelectMany(x => x.order1.DefaultIfEmpty(), (x, order1) => new
+								{
+									FirstId = x.order.First.OrderId,
+									SecondId = (int?) x.order.Second.OrderId,
+									ThirdId = (int?) order1.OrderId
+								})
+								.ToListAsync());
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(830));
+				Assert.IsTrue(orders.Where(x => x.SecondId.HasValue && x.ThirdId.HasValue)
+									.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
+			}
+		}
+
+		[Test]
+		public async Task MultipleLinqJoinsWithSameProjectionNamesWithLeftJoinExtensionMethodAsync()
+		{
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = await (db.Orders
+								.LeftJoin(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
+								.Select(x => new { First = x.order, Second = x.order1 })
+								.LeftJoin(db.Orders, x => x.First.OrderId, x => x.OrderId - 2, (order, order1) => new { order, order1 })
+								.Select(x => new
+								{
+									FirstId = x.order.First.OrderId,
+									SecondId = (int?) x.order.Second.OrderId,
+									ThirdId = (int?) x.order1.OrderId
+								})
+								.ToListAsync());
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(830));
+				Assert.IsTrue(orders.Where(x => x.SecondId.HasValue && x.ThirdId.HasValue)
+									.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
+			}
 		}
 
 		[TestCase(false)]

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -1073,6 +1073,25 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample joins two tables and projects results from the first table.")]
+		public async Task DLinqJoin5eAsync()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId
+				where c.ContactName != null
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample explictly joins three tables and projects results from each of them.")]
 		public async Task DLinqJoin6Async()
 		{

--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -769,6 +769,26 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample uses foreign key navigation in the " +
+							"from clause to select all orders for customers in London.")]
+		public async Task DLinqJoin1LeftJoinAsync()
+		{
+			IQueryable<Order> q =
+				from c in db.Customers
+				from o in c.Orders.DefaultIfEmpty()
+				where c.Address.City == "London"
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample shows how to construct a join where one side is nullable and the other isn't.")]
 		public async Task DLinqJoin10Async()
 		{
@@ -975,6 +995,26 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample explictly joins two tables and projects results from both tables.")]
+		public async Task DLinqJoin5aLeftJoinAsync()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId into orders
+				from o in orders.DefaultIfEmpty()
+				where o != null
+				select new { c.ContactName, o.OrderId };
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample explictly joins two tables and projects results from both tables using a group join.")]
 		public async Task DLinqJoin5bAsync()
 		{
@@ -1033,6 +1073,21 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
+		public void DLinqJoin5dLeftJoinAsync()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on
+					new { c.CustomerId, HasContractTitle = c.ContactTitle != null } equals
+					new { o.Customer.CustomerId, HasContractTitle = o.Customer.ContactTitle != null } into orders
+				from o in orders.DefaultIfEmpty()
+				select new { c.ContactName, o.OrderId };
+
+			Assert.ThrowsAsync<NotSupportedException>(() => ObjectDumper.WriteAsync(q));
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample joins two tables and projects results from the first table.")]
 		public async Task DLinqJoin5eAsync()
 		{
@@ -1048,6 +1103,26 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
+		[Test(Description = "This sample joins two tables and projects results from the first table.")]
+		public async Task DLinqJoin5eLeftJoinAsync()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId into orders
+				from o in orders.DefaultIfEmpty()
+				where c.ContactName != null
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
 			}
 		}
 
@@ -1073,21 +1148,24 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
-		[Test(Description = "This sample joins two tables and projects results from the first table.")]
-		public async Task DLinqJoin5eAsync()
+		[TestCase(Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
+		public async Task DLinqJoin5fLeftJoinAsync()
 		{
 			var q =
-				from c in db.Customers
-				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId
-				where c.ContactName != null
-				select o;
+				from o in db.Orders
+				join c in db.Customers on
+					new { o.Customer.CustomerId, HasContractTitle = o.Customer.ContactTitle != null } equals
+					new { c.CustomerId, HasContractTitle = c.ContactTitle != null } into customers
+				from c in customers.DefaultIfEmpty()
+				select new { c.ContactName, o.OrderId };
 
 			using (var sqlSpy = new SqlLogSpy())
 			{
 				await (ObjectDumper.WriteAsync(q));
 
 				var sql = sqlSpy.GetWholeLog();
-				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(0));
 			}
 		}
 
@@ -1110,6 +1188,28 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(GetTotalOccurrences(sql, "join"), Is.EqualTo(0));
+			}
+		}
+
+		[Category("JOIN")]
+		[Test(
+			Description =
+				"This sample shows how to get LEFT OUTER JOIN by using DefaultIfEmpty(). The DefaultIfEmpty() method returns null when there is no Order for the Employee."
+			)]
+		public async Task DLinqJoin7Async()
+		{
+			var q =
+				from e in db.Employees
+				join o in db.Orders on e equals o.Employee into ords
+				from o in ords.DefaultIfEmpty()
+				select new {e.FirstName, e.LastName, Order = o};
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
 			}
 		}
 
@@ -1176,6 +1276,51 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[TestCase(true, Description = "This sample shows a group left join with a composite key.")]
+		[TestCase(false, Description = "This sample shows a group left join with a composite key.")]
+		public async Task DLinqJoin9LeftJoinAsync(bool useCrossJoin)
+		{
+			if (useCrossJoin && !Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
+
+			ICollection expected, actual;
+			expected =
+				(from o in db.Orders.ToList()
+				from p in db.Products.ToList()
+				join d in db.OrderLines.ToList()
+					on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
+					into details
+				from d in details.DefaultIfEmpty()
+				where d != null && d.UnitPrice > 50
+				select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
+
+			using (var substitute = SubstituteDialect())
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ClearQueryPlanCache();
+				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
+
+				actual =
+					await ((from o in db.Orders
+					from p in db.Products
+					join d in db.OrderLines
+						on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
+						into details
+					from d in details.DefaultIfEmpty()
+					where d != null && d.UnitPrice > 50
+					select new {o.OrderId, p.ProductId, d.UnitPrice}).ToListAsync());
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+
+			Assert.AreEqual(expected.Count, actual.Count);
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample shows a join which is then grouped")]
 		public async Task DLinqJoin9bAsync()
 		{
@@ -1203,6 +1348,27 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
+			}
+		}
+
+		[Category("JOIN")]
+		[Test(Description = "This sample shows how to join multiple tables using a left join.")]
+		public async Task DLinqJoin10aLeftJoinAsync()
+		{
+			var q =
+				from e in db.Employees
+				join s in db.Employees on e.Superior.EmployeeId equals s.EmployeeId into sup
+				from s in sup.DefaultIfEmpty()
+				join s2 in db.Employees on s.Superior.EmployeeId equals s2.EmployeeId into sup2
+				from s2 in sup2.DefaultIfEmpty()
+				select new { e.FirstName, SuperiorName = s.FirstName, Superior2Name = s2.FirstName };
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				await (ObjectDumper.WriteAsync(q));
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
 			}
 		}
 	}

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using NHibernate.Cfg;
 using NHibernate.Engine.Query;
+using NHibernate.Linq;
 using NHibernate.Util;
 using NSubstitute;
 using NUnit.Framework;
@@ -15,15 +16,70 @@ namespace NHibernate.Test.Linq.ByMethod
 		[Test]
 		public void MultipleLinqJoinsWithSameProjectionNames()
 		{
-			var orders = db.Orders
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = db.Orders
 						   .Join(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
 						   .Select(x => new { First = x.order, Second = x.order1 })
 						   .Join(db.Orders, x => x.First.OrderId, x => x.OrderId - 2, (order, order1) => new { order, order1 })
 						   .Select(x => new { FirstId = x.order.First.OrderId, SecondId = x.order.Second.OrderId, ThirdId = x.order1.OrderId })
 						   .ToList();
 
-			Assert.That(orders.Count, Is.EqualTo(828));
-			Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(828));
+				Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
+			}
+		}
+
+		[Test]
+		public void MultipleLinqJoinsWithSameProjectionNamesWithLeftJoin()
+		{
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = db.Orders
+								.GroupJoin(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
+								.SelectMany(x => x.order1.DefaultIfEmpty(), (x, order1) => new { First = x.order, Second = order1 })
+								.GroupJoin(db.Orders, x => x.First.OrderId, x => x.OrderId - 2, (order, order1) => new { order, order1 })
+								.SelectMany(x => x.order1.DefaultIfEmpty(), (x, order1) => new
+								{
+									FirstId = x.order.First.OrderId,
+									SecondId = (int?) x.order.Second.OrderId,
+									ThirdId = (int?) order1.OrderId
+								})
+								.ToList();
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(830));
+				Assert.IsTrue(orders.Where(x => x.SecondId.HasValue && x.ThirdId.HasValue)
+									.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
+			}
+		}
+
+		[Test]
+		public void MultipleLinqJoinsWithSameProjectionNamesWithLeftJoinExtensionMethod()
+		{
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = db.Orders
+								.LeftJoin(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
+								.Select(x => new { First = x.order, Second = x.order1 })
+								.LeftJoin(db.Orders, x => x.First.OrderId, x => x.OrderId - 2, (order, order1) => new { order, order1 })
+								.Select(x => new
+								{
+									FirstId = x.order.First.OrderId,
+									SecondId = (int?) x.order.Second.OrderId,
+									ThirdId = (int?) x.order1.OrderId
+								})
+								.ToList();
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(830));
+				Assert.IsTrue(orders.Where(x => x.SecondId.HasValue && x.ThirdId.HasValue)
+									.All(x => x.FirstId == x.SecondId - 1 && x.SecondId == x.ThirdId - 1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
+			}
 		}
 
 		[TestCase(false)]

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -82,6 +82,27 @@ namespace NHibernate.Test.Linq.ByMethod
 			}
 		}
 
+		[Test]
+		public void LeftJoinExtensionMethodWithMultipleKeyProperties()
+		{
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				var orders = db.Orders
+				               .LeftJoin(
+					               db.Orders,
+					               x => new {x.OrderId, x.Customer.CustomerId},
+					               x => new {x.OrderId, x.Customer.CustomerId},
+					               (order, order1) => new {order, order1})
+				               .Select(x => new {FirstId = x.order.OrderId, SecondId = x.order1.OrderId})
+				               .ToList();
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(orders.Count, Is.EqualTo(830));
+				Assert.IsTrue(orders.All(x => x.FirstId == x.SecondId));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+		}
+
 		[TestCase(false)]
 		[TestCase(true)]
 		public void CrossJoinWithPredicateInWhereStatement(bool useCrossJoin)

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1313,6 +1313,26 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample uses foreign key navigation in the " +
+							"from clause to select all orders for customers in London.")]
+		public void DLinqJoin1LeftJoin()
+		{
+			IQueryable<Order> q =
+				from c in db.Customers
+				from o in c.Orders.DefaultIfEmpty()
+				where c.Address.City == "London"
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ObjectDumper.Write(q);
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample shows how to construct a join where one side is nullable and the other isn't.")]
 		public void DLinqJoin10()
 		{
@@ -1519,6 +1539,26 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample explictly joins two tables and projects results from both tables.")]
+		public void DLinqJoin5aLeftJoin()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId into orders
+				from o in orders.DefaultIfEmpty()
+				where o != null
+				select new { c.ContactName, o.OrderId };
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ObjectDumper.Write(q);
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample explictly joins two tables and projects results from both tables using a group join.")]
 		public void DLinqJoin5b()
 		{
@@ -1577,6 +1617,21 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
+		public void DLinqJoin5dLeftJoin()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on
+					new { c.CustomerId, HasContractTitle = c.ContactTitle != null } equals
+					new { o.Customer.CustomerId, HasContractTitle = o.Customer.ContactTitle != null } into orders
+				from o in orders.DefaultIfEmpty()
+				select new { c.ContactName, o.OrderId };
+
+			Assert.Throws<NotSupportedException>(() => ObjectDumper.Write(q));
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample joins two tables and projects results from the first table.")]
 		public void DLinqJoin5e()
 		{
@@ -1592,6 +1647,26 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
+		[Test(Description = "This sample joins two tables and projects results from the first table.")]
+		public void DLinqJoin5eLeftJoin()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId into orders
+				from o in orders.DefaultIfEmpty()
+				where c.ContactName != null
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ObjectDumper.Write(q);
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
 			}
 		}
 
@@ -1617,21 +1692,24 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
-		[Test(Description = "This sample joins two tables and projects results from the first table.")]
-		public void DLinqJoin5e()
+		[TestCase(Description = "This sample explictly joins two tables with a composite key and projects results from both tables.")]
+		public void DLinqJoin5fLeftJoin()
 		{
 			var q =
-				from c in db.Customers
-				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId
-				where c.ContactName != null
-				select o;
+				from o in db.Orders
+				join c in db.Customers on
+					new { o.Customer.CustomerId, HasContractTitle = o.Customer.ContactTitle != null } equals
+					new { c.CustomerId, HasContractTitle = c.ContactTitle != null } into customers
+				from c in customers.DefaultIfEmpty()
+				select new { c.ContactName, o.OrderId };
 
 			using (var sqlSpy = new SqlLogSpy())
 			{
 				ObjectDumper.Write(q);
 
 				var sql = sqlSpy.GetWholeLog();
-				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(0));
 			}
 		}
 
@@ -1662,7 +1740,6 @@ namespace NHibernate.Test.Linq
 			Description =
 				"This sample shows how to get LEFT OUTER JOIN by using DefaultIfEmpty(). The DefaultIfEmpty() method returns null when there is no Order for the Employee."
 			)]
-		[Ignore("TODO left outer join")]
 		public void DLinqJoin7()
 		{
 			var q =
@@ -1743,6 +1820,51 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[TestCase(true, Description = "This sample shows a group left join with a composite key.")]
+		[TestCase(false, Description = "This sample shows a group left join with a composite key.")]
+		public void DLinqJoin9LeftJoin(bool useCrossJoin)
+		{
+			if (useCrossJoin && !Dialect.SupportsCrossJoin)
+			{
+				Assert.Ignore("Dialect does not support cross join.");
+			}
+
+			ICollection expected, actual;
+			expected =
+				(from o in db.Orders.ToList()
+				from p in db.Products.ToList()
+				join d in db.OrderLines.ToList()
+					on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
+					into details
+				from d in details.DefaultIfEmpty()
+				where d != null && d.UnitPrice > 50
+				select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
+
+			using (var substitute = SubstituteDialect())
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ClearQueryPlanCache();
+				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
+
+				actual =
+					(from o in db.Orders
+					from p in db.Products
+					join d in db.OrderLines
+						on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
+						into details
+					from d in details.DefaultIfEmpty()
+					where d != null && d.UnitPrice > 50
+					select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
+			}
+
+			Assert.AreEqual(expected.Count, actual.Count);
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample shows a join which is then grouped")]
 		public void DLinqJoin9b()
 		{
@@ -1770,6 +1892,27 @@ namespace NHibernate.Test.Linq
 
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(2));
+			}
+		}
+
+		[Category("JOIN")]
+		[Test(Description = "This sample shows how to join multiple tables using a left join.")]
+		public void DLinqJoin10aLeftJoin()
+		{
+			var q =
+				from e in db.Employees
+				join s in db.Employees on e.Superior.EmployeeId equals s.EmployeeId into sup
+				from s in sup.DefaultIfEmpty()
+				join s2 in db.Employees on s.Superior.EmployeeId equals s2.EmployeeId into sup2
+				from s2 in sup2.DefaultIfEmpty()
+				select new { e.FirstName, SuperiorName = s.FirstName, Superior2Name = s2.FirstName };
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ObjectDumper.Write(q);
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1617,6 +1617,25 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Category("JOIN")]
+		[Test(Description = "This sample joins two tables and projects results from the first table.")]
+		public void DLinqJoin5e()
+		{
+			var q =
+				from c in db.Customers
+				join o in db.Orders on c.CustomerId equals o.Customer.CustomerId
+				where c.ContactName != null
+				select o;
+
+			using (var sqlSpy = new SqlLogSpy())
+			{
+				ObjectDumper.Write(q);
+
+				var sql = sqlSpy.GetWholeLog();
+				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(1));
+			}
+		}
+
+		[Category("JOIN")]
 		[Test(Description = "This sample explictly joins three tables and projects results from each of them.")]
 		public void DLinqJoin6()
 		{

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -1829,16 +1829,16 @@ namespace NHibernate.Test.Linq
 				Assert.Ignore("Dialect does not support cross join.");
 			}
 
-			ICollection expected, actual;
-			expected =
-				(from o in db.Orders.ToList()
-				from p in db.Products.ToList()
-				join d in db.OrderLines.ToList()
-					on new {o.OrderId, p.ProductId} equals new {d.Order.OrderId, d.Product.ProductId}
-					into details
-				from d in details.DefaultIfEmpty()
-				where d != null && d.UnitPrice > 50
-				select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
+			// The expected collection can be obtained from the below Linq to Objects query.
+			//var expected =
+			//	(from o in db.Orders.ToList()
+			//	 from p in db.Products.ToList()
+			//	 join d in db.OrderLines.ToList()
+			//		 on new { o.OrderId, p.ProductId } equals new { d.Order.OrderId, d.Product.ProductId }
+			//		 into details
+			//	 from d in details.DefaultIfEmpty()
+			//	 where d != null && d.UnitPrice > 50
+			//	 select new { o.OrderId, p.ProductId, d.UnitPrice }).ToList();
 
 			using (var substitute = SubstituteDialect())
 			using (var sqlSpy = new SqlLogSpy())
@@ -1846,7 +1846,7 @@ namespace NHibernate.Test.Linq
 				ClearQueryPlanCache();
 				substitute.Value.SupportsCrossJoin.Returns(useCrossJoin);
 
-				actual =
+				var actual =
 					(from o in db.Orders
 					from p in db.Products
 					join d in db.OrderLines
@@ -1857,11 +1857,10 @@ namespace NHibernate.Test.Linq
 					select new {o.OrderId, p.ProductId, d.UnitPrice}).ToList();
 
 				var sql = sqlSpy.GetWholeLog();
+				Assert.That(actual.Count, Is.EqualTo(163));
 				Assert.That(sql, Does.Contain(useCrossJoin ? "cross join" : "inner join"));
 				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(1));
 			}
-
-			Assert.AreEqual(expected.Count, actual.Count);
 		}
 
 		[Category("JOIN")]

--- a/src/NHibernate/Linq/Clauses/NhOuterJoinClause.cs
+++ b/src/NHibernate/Linq/Clauses/NhOuterJoinClause.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq.Expressions;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace NHibernate.Linq.Clauses
+{
+	/// <summary>
+	/// A wrapper for <see cref="JoinClause"/> that is used to mark it as an outer join.
+	/// </summary>
+	public class NhOuterJoinClause : NhClauseBase, IBodyClause, IClause, IQuerySource
+	{
+		public NhOuterJoinClause(JoinClause joinClause)
+		{
+			JoinClause = joinClause;
+		}
+
+		public JoinClause JoinClause { get; }
+
+		public string ItemName => JoinClause.ItemName;
+
+		public System.Type ItemType => JoinClause.ItemType;
+
+		public void TransformExpressions(Func<Expression, Expression> transformation)
+		{
+			JoinClause.TransformExpressions(transformation);
+		}
+
+		public IBodyClause Clone(CloneContext cloneContext)
+		{
+			return new NhOuterJoinClause(JoinClause.Clone(cloneContext));
+		}
+
+		protected override void Accept(INhQueryModelVisitor visitor, QueryModel queryModel, int index)
+		{
+			if (visitor is INhQueryModelVisitorExtended queryModelVisitorExtended)
+			{
+				queryModelVisitorExtended.VisitNhOuterJoinClause(this, queryModel, index);
+			}
+			else
+			{
+				visitor.VisitJoinClause(JoinClause, queryModel, index);
+			}
+		}
+	}
+}

--- a/src/NHibernate/Linq/GroupJoin/GroupJoinAggregateDetectionVisitor.cs
+++ b/src/NHibernate/Linq/GroupJoin/GroupJoinAggregateDetectionVisitor.cs
@@ -79,6 +79,12 @@ namespace NHibernate.Linq.GroupJoin
 					}
 				}
 			}
+			// In order to detect a left join (e.g. from a in A join b in B on a.Id equals b.Id into c from b in c.DefaultIfEmpty())
+			// we have to visit the subquery in order to find the group join
+			else if (fromClause.FromExpression is SubQueryExpression subQuery)
+			{
+				VisitSubQuery(subQuery);
+			}
 
 			return base.VisitQuerySourceReference(expression);
 		}

--- a/src/NHibernate/Linq/GroupJoin/NonAggregatingGroupJoinRewriter.cs
+++ b/src/NHibernate/Linq/GroupJoin/NonAggregatingGroupJoinRewriter.cs
@@ -168,7 +168,6 @@ namespace NHibernate.Linq.Visitors
 	{
 		private readonly IQuerySource _querySource;
 		private bool _references;
-		private readonly List<IQuerySource> _usages = new List<IQuerySource>();
 
 		public QuerySourceUsageLocator(IQuerySource querySource)
 		{
@@ -177,10 +176,7 @@ namespace NHibernate.Linq.Visitors
 
 		internal bool LeftJoin { get; private set; }
 
-		public IList<IQuerySource> Usages
-		{
-			get { return _usages.AsReadOnly(); }
-		}
+		public IList<IQuerySource> Usages { get; } = new List<IQuerySource>();
 
 		public void Search(IBodyClause clause)
 		{
@@ -195,7 +191,7 @@ namespace NHibernate.Linq.Visitors
 
 			if (_references)
 			{
-				_usages.Add(querySource);
+				Usages.Add(querySource);
 			}
 		}
 

--- a/src/NHibernate/Linq/GroupJoin/NonAggregatingGroupJoinRewriter.cs
+++ b/src/NHibernate/Linq/GroupJoin/NonAggregatingGroupJoinRewriter.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using NHibernate.Linq.Clauses;
 using NHibernate.Linq.GroupJoin;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Parsing;
 
 namespace NHibernate.Linq.Visitors
@@ -14,7 +16,6 @@ namespace NHibernate.Linq.Visitors
 	{
 		private readonly QueryModel _model;
 		private readonly IEnumerable<GroupJoinClause> _groupJoinClauses;
-		private QuerySourceUsageLocator _locator;
 
 		private NonAggregatingGroupJoinRewriter(QueryModel model, IEnumerable<GroupJoinClause> groupJoinClauses)
 		{
@@ -67,19 +68,19 @@ namespace NHibernate.Linq.Visitors
 				//            This is used to repesent an outer join, and again the "from" is removing the hierarchy. So
 				//            simply change the group join to an outer join
 
-				_locator = new QuerySourceUsageLocator(nonAggregatingJoin);
+				var locator = new QuerySourceUsageLocator(nonAggregatingJoin);
 
 				foreach (var bodyClause in _model.BodyClauses)
 				{
-					_locator.Search(bodyClause);
+					locator.Search(bodyClause);
 				}
 
-				if (IsHierarchicalJoin(nonAggregatingJoin))
+				if (IsHierarchicalJoin(nonAggregatingJoin, locator))
 				{
 				}
-				else if (IsFlattenedJoin(nonAggregatingJoin))
+				else if (IsFlattenedJoin(nonAggregatingJoin, locator))
 				{
-					ProcessFlattenedJoin(nonAggregatingJoin);
+					ProcessFlattenedJoin(nonAggregatingJoin, locator);
 				}
 				else if (IsOuterJoin(nonAggregatingJoin))
 				{
@@ -92,19 +93,30 @@ namespace NHibernate.Linq.Visitors
 			}
 		}
 
-		private void ProcessFlattenedJoin(GroupJoinClause nonAggregatingJoin)
+		private void ProcessFlattenedJoin(GroupJoinClause nonAggregatingJoin, QuerySourceUsageLocator locator)
 		{
+			var nhJoin = locator.LeftJoin
+				? new NhOuterJoinClause(nonAggregatingJoin.JoinClause)
+				: (IQuerySource) nonAggregatingJoin.JoinClause;
+
 			// Need to:
 			// 1. Remove the group join and replace it with a join
 			// 2. Remove the corresponding "from" clause (the thing that was doing the flattening)
-			// 3. Rewrite the selector to reference the "join" rather than the "from" clause
-			SwapClause(nonAggregatingJoin, nonAggregatingJoin.JoinClause);
+			// 3. Rewrite the query model to reference the "join" rather than the "from" clause
+			SwapClause(nonAggregatingJoin, (IBodyClause) nhJoin);
 
-			// TODO - don't like use of _locator here; would rather we got this passed in.  Ditto on next line (esp. the cast)
-			_model.BodyClauses.Remove(_locator.Clauses[0]);
+			_model.BodyClauses.Remove((IBodyClause) locator.Usages[0]);
+			
+			SwapQuerySourceVisitor querySourceSwapper;
+			if (locator.LeftJoin)
+			{
+				// As we wrapped the join clause we have to update all references to the wrapped clause
+				querySourceSwapper = new SwapQuerySourceVisitor(nonAggregatingJoin.JoinClause, nhJoin);
+				_model.TransformExpressions(querySourceSwapper.Swap);
+			}
 
-			var querySourceSwapper = new SwapQuerySourceVisitor((IQuerySource)_locator.Clauses[0], nonAggregatingJoin.JoinClause);
-			_model.SelectClause.TransformExpressions(querySourceSwapper.Swap);
+			querySourceSwapper = new SwapQuerySourceVisitor(locator.Usages[0], nhJoin);
+			_model.TransformExpressions(querySourceSwapper.Swap);
 		}
 
 		// TODO - store the indexes of the join clauses when we find them, then can remove this loop
@@ -125,11 +137,11 @@ namespace NHibernate.Linq.Visitors
 			return false;
 		}
 
-		private bool IsFlattenedJoin(GroupJoinClause nonAggregatingJoin)
+		private bool IsFlattenedJoin(GroupJoinClause nonAggregatingJoin, QuerySourceUsageLocator locator)
 		{
-			if (_locator.Clauses.Count == 1)
+			if (locator.Usages.Count == 1)
 			{
-				var from = _locator.Clauses[0] as AdditionalFromClause;
+				var from = locator.Usages[0] as AdditionalFromClause;
 
 				if (from != null)
 				{
@@ -140,9 +152,9 @@ namespace NHibernate.Linq.Visitors
 			return false;
 		}
 
-		private bool IsHierarchicalJoin(GroupJoinClause nonAggregatingJoin)
+		private bool IsHierarchicalJoin(GroupJoinClause nonAggregatingJoin, QuerySourceUsageLocator locator)
 		{
-			return _locator.Clauses.Count == 0;
+			return locator.Usages.Count == 0;
 		}
 
 		// TODO - rename this and share with the AggregatingGroupJoinRewriter
@@ -156,27 +168,34 @@ namespace NHibernate.Linq.Visitors
 	{
 		private readonly IQuerySource _querySource;
 		private bool _references;
-		private readonly List<IBodyClause> _clauses = new List<IBodyClause>();
+		private readonly List<IQuerySource> _usages = new List<IQuerySource>();
 
 		public QuerySourceUsageLocator(IQuerySource querySource)
 		{
 			_querySource = querySource;
 		}
 
-		public IList<IBodyClause> Clauses
+		internal bool LeftJoin { get; private set; }
+
+		public IList<IQuerySource> Usages
 		{
-			get { return _clauses.AsReadOnly(); }
+			get { return _usages.AsReadOnly(); }
 		}
 
 		public void Search(IBodyClause clause)
 		{
+			if (!(clause is IQuerySource querySource))
+			{
+				return;
+			}
+
 			_references = false;
 
 			clause.TransformExpressions(ExpressionSearcher);
 
 			if (_references)
 			{
-				_clauses.Add(clause);
+				_usages.Add(querySource);
 			}
 		}
 
@@ -194,6 +213,23 @@ namespace NHibernate.Linq.Visitors
 			}
 
 			return expression;
+		}
+
+		protected override Expression VisitSubQuery(SubQueryExpression expression)
+		{
+			if (IsLeftJoin(expression.QueryModel))
+			{
+				LeftJoin = true;
+				expression.QueryModel.MainFromClause.TransformExpressions(ExpressionSearcher);
+			}
+
+			return expression;
+		}
+
+		private static bool IsLeftJoin(QueryModel subQueryModel)
+		{
+			return subQueryModel.ResultOperators.Count == 1 &&
+					subQueryModel.ResultOperators[0] is DefaultIfEmptyResultOperator;
 		}
 	}
 }

--- a/src/NHibernate/Linq/INhQueryModelVisitor.cs
+++ b/src/NHibernate/Linq/INhQueryModelVisitor.cs
@@ -11,4 +11,10 @@ namespace NHibernate.Linq
 
 		void VisitNhHavingClause(NhHavingClause nhWhereClause, QueryModel queryModel, int index);
 	}
+
+	// TODO 6.0: Move members into INhQueryModelVisitor 
+	internal interface INhQueryModelVisitorExtended : INhQueryModelVisitor
+	{
+		void VisitNhOuterJoinClause(NhOuterJoinClause nhOuterJoinClause, QueryModel queryModel, int index);
+	}
 }

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -10,6 +10,7 @@ using Remotion.Linq.Parsing.ExpressionVisitors;
 using System.Threading;
 using System.Threading.Tasks;
 using NHibernate.Engine;
+using static NHibernate.Util.ReflectionCache.QueryableMethods;
 
 namespace NHibernate.Linq
 {
@@ -2465,6 +2466,97 @@ namespace NHibernate.Linq
 			return provider.ExecuteFutureValue<TResult>(expression);
 #pragma warning restore CS0618 // Type or member is obsolete
 		}
+
+		#region LeftJoin
+
+		// Code based on: https://stackoverflow.com/a/18782867
+		/// <summary>
+		/// Correlates the elements of two sequences based on matching keys. The default equality comparer is used to compare keys.
+		/// </summary>
+		/// <param name="outer">The first sequence to join.</param>
+		/// <param name="inner">The sequence to join to the first sequence.</param>
+		/// <param name="outerKeySelector">A dynamic function to extract the join key from each element of the first sequence.</param>
+		/// <param name="innerKeySelector">A dynamic function to extract the join key from each element of the second sequence.</param>
+		/// <param name="resultSelector">A dynamic function to create a result element from two matching elements.</param>
+		/// <returns>An <see cref="IQueryable"/> obtained by performing a left join on two sequences.</returns>
+		public static IQueryable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(
+			this IQueryable<TOuter> outer,
+			IQueryable<TInner> inner,
+			Expression<Func<TOuter, TKey>> outerKeySelector,
+			Expression<Func<TInner, TKey>> innerKeySelector,
+			Expression<Func<TOuter, TInner, TResult>> resultSelector)
+		{
+			outer = outer ?? throw new ArgumentNullException(nameof(outer));
+			inner = inner ?? throw new ArgumentNullException(nameof(inner));
+			outerKeySelector = outerKeySelector ?? throw new ArgumentNullException(nameof(outerKeySelector));
+			innerKeySelector = innerKeySelector ?? throw new ArgumentNullException(nameof(innerKeySelector));
+			resultSelector = resultSelector ?? throw new ArgumentNullException(nameof(resultSelector));
+
+			Expression<Func<TOuter, IEnumerable<TInner>, LeftJoinIntermediate<TOuter, TInner>>> groupJoinResultSelector =
+				(oneOuter, manyInners) => new LeftJoinIntermediate<TOuter, TInner>
+				{
+					OneOuter = oneOuter,
+					ManyInners = manyInners
+				};
+			var groupJoin = GroupJoinDefinition.MakeGenericMethod(
+				typeof(TOuter),
+				typeof(TInner),
+				typeof(TKey),
+				typeof(LeftJoinIntermediate<TOuter, TInner>));
+			var selectMany = SelectManyDefinition.MakeGenericMethod(
+				typeof(LeftJoinIntermediate<TOuter, TInner>),
+				typeof(TInner),
+				typeof(TResult));
+			var exprGroupJoin = Expression.Call(
+				groupJoin,
+				outer.Expression,
+				inner.Expression,
+				outerKeySelector,
+				innerKeySelector,
+				groupJoinResultSelector);
+			var selectManyCollectionSelector = (Expression<Func<LeftJoinIntermediate<TOuter, TInner>, IEnumerable<TInner>>>)
+				(t => t.ManyInners.DefaultIfEmpty());
+			var outerParameter = resultSelector.Parameters[0];
+			var paramNew = Expression.Parameter(typeof(LeftJoinIntermediate<TOuter, TInner>));
+			var outerProperty = Expression.Property(paramNew, nameof(LeftJoinIntermediate<TOuter, TInner>.OneOuter));
+			var selectManyResultSelector = Expression.Lambda(
+				new Replacer(outerParameter, outerProperty).Visit(resultSelector.Body),
+				paramNew,
+				resultSelector.Parameters[1]);
+
+			return outer.Provider.CreateQuery<TResult>(
+				Expression.Call(selectMany, exprGroupJoin, selectManyCollectionSelector, selectManyResultSelector));
+		}
+
+		private class LeftJoinIntermediate<TOuter, TInner>
+		{
+			public TOuter OneOuter { get; set; }
+			public IEnumerable<TInner> ManyInners { get; set; }
+		}
+
+		private class Replacer : ExpressionVisitor
+		{
+			private readonly ParameterExpression _oldParam;
+			private readonly Expression _replacement;
+
+			public Replacer(ParameterExpression oldParam, Expression replacement)
+			{
+				_oldParam = oldParam;
+				_replacement = replacement;
+			}
+
+			public override Expression Visit(Expression exp)
+			{
+				if (exp == _oldParam)
+				{
+					return _replacement;
+				}
+
+				return base.Visit(exp);
+			}
+		}
+
+		#endregion
 
 		/// <summary>
 		/// Allows to set NHibernate query options.

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -2520,7 +2520,7 @@ namespace NHibernate.Linq
 			var paramNew = Expression.Parameter(typeof(LeftJoinIntermediate<TOuter, TInner>));
 			var outerProperty = Expression.Property(paramNew, nameof(LeftJoinIntermediate<TOuter, TInner>.OneOuter));
 			var selectManyResultSelector = Expression.Lambda(
-				new Replacer(outerParameter, outerProperty).Visit(resultSelector.Body),
+				ReplacingExpressionVisitor.Replace(outerParameter, outerProperty, resultSelector.Body),
 				paramNew,
 				resultSelector.Parameters[1]);
 
@@ -2532,28 +2532,6 @@ namespace NHibernate.Linq
 		{
 			public TOuter OneOuter { get; set; }
 			public IEnumerable<TInner> ManyInners { get; set; }
-		}
-
-		private class Replacer : ExpressionVisitor
-		{
-			private readonly ParameterExpression _oldParam;
-			private readonly Expression _replacement;
-
-			public Replacer(ParameterExpression oldParam, Expression replacement)
-			{
-				_oldParam = oldParam;
-				_replacement = replacement;
-			}
-
-			public override Expression Visit(Expression exp)
-			{
-				if (exp == _oldParam)
-				{
-					return _replacement;
-				}
-
-				return base.Visit(exp);
-			}
 		}
 
 		#endregion

--- a/src/NHibernate/Linq/QuerySourceNamer.cs
+++ b/src/NHibernate/Linq/QuerySourceNamer.cs
@@ -16,7 +16,10 @@ namespace NHibernate.Linq
 
 		public void Add(IQuerySource querySource)
 		{
-			Add(querySource, CreateUniqueName(querySource.ItemName));
+			if (_map.ContainsKey(querySource))
+				return;
+
+			_map.Add(querySource, CreateUniqueName(querySource.ItemName));
 		}
 
 		internal void Add(IQuerySource querySource, string name)

--- a/src/NHibernate/Linq/QuerySourceNamer.cs
+++ b/src/NHibernate/Linq/QuerySourceNamer.cs
@@ -16,10 +16,15 @@ namespace NHibernate.Linq
 
 		public void Add(IQuerySource querySource)
 		{
+			Add(querySource, CreateUniqueName(querySource.ItemName));
+		}
+
+		internal void Add(IQuerySource querySource, string name)
+		{
 			if (_map.ContainsKey(querySource))
 				return;
 
-			_map.Add(querySource, CreateUniqueName(querySource.ItemName));
+			_map.Add(querySource, name);
 		}
 
 		public string GetName(IQuerySource querySource)

--- a/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
+++ b/src/NHibernate/Linq/ReWriters/AddJoinsReWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using NHibernate.Engine;
@@ -15,7 +16,7 @@ namespace NHibernate.Linq.ReWriters
 		bool IsIdentifier(System.Type type, string propertyName);
 	}
 
-	public class AddJoinsReWriter : NhQueryModelVisitorBase, IIsEntityDecider
+	public class AddJoinsReWriter : NhQueryModelVisitorBase, IIsEntityDecider, INhQueryModelVisitorExtended
 	{
 		private readonly ISessionFactoryImplementor _sessionFactory;
 		private readonly MemberExpressionJoinDetector _memberExpressionJoinDetector;
@@ -59,6 +60,11 @@ namespace NHibernate.Linq.ReWriters
 		public override void VisitNhHavingClause(NhHavingClause havingClause, QueryModel queryModel, int index)
 		{
 			_whereJoinDetector.Transform(havingClause);
+		}
+
+		public void VisitNhOuterJoinClause(NhOuterJoinClause nhOuterJoinClause, QueryModel queryModel, int index)
+		{
+			VisitJoinClause(nhOuterJoinClause.JoinClause, queryModel, nhOuterJoinClause);
 		}
 
 		public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)

--- a/src/NHibernate/Linq/Visitors/QuerySourceIdentifier.cs
+++ b/src/NHibernate/Linq/Visitors/QuerySourceIdentifier.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Linq.Visitors
 	/// the HQL expression tree) means a query source may be referenced by a <c>QuerySourceReference</c>
 	/// before it has been identified - and named.
 	/// </remarks>
-	public class QuerySourceIdentifier : NhQueryModelVisitorBase
+	public class QuerySourceIdentifier : NhQueryModelVisitorBase, INhQueryModelVisitorExtended
 	{
 		private readonly QuerySourceNamer _namer;
 
@@ -56,6 +56,12 @@ namespace NHibernate.Linq.Visitors
 		public override void VisitNhJoinClause(NhJoinClause joinClause, QueryModel queryModel, int index)
 		{
 			_namer.Add(joinClause);
+		}
+
+		public void VisitNhOuterJoinClause(NhOuterJoinClause outerJoinClause, QueryModel queryModel, int index)
+		{
+			_namer.Add(outerJoinClause);
+			_namer.Add(outerJoinClause.JoinClause, _namer.GetName(outerJoinClause));
 		}
 
 		public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -180,6 +180,19 @@ namespace NHibernate.Util
 			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
 		}
 
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+		/// <param name="func">A method group</param>
+		/// <param name="a1">A dummy parameter</param>
+		/// <param name="a2">A dummy parameter</param>
+		/// <param name="a3">A dummy parameter</param>
+		/// <param name="a4">A dummy parameter</param>
+		/// <param name="a5">A dummy parameter</param>
+		internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, T4, T5, TResult>(System.Func<T1, T2, T3, T4, T5, TResult> func, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
+		{
+			var method = func.Method;
+			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
+		}
+
 		/// <summary>
 		/// Get the <see cref="MethodInfo"/> for a public overload of a given method if the method does not match
 		/// given parameter types, otherwise directly yield the given method.

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -68,6 +68,11 @@ namespace NHibernate.Util
 		{
 			internal static readonly MethodInfo SelectDefinition =
 				ReflectHelper.FastGetMethodDefinition(Queryable.Select, default(IQueryable<object>), default(Expression<Func<object, object>>));
+			internal static readonly MethodInfo SelectManyDefinition =
+				ReflectHelper.GetMethodDefinition(() => Queryable.SelectMany<object, object, object>(null, (Expression<Func<object, IEnumerable<object>>>) null, null));
+
+			internal static readonly MethodInfo GroupJoinDefinition =
+				ReflectHelper.GetMethodDefinition(() => Queryable.GroupJoin<object, object, object, object>(null, null, null, null, null));
 
 			internal static readonly MethodInfo CountDefinition =
 				ReflectHelper.FastGetMethodDefinition(Queryable.Count, default(IQueryable<object>));

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -69,10 +69,20 @@ namespace NHibernate.Util
 			internal static readonly MethodInfo SelectDefinition =
 				ReflectHelper.FastGetMethodDefinition(Queryable.Select, default(IQueryable<object>), default(Expression<Func<object, object>>));
 			internal static readonly MethodInfo SelectManyDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.SelectMany<object, object, object>(null, (Expression<Func<object, IEnumerable<object>>>) null, null));
+				ReflectHelper.FastGetMethodDefinition(
+					Queryable.SelectMany,
+					default(IQueryable<object>),
+					default(Expression<Func<object, IEnumerable<object>>>),
+					default(Expression<Func<object, object, object>>));
 
 			internal static readonly MethodInfo GroupJoinDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.GroupJoin<object, object, object, object>(null, null, null, null, null));
+				ReflectHelper.FastGetMethodDefinition(
+					Queryable.GroupJoin,
+					default(IQueryable<object>),
+					default(IEnumerable<object>),
+					default(Expression<Func<object, int>>),
+					default(Expression<Func<object, int>>),
+					default(Expression<Func<object, IEnumerable<object>, object>>));
 
 			internal static readonly MethodInfo CountDefinition =
 				ReflectHelper.FastGetMethodDefinition(Queryable.Count, default(IQueryable<object>));


### PR DESCRIPTION
Fixes: #864

This PR provides two additional ways to do a left join:
- Query syntax
```C#
from c in db.Customers
  join o in db.Orders on c.CustomerId equals o.Customer.CustomerId into orders
  from o in orders.DefaultIfEmpty()
  select o;
```
- Extension method
```C#
db.Orders
  .LeftJoin(db.Orders, x => x.OrderId, x => x.OrderId - 1, (order, order1) => new { order, order1 })
  .Select(x => new { First = x.order, Second = x.order1 })
  .ToList();
```