### PR TITLE
Fix OData string comparisons (lt, gt, ge, le)

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ODataTests.cs
@@ -94,7 +94,7 @@ namespace NHibernate.Test.Linq
 		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1, true)]
 		public async Task StringFilterAsync(string queryString, int expectedCount, bool locateFunction = false)
 		{
-			if(locateFunction && !TestDialect.SupportsLocate)
+			if (locateFunction && !TestDialect.SupportsLocate)
 				Assert.Ignore("Locate function is not supported.");
 
 			Assert.That(

--- a/src/NHibernate.Test/Async/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ODataTests.cs
@@ -91,9 +91,12 @@ namespace NHibernate.Test.Linq
 		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
 		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
 		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]
-		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1)]
-		public async Task StringFilterAsync(string queryString, int expectedCount)
+		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1, true)]
+		public async Task StringFilterAsync(string queryString, int expectedCount, bool locateFunction = false)
 		{
+			if(locateFunction && !TestDialect.SupportsLocate)
+				Assert.Ignore("Locate function is not supported.");
+
 			Assert.That(
 				await (ApplyFilter(session.Query<Customer>(), queryString).Cast<Customer>().ToListAsync()),
 				Has.Count.EqualTo(expectedCount));

--- a/src/NHibernate.Test/Async/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ODataTests.cs
@@ -87,6 +87,17 @@ namespace NHibernate.Test.Linq
 			Assert.That(results, Has.Count.EqualTo(expectedRows));
 		}
 
+		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
+		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
+		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]
+		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1)]
+		public async Task StringFilterAsync(string queryString, int expectedCount)
+		{
+			Assert.That(
+				await (ApplyFilter(session.Query<Customer>(), queryString).Cast<Customer>().ToListAsync()),
+				Has.Count.EqualTo(expectedCount));
+		}
+
 		private IQueryable ApplyFilter<T>(IQueryable<T> query, string queryString)
 		{
 			var context = new ODataQueryContext(CreatEdmModel(), typeof(T), null) { };

--- a/src/NHibernate.Test/Async/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ODataTests.cs
@@ -88,15 +88,12 @@ namespace NHibernate.Test.Linq
 		}
 
 		//GH-2362
-		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
+		[TestCase("$filter=CustomerId le 'ANATR'", 2)]
 		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
 		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]
-		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1, true)]
-		public async Task StringFilterAsync(string queryString, int expectedCount, bool locateFunction = false)
+		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1)]
+		public async Task StringFilterAsync(string queryString, int expectedCount)
 		{
-			if (locateFunction && !TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function is not supported.");
-
 			Assert.That(
 				await (ApplyFilter(session.Query<Customer>(), queryString).Cast<Customer>().ToListAsync()),
 				Has.Count.EqualTo(expectedCount));

--- a/src/NHibernate.Test/Async/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ODataTests.cs
@@ -87,6 +87,7 @@ namespace NHibernate.Test.Linq
 			Assert.That(results, Has.Count.EqualTo(expectedRows));
 		}
 
+		//GH-2362
 		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
 		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
 		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]

--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -442,8 +442,11 @@ namespace NHibernate.Test.Linq
 					await (AssertStringComparisonWarningAsync(x => string.Compare(x.CustomerId, "ANATR", StringComparison.Ordinal) <= 0, 2));
 					await (AssertStringComparisonWarningAsync(x => x.CustomerId.StartsWith("ANATR", StringComparison.Ordinal), 1));
 					await (AssertStringComparisonWarningAsync(x => x.CustomerId.EndsWith("ANATR", StringComparison.Ordinal), 1));
-					await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1));
-					await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1));
+					if (TestDialect.SupportsLocate)
+					{
+						await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1));
+						await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1));
+					}
 #if NETCOREAPP2_0
 					await (AssertStringComparisonWarningAsync(x => x.CustomerId.Replace("AN", "XX", StringComparison.Ordinal) == "XXATR", 1));
 #endif

--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -433,7 +433,7 @@ namespace NHibernate.Test.Linq
 			Assert.That(users.Count, Is.EqualTo(1));
 		}
 
-		[Test()]
+		[Test]
 		public void StringComparisonParamEmitsWarningAsync()
 		{
 			Assert.Multiple(
@@ -442,18 +442,15 @@ namespace NHibernate.Test.Linq
 					await (AssertStringComparisonWarningAsync(x => string.Compare(x.CustomerId, "ANATR", StringComparison.Ordinal) <= 0, 2));
 					await (AssertStringComparisonWarningAsync(x => x.CustomerId.StartsWith("ANATR", StringComparison.Ordinal), 1));
 					await (AssertStringComparisonWarningAsync(x => x.CustomerId.EndsWith("ANATR", StringComparison.Ordinal), 1));
-					if (TestDialect.SupportsLocate)
-					{
-						await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1));
-						await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1));
-					}
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1));
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1));
 #if NETCOREAPP2_0
 					await (AssertStringComparisonWarningAsync(x => x.CustomerId.Replace("AN", "XX", StringComparison.Ordinal) == "XXATR", 1));
 #endif
 				});
 		}
 
-		private async Task AssertStringComparisonWarningAsync(Expression<Func<Customer,bool>> whereParam, int expected, CancellationToken cancellationToken = default(CancellationToken))
+		private async Task AssertStringComparisonWarningAsync(Expression<Func<Customer, bool>> whereParam, int expected, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			using (var log = new LogSpy(typeof(BaseHqlGeneratorForMethod)))
 			{

--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -14,14 +14,17 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
+using log4net.Core;
 using NHibernate.Engine.Query;
 using NHibernate.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
+using NHibernate.Linq.Functions;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
+	using System.Threading;
 	[TestFixture]
 	public class WhereTestsAsync : LinqTestCase
 	{
@@ -428,6 +431,34 @@ namespace NHibernate.Test.Linq
 			var users = await (session.CreateQuery("from User u where (case when u.Name is null then 'false' else (case when u.Name LIKE '%yend%' then 'true' else 'false' end) end) = 'true'").ListAsync<User>());
 
 			Assert.That(users.Count, Is.EqualTo(1));
+		}
+
+		[Test()]
+		public void StringComparisonParamEmitsWarningAsync()
+		{
+			Assert.Multiple(
+				async () =>
+				{
+					await (AssertStringComparisonWarningAsync(x => string.Compare(x.CustomerId, "ANATR", StringComparison.Ordinal) <= 0, 2));
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.StartsWith("ANATR", StringComparison.Ordinal), 1));
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.EndsWith("ANATR", StringComparison.Ordinal), 1));
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1));
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1));
+#if NETCOREAPP2_0
+					await (AssertStringComparisonWarningAsync(x => x.CustomerId.Replace("AN", "XX", StringComparison.Ordinal) == "XXATR", 1));
+#endif
+				});
+		}
+
+		private async Task AssertStringComparisonWarningAsync(Expression<Func<Customer,bool>> whereParam, int expected, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			using (var log = new LogSpy(typeof(BaseHqlGeneratorForMethod)))
+			{
+				var customers = await (session.Query<Customer>().Where(whereParam).ToListAsync(cancellationToken));
+
+				Assert.That(customers, Has.Count.EqualTo(expected), whereParam.ToString);
+				Assert.That(log.GetWholeLog(), Does.Contain($"parameter of type '{nameof(StringComparison)}' is ignored"), whereParam.ToString);
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Linq/ODataTests.cs
@@ -75,6 +75,7 @@ namespace NHibernate.Test.Linq
 			Assert.That(results, Has.Count.EqualTo(expectedRows));
 		}
 
+		//GH-2362
 		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
 		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
 		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]

--- a/src/NHibernate.Test/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Linq/ODataTests.cs
@@ -79,9 +79,12 @@ namespace NHibernate.Test.Linq
 		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
 		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
 		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]
-		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1)]
-		public void StringFilter(string queryString, int expectedCount)
+		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1, true)]
+		public void StringFilter(string queryString, int expectedCount, bool locateFunction = false)
 		{
+			if(locateFunction && !TestDialect.SupportsLocate)
+				Assert.Ignore("Locate function is not supported.");
+
 			Assert.That(
 				ApplyFilter(session.Query<Customer>(), queryString).Cast<Customer>().ToList(),
 				Has.Count.EqualTo(expectedCount));

--- a/src/NHibernate.Test/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Linq/ODataTests.cs
@@ -75,6 +75,17 @@ namespace NHibernate.Test.Linq
 			Assert.That(results, Has.Count.EqualTo(expectedRows));
 		}
 
+		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
+		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
+		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]
+		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1)]
+		public void StringFilter(string queryString, int expectedCount)
+		{
+			Assert.That(
+				ApplyFilter(session.Query<Customer>(), queryString).Cast<Customer>().ToList(),
+				Has.Count.EqualTo(expectedCount));
+		}
+
 		private IQueryable ApplyFilter<T>(IQueryable<T> query, string queryString)
 		{
 			var context = new ODataQueryContext(CreatEdmModel(), typeof(T), null) { };

--- a/src/NHibernate.Test/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Linq/ODataTests.cs
@@ -76,15 +76,12 @@ namespace NHibernate.Test.Linq
 		}
 
 		//GH-2362
-		[TestCase("$filter=CustomerId le 'ANATR'",2 )]
+		[TestCase("$filter=CustomerId le 'ANATR'", 2)]
 		[TestCase("$filter=startswith(CustomerId, 'ANATR')", 1)]
 		[TestCase("$filter=endswith(CustomerId, 'ANATR')", 1)]
-		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1, true)]
-		public void StringFilter(string queryString, int expectedCount, bool locateFunction = false)
+		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1)]
+		public void StringFilter(string queryString, int expectedCount)
 		{
-			if (locateFunction && !TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function is not supported.");
-
 			Assert.That(
 				ApplyFilter(session.Query<Customer>(), queryString).Cast<Customer>().ToList(),
 				Has.Count.EqualTo(expectedCount));

--- a/src/NHibernate.Test/Linq/ODataTests.cs
+++ b/src/NHibernate.Test/Linq/ODataTests.cs
@@ -82,7 +82,7 @@ namespace NHibernate.Test.Linq
 		[TestCase("$filter=indexof(CustomerId, 'ANATR') eq 0", 1, true)]
 		public void StringFilter(string queryString, int expectedCount, bool locateFunction = false)
 		{
-			if(locateFunction && !TestDialect.SupportsLocate)
+			if (locateFunction && !TestDialect.SupportsLocate)
 				Assert.Ignore("Locate function is not supported.");
 
 			Assert.That(

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -421,7 +421,7 @@ namespace NHibernate.Test.Linq
 			Assert.That(users.Count, Is.EqualTo(1));
 		}
 
-		[Test()]
+		[Test]
 		public void StringComparisonParamEmitsWarning()
 		{
 			Assert.Multiple(
@@ -430,18 +430,15 @@ namespace NHibernate.Test.Linq
 					AssertStringComparisonWarning(x => string.Compare(x.CustomerId, "ANATR", StringComparison.Ordinal) <= 0, 2);
 					AssertStringComparisonWarning(x => x.CustomerId.StartsWith("ANATR", StringComparison.Ordinal), 1);
 					AssertStringComparisonWarning(x => x.CustomerId.EndsWith("ANATR", StringComparison.Ordinal), 1);
-					if (TestDialect.SupportsLocate)
-					{
-						AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1);
-						AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1);
-					}
+					AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1);
+					AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1);
 #if NETCOREAPP2_0
 					AssertStringComparisonWarning(x => x.CustomerId.Replace("AN", "XX", StringComparison.Ordinal) == "XXATR", 1);
 #endif
 				});
 		}
 
-		private void AssertStringComparisonWarning(Expression<Func<Customer,bool>> whereParam, int expected)
+		private void AssertStringComparisonWarning(Expression<Func<Customer, bool>> whereParam, int expected)
 		{
 			using (var log = new LogSpy(typeof(BaseHqlGeneratorForMethod)))
 			{

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -4,9 +4,11 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
+using log4net.Core;
 using NHibernate.Engine.Query;
 using NHibernate.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
+using NHibernate.Linq.Functions;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
@@ -417,6 +419,34 @@ namespace NHibernate.Test.Linq
 			var users = session.CreateQuery("from User u where (case when u.Name is null then 'false' else (case when u.Name LIKE '%yend%' then 'true' else 'false' end) end) = 'true'").List<User>();
 
 			Assert.That(users.Count, Is.EqualTo(1));
+		}
+
+		[Test()]
+		public void StringComparisonParamEmitsWarning()
+		{
+			Assert.Multiple(
+				() =>
+				{
+					AssertStringComparisonWarning(x => string.Compare(x.CustomerId, "ANATR", StringComparison.Ordinal) <= 0, 2);
+					AssertStringComparisonWarning(x => x.CustomerId.StartsWith("ANATR", StringComparison.Ordinal), 1);
+					AssertStringComparisonWarning(x => x.CustomerId.EndsWith("ANATR", StringComparison.Ordinal), 1);
+					AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1);
+					AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1);
+#if NETCOREAPP2_0
+					AssertStringComparisonWarning(x => x.CustomerId.Replace("AN", "XX", StringComparison.Ordinal) == "XXATR", 1);
+#endif
+				});
+		}
+
+		private void AssertStringComparisonWarning(Expression<Func<Customer,bool>> whereParam, int expected)
+		{
+			using (var log = new LogSpy(typeof(BaseHqlGeneratorForMethod)))
+			{
+				var customers = session.Query<Customer>().Where(whereParam).ToList();
+
+				Assert.That(customers, Has.Count.EqualTo(expected), whereParam.ToString);
+				Assert.That(log.GetWholeLog(), Does.Contain($"parameter of type '{nameof(StringComparison)}' is ignored"), whereParam.ToString);
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -430,8 +430,11 @@ namespace NHibernate.Test.Linq
 					AssertStringComparisonWarning(x => string.Compare(x.CustomerId, "ANATR", StringComparison.Ordinal) <= 0, 2);
 					AssertStringComparisonWarning(x => x.CustomerId.StartsWith("ANATR", StringComparison.Ordinal), 1);
 					AssertStringComparisonWarning(x => x.CustomerId.EndsWith("ANATR", StringComparison.Ordinal), 1);
-					AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1);
-					AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1);
+					if (TestDialect.SupportsLocate)
+					{
+						AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", StringComparison.Ordinal) == 0, 1);
+						AssertStringComparisonWarning(x => x.CustomerId.IndexOf("ANATR", 0, StringComparison.Ordinal) == 0, 1);
+					}
 #if NETCOREAPP2_0
 					AssertStringComparisonWarning(x => x.CustomerId.Replace("AN", "XX", StringComparison.Ordinal) == "XXATR", 1);
 #endif

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -105,6 +105,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("current_date", new SQLFunctionTemplate(NHibernateUtil.LocalDate, "datetime(date(current_timestamp, 'localtime'))"));
 
 			RegisterFunction("substring", new StandardSQLFunction("substr", NHibernateUtil.String));
+			RegisterFunction("locate", new StandardSQLFunction("instr",  NHibernateUtil.Int32));
 			RegisterFunction("left", new SQLFunctionTemplate(NHibernateUtil.String, "substr(?1,1,?2)"));
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -105,7 +105,6 @@ namespace NHibernate.Dialect
 			RegisterFunction("current_date", new SQLFunctionTemplate(NHibernateUtil.LocalDate, "datetime(date(current_timestamp, 'localtime'))"));
 
 			RegisterFunction("substring", new StandardSQLFunction("substr", NHibernateUtil.String));
-			RegisterFunction("locate", new StandardSQLFunction("instr",  NHibernateUtil.Int32));
 			RegisterFunction("left", new SQLFunctionTemplate(NHibernateUtil.String, "substr(?1,1,?2)"));
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));

--- a/src/NHibernate/Linq/Functions/BaseHqlGeneratorForMethod.cs
+++ b/src/NHibernate/Linq/Functions/BaseHqlGeneratorForMethod.cs
@@ -21,13 +21,13 @@ namespace NHibernate.Linq.Functions
 
 		private protected static void LogIgnoredParameter(MethodInfo method, string paramType)
 		{
-			if(Log.IsWarnEnabled())
+			if (Log.IsWarnEnabled())
 				Log.Warn("Method parameter of type '{0}' is ignored when converting to hql the following method: {1}", paramType, method);
 		}
 
 		private protected static void LogIgnoredStringComparisonParameter(MethodInfo actualMethod, MethodInfo methodWithStringComparison)
 		{
-			if(actualMethod == methodWithStringComparison)
+			if (actualMethod == methodWithStringComparison)
 				LogIgnoredParameter(actualMethod, nameof(StringComparison));
 		}
 

--- a/src/NHibernate/Linq/Functions/BaseHqlGeneratorForMethod.cs
+++ b/src/NHibernate/Linq/Functions/BaseHqlGeneratorForMethod.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NHibernate.Hql.Ast;
@@ -9,10 +11,33 @@ namespace NHibernate.Linq.Functions
 {
 	public abstract class BaseHqlGeneratorForMethod : IHqlGeneratorForMethod, IHqlGeneratorForMethodExtended
 	{
+		protected static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(BaseHqlGeneratorForMethod));
+
 		public IEnumerable<MethodInfo> SupportedMethods { get; protected set; }
 
 		public abstract HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor);
 
 		public virtual bool AllowsNullableReturnType(MethodInfo method) => true;
+
+		private protected static void LogIgnoredParameter(MethodInfo method, string paramType)
+		{
+			if(Log.IsWarnEnabled())
+				Log.Warn("Method parameter of type '{0}' is ignored when converting to hql the following method: {1}", paramType, method);
+		}
+
+		private protected static void LogIgnoredStringComparisonParameter(MethodInfo actualMethod, MethodInfo methodWithStringComparison)
+		{
+			if(actualMethod == methodWithStringComparison)
+				LogIgnoredParameter(actualMethod, nameof(StringComparison));
+		}
+
+		private protected bool LogIgnoredStringComparisonParameter(MethodInfo actualMethod, params MethodInfo[] methodsWithStringComparison)
+		{
+			if (!methodsWithStringComparison.Contains(actualMethod))
+				return false;
+
+			LogIgnoredParameter(actualMethod, nameof(StringComparison));
+			return true;
+		}
 	}
 }

--- a/src/NHibernate/Linq/Functions/CompareGenerator.cs
+++ b/src/NHibernate/Linq/Functions/CompareGenerator.cs
@@ -12,10 +12,12 @@ namespace NHibernate.Linq.Functions
 {
 	internal class CompareGenerator : BaseHqlGeneratorForMethod, IRuntimeMethodHqlGenerator
 	{
+		private static readonly MethodInfo MethodWithComparer = ReflectHelper.FastGetMethod(string.Compare, default(string), default(string), default(StringComparison));
+
 		private static readonly HashSet<MethodInfo> ActingMethods = new HashSet<MethodInfo>
 			{
 				ReflectHelper.FastGetMethod(string.Compare, default(string), default(string)),
-				ReflectHelper.FastGetMethod(string.Compare, default(string), default(string), default(StringComparison)),
+				MethodWithComparer,
 				ReflectHelper.GetMethodDefinition<string>(s => s.CompareTo(s)),
 				ReflectHelper.GetMethodDefinition<char>(x => x.CompareTo(x)),
 
@@ -44,7 +46,10 @@ namespace NHibernate.Linq.Functions
 		internal static bool IsCompareMethod(MethodInfo methodInfo)
 		{
 			if (ActingMethods.Contains(methodInfo))
+			{
+				LogIgnoredStringComparisonParameter(methodInfo, MethodWithComparer);
 				return true;
+			}
 
 			// This is .Net 4 only, and in the System.Data.Services assembly, which we don't depend directly on.
 			return methodInfo != null && methodInfo.Name == "Compare" &&

--- a/src/NHibernate/Linq/Functions/CompareGenerator.cs
+++ b/src/NHibernate/Linq/Functions/CompareGenerator.cs
@@ -15,6 +15,7 @@ namespace NHibernate.Linq.Functions
 		private static readonly HashSet<MethodInfo> ActingMethods = new HashSet<MethodInfo>
 			{
 				ReflectHelper.FastGetMethod(string.Compare, default(string), default(string)),
+				ReflectHelper.FastGetMethod(string.Compare, default(string), default(string), default(StringComparison)),
 				ReflectHelper.GetMethodDefinition<string>(s => s.CompareTo(s)),
 				ReflectHelper.GetMethodDefinition<char>(x => x.CompareTo(x)),
 

--- a/src/NHibernate/Linq/Functions/StringGenerator.cs
+++ b/src/NHibernate/Linq/Functions/StringGenerator.cs
@@ -233,13 +233,15 @@ namespace NHibernate.Linq.Functions
 		}
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
 		{
+			var argsCount = arguments.Count;
 			if (LogIgnoredStringComparisonParameter(method, MethodWithComparer1, MethodWithComparer2))
 			{
-				arguments = arguments.Where(a => a.Type != typeof(StringComparison)).ToList().AsReadOnly();
+				//StringComparison is last argument, just ignore it
+				argsCount--;
 			}
 
 			HqlMethodCall locate;
-			if (arguments.Count == 1)
+			if (argsCount == 1)
 			{
 				locate = treeBuilder.MethodCall("locate",
 					visitor.Visit(arguments[0]).AsExpression(),

--- a/src/NHibernate/Linq/Functions/StringGenerator.cs
+++ b/src/NHibernate/Linq/Functions/StringGenerator.cs
@@ -76,15 +76,18 @@ namespace NHibernate.Linq.Functions
 
 	public class StartsWithGenerator : BaseHqlGeneratorForMethod
 	{
+		private static readonly MethodInfo MethodWithComparer = ReflectHelper.GetMethodDefinition<string>(x => x.StartsWith(null, default(StringComparison)));
+
 		public StartsWithGenerator()
 		{
-			SupportedMethods = new[] { ReflectHelper.GetMethodDefinition<string>(x => x.StartsWith(null)) };
+			SupportedMethods = new[] {ReflectHelper.GetMethodDefinition<string>(x => x.StartsWith(null)), MethodWithComparer};
 		}
 
 		public override bool AllowsNullableReturnType(MethodInfo method) => false;
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
 		{
+			LogIgnoredStringComparisonParameter(method, MethodWithComparer);
 			return treeBuilder.Like(
 					visitor.Visit(targetObject).AsExpression(),
 					treeBuilder.Concat(
@@ -95,15 +98,18 @@ namespace NHibernate.Linq.Functions
 
 	public class EndsWithGenerator : BaseHqlGeneratorForMethod
 	{
+		private static readonly MethodInfo MethodWithComparer = ReflectHelper.GetMethodDefinition<string>(x => x.EndsWith(null, default(StringComparison)));
+
 		public EndsWithGenerator()
 		{
-			SupportedMethods = new[] { ReflectHelper.GetMethodDefinition<string>(x => x.EndsWith(null)) };
+			SupportedMethods = new[] {ReflectHelper.GetMethodDefinition<string>(x => x.EndsWith(null)), MethodWithComparer,};
 		}
 
 		public override bool AllowsNullableReturnType(MethodInfo method) => false;
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
 		{
+			LogIgnoredStringComparisonParameter(method, MethodWithComparer);
 			return treeBuilder.Like(
 					visitor.Visit(targetObject).AsExpression(),
 					treeBuilder.Concat(
@@ -210,6 +216,9 @@ namespace NHibernate.Linq.Functions
 
 	public class IndexOfGenerator : BaseHqlGeneratorForMethod
 	{
+		private static readonly MethodInfo MethodWithComparer1 = ReflectHelper.GetMethodDefinition<string>(x => x.IndexOf(string.Empty, default(StringComparison)));
+		private static readonly MethodInfo MethodWithComparer2 = ReflectHelper.GetMethodDefinition<string>(x => x.IndexOf(string.Empty, 0, default(StringComparison)));
+
 		public IndexOfGenerator()
 		{
 			SupportedMethods = new[]
@@ -217,11 +226,18 @@ namespace NHibernate.Linq.Functions
 										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(' ')),
 										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(" ")),
 										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(' ', 0)),
-										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(" ", 0))
+										ReflectHelper.GetMethodDefinition<string>(s => s.IndexOf(" ", 0)),
+										MethodWithComparer1,
+										MethodWithComparer2,
 									};
 		}
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
 		{
+			if (LogIgnoredStringComparisonParameter(method, MethodWithComparer1, MethodWithComparer2))
+			{
+				arguments = arguments.Where(a => a.Type != typeof(StringComparison)).ToList().AsReadOnly();
+			}
+
 			HqlMethodCall locate;
 			if (arguments.Count == 1)
 			{
@@ -244,21 +260,32 @@ namespace NHibernate.Linq.Functions
 
 	public class ReplaceGenerator : BaseHqlGeneratorForMethod
 	{
+#if NETCOREAPP2_0  
+		private static readonly MethodInfo MethodWithComparer = ReflectHelper.GetMethodDefinition<string>(x => x.Replace(string.Empty, string.Empty, default(StringComparison)));
+#endif
+
 		public ReplaceGenerator()
 		{
 			SupportedMethods = new[]
-									{
-										ReflectHelper.GetMethodDefinition<string>(s => s.Replace(' ', ' ')),
-										ReflectHelper.GetMethodDefinition<string>(s => s.Replace("", ""))
-									};
+			{
+				ReflectHelper.GetMethodDefinition<string>(s => s.Replace(' ', ' ')),
+				ReflectHelper.GetMethodDefinition<string>(s => s.Replace("", "")),
+#if NETCOREAPP2_0
+				MethodWithComparer,
+#endif
+			};
 		}
 
 		public override HqlTreeNode BuildHql(MethodInfo method, Expression targetObject, ReadOnlyCollection<Expression> arguments, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)
 		{
-			return treeBuilder.MethodCall("replace",
-																		visitor.Visit(targetObject).AsExpression(),
-																		visitor.Visit(arguments[0]).AsExpression(),
-																		visitor.Visit(arguments[1]).AsExpression());
+#if NETCOREAPP2_0
+			LogIgnoredStringComparisonParameter(method, MethodWithComparer);
+#endif
+			return treeBuilder.MethodCall(
+				"replace",
+				visitor.Visit(targetObject).AsExpression(),
+				visitor.Visit(arguments[0]).AsExpression(),
+				visitor.Visit(arguments[1]).AsExpression());
 		}
 	}
 


### PR DESCRIPTION
Fixes #2362

Support StringComparison parameter with warning for string  methods (StartsWith, EndsWith, IndexOf, Replace)