### PR TITLE
Obsolete IdentitySet class

### DIFF
--- a/src/NHibernate.Test/UtilityTest/IdentitySetFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/IdentitySetFixture.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using NHibernate.Util;
 using NUnit.Framework;
 
@@ -10,6 +9,8 @@ namespace NHibernate.Test.UtilityTest
 	/// <summary>
 	/// Test for the IdentityMap.
 	/// </summary>
+	// Since 5.3
+	[Obsolete("This class has no more usages and will be removed in a future version")]
 	[TestFixture]
 	public class IdentitySetFixture
 	{

--- a/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Engine.Query
 			}
 
 			IList combinedResults = results ?? new List<object>();
-			IdentitySet distinction = new IdentitySet();
+			var distinction = new HashSet<object>(ReferenceComparer<object>.Instance);
 			int includedCount = -1;
 			for (int i = 0; i < Translators.Length; i++)
 			{

--- a/src/NHibernate/Async/Event/Default/DefaultDeleteEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultDeleteEventListener.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Event.Default
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return OnDeleteAsync(@event, new IdentitySet(), cancellationToken);
+			return OnDeleteAsync(@event, new HashSet<object>(ReferenceComparer<object>.Instance), cancellationToken);
 		}
 
 		public virtual async Task OnDeleteAsync(DeleteEvent @event, ISet<object> transientEntities, CancellationToken cancellationToken)
@@ -145,7 +145,7 @@ namespace NHibernate.Event.Default
 			// NH different impl : NH-1895
 			if(transientEntities == null)
 			{
-				transientEntities = new HashSet<object>();
+				transientEntities = new HashSet<object>(ReferenceComparer<object>.Instance);
 			}
 			if (!transientEntities.Add(entity))
 			{

--- a/src/NHibernate/Async/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
+++ b/src/NHibernate/Async/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
@@ -77,7 +77,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 
 				int size = results.Count;
 				var tmp = new List<object>();
-				var distinction = new IdentitySet();
+				var distinction = new HashSet<object>(ReferenceComparer<object>.Instance);
 
 				for ( int i = 0; i < size; i++ ) 
 				{

--- a/src/NHibernate/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Engine/Query/HQLQueryPlan.cs
@@ -108,7 +108,7 @@ namespace NHibernate.Engine.Query
 			}
 
 			IList combinedResults = results ?? new List<object>();
-			IdentitySet distinction = new IdentitySet();
+			var distinction = new HashSet<object>(ReferenceComparer<object>.Instance);
 			int includedCount = -1;
 			for (int i = 0; i < Translators.Length; i++)
 			{

--- a/src/NHibernate/Event/Default/DefaultDeleteEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultDeleteEventListener.cs
@@ -26,7 +26,7 @@ namespace NHibernate.Event.Default
 		/// <param name="event">The delete event to be handled. </param>
 		public virtual void OnDelete(DeleteEvent @event)
 		{
-			OnDelete(@event, new IdentitySet());
+			OnDelete(@event, new HashSet<object>(ReferenceComparer<object>.Instance));
 		}
 
 		public virtual void OnDelete(DeleteEvent @event, ISet<object> transientEntities)
@@ -143,7 +143,7 @@ namespace NHibernate.Event.Default
 			// NH different impl : NH-1895
 			if(transientEntities == null)
 			{
-				transientEntities = new HashSet<object>();
+				transientEntities = new HashSet<object>(ReferenceComparer<object>.Instance);
 			}
 			if (!transientEntities.Add(entity))
 			{

--- a/src/NHibernate/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
@@ -123,7 +123,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 
 				int size = results.Count;
 				var tmp = new List<object>();
-				var distinction = new IdentitySet();
+				var distinction = new HashSet<object>(ReferenceComparer<object>.Instance);
 
 				for ( int i = 0; i < size; i++ ) 
 				{

--- a/src/NHibernate/Util/IdentitySet.cs
+++ b/src/NHibernate/Util/IdentitySet.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace NHibernate.Util
 {
 	/// <summary> 
 	/// Set implementation that use reference equals instead of Equals() as its comparison mechanism.
 	/// </summary>
+	// Since 5.3
+	[Obsolete("This class has no more usages and will be removed in a future version")]
 	public class IdentitySet : ISet<object>
 	{
 		private IDictionary map;


### PR DESCRIPTION
All usages replaced with `new HashSet<object>(ReferenceComparer<object>.Instance)`