### PR TITLE
Rename ISQLFunctionExtended.FunctionName to Name

### DIFF
--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -148,7 +148,7 @@ namespace NHibernate.Dialect
 
 			public override SqlString Render(IList args, ISessionFactoryImplementor factory)
 			{
-				return new SqlString("cast('", FunctionName, "' as ", FunctionReturnType.SqlTypes(factory)[0].ToString(), ")");
+				return new SqlString("cast('", Name, "' as ", FunctionReturnType.SqlTypes(factory)[0].ToString(), ")");
 			}
 		}
 
@@ -161,7 +161,7 @@ namespace NHibernate.Dialect
 
 			public override SqlString Render(IList args, ISessionFactoryImplementor factory)
 			{
-				return new SqlString(FunctionName);
+				return new SqlString(Name);
 			}
 		}
 
@@ -235,7 +235,7 @@ namespace NHibernate.Dialect
 			}
 
 			/// <inheritdoc />
-			public string FunctionName => "position";
+			public string Name => "position";
 
 			public bool HasArguments
 			{

--- a/src/NHibernate/Dialect/Function/AnsiSubstringFunction.cs
+++ b/src/NHibernate/Dialect/Function/AnsiSubstringFunction.cs
@@ -50,7 +50,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => "substring";
+		public string Name => "substring";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/AnsiTrimEmulationFunction.cs
+++ b/src/NHibernate/Dialect/Function/AnsiTrimEmulationFunction.cs
@@ -98,7 +98,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => null;
+		public string Name => null;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/BitwiseFunctionOperation.cs
+++ b/src/NHibernate/Dialect/Function/BitwiseFunctionOperation.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => _functionName;
+		public string Name => _functionName;
 
 		/// <inheritdoc />
 		public bool HasArguments => true;

--- a/src/NHibernate/Dialect/Function/BitwiseNativeOperation.cs
+++ b/src/NHibernate/Dialect/Function/BitwiseNativeOperation.cs
@@ -89,7 +89,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => null;
+		public string Name => null;
 
 		/// <inheritdoc />
 		public bool HasArguments => true;

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => "cast";
+		public string Name => "cast";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/CharIndexFunction.cs
+++ b/src/NHibernate/Dialect/Function/CharIndexFunction.cs
@@ -43,7 +43,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => "charindex";
+		public string Name => "charindex";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/ClassicAggregateFunction.cs
+++ b/src/NHibernate/Dialect/Function/ClassicAggregateFunction.cs
@@ -63,7 +63,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => name;
+		public string Name => name;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/ISQLFunctionExtended.cs
+++ b/src/NHibernate/Dialect/Function/ISQLFunctionExtended.cs
@@ -10,7 +10,7 @@ namespace NHibernate.Dialect.Function
 		/// <summary>
 		/// The function name or <see langword="null"/> when multiple functions/operators/statements are used.
 		/// </summary>
-		string FunctionName { get; }
+		string Name { get; }
 
 		/// <summary>
 		/// Get the function general return type, ignoring underlying database specifics.

--- a/src/NHibernate/Dialect/Function/NoArgSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/NoArgSQLFunction.cs
@@ -21,18 +21,12 @@ namespace NHibernate.Dialect.Function
 
 		public NoArgSQLFunction(string name, IType returnType, bool hasParenthesesIfNoArguments)
 		{
-#pragma warning disable 618
 			Name = name;
-#pragma warning restore 618
 			FunctionReturnType = returnType;
 			HasParenthesesIfNoArguments = hasParenthesesIfNoArguments;
 		}
 
 		public IType FunctionReturnType { get; protected set; }
-
-		// Since v5.3
-		[Obsolete("Use FunctionName property instead.")]
-		public string Name { get; protected set; }
 
 		#region ISQLFunction Members
 
@@ -58,9 +52,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-#pragma warning disable 618
-		public string FunctionName => Name;
-#pragma warning restore 618
+		public string Name { get; protected set; }
 
 		public bool HasArguments
 		{
@@ -73,15 +65,15 @@ namespace NHibernate.Dialect.Function
 		{
 			if (args.Count > 0)
 			{
-				throw new QueryException("function takes no arguments: " + FunctionName);
+				throw new QueryException("function takes no arguments: " + Name);
 			}
 
 			if (HasParenthesesIfNoArguments)
 			{
-				return new SqlString(FunctionName + "()");
+				return new SqlString(Name + "()");
 			}
 
-			return new SqlString(FunctionName);
+			return new SqlString(Name);
 		}
 
 		#endregion

--- a/src/NHibernate/Dialect/Function/NvlFunction.cs
+++ b/src/NHibernate/Dialect/Function/NvlFunction.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => "nvl";
+		public string Name => "nvl";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/PositionSubstringFunction.cs
+++ b/src/NHibernate/Dialect/Function/PositionSubstringFunction.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => "position";
+		public string Name => "position";
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
+++ b/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
@@ -104,7 +104,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public virtual string FunctionName => null;
+		public virtual string Name => null;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/StandardSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/StandardSQLFunction.cs
@@ -67,7 +67,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public string FunctionName => name;
+		public string Name => name;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/Function/VarArgsSQLFunction.cs
+++ b/src/NHibernate/Dialect/Function/VarArgsSQLFunction.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Dialect.Function
 		}
 
 		/// <inheritdoc />
-		public virtual string FunctionName => null;
+		public virtual string Name => null;
 
 		public bool HasArguments
 		{

--- a/src/NHibernate/Dialect/HanaDialectBase.cs
+++ b/src/NHibernate/Dialect/HanaDialectBase.cs
@@ -58,7 +58,7 @@ namespace NHibernate.Dialect
 			}
 
 			/// <inheritdoc />
-			public virtual string FunctionName => "cast";
+			public virtual string Name => "cast";
 
 			public bool HasArguments => true;
 

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -583,7 +583,7 @@ namespace NHibernate.Dialect
 
 			public override SqlString Render(IList args, ISessionFactoryImplementor factory)
 			{
-				return new SqlString(FunctionName);
+				return new SqlString(Name);
 			}
 		}
 		[Serializable]
@@ -619,7 +619,7 @@ namespace NHibernate.Dialect
 			}
 
 			/// <inheritdoc />
-			public string FunctionName => "instr";
+			public string Name => "instr";
 
 			public bool HasArguments
 			{

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -400,7 +400,7 @@ namespace NHibernate.Dialect
 			}
 
 			/// <inheritdoc />
-			public string FunctionName => _name;
+			public string Name => _name;
 
 			public bool HasArguments => true;
 

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/AggregateNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/AggregateNode.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			{
 				if (SessionFactoryHelper.FindSQLFunction(Text) is ISQLFunctionExtended sqlFunction)
 				{
-					return sqlFunction.FunctionName;
+					return sqlFunction.Name;
 				}
 
 				return Text;


### PR DESCRIPTION
Suggested by @hazzik  in [comment](https://github.com/nhibernate/nhibernate-core/pull/2061#discussion_r412479614), to avoid the need of obsoleting `NoArgSQLFunction.Name`.