### PR TITLE
Fix SQLite typing

### DIFF
--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -498,5 +499,19 @@ namespace NHibernate.Dialect
 		// Said to be unlimited. http://sqlite.1065341.n5.nabble.com/Max-limits-on-the-following-td37859.html
 		/// <inheritdoc />
 		public override int MaxAliasLength => 128;
+
+		// Since v5.3
+		[Obsolete("This class has no usage in NHibernate anymore and will be removed in a future version. Use or extend CastFunction instead.")]
+		[Serializable]
+		protected class SQLiteCastFunction : CastFunction
+		{
+			protected override bool CastingIsRequired(string sqlType)
+			{
+				if (StringHelper.ContainsCaseInsensitive(sqlType, "date") ||
+					StringHelper.ContainsCaseInsensitive(sqlType, "time"))
+					return false;
+				return true;
+			}
+		}
 	}
 }

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -53,11 +53,13 @@ namespace NHibernate.Dialect
 			// NUMERIC and REAL are almost the same, they are binary floating point numbers. There is only a slight difference
 			// for values without a floating part. They will be represented as integers with numeric, but still as floating
 			// values with real. The side-effect of this is numeric being able of storing exactly bigger integers than real.
-			RegisterColumnType(DbType.Currency, "NUMERIC");
-			RegisterColumnType(DbType.Decimal, "NUMERIC");
+			// But it also creates bugs in division, when dividing two numeric happening to be integers, the result is then
+			// never fractional. So we use "REAL" for all.
+			RegisterColumnType(DbType.Currency, "REAL");
+			RegisterColumnType(DbType.Decimal, "REAL");
 			RegisterColumnType(DbType.Double, "REAL");
 			RegisterColumnType(DbType.Single, "REAL");
-			RegisterColumnType(DbType.VarNumeric, "NUMERIC");
+			RegisterColumnType(DbType.VarNumeric, "REAL");
 
 			RegisterColumnType(DbType.AnsiString, "TEXT");
 			RegisterColumnType(DbType.String, "TEXT");

--- a/src/NHibernate/Type/TimeAsTimeSpanType.cs
+++ b/src/NHibernate/Type/TimeAsTimeSpanType.cs
@@ -46,6 +46,8 @@ namespace NHibernate.Type
 				if (value is TimeSpan time) //For those dialects where DbType.Time means TimeSpan.
 					return time;
 
+				// Todo: investigate if this convert should be made culture invariant, here and in other NHibernate types,
+				// such as AbstractDateTimeType and TimeType, or even in all other places doing such converts in NHibernate.
 				var dbValue = Convert.ToDateTime(value);
 				return dbValue.TimeOfDay;
 			}

--- a/src/NHibernate/Type/TimeAsTimeSpanType.cs
+++ b/src/NHibernate/Type/TimeAsTimeSpanType.cs
@@ -43,10 +43,11 @@ namespace NHibernate.Type
 			try
 			{
 				var value = rs[index];
-				if(value is TimeSpan time) //For those dialects where DbType.Time means TimeSpan.
+				if (value is TimeSpan time) //For those dialects where DbType.Time means TimeSpan.
 					return time;
-                
-				return ((DateTime)value).TimeOfDay;
+
+				var dbValue = Convert.ToDateTime(value);
+				return dbValue.TimeOfDay;
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Invalid types were declared in SQLite dialect, causing cast errors, and having led to an undue hack disabling casting for some types.

Possible breaking change: in order to avoid a floating point division bug losing the fractional part, decimal are now stored as `REAL` instead of `NUMERIC`. Both are binary floating point types, excepted that `NUMERIC` stores integral values as `INTEGER`. This change may cause big integral decimal values to lose more precision in SQLite.