### PR TITLE
Fix KeyNotFoundException in StatefulPersistenceContext.RemoveEntity on Evict

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1845/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1845/Fixture.cs
@@ -8,35 +8,14 @@
 //------------------------------------------------------------------------------
 
 
-using NHibernate.Cfg.MappingSchema;
-using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1845
 {
 	using System.Threading.Tasks;
 	using System.Threading;
 	[TestFixture]
-	public class FixtureAsync : TestCaseMappingByCode
+	public class FixtureAsync : BugTestCase
 	{
-		protected override HbmMapping GetMappings()
-		{
-			var mapper = new ModelMapper();
-			mapper.Class<Category>(rc =>
-								   {
-									   rc.Id(x => x.Id, map => map.Generator(Generators.Native));
-									   rc.Property(x => x.Name);
-									   rc.ManyToOne(x => x.Parent, map => map.Column("ParentId"));
-									   rc.Bag(x => x.Subcategories, map =>
-																	{
-																		map.Access(Accessor.NoSetter);
-																		map.Key(km => km.Column("ParentId"));
-																		map.Cascade(Mapping.ByCode.Cascade.All.Include(Mapping.ByCode.Cascade.DeleteOrphans));
-																	}, rel => rel.OneToMany());
-								   });
-			var mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
-			return mappings;
-		}
-
 		[Test]
 		public async Task LazyLoad_Initialize_AndEvictAsync()
 		{

--- a/src/NHibernate.Test/NHSpecificTest/NH1845/Category.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1845/Category.cs
@@ -6,7 +6,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1845
 	{
 		private readonly IList<Category> subcategories = new List<Category>();
 
-		public Category() : this("") {}
+		public Category() : this("")
+		{
+		}
 
 		public Category(string name)
 		{
@@ -16,6 +18,8 @@ namespace NHibernate.Test.NHSpecificTest.NH1845
 		public virtual int Id { get; set; }
 
 		public virtual string Name { get; set; }
+
+		public virtual int SortIndex { get; set; }
 
 		public virtual Category Parent { get; set; }
 

--- a/src/NHibernate.Test/NHSpecificTest/NH1845/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1845/Fixture.cs
@@ -1,30 +1,9 @@
-using NHibernate.Cfg.MappingSchema;
-using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1845
 {
 	[TestFixture]
-	public class Fixture : TestCaseMappingByCode
+	public class Fixture : BugTestCase
 	{
-		protected override HbmMapping GetMappings()
-		{
-			var mapper = new ModelMapper();
-			mapper.Class<Category>(rc =>
-								   {
-									   rc.Id(x => x.Id, map => map.Generator(Generators.Native));
-									   rc.Property(x => x.Name);
-									   rc.ManyToOne(x => x.Parent, map => map.Column("ParentId"));
-									   rc.Bag(x => x.Subcategories, map =>
-																	{
-																		map.Access(Accessor.NoSetter);
-																		map.Key(km => km.Column("ParentId"));
-																		map.Cascade(Mapping.ByCode.Cascade.All.Include(Mapping.ByCode.Cascade.DeleteOrphans));
-																	}, rel => rel.OneToMany());
-								   });
-			var mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
-			return mappings;
-		}
-
 		[Test]
 		public void LazyLoad_Initialize_AndEvict()
 		{

--- a/src/NHibernate.Test/NHSpecificTest/NH1845/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH1845/Mappings.hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" assembly="NHibernate.Test"
+                   namespace="NHibernate.Test.NHSpecificTest.NH1845"
+                   default-cascade="all" >
+  <class name="Category" table="Categories" lazy="true"
+         dynamic-update="true" select-before-update="true">
+
+    <id name="Id" column="Id" type="Int32" unsaved-value="0">
+      <generator class="identity" />
+    </id>
+
+    <property name="Name" />
+    <property name="SortIndex" />
+
+    <many-to-one name="Parent" column="ParentCategoryId" class="Category" not-null="false"/>
+
+    <list name="Subcategories" cascade="all" generic="true" access="nosetter.camelcase"
+          inverse="true" lazy="true">
+      <key column="ParentCategoryId"/>
+      <index column="SortIndex"/>
+      <one-to-many class="Category"/>
+    </list>
+  </class>
+</hibernate-mapping>

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -443,18 +443,18 @@ namespace NHibernate.Engine
 		/// </summary>
 		public object RemoveEntity(EntityKey key)
 		{
-			if (!entitiesByKey.Remove(key, out var tempObject))
-				throw new KeyNotFoundException(key.ToString());
+			if (entitiesByKey.Remove(key, out var entity))
+			{
+				List<EntityUniqueKey> toRemove = new List<EntityUniqueKey>();
+				foreach (KeyValuePair<EntityUniqueKey, object> pair in entitiesByUniqueKey)
+				{
+					if (pair.Value == entity) toRemove.Add(pair.Key);
+				}
 
-			object entity = tempObject;
-			List<EntityUniqueKey> toRemove = new List<EntityUniqueKey>();
-			foreach (KeyValuePair<EntityUniqueKey, object> pair in entitiesByUniqueKey)
-			{
-				if (pair.Value == entity) toRemove.Add(pair.Key);
-			}
-			foreach (EntityUniqueKey uniqueKey in toRemove)
-			{
-				entitiesByUniqueKey.Remove(uniqueKey);
+				foreach (EntityUniqueKey uniqueKey in toRemove)
+				{
+					entitiesByUniqueKey.Remove(uniqueKey);
+				}
 			}
 
 			entitySnapshotsByKey.Remove(key);


### PR DESCRIPTION
Fixes #1310 
Initially the test was committed with a modification which made the bug not reproducible. 

---

_from @bahusoid in https://github.com/nhibernate/nhibernate-core/pull/2381/files#r425997839_:
> Java version doesn't throw here ([`HashMap.remove`](https://www.geeksforgeeks.org/hashmap-remove-method-in-java/) is [used](https://github.com/hibernate/hibernate-orm/blob/2bcb1b0a6d8600ba3a60eae6460dcb52bf5628e7/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java#L418) which returns null instead). Maybe we shouldn't either?
