### PR TITLE
Replace SafetyEnumerable<T> with OfType<T> where applicable

### DIFF
--- a/src/NHibernate.Test/UtilityTest/SafetyEnumerableFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/SafetyEnumerableFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NHibernate.Util;
 using NUnit.Framework;
@@ -7,6 +8,8 @@ namespace NHibernate.Test.UtilityTest
 	/// <summary>
 	/// Test cases for the <see cref="SafetyEnumerable{T}"/> class.
 	/// </summary>
+	// Since v5.3 
+	[Obsolete("This class has no more usages and will be removed in a future version")]
 	[TestFixture]
 	public class SafetyEnumerableFixture
 	{

--- a/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
@@ -128,7 +128,7 @@ namespace NHibernate.Engine.Query
 		public async Task<IEnumerable<T>> PerformIterateAsync<T>(QueryParameters queryParameters, IEventSource session, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			return new SafetyEnumerable<T>(await (PerformIterateAsync(queryParameters, session, cancellationToken)).ConfigureAwait(false));
+			return (await (PerformIterateAsync(queryParameters, session, cancellationToken)).ConfigureAwait(false)).CastOrDefault<T>();
 		}
 
         public async Task<int> PerformExecuteUpdateAsync(QueryParameters queryParameters, ISessionImplementor session, CancellationToken cancellationToken)

--- a/src/NHibernate/Cfg/XmlHbmBinding/RootClassBinder.cs
+++ b/src/NHibernate/Cfg/XmlHbmBinding/RootClassBinder.cs
@@ -90,7 +90,7 @@ namespace NHibernate.Cfg.XmlHbmBinding
 						property.IsUpdateable = false;
 					property.IsNaturalIdentifier = true;
 
-					uk.AddColumns(property.ColumnIterator.OfType<Column>());
+					uk.AddColumns(property.ColumnIterator);
 				});
 
 			rootClass.Table.AddUniqueKey(uk);	

--- a/src/NHibernate/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Engine/Query/HQLQueryPlan.cs
@@ -176,7 +176,7 @@ namespace NHibernate.Engine.Query
 
 		public IEnumerable<T> PerformIterate<T>(QueryParameters queryParameters, IEventSource session)
 		{
-			return new SafetyEnumerable<T>(PerformIterate(queryParameters, session));
+			return PerformIterate(queryParameters, session).CastOrDefault<T>();
 		}
 
         public int PerformExecuteUpdate(QueryParameters queryParameters, ISessionImplementor session)

--- a/src/NHibernate/Mapping/Constraint.cs
+++ b/src/NHibernate/Mapping/Constraint.cs
@@ -91,9 +91,13 @@ namespace NHibernate.Mapping
 		{
 			foreach (Column col in columnIterator)
 			{
-				if (!col.IsFormula)
-					AddColumn(col);
+				AddColumn(col);
 			}
+		}
+
+		public void AddColumns(IEnumerable<ISelectable> columnIterator)
+		{
+			AddColumns(columnIterator.OfType<Column>());
 		}
 
 		/// <summary>

--- a/src/NHibernate/Mapping/IdentifierCollection.cs
+++ b/src/NHibernate/Mapping/IdentifierCollection.cs
@@ -1,6 +1,5 @@
 using System;
 using NHibernate.Engine;
-using NHibernate.Util;
 
 namespace NHibernate.Mapping
 {
@@ -40,7 +39,7 @@ namespace NHibernate.Mapping
 			if (!IsOneToMany)
 			{
 				PrimaryKey pk = new PrimaryKey();
-				pk.AddColumns(new SafetyEnumerable<Column>(Identifier.ColumnIterator));
+				pk.AddColumns(Identifier.ColumnIterator);
 				CollectionTable.PrimaryKey = pk;
 			}
 			//else // Create an index on the key columns?

--- a/src/NHibernate/Mapping/IndexedCollection.cs
+++ b/src/NHibernate/Mapping/IndexedCollection.cs
@@ -1,6 +1,5 @@
 using System;
 using NHibernate.Engine;
-using NHibernate.Util;
 
 namespace NHibernate.Mapping
 {
@@ -40,7 +39,7 @@ namespace NHibernate.Mapping
 			if (!IsOneToMany)
 			{
 				PrimaryKey pk = new PrimaryKey();
-				pk.AddColumns(new SafetyEnumerable<Column>(Key.ColumnIterator));
+				pk.AddColumns(Key.ColumnIterator);
 
 				// index should be last column listed
 				bool isFormula = false;
@@ -52,11 +51,11 @@ namespace NHibernate.Mapping
 				if (isFormula)
 				{
 					//if it is a formula index, use the element columns in the PK
-					pk.AddColumns(new SafetyEnumerable<Column>(Element.ColumnIterator));
+					pk.AddColumns(Element.ColumnIterator);
 				}
 				else
 				{
-					pk.AddColumns(new SafetyEnumerable<Column>(Index.ColumnIterator));
+					pk.AddColumns(Index.ColumnIterator);
 				}
 
 				CollectionTable.PrimaryKey = pk;

--- a/src/NHibernate/Mapping/Join.cs
+++ b/src/NHibernate/Mapping/Join.cs
@@ -100,7 +100,7 @@ namespace NHibernate.Mapping
 			pk.Name = PK_ALIAS.ToAliasString(table.Name);
 			table.PrimaryKey = pk;
 
-			pk.AddColumns(Key.ColumnIterator.OfType<Column>());
+			pk.AddColumns(Key.ColumnIterator);
 		}
 
 		public int PropertySpan

--- a/src/NHibernate/Mapping/ManyToOne.cs
+++ b/src/NHibernate/Mapping/ManyToOne.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using NHibernate.Type;
-using NHibernate.Util;
 using System;
+using System.Linq;
 
 namespace NHibernate.Mapping
 {
@@ -77,7 +77,7 @@ namespace NHibernate.Mapping
 
 				if (!HasFormula && !"none".Equals(ForeignKeyName, StringComparison.OrdinalIgnoreCase))
 				{
-					IEnumerable<Column> ce = new SafetyEnumerable<Column>(property.ColumnIterator);
+					IEnumerable<Column> ce = property.ColumnIterator.OfType<Column>();
 
 					// NH : Ensure that related columns have same length
 					ForeignKey.AlignColumns(ConstraintColumns, ce);

--- a/src/NHibernate/Mapping/OneToOne.cs
+++ b/src/NHibernate/Mapping/OneToOne.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Type;
 using NHibernate.Util;
 
@@ -40,10 +41,7 @@ namespace NHibernate.Mapping
 		}
 
 		/// <summary></summary>
-		public override IEnumerable<Column> ConstraintColumns
-		{
-			get { return new SafetyEnumerable<Column>(identifier.ColumnIterator); }
-		}
+		public override IEnumerable<Column> ConstraintColumns => identifier.ColumnIterator.OfType<Column>();
 
 		/// <summary></summary>
 		public bool IsConstrained

--- a/src/NHibernate/Mapping/PersistentClass.cs
+++ b/src/NHibernate/Mapping/PersistentClass.cs
@@ -761,7 +761,7 @@ namespace NHibernate.Mapping
 			pk.Name = PKAlias.ToAliasString(table.Name);
 			table.PrimaryKey = pk;
 
-			pk.AddColumns(new SafetyEnumerable<Column>(Key.ColumnIterator));
+			pk.AddColumns(Key.ColumnIterator);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Mapping/SimpleValue.cs
+++ b/src/NHibernate/Mapping/SimpleValue.cs
@@ -37,10 +37,7 @@ namespace NHibernate.Mapping
 			this.table = table;
 		}
 
-		public virtual IEnumerable<Column> ConstraintColumns
-		{
-			get { return new SafetyEnumerable<Column>(columns); }
-		}
+		public virtual IEnumerable<Column> ConstraintColumns => columns.OfType<Column>();
 
 		public string ForeignKeyName
 		{

--- a/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/JoinedSubclassEntityPersister.cs
@@ -140,8 +140,7 @@ namespace NHibernate.Persister.Entity
 					tables.Add(tabname);
 
 					var keyCols = new List<string>(idColumnSpan);
-					var enumerableKCols = new SafetyEnumerable<Column>(key.ColumnIterator);
-					foreach (var kcol in enumerableKCols)
+					foreach (var kcol in key.ColumnIterator.OfType<Column>())
 						keyCols.Add(kcol.GetQuotedName(factory.Dialect));
 
 					keyColumns.Add(keyCols.ToArray());

--- a/src/NHibernate/SqlCommand/SqlInsertBuilder.cs
+++ b/src/NHibernate/SqlCommand/SqlInsertBuilder.cs
@@ -219,7 +219,7 @@ namespace NHibernate.SqlCommand
 
 		public SqlType[] GetParametersTypeArray()
 		{
-			return new SafetyEnumerable<SqlType>(columns.Values).ToArray();
+			return columns.Values.OfType<SqlType>().ToArray();
 		}
 	}
 }

--- a/src/NHibernate/SqlCommand/SqlUpdateBuilder.cs
+++ b/src/NHibernate/SqlCommand/SqlUpdateBuilder.cs
@@ -356,7 +356,8 @@ namespace NHibernate.SqlCommand
 		public SqlCommandInfo ToSqlCommandInfo()
 		{
 			SqlString text = ToSqlString();
-			List<SqlType> parameterTypes = new List<SqlType>(new SafetyEnumerable<SqlType>(columns.Values));
+
+			var parameterTypes = columns.Values.OfType<SqlType>().ToList(); 
 			parameterTypes.AddRange(whereParameterTypes);
 			return new SqlCommandInfo(text, parameterTypes.ToArray());
 		}

--- a/src/NHibernate/Util/EnumerableExtensions.cs
+++ b/src/NHibernate/Util/EnumerableExtensions.cs
@@ -107,5 +107,15 @@ namespace NHibernate.Util
 		{
 			return list ?? Array.Empty<T>();
 		}
+
+		internal static IEnumerable<T> CastOrDefault<T>(this IEnumerable list)
+		{
+			foreach (var obj in list)
+			{
+				yield return obj == null
+					? default(T)
+					: (T) obj;
+			}
+		}
 	}
 }

--- a/src/NHibernate/Util/SafetyEnumerable.cs
+++ b/src/NHibernate/Util/SafetyEnumerable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -7,6 +8,8 @@ namespace NHibernate.Util
 	/// Used to ensure a collection filtering a given IEnumerable by a certain type.
 	/// </summary>
 	/// <typeparam name="T">The type used like filter.</typeparam>
+	// Since v5.3 
+	[Obsolete("This class has no more usages and will be removed in a future version")]
 	public class SafetyEnumerable<T> : IEnumerable<T>
 	{
 		/*

--- a/src/NHibernate/Util/SafetyEnumerable.cs
+++ b/src/NHibernate/Util/SafetyEnumerable.cs
@@ -25,8 +25,8 @@ namespace NHibernate.Util
 			{
 				if (element == null)
 					yield return default(T);
-				else if (element is T)
-					yield return (T) element;
+				else if (element is T elem)
+					yield return elem;
 			}
 		}
 


### PR DESCRIPTION
Obsolete `SafetyEnumerable<T>` by replacing with `OfType<T>` extension.
Exception  [`HQLQueryPlan`](https://github.com/nhibernate/nhibernate-core/blob/b25f9227249a34663bee56269ddf0946306184a2/src/NHibernate/Engine/Query/HQLQueryPlan.cs#L179)  where `Cast` is applied (as more appropriate behavior in this context)