### PR TITLE
Improve performance of ReflectHelper.GetMethod/Definition

### DIFF
--- a/src/NHibernate/Linq/ExpressionTransformers/SimplifyCompareTransformer.cs
+++ b/src/NHibernate/Linq/ExpressionTransformers/SimplifyCompareTransformer.cs
@@ -99,13 +99,13 @@ namespace NHibernate.Linq.ExpressionTransformers
 		private static readonly Dictionary<System.Type, MethodInfo> dummies = new Dictionary<System.Type, MethodInfo>
 			{
 				// Corresponds to string.Compare(a, b).
-				{typeof (string), ReflectHelper.FastGetMethod(DummyComparison,default(string), default(string))},
+				{typeof (string), ReflectHelper.FastGetMethod(DummyComparison, default(string), default(string))},
 
 				// System.Data.Services.Providers.DataServiceProviderMethods has Compare methods for these types.
-				{typeof (bool), ReflectHelper.FastGetMethod(DummyComparison,false, false)},
-				{typeof (bool?), ReflectHelper.FastGetMethod(DummyComparison,default(bool?), default(bool?))},
-				{typeof (Guid), ReflectHelper.FastGetMethod(DummyComparison,default(Guid), default(Guid))},
-				{typeof (Guid?), ReflectHelper.FastGetMethod(DummyComparison,default(Guid?), default(Guid?))},
+				{typeof (bool), ReflectHelper.FastGetMethod(DummyComparison, false, false)},
+				{typeof (bool?), ReflectHelper.FastGetMethod(DummyComparison, default(bool?), default(bool?))},
+				{typeof (Guid), ReflectHelper.FastGetMethod(DummyComparison, default(Guid), default(Guid))},
+				{typeof (Guid?), ReflectHelper.FastGetMethod(DummyComparison, default(Guid?), default(Guid?))},
 			};
 
 		private static bool DummyComparison<T>(T lhs, T rhs)

--- a/src/NHibernate/Linq/ExpressionTransformers/SimplifyCompareTransformer.cs
+++ b/src/NHibernate/Linq/ExpressionTransformers/SimplifyCompareTransformer.cs
@@ -99,13 +99,13 @@ namespace NHibernate.Linq.ExpressionTransformers
 		private static readonly Dictionary<System.Type, MethodInfo> dummies = new Dictionary<System.Type, MethodInfo>
 			{
 				// Corresponds to string.Compare(a, b).
-				{typeof (string), ReflectHelper.GetMethod(() => DummyComparison<string>(null, null))},
+				{typeof (string), ReflectHelper.FastGetMethod(DummyComparison,default(string), default(string))},
 
 				// System.Data.Services.Providers.DataServiceProviderMethods has Compare methods for these types.
-				{typeof (bool), ReflectHelper.GetMethod(() => DummyComparison<bool>(false, false))},
-				{typeof (bool?), ReflectHelper.GetMethod(() => DummyComparison<bool?>(null, null))},
-				{typeof (Guid), ReflectHelper.GetMethod(() => DummyComparison<Guid>(Guid.Empty, Guid.Empty))},
-				{typeof (Guid?), ReflectHelper.GetMethod(() => DummyComparison<Guid?>(null, null))},
+				{typeof (bool), ReflectHelper.FastGetMethod(DummyComparison,false, false)},
+				{typeof (bool?), ReflectHelper.FastGetMethod(DummyComparison,default(bool?), default(bool?))},
+				{typeof (Guid), ReflectHelper.FastGetMethod(DummyComparison,default(Guid), default(Guid))},
+				{typeof (Guid?), ReflectHelper.FastGetMethod(DummyComparison,default(Guid?), default(Guid?))},
 			};
 
 		private static bool DummyComparison<T>(T lhs, T rhs)

--- a/src/NHibernate/Linq/Functions/CompareGenerator.cs
+++ b/src/NHibernate/Linq/Functions/CompareGenerator.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Linq.Functions
 	{
 		private static readonly HashSet<MethodInfo> ActingMethods = new HashSet<MethodInfo>
 			{
-				ReflectHelper.GetMethodDefinition(() => string.Compare(null, null)),
+				ReflectHelper.FastGetMethod(string.Compare, default(string), default(string)),
 				ReflectHelper.GetMethodDefinition<string>(s => s.CompareTo(s)),
 				ReflectHelper.GetMethodDefinition<char>(x => x.CompareTo(x)),
 
@@ -33,7 +33,7 @@ namespace NHibernate.Linq.Functions
 				ReflectHelper.GetMethodDefinition<float>(x => x.CompareTo(x)),
 				ReflectHelper.GetMethodDefinition<double>(x => x.CompareTo(x)),
 				
-				ReflectHelper.GetMethodDefinition(() => decimal.Compare(default(decimal), default(decimal))),
+				ReflectHelper.FastGetMethod(decimal.Compare, default(decimal), default(decimal)),
 				ReflectHelper.GetMethodDefinition<decimal>(x => x.CompareTo(x)),
 
 				ReflectHelper.GetMethodDefinition<DateTime>(x => x.CompareTo(x)),

--- a/src/NHibernate/Linq/Functions/ConvertGenerator.cs
+++ b/src/NHibernate/Linq/Functions/ConvertGenerator.cs
@@ -25,8 +25,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition<string>(s => DateTime.Parse(s)),
-				ReflectHelper.GetMethodDefinition<string>(o => Convert.ToDateTime(o))
+				ReflectHelper.FastGetMethod(DateTime.Parse, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToDateTime, default(string))
 			};
 		}
 	}
@@ -38,8 +38,8 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition<string>(s => Boolean.Parse(s)),
-				ReflectHelper.GetMethodDefinition<string>(o => Convert.ToBoolean(o))
+				ReflectHelper.FastGetMethod(bool.Parse, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToBoolean, default(string))
 			};
 		}
 	}
@@ -49,24 +49,24 @@ namespace NHibernate.Linq.Functions
 		public ConvertToInt32Generator()
 		{
 			SupportedMethods = new[]
-								   {
-									   ReflectHelper.GetMethodDefinition<string>(s => int.Parse(s)),
-									   ReflectHelper.GetMethodDefinition<bool>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<byte>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<char>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<decimal>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<double>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<float>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<int>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<long>(o => Convert.ToInt32(o)), 
-									   ReflectHelper.GetMethodDefinition<object>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<sbyte>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<short>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<string>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<uint>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<ulong>(o => Convert.ToInt32(o)),
-									   ReflectHelper.GetMethodDefinition<ushort>(o => Convert.ToInt32(o))
-								   };
+			{
+				ReflectHelper.FastGetMethod(int.Parse, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(bool)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(byte)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(char)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(decimal)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(double)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(float)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(int)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(long)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(object)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(sbyte)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(short)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(uint)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(ulong)),
+				ReflectHelper.FastGetMethod(Convert.ToInt32, default(ushort))
+			};
 		}
 	}
 
@@ -75,23 +75,23 @@ namespace NHibernate.Linq.Functions
 		public ConvertToDecimalGenerator()
 		{
 			SupportedMethods = new[]
-								   {
-									   ReflectHelper.GetMethodDefinition<string>(s => decimal.Parse(s)),
-									   ReflectHelper.GetMethodDefinition<bool>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<byte>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<decimal>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<double>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<float>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<int>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<long>(o => Convert.ToDecimal(o)), 
-									   ReflectHelper.GetMethodDefinition<object>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<sbyte>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<short>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<string>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<uint>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<ulong>(o => Convert.ToDecimal(o)),
-									   ReflectHelper.GetMethodDefinition<ushort>(o => Convert.ToDecimal(o))
-								   };
+			{
+				ReflectHelper.FastGetMethod(decimal.Parse, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(bool)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(byte)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(decimal)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(double)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(float)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(int)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(long)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(object)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(sbyte)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(short)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(uint)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(ulong)),
+				ReflectHelper.FastGetMethod(Convert.ToDecimal, default(ushort))
+			};
 		}
 	}
 
@@ -100,23 +100,23 @@ namespace NHibernate.Linq.Functions
 		public ConvertToDoubleGenerator()
 		{
 			SupportedMethods = new[]
-								   {
-									   ReflectHelper.GetMethodDefinition<string>(s => double.Parse(s)),
-									   ReflectHelper.GetMethodDefinition<bool>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<byte>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<decimal>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<double>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<float>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<int>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<long>(o => Convert.ToDouble(o)), 
-									   ReflectHelper.GetMethodDefinition<object>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<sbyte>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<short>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<string>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<uint>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<ulong>(o => Convert.ToDouble(o)),
-									   ReflectHelper.GetMethodDefinition<ushort>(o => Convert.ToDouble(o))
-								   };
+			{
+				ReflectHelper.FastGetMethod(double.Parse, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(bool)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(byte)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(decimal)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(double)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(float)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(int)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(long)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(object)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(sbyte)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(short)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(string)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(uint)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(ulong)),
+				ReflectHelper.FastGetMethod(Convert.ToDouble, default(ushort))
+			};
 		}
 	}
 }

--- a/src/NHibernate/Linq/Functions/DecimalGenerator.cs
+++ b/src/NHibernate/Linq/Functions/DecimalGenerator.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => decimal.Add(default(decimal), default(decimal)))
+				ReflectHelper.FastGetMethod(decimal.Add, default(decimal), default(decimal))
 			};
 		}
 
@@ -30,7 +30,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => decimal.Divide(default(decimal), default(decimal)))
+				ReflectHelper.FastGetMethod(decimal.Divide, default(decimal), default(decimal))
 			};
 		}
 
@@ -46,7 +46,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => decimal.Multiply(default(decimal), default(decimal)))
+				ReflectHelper.FastGetMethod(decimal.Multiply, default(decimal), default(decimal))
 			};
 		}
 
@@ -62,7 +62,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => decimal.Subtract(default(decimal), default(decimal)))
+				ReflectHelper.FastGetMethod(decimal.Subtract, default(decimal), default(decimal))
 			};
 		}
 
@@ -78,7 +78,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => decimal.Remainder(default(decimal), default(decimal)))
+				ReflectHelper.FastGetMethod(decimal.Remainder, default(decimal), default(decimal))
 			};
 		}
 
@@ -94,7 +94,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => decimal.Negate(default(decimal)))
+				ReflectHelper.FastGetMethod(decimal.Negate, default(decimal))
 			};
 		}
 

--- a/src/NHibernate/Linq/Functions/EqualsGenerator.cs
+++ b/src/NHibernate/Linq/Functions/EqualsGenerator.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 				{
-					ReflectHelper.GetMethodDefinition(() => string.Equals(default(string), default(string))),
+					ReflectHelper.FastGetMethod(string.Equals, default(string), default(string)),
 					ReflectHelper.GetMethodDefinition<string>(x => x.Equals(x)),
 					ReflectHelper.GetMethodDefinition<char>(x => x.Equals(x)),
 
@@ -33,7 +33,7 @@ namespace NHibernate.Linq.Functions
 					ReflectHelper.GetMethodDefinition<float>(x => x.Equals(x)),
 					ReflectHelper.GetMethodDefinition<double>(x => x.Equals(x)),
 					
-					ReflectHelper.GetMethodDefinition(() => decimal.Equals(default(decimal), default(decimal))),
+					ReflectHelper.FastGetMethod(decimal.Equals, default(decimal), default(decimal)),
 					ReflectHelper.GetMethodDefinition<decimal>(x => x.Equals(x)),
 
 					ReflectHelper.GetMethodDefinition<Guid>(x => x.Equals(x)),

--- a/src/NHibernate/Linq/Functions/ListIndexerGenerator.cs
+++ b/src/NHibernate/Linq/Functions/ListIndexerGenerator.cs
@@ -14,8 +14,8 @@ namespace NHibernate.Linq.Functions
 	{
 		private static readonly HashSet<MethodInfo> _supportedMethods = new HashSet<MethodInfo>
 		{
-			ReflectHelper.GetMethodDefinition(() => Enumerable.ElementAt<object>(null, 0)),
-			ReflectHelper.GetMethodDefinition(() => Queryable.ElementAt<object>(null, 0))
+			ReflectHelper.FastGetMethodDefinition(Enumerable.ElementAt, default(IEnumerable<object>), 0),
+			ReflectHelper.FastGetMethodDefinition(Queryable.ElementAt, default(IQueryable<object>), 0)
 		};
 
 		public ListIndexerGenerator()

--- a/src/NHibernate/Linq/Functions/MathGenerator.cs
+++ b/src/NHibernate/Linq/Functions/MathGenerator.cs
@@ -14,72 +14,72 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => Math.Sin(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Cos(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Tan(default(double))),
+				ReflectHelper.FastGetMethod(Math.Sin, default(double)),
+				ReflectHelper.FastGetMethod(Math.Cos, default(double)),
+				ReflectHelper.FastGetMethod(Math.Tan, default(double)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Sinh(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Cosh(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Tanh(default(double))),
+				ReflectHelper.FastGetMethod(Math.Sinh, default(double)),
+				ReflectHelper.FastGetMethod(Math.Cosh, default(double)),
+				ReflectHelper.FastGetMethod(Math.Tanh, default(double)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Asin(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Acos(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Atan(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Atan2(default(double), default(double))),
+				ReflectHelper.FastGetMethod(Math.Asin, default(double)),
+				ReflectHelper.FastGetMethod(Math.Acos, default(double)),
+				ReflectHelper.FastGetMethod(Math.Atan, default(double)),
+				ReflectHelper.FastGetMethod(Math.Atan2, default(double), default(double)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Sqrt(default(double))),
+				ReflectHelper.FastGetMethod(Math.Sqrt, default(double)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(float))),
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(long))),
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(int))),
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(short))),
-				ReflectHelper.GetMethodDefinition(() => Math.Abs(default(sbyte))),
+				ReflectHelper.FastGetMethod(Math.Abs, default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Abs, default(double)),
+				ReflectHelper.FastGetMethod(Math.Abs, default(float)),
+				ReflectHelper.FastGetMethod(Math.Abs, default(long)),
+				ReflectHelper.FastGetMethod(Math.Abs, default(int)),
+				ReflectHelper.FastGetMethod(Math.Abs, default(short)),
+				ReflectHelper.FastGetMethod(Math.Abs, default(sbyte)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(float))),
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(long))),
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(int))),
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(short))),
-				ReflectHelper.GetMethodDefinition(() => Math.Sign(default(sbyte))),
+				ReflectHelper.FastGetMethod(Math.Sign, default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Sign, default(double)),
+				ReflectHelper.FastGetMethod(Math.Sign, default(float)),
+				ReflectHelper.FastGetMethod(Math.Sign, default(long)),
+				ReflectHelper.FastGetMethod(Math.Sign, default(int)),
+				ReflectHelper.FastGetMethod(Math.Sign, default(short)),
+				ReflectHelper.FastGetMethod(Math.Sign, default(sbyte)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Floor(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => Math.Floor(default(double))),
-				ReflectHelper.GetMethodDefinition(() => decimal.Floor(default(decimal))),
+				ReflectHelper.FastGetMethod(Math.Floor, default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Floor, default(double)),
+				ReflectHelper.FastGetMethod(decimal.Floor, default(decimal)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Ceiling(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => Math.Ceiling(default(double))),
-				ReflectHelper.GetMethodDefinition(() => decimal.Ceiling(default(decimal))),
+				ReflectHelper.FastGetMethod(Math.Ceiling, default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Ceiling, default(double)),
+				ReflectHelper.FastGetMethod(decimal.Ceiling, default(decimal)),
 
-				ReflectHelper.GetMethodDefinition(() => Math.Pow(default(double), default(double))),
+				ReflectHelper.FastGetMethod(Math.Pow, default(double), default(double)),
 
 #if NETCOREAPP2_0
-				ReflectHelper.GetMethodDefinition(() => MathF.Sin(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Cos(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Tan(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Sin, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Cos, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Tan, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Sinh(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Cosh(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Tanh(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Sinh, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Cosh, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Tanh, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Asin(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Acos(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Atan(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Atan2(default(float), default(float))),
+				ReflectHelper.FastGetMethod(MathF.Asin, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Acos, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Atan, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Atan2, default(float), default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Sqrt(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Sqrt, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Abs(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Abs, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Sign(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Sign, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Floor(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Floor, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Ceiling(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Ceiling, default(float)),
 
-				ReflectHelper.GetMethodDefinition(() => MathF.Pow(default(float), default(float))),
+				ReflectHelper.FastGetMethod(MathF.Pow, default(float), default(float)),
 #endif
 			};
 		}
@@ -91,7 +91,7 @@ namespace NHibernate.Linq.Functions
 			if (function == "pow")
 				function = "power";
 
-			HqlExpression firstArgument = visitor.Visit(arguments[0]).AsExpression();
+			var firstArgument = visitor.Visit(arguments[0]).AsExpression();
 
 			if (arguments.Count == 2)
 			{

--- a/src/NHibernate/Linq/Functions/NewGuidHqlGenerator.cs
+++ b/src/NHibernate/Linq/Functions/NewGuidHqlGenerator.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethod(() => Guid.NewGuid())
+				ReflectHelper.FastGetMethod(Guid.NewGuid)
 			};
 		}
 

--- a/src/NHibernate/Linq/Functions/QueryableGenerator.cs
+++ b/src/NHibernate/Linq/Functions/QueryableGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
@@ -17,8 +18,8 @@ namespace NHibernate.Linq.Functions
 			{
 				ReflectionCache.QueryableMethods.AnyDefinition,
 				ReflectionCache.QueryableMethods.AnyWithPredicateDefinition,
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Any<object>(null)),
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Any<object>(null, null))
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Any, default(IEnumerable<object>)),
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Any, default(IEnumerable<object>), default(Func<object, bool>))
 			};
 		}
 
@@ -57,7 +58,7 @@ namespace NHibernate.Linq.Functions
 			SupportedMethods = new[]
 			{
 				ReflectionCache.QueryableMethods.AllDefinition,
-				ReflectHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null))
+				ReflectHelper.FastGetMethodDefinition(Enumerable.All, default(IEnumerable<object>), default(Func<object, bool>))
 			};
 		}
 
@@ -94,7 +95,7 @@ namespace NHibernate.Linq.Functions
 			SupportedMethods = new[]
 			{
 				ReflectionCache.QueryableMethods.MinDefinition,
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Min<object>(null))
+				ReflectionCache.EnumerableMethods.MinDefinition
 			};
 		}
 
@@ -111,7 +112,7 @@ namespace NHibernate.Linq.Functions
 			SupportedMethods = new[]
 			{
 				ReflectionCache.QueryableMethods.MaxDefinition,
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Max<object>(null))
+				ReflectionCache.EnumerableMethods.MaxDefinition,
 			};
 		}
 
@@ -146,10 +147,10 @@ namespace NHibernate.Linq.Functions
 		public CollectionContainsGenerator()
 		{
 			SupportedMethods = new[]
-			                   	{
-			                   		ReflectHelper.GetMethodDefinition(() => Queryable.Contains<object>(null, null)),
-			                   		ReflectHelper.GetMethodDefinition(() => Enumerable.Contains<object>(null, null))
-			                   	};
+			{
+				ReflectHelper.FastGetMethodDefinition(Queryable.Contains, default(IQueryable<object>), default(object)),
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Contains, default(IEnumerable<object>), default(object))
+			};
 		}
 
 		public override bool AllowsNullableReturnType(MethodInfo method) => false;

--- a/src/NHibernate/Linq/Functions/RoundGenerator.cs
+++ b/src/NHibernate/Linq/Functions/RoundGenerator.cs
@@ -14,16 +14,16 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => Math.Round(default(double))),
-				ReflectHelper.GetMethodDefinition(() => Math.Round(default(double), default(int))),
-				ReflectHelper.GetMethodDefinition(() => Math.Round(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => Math.Round(default(decimal), default(int))),
-				ReflectHelper.GetMethodDefinition(() => decimal.Round(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => decimal.Round(default(decimal), default(int))),
+				ReflectHelper.FastGetMethod(Math.Round, default(double)),
+				ReflectHelper.FastGetMethod(Math.Round, default(double), default(int)),
+				ReflectHelper.FastGetMethod(Math.Round, default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Round, default(decimal), default(int)),
+				ReflectHelper.FastGetMethod(decimal.Round, default(decimal)),
+				ReflectHelper.FastGetMethod(decimal.Round, default(decimal), default(int)),
 
 #if NETCOREAPP2_0
-				ReflectHelper.GetMethodDefinition(() => MathF.Round(default(float))),
-				ReflectHelper.GetMethodDefinition(() => MathF.Round(default(float), default(int))),
+				ReflectHelper.FastGetMethod(MathF.Round, default(float)),
+				ReflectHelper.FastGetMethod(MathF.Round, default(float), default(int)),
 #endif
 			};
 		}

--- a/src/NHibernate/Linq/Functions/TruncateGenerator.cs
+++ b/src/NHibernate/Linq/Functions/TruncateGenerator.cs
@@ -14,12 +14,12 @@ namespace NHibernate.Linq.Functions
 		{
 			SupportedMethods = new[]
 			{
-				ReflectHelper.GetMethodDefinition(() => Math.Truncate(default(decimal))),
-				ReflectHelper.GetMethodDefinition(() => Math.Truncate(default(double))),
-				ReflectHelper.GetMethodDefinition(() => decimal.Truncate(default(decimal))),
-				
+				ReflectHelper.FastGetMethod(Math.Truncate, default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Truncate, default(double)),
+				ReflectHelper.FastGetMethod(decimal.Truncate, default(decimal)),
+
 #if NETCOREAPP2_0
-				ReflectHelper.GetMethodDefinition(() => MathF.Truncate(default(float))),
+				ReflectHelper.FastGetMethod(MathF.Truncate, default(float)),
 #endif
 			};
 		}

--- a/src/NHibernate/Linq/LinqExtensionMethods.cs
+++ b/src/NHibernate/Linq/LinqExtensionMethods.cs
@@ -2518,7 +2518,7 @@ namespace NHibernate.Linq
 
 		public static IQueryable<T> WithLock<T>(this IQueryable<T> query, LockMode lockMode)
 		{
-			var method = ReflectHelper.GetMethod(() => WithLock(query, lockMode));
+			var method = ReflectHelper.FastGetMethod(WithLock, query, lockMode);
 
 			var callExpression = Expression.Call(method, query.Expression, Expression.Constant(lockMode));
 

--- a/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
+++ b/src/NHibernate/Linq/NestedSelects/NestedSelectRewriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -16,13 +17,13 @@ namespace NHibernate.Linq.NestedSelects
 	static class NestedSelectRewriter
 	{
 		private static readonly MethodInfo CastMethod =
-			ReflectHelper.GetMethod(() => Enumerable.Cast<object[]>(null));
-		private static readonly MethodInfo GroupByMethod = ReflectHelper.GetMethod(
-			() => Enumerable.GroupBy<object[], Tuple, Tuple>(null, null, (Func<object[], Tuple>)null));
-		private static readonly MethodInfo WhereMethod = ReflectHelper.GetMethod(
-			() => Enumerable.Where(null, (Func<Tuple, bool>)null));
-		private static readonly MethodInfo ObjectReferenceEquals = ReflectHelper.GetMethod(
-			() => ReferenceEquals(null, null));
+			ReflectHelper.FastGetMethod(Enumerable.Cast<object[]>, default(IEnumerable));
+		private static readonly MethodInfo GroupByMethod = 
+			ReflectHelper.FastGetMethod(Enumerable.GroupBy, default(IEnumerable<object[]>), default(Func<object[], Tuple>), default(Func<object[], Tuple>));
+		private static readonly MethodInfo WhereMethod = 
+			ReflectHelper.FastGetMethod(Enumerable.Where, default(IEnumerable<Tuple>), default(Func<Tuple, bool>));
+		private static readonly MethodInfo ObjectReferenceEquals =
+			ReflectHelper.FastGetMethod(ReferenceEquals, default(object), default(object));
 		private static readonly PropertyInfo IGroupingKeyProperty = (PropertyInfo)
 			ReflectHelper.GetProperty<IGrouping<Tuple, Tuple>, Tuple>(g => g.Key);
 

--- a/src/NHibernate/Linq/NhRelinqQueryParser.cs
+++ b/src/NHibernate/Linq/NhRelinqQueryParser.cs
@@ -88,25 +88,25 @@ namespace NHibernate.Linq
 			var methodInfoRegistry = new MethodInfoBasedNodeTypeRegistry();
 
 			methodInfoRegistry.Register(
-				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.Fetch<object, object>(null, null)) },
+				new[] { ReflectHelper.FastGetMethodDefinition(EagerFetchingExtensionMethods.Fetch, default(IQueryable<object>), default(Expression<Func<object, object>>)) },
 				typeof(FetchOneExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.FetchLazyProperties<object>(null)) },
+				new[] { ReflectHelper.FastGetMethodDefinition(EagerFetchingExtensionMethods.FetchLazyProperties, default(IQueryable<object>)) },
 				typeof(FetchLazyPropertiesExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.FetchMany<object, object>(null, null)) },
+				new[] { ReflectHelper.FastGetMethodDefinition(EagerFetchingExtensionMethods.FetchMany, default(IQueryable<object>), default(Expression<Func<object, IEnumerable<object>>>)) },
 				typeof(FetchManyExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetch<object, object, object>(null, null)) },
+				new[] { ReflectHelper.FastGetMethodDefinition(EagerFetchingExtensionMethods.ThenFetch, default(INhFetchRequest<object, object>), default(Expression<Func<object, object>>)) },
 				typeof(ThenFetchOneExpressionNode));
 			methodInfoRegistry.Register(
-				new[] { ReflectHelper.GetMethodDefinition(() => EagerFetchingExtensionMethods.ThenFetchMany<object, object, object>(null, null)) },
+				new[] { ReflectHelper.FastGetMethodDefinition( EagerFetchingExtensionMethods.ThenFetchMany, default(INhFetchRequest<object, object>), default(Expression<Func<object, IEnumerable<object>>>)) },
 				typeof(ThenFetchManyExpressionNode));
 			methodInfoRegistry.Register(
 				new[]
 				{
-					ReflectHelper.GetMethodDefinition(() => default(IQueryable<object>).WithLock(LockMode.Read)),
-					ReflectHelper.GetMethodDefinition(() => default(IEnumerable<object>).WithLock(LockMode.Read))
+					ReflectHelper.FastGetMethodDefinition(LinqExtensionMethods.WithLock, default(IQueryable<object>), default(LockMode)),
+					ReflectHelper.FastGetMethodDefinition(LinqExtensionMethods.WithLock, default(IEnumerable<object>), default(LockMode))
 				}, 
 				typeof(LockExpressionNode));
 

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -20,13 +20,13 @@ namespace NHibernate.Linq.Visitors
 		private readonly ISessionFactoryImplementor _sessionFactory;
 
 		private static readonly MethodInfo QueryableSkipDefinition =
-			ReflectHelper.GetMethodDefinition(() => Queryable.Skip<object>(null, 0));
+			ReflectHelper.FastGetMethodDefinition(Queryable.Skip, default(IQueryable<object>), 0);
 		private static readonly MethodInfo QueryableTakeDefinition =
-			ReflectHelper.GetMethodDefinition(() => Queryable.Take<object>(null, 0));
+			ReflectHelper.FastGetMethodDefinition(Queryable.Take, default(IQueryable<object>), 0);
 		private static readonly MethodInfo EnumerableSkipDefinition =
-			ReflectHelper.GetMethodDefinition(() => Enumerable.Skip<object>(null, 0));
+			ReflectHelper.FastGetMethodDefinition(Enumerable.Skip, default(IEnumerable<object>), 0);
 		private static readonly MethodInfo EnumerableTakeDefinition =
-			ReflectHelper.GetMethodDefinition(() => Enumerable.Take<object>(null, 0));
+			ReflectHelper.FastGetMethodDefinition(Enumerable.Take, default(IEnumerable<object>), 0);
 
 		private readonly ICollection<MethodBase> _pagingMethods = new HashSet<MethodBase>
 			{

--- a/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
@@ -93,7 +93,7 @@ namespace NHibernate.Linq.Visitors
 		}
 
 		private static readonly MethodInfo ConvertChangeType =
-			ReflectHelper.GetMethod(() => System.Convert.ChangeType(default(object), default(System.Type)));
+			ReflectHelper.FastGetMethod(System.Convert.ChangeType, default(object), default(System.Type));
 
 		private static Expression Convert(Expression expression, System.Type type)
 		{

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -129,11 +129,11 @@ namespace NHibernate.Util
 		}
 
 		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
-        /// <param name="func">A method group</param>
+		/// <param name="func">A method group</param>
 		/// <param name="a1">A dummy parameter</param>
 		/// <param name="a2">A dummy parameter</param>
 		/// <param name="a3">A dummy parameter</param>
-        internal static MethodInfo FastGetMethod<T1, T2, T3, TResult>(System.Func<T1, T2, T3, TResult> func, T1 a1, T2 a2, T3 a3)
+		internal static MethodInfo FastGetMethod<T1, T2, T3, TResult>(System.Func<T1, T2, T3, TResult> func, T1 a1, T2 a2, T3 a3)
 		{
 			return func.Method;
 		}
@@ -158,23 +158,23 @@ namespace NHibernate.Util
 		}
 
 		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
-        /// <param name="func">A method group</param>
+		/// <param name="func">A method group</param>
 		/// <param name="a1">A dummy parameter</param>
 		/// <param name="a2">A dummy parameter</param>
 		/// <param name="a3">A dummy parameter</param>
-        internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, TResult>(System.Func<T1, T2, T3, TResult> func, T1 a1, T2 a2, T3 a3)
+		internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, TResult>(System.Func<T1, T2, T3, TResult> func, T1 a1, T2 a2, T3 a3)
 		{
 			var method = func.Method;
 			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
 		}
 
 		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
-        /// <param name="func">A method group</param>
+		/// <param name="func">A method group</param>
 		/// <param name="a1">A dummy parameter</param>
 		/// <param name="a2">A dummy parameter</param>
 		/// <param name="a3">A dummy parameter</param>
 		/// <param name="a4">A dummy parameter</param>
-        internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, T4, TResult>(System.Func<T1, T2, T3, T4, TResult> func, T1 a1, T2 a2, T3 a3, T4 a4)
+		internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, T4, TResult>(System.Func<T1, T2, T3, T4, TResult> func, T1 a1, T2 a2, T3 a3, T4 a4)
 		{
 			var method = func.Method;
 			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
@@ -441,7 +441,7 @@ namespace NHibernate.Util
 		/// the method try to find the System.Type scanning all Assemblies of the <see cref="AppDomain.CurrentDomain"/>.
 		/// </remarks>
 		/// <exception cref="TypeLoadException">If no System.Type was found for <paramref name="classFullName"/>.</exception>
-				public static System.Type ClassForFullName(string classFullName)
+		public static System.Type ClassForFullName(string classFullName)
 		{
 			var result = ClassForFullNameOrNull(classFullName);
 			if (result == null)

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -104,6 +104,82 @@ namespace NHibernate.Util
 			return ((MethodCallExpression)method.Body).Method;
 		}
 
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+		/// <param name="func">A method group</param>
+		internal static MethodInfo FastGetMethod<TResult>(System.Func<TResult> func)
+		{
+			return func.Method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+		/// <param name="func">A method group</param>
+		/// <param name="a">A dummy parameter</param>
+		internal static MethodInfo FastGetMethod<T, TResult>(System.Func<T, TResult> func, T a)
+		{
+			return func.Method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+		/// <param name="func">A method group</param>
+		/// <param name="a1">A dummy parameter</param>
+		/// <param name="a2">A dummy parameter</param>
+		internal static MethodInfo FastGetMethod<T1, T2, TResult>(System.Func<T1, T2, TResult> func, T1 a1, T2 a2)
+		{
+			return func.Method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+        /// <param name="func">A method group</param>
+		/// <param name="a1">A dummy parameter</param>
+		/// <param name="a2">A dummy parameter</param>
+		/// <param name="a3">A dummy parameter</param>
+        internal static MethodInfo FastGetMethod<T1, T2, T3, TResult>(System.Func<T1, T2, T3, TResult> func, T1 a1, T2 a2, T3 a3)
+		{
+			return func.Method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+		/// <param name="func">A method group</param>
+		/// <param name="a">A dummy parameter</param>
+		internal static MethodInfo FastGetMethodDefinition<T, TResult>(System.Func<T, TResult> func, T a)
+		{
+			var method = func.Method;
+			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+		/// <param name="func">A method group</param>
+		/// <param name="a1">A dummy parameter</param>
+		/// <param name="a2">A dummy parameter</param>
+		internal static MethodInfo FastGetMethodDefinition<T1, T2, TResult>(System.Func<T1, T2, TResult> func, T1 a1, T2 a2)
+		{
+			var method = func.Method;
+			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+        /// <param name="func">A method group</param>
+		/// <param name="a1">A dummy parameter</param>
+		/// <param name="a2">A dummy parameter</param>
+		/// <param name="a3">A dummy parameter</param>
+        internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, TResult>(System.Func<T1, T2, T3, TResult> func, T1 a1, T2 a2, T3 a3)
+		{
+			var method = func.Method;
+			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
+		}
+
+		/// <summary> Get a <see cref="MethodInfo"/> from a method group </summary>
+        /// <param name="func">A method group</param>
+		/// <param name="a1">A dummy parameter</param>
+		/// <param name="a2">A dummy parameter</param>
+		/// <param name="a3">A dummy parameter</param>
+		/// <param name="a4">A dummy parameter</param>
+        internal static MethodInfo FastGetMethodDefinition<T1, T2, T3, T4, TResult>(System.Func<T1, T2, T3, T4, TResult> func, T1 a1, T2 a2, T3 a3, T4 a4)
+		{
+			var method = func.Method;
+			return method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
+		}
+
 		/// <summary>
 		/// Get the <see cref="MethodInfo"/> for a public overload of a given method if the method does not match
 		/// given parameter types, otherwise directly yield the given method.

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -21,190 +22,194 @@ namespace NHibernate.Util
 		internal static class EnumerableMethods
 		{
 			internal static readonly MethodInfo AggregateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Aggregate, default(IEnumerable<object>), default(Func<object, object, object>));
 			internal static readonly MethodInfo AggregateWithSeedDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object>(null, null, null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Aggregate, default(IEnumerable<object>), default(object), default(Func<object, object, object>));
 			internal static readonly MethodInfo AggregateWithSeedAndResultSelectorDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Aggregate<object, object, object>(null, null, null, null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Aggregate, default(IEnumerable<object>), default(object), default(Func<object, object, object>), default(Func<object, object>));
 
 			internal static readonly MethodInfo AllDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.All<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.All, default(IEnumerable<object>), default(Func<object, bool>));
 
 			internal static readonly MethodInfo CastDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Cast<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Cast<object>, default(IEnumerable));
 
-			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = ReflectHelper.GetMethodDefinition(
-				() => Enumerable.GroupBy<object, object, object>(null, null, default(Func<object, object>)));
+			internal static readonly MethodInfo GroupByWithElementSelectorDefinition = 
+				ReflectHelper.FastGetMethodDefinition(Enumerable.GroupBy, default(IEnumerable<object>), default(Func<object, object>), default(Func<object, object>));
 
 			internal static readonly MethodInfo MaxDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Max<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Max, default(IEnumerable<object>));
 
 			internal static readonly MethodInfo MinDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Min<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Min, default(IEnumerable<object>));
 
 			internal static readonly MethodInfo SelectDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.Select(null, default(Func<object, object>)));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.Select, default(IEnumerable<object>), default(Func<object, object>));
 
 			internal static readonly MethodInfo SumOnInt =
-				ReflectHelper.GetMethod(() => Enumerable.Sum(default(IEnumerable<int>)));
+				ReflectHelper.FastGetMethod(Enumerable.Sum, default(IEnumerable<int>));
 
 			internal static readonly MethodInfo ToArrayDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.ToArray<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.ToArray, default(IEnumerable<object>));
 
 			internal static readonly MethodInfo ToListDefinition =
-				ReflectHelper.GetMethodDefinition(() => Enumerable.ToList<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Enumerable.ToList, default(IEnumerable<object>));
 		}
 
 		internal static class MethodBaseMethods
 		{
 			internal static readonly MethodInfo GetMethodFromHandle =
-				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(default(RuntimeMethodHandle)));
+				ReflectHelper.FastGetMethod(MethodBase.GetMethodFromHandle, default(RuntimeMethodHandle));
 			internal static readonly MethodInfo GetMethodFromHandleWithDeclaringType =
-				ReflectHelper.GetMethod(() => MethodBase.GetMethodFromHandle(default(RuntimeMethodHandle), default(RuntimeTypeHandle)));
+				ReflectHelper.FastGetMethod(MethodBase.GetMethodFromHandle, default(RuntimeMethodHandle), default(RuntimeTypeHandle));
 		}
 
 		internal static class QueryableMethods
 		{
 			internal static readonly MethodInfo SelectDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Select(null, default(Expression<Func<object, object>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Select, default(IQueryable<object>), default(Expression<Func<object, object>>));
 
 			internal static readonly MethodInfo CountDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Count<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Count, default(IQueryable<object>));
 			internal static readonly MethodInfo CountWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Count<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Count, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo LongCountDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.LongCount<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.LongCount, default(IQueryable<object>));
 			internal static readonly MethodInfo LongCountWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.LongCount<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.LongCount, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo AnyDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Any<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Any, default(IQueryable<object>));
 			internal static readonly MethodInfo AnyWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Any<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Any, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 			
 			internal static readonly MethodInfo AllDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.All<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.All, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo FirstDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.First<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.First, default(IQueryable<object>));
 			internal static readonly MethodInfo FirstWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.First<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.First, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo FirstOrDefaultDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.FirstOrDefault<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.FirstOrDefault, default(IQueryable<object>));
 			internal static readonly MethodInfo FirstOrDefaultWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.FirstOrDefault<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.FirstOrDefault, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo SingleDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Single<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Single, default(IQueryable<object>));
 			internal static readonly MethodInfo SingleWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Single<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Single, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo SingleOrDefaultDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.SingleOrDefault<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.SingleOrDefault<object>, default(IQueryable<object>));
 			internal static readonly MethodInfo SingleOrDefaultWithPredicateDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.SingleOrDefault<object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.SingleOrDefault<object>, default(IQueryable<object>), default(Expression<Func<object, bool>>));
 
 			internal static readonly MethodInfo MinDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Min<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Min<object>, default(IQueryable<object>));
 			internal static readonly MethodInfo MinWithSelectorDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Min<object, object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Min<object, object>, default(IQueryable<object>), default(Expression<Func<object, object>>));
 
 			internal static readonly MethodInfo MaxDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Max<object>(null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Max<object>, default(IQueryable<object>));
 			internal static readonly MethodInfo MaxWithSelectorDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Max<object, object>(null, null));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Max<object, object>, default(IQueryable<object>), default(Expression<Func<object, object>>));
 
 			internal static readonly MethodInfo SumOfInt =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<int>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<int>));
 			internal static readonly MethodInfo SumOfNullableInt =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<int?>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<int?>));
 			internal static readonly MethodInfo SumOfLong =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<long>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<long>));
 			internal static readonly MethodInfo SumOfNullableLong =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<long?>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<long?>));
 			internal static readonly MethodInfo SumOfFloat =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<float>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<float>));
 			internal static readonly MethodInfo SumOfNullableFloat =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<float?>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<float?>));
 			internal static readonly MethodInfo SumOfDouble =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<double>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<double>));
 			internal static readonly MethodInfo SumOfNullableDouble =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<double?>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<double?>));
 			internal static readonly MethodInfo SumOfDecimal =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<decimal>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<decimal>));
 			internal static readonly MethodInfo SumOfNullableDecimal =
-				ReflectHelper.GetMethod(() => Queryable.Sum(default(IQueryable<decimal?>)));
+				ReflectHelper.FastGetMethod(Queryable.Sum, default(IQueryable<decimal?>));
 
 			internal static readonly MethodInfo SumWithSelectorOfIntDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, int>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, int>>));
 			internal static readonly MethodInfo SumWithSelectorOfNullableIntDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, int?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, int?>>));
 			internal static readonly MethodInfo SumWithSelectorOfLongDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, long>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, long>>));
 			internal static readonly MethodInfo SumWithSelectorOfNullableLongDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, long?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, long?>>));
 			internal static readonly MethodInfo SumWithSelectorOfFloatDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, float>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, float>>));
 			internal static readonly MethodInfo SumWithSelectorOfNullableFloatDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, float?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, float?>>));
 			internal static readonly MethodInfo SumWithSelectorOfDoubleDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, double>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, double>>));
 			internal static readonly MethodInfo SumWithSelectorOfNullableDoubleDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, double?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, double?>>));
 			internal static readonly MethodInfo SumWithSelectorOfDecimalDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, decimal>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, decimal>>));
 			internal static readonly MethodInfo SumWithSelectorOfNullableDecimalDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Sum(null, default(Expression<Func<object, decimal?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Sum, default(IQueryable<object>), default(Expression<Func<object, decimal?>>));
 
 			internal static readonly MethodInfo AverageOfInt =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<int>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<int>));
 			internal static readonly MethodInfo AverageOfNullableInt =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<int?>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<int?>));
 			internal static readonly MethodInfo AverageOfLong =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<long>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<long>));
 			internal static readonly MethodInfo AverageOfNullableLong =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<long?>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<long?>));
 			internal static readonly MethodInfo AverageOfFloat =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<float>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<float>));
 			internal static readonly MethodInfo AverageOfNullableFloat =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<float?>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<float?>));
 			internal static readonly MethodInfo AverageOfDouble =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<double>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<double>));
 			internal static readonly MethodInfo AverageOfNullableDouble =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<double?>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<double?>));
 			internal static readonly MethodInfo AverageOfDecimal =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<decimal>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<decimal>));
 			internal static readonly MethodInfo AverageOfNullableDecimal =
-				ReflectHelper.GetMethod(() => Queryable.Average(default(IQueryable<decimal?>)));
+				ReflectHelper.FastGetMethod(Queryable.Average, default(IQueryable<decimal?>));
 
 			internal static readonly MethodInfo AverageWithSelectorOfIntDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, int>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, int>>));
 			internal static readonly MethodInfo AverageWithSelectorOfNullableIntDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, int?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, int?>>));
 			internal static readonly MethodInfo AverageWithSelectorOfLongDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, long>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, long>>));
 			internal static readonly MethodInfo AverageWithSelectorOfNullableLongDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, long?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, long?>>));
 			internal static readonly MethodInfo AverageWithSelectorOfFloatDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, float>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, float>>));
 			internal static readonly MethodInfo AverageWithSelectorOfNullableFloatDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, float?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, float?>>));
 			internal static readonly MethodInfo AverageWithSelectorOfDoubleDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, double>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, double>>));
 			internal static readonly MethodInfo AverageWithSelectorOfNullableDoubleDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, double?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, double?>>));
 			internal static readonly MethodInfo AverageWithSelectorOfDecimalDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, decimal>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, decimal>>));
 			internal static readonly MethodInfo AverageWithSelectorOfNullableDecimalDefinition =
-				ReflectHelper.GetMethodDefinition(() => Queryable.Average(null, default(Expression<Func<object, decimal?>>)));
+				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, decimal?>>));
+
+			static QueryableMethods()
+			{
+			}
 		}
 
 		internal static class TypeMethods
 		{
 			internal static readonly MethodInfo GetTypeFromHandle =
-				ReflectHelper.GetMethod(() => System.Type.GetTypeFromHandle(default(RuntimeTypeHandle)));
+				ReflectHelper.FastGetMethod(System.Type.GetTypeFromHandle, default(RuntimeTypeHandle));
 		}
 	}
 }

--- a/src/NHibernate/Util/ReflectionCache.cs
+++ b/src/NHibernate/Util/ReflectionCache.cs
@@ -200,10 +200,6 @@ namespace NHibernate.Util
 				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, decimal>>));
 			internal static readonly MethodInfo AverageWithSelectorOfNullableDecimalDefinition =
 				ReflectHelper.FastGetMethodDefinition(Queryable.Average, default(IQueryable<object>), default(Expression<Func<object, decimal?>>));
-
-			static QueryableMethods()
-			{
-			}
 		}
 
 		internal static class TypeMethods


### PR DESCRIPTION
Usage of ReflectHelper.GetMethod requires a runtime construction of a lambda expression and later deconstruction of it. 

<details>
<summary>The decompiled code of old GetMethod</summary>

```il
    .method public hidebysig 
        instance void M2 () cil managed 
    {
        // Method begins at RVA 0x2080
        // Code size 84 (0x54)
        .maxstack 7

        IL_0000: nop
        IL_0001: ldarg.0
        IL_0002: ldtoken C
        IL_0007: call class [System.Private.CoreLib]System.Type [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
        IL_000c: call class [System.Linq.Expressions]System.Linq.Expressions.ConstantExpression [System.Linq.Expressions]System.Linq.Expressions.Expression::Constant(object, class [System.Private.CoreLib]System.Type)
        IL_0011: ldtoken method instance int32 C::A(int32)
        IL_0016: call class [System.Private.CoreLib]System.Reflection.MethodBase [System.Private.CoreLib]System.Reflection.MethodBase::GetMethodFromHandle(valuetype [System.Private.CoreLib]System.RuntimeMethodHandle)
        IL_001b: castclass [System.Private.CoreLib]System.Reflection.MethodInfo
        IL_0020: ldc.i4.1
        IL_0021: newarr [System.Linq.Expressions]System.Linq.Expressions.Expression
        IL_0026: dup
        IL_0027: ldc.i4.0
        IL_0028: ldc.i4.0
        IL_0029: box [System.Private.CoreLib]System.Int32
        IL_002e: ldtoken [System.Private.CoreLib]System.Int32
        IL_0033: call class [System.Private.CoreLib]System.Type [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
        IL_0038: call class [System.Linq.Expressions]System.Linq.Expressions.ConstantExpression [System.Linq.Expressions]System.Linq.Expressions.Expression::Constant(object, class [System.Private.CoreLib]System.Type)
        IL_003d: stelem.ref
        IL_003e: call class [System.Linq.Expressions]System.Linq.Expressions.MethodCallExpression [System.Linq.Expressions]System.Linq.Expressions.Expression::Call(class [System.Linq.Expressions]System.Linq.Expressions.Expression, class [System.Private.CoreLib]System.Reflection.MethodInfo, class [System.Linq.Expressions]System.Linq.Expressions.Expression[])
        IL_0043: call !!0[] [System.Private.CoreLib]System.Array::Empty<class [System.Linq.Expressions]System.Linq.Expressions.ParameterExpression>()
        IL_0048: call class [System.Linq.Expressions]System.Linq.Expressions.Expression`1<!!0> [System.Linq.Expressions]System.Linq.Expressions.Expression::Lambda<class [System.Private.CoreLib]System.Action>(class [System.Linq.Expressions]System.Linq.Expressions.Expression, class [System.Linq.Expressions]System.Linq.Expressions.ParameterExpression[])
        IL_004d: call class [System.Private.CoreLib]System.Reflection.MethodInfo C::GetMethod(class [System.Linq.Expressions]System.Linq.Expressions.Expression`1<class [System.Private.CoreLib]System.Action>)
        IL_0052: pop
        IL_0053: ret
    } // end of method C::M2

    .method public hidebysig static 
        class [System.Private.CoreLib]System.Reflection.MethodInfo GetMethod (
            class [System.Linq.Expressions]System.Linq.Expressions.Expression`1<class [System.Private.CoreLib]System.Action> 'method'
        ) cil managed 
    {
        // Method begins at RVA 0x20e0
        // Code size 41 (0x29)
        .maxstack 2
        .locals init (
            [0] bool,
            [1] class [System.Private.CoreLib]System.Reflection.MethodInfo
        )

        IL_0000: nop
        IL_0001: ldarg.0
        IL_0002: ldnull
        IL_0003: ceq
        IL_0005: stloc.0
        // sequence point: hidden
        IL_0006: ldloc.0
        IL_0007: brfalse.s IL_0014

        IL_0009: ldstr "method"
        IL_000e: newobj instance void [System.Private.CoreLib]System.ArgumentNullException::.ctor(string)
        IL_0013: throw

        IL_0014: ldarg.0
        IL_0015: callvirt instance class [System.Linq.Expressions]System.Linq.Expressions.Expression [System.Linq.Expressions]System.Linq.Expressions.LambdaExpression::get_Body()
        IL_001a: castclass [System.Linq.Expressions]System.Linq.Expressions.MethodCallExpression
        IL_001f: callvirt instance class [System.Private.CoreLib]System.Reflection.MethodInfo [System.Linq.Expressions]System.Linq.Expressions.MethodCallExpression::get_Method()
        IL_0024: stloc.1
        IL_0025: br.s IL_0027

        IL_0027: ldloc.1
        IL_0028: ret
    } // end of method C::GetMethod

```
</details>

The idea of a new method is that we utilize the creation of the delegate from a method group and later use delegate's `.Method` property.

<details>
<summary>The decompiled code of FastGetMethod</summary>

```il
    // Methods
    .method public hidebysig 
        instance void M1 () cil managed 
    {
        // Method begins at RVA 0x2050
        // Code size 21 (0x15)
        .maxstack 8

        IL_0000: nop
        IL_0001: ldarg.0
        IL_0002: ldftn instance int32 C::A(int32)
        IL_0008: newobj instance void class [System.Private.CoreLib]System.Func`2<int32, int32>::.ctor(object, native int)
        IL_000d: ldc.i4.0
        IL_000e: call class [System.Private.CoreLib]System.Reflection.MethodInfo C::FastGetMethod<int32, int32>(class [System.Private.CoreLib]System.Func`2<!!0, !!1>, !!0)
        IL_0013: pop
        IL_0014: ret
    } // end of method C::M1

    .method public hidebysig static 
        class [System.Private.CoreLib]System.Reflection.MethodInfo FastGetMethod<T, TResult> (
            class [System.Private.CoreLib]System.Func`2<!!T, !!TResult> func,
            !!T a
        ) cil managed 
    {
        // Method begins at RVA 0x2068
        // Code size 12 (0xc)
        .maxstack 1
        .locals init (
            [0] class [System.Private.CoreLib]System.Reflection.MethodInfo
        )

        IL_0000: nop
        IL_0001: ldarg.0
        IL_0002: callvirt instance class [System.Private.CoreLib]System.Reflection.MethodInfo [System.Private.CoreLib]System.Delegate::get_Method()
        IL_0007: stloc.0
        IL_0008: br.s IL_000a

        IL_000a: ldloc.0
        IL_000b: ret
    } // end of method C::FastGetMethod
```
</details>