### PR TITLE
Add locate support for SQLite

### DIFF
--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -310,7 +310,6 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public async Task LocateAsync()
 		{
-			AssumeFunctionSupported("locate");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);

--- a/src/NHibernate.Test/Async/Linq/FunctionTests.cs
+++ b/src/NHibernate.Test/Async/Linq/FunctionTests.cs
@@ -13,8 +13,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NHibernate.DomainModel;
 using NHibernate.DomainModel.Northwind.Entities;
-using NHibernate.Linq;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.Linq
 {
@@ -211,9 +211,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task CharIndexOffsetNegativeFunctionAsync()
 		{
-			if (!TestDialect.SupportsLocateStartIndex)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = await ((from e in db.Employees select e.FirstName).ToListAsync());
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.IndexOf('a', 2) == -1).ToList();
 
@@ -246,9 +243,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task IndexOfFunctionProjectionAsync()
 		{
-			if (!TestDialect.SupportsLocateStartIndex)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = await ((from e in db.Employees select e.FirstName).ToListAsync());
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.Contains("a")).Select(x => x.IndexOf("a", 1)).ToList();
 

--- a/src/NHibernate.Test/Async/Linq/FunctionTests.cs
+++ b/src/NHibernate.Test/Async/Linq/FunctionTests.cs
@@ -195,9 +195,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task CharIndexFunctionAsync()
 		{
-			if (!TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = await ((from e in db.Employees select e.FirstName).ToListAsync());
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.IndexOf('a') == 0).ToList();
 
@@ -214,7 +211,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task CharIndexOffsetNegativeFunctionAsync()
 		{
-			if (!TestDialect.SupportsLocate)
+			if (!TestDialect.SupportsLocateStartIndex)
 				Assert.Ignore("Locate function not supported.");
 
 			var raw = await ((from e in db.Employees select e.FirstName).ToListAsync());
@@ -233,9 +230,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task IndexOfFunctionExpressionAsync()
 		{
-			if (!TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = await ((from e in db.Employees select e.FirstName).ToListAsync());
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.IndexOf("an") == 0).ToList();
 
@@ -252,7 +246,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task IndexOfFunctionProjectionAsync()
 		{
-			if (!TestDialect.SupportsLocate)
+			if (!TestDialect.SupportsLocateStartIndex)
 				Assert.Ignore("Locate function not supported.");
 
 			var raw = await ((from e in db.Employees select e.FirstName).ToListAsync());
@@ -271,9 +265,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task TwoFunctionExpressionAsync()
 		{
-			if (!TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function not supported.");
-
 			var query = from e in db.Employees
 						where e.FirstName.IndexOf("A") == e.BirthDate.Value.Month 
 						select e.FirstName;

--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -299,7 +299,6 @@ namespace NHibernate.Test.Hql
 		[Test]
 		public void Locate()
 		{
-			AssumeFunctionSupported("locate");
 			using (ISession s = OpenSession())
 			{
 				Animal a1 = new Animal("abcdef", 20);

--- a/src/NHibernate.Test/Linq/FunctionTests.cs
+++ b/src/NHibernate.Test/Linq/FunctionTests.cs
@@ -184,9 +184,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void CharIndexFunction()
 		{
-			if (!TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = (from e in db.Employees select e.FirstName).ToList();
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.IndexOf('a') == 0).ToList();
 
@@ -203,7 +200,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void CharIndexOffsetNegativeFunction()
 		{
-			if (!TestDialect.SupportsLocate)
+			if (!TestDialect.SupportsLocateStartIndex)
 				Assert.Ignore("Locate function not supported.");
 
 			var raw = (from e in db.Employees select e.FirstName).ToList();
@@ -222,9 +219,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void IndexOfFunctionExpression()
 		{
-			if (!TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = (from e in db.Employees select e.FirstName).ToList();
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.IndexOf("an") == 0).ToList();
 
@@ -241,7 +235,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void IndexOfFunctionProjection()
 		{
-			if (!TestDialect.SupportsLocate)
+			if (!TestDialect.SupportsLocateStartIndex)
 				Assert.Ignore("Locate function not supported.");
 
 			var raw = (from e in db.Employees select e.FirstName).ToList();
@@ -260,9 +254,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void TwoFunctionExpression()
 		{
-			if (!TestDialect.SupportsLocate)
-				Assert.Ignore("Locate function not supported.");
-
 			var query = from e in db.Employees
 						where e.FirstName.IndexOf("A") == e.BirthDate.Value.Month 
 						select e.FirstName;

--- a/src/NHibernate.Test/Linq/FunctionTests.cs
+++ b/src/NHibernate.Test/Linq/FunctionTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NHibernate.DomainModel;
 using NHibernate.DomainModel.Northwind.Entities;
-using NHibernate.Linq;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
@@ -200,9 +199,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void CharIndexOffsetNegativeFunction()
 		{
-			if (!TestDialect.SupportsLocateStartIndex)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = (from e in db.Employees select e.FirstName).ToList();
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.IndexOf('a', 2) == -1).ToList();
 
@@ -235,9 +231,6 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void IndexOfFunctionProjection()
 		{
-			if (!TestDialect.SupportsLocateStartIndex)
-				Assert.Ignore("Locate function not supported.");
-
 			var raw = (from e in db.Employees select e.FirstName).ToList();
 			var expected = raw.Select(x => x.ToLower()).Where(x => x.Contains("a")).Select(x => x.IndexOf("a", 1)).ToList();
 

--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -440,7 +440,6 @@ namespace NHibernate.Test
 		private static readonly Dictionary<string, HashSet<System.Type>> DialectsNotSupportingStandardFunction =
 			new Dictionary<string, HashSet<System.Type>>
 			{
-				{"locate", new HashSet<System.Type> {typeof (SQLiteDialect)}},
 				{"bit_length", new HashSet<System.Type> {typeof (SQLiteDialect)}},
 				{"extract", new HashSet<System.Type> {typeof (SQLiteDialect)}},
 				{

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Test
 
 		public virtual bool SupportsOperatorAll => true;
 		public virtual bool SupportsOperatorSome => true;
-		public virtual bool SupportsLocate => true;
+		public virtual bool SupportsLocateStartIndex => true;
 
 		public virtual bool SupportsFullJoin => true;
 

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -44,7 +44,6 @@ namespace NHibernate.Test
 
 		public virtual bool SupportsOperatorAll => true;
 		public virtual bool SupportsOperatorSome => true;
-		public virtual bool SupportsLocateStartIndex => true;
 
 		public virtual bool SupportsFullJoin => true;
 

--- a/src/NHibernate.Test/TestDialects/SQLiteTestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/SQLiteTestDialect.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Test.TestDialects
 			get { return false; }
 		}
 
-		public override bool SupportsLocate
+		public override bool SupportsLocateStartIndex
 		{
 			get { return false; }
 		}

--- a/src/NHibernate.Test/TestDialects/SQLiteTestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/SQLiteTestDialect.cs
@@ -22,11 +22,6 @@ namespace NHibernate.Test.TestDialects
 			get { return false; }
 		}
 
-		public override bool SupportsLocateStartIndex
-		{
-			get { return false; }
-		}
-
 		public override bool SupportsFullJoin
 		{
 			get { return false; }

--- a/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
+++ b/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
@@ -44,8 +44,6 @@ namespace NHibernate.Dialect.Function
 		private readonly string template;
 		private TemplateChunk[] chunks;
 
-		public int? MaxArgumentsCount { get; set; }
-
 		public SQLFunctionTemplate(IType type, string template) : this(type, template, true)
 		{
 		}
@@ -126,9 +124,6 @@ namespace NHibernate.Dialect.Function
 		/// <returns></returns>
 		public virtual SqlString Render(IList args, ISessionFactoryImplementor factory)
 		{
-			if (args.Count > MaxArgumentsCount)
-				throw new QueryException($"Function template '{template}' takes max {MaxArgumentsCount} arguments. Provided count: {args.Count}");
-
 			SqlStringBuilder buf = new SqlStringBuilder();
 			foreach (TemplateChunk tc in chunks)
 			{

--- a/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
+++ b/src/NHibernate/Dialect/Function/SQLFunctionTemplate.cs
@@ -44,6 +44,8 @@ namespace NHibernate.Dialect.Function
 		private readonly string template;
 		private TemplateChunk[] chunks;
 
+		public int? MaxArgumentsCount { get; set; }
+
 		public SQLFunctionTemplate(IType type, string template) : this(type, template, true)
 		{
 		}
@@ -124,6 +126,9 @@ namespace NHibernate.Dialect.Function
 		/// <returns></returns>
 		public virtual SqlString Render(IList args, ISessionFactoryImplementor factory)
 		{
+			if (args.Count > MaxArgumentsCount)
+				throw new QueryException($"Function template '{template}' takes max {MaxArgumentsCount} arguments. Provided count: {args.Count}");
+
 			SqlStringBuilder buf = new SqlStringBuilder();
 			foreach (TemplateChunk tc in chunks)
 			{

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -109,6 +109,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));
 			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
+			RegisterFunction("locate", new StandardSQLFunction("instr",  NHibernateUtil.Int32));
 
 			RegisterFunction("mod", new ModulusFunctionTemplate(false));
 

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -518,12 +518,10 @@ namespace NHibernate.Dialect
 				return true;
 			}
 		}
-		
+
 		[Serializable]
 		private class LocateFunction : ISQLFunction, ISQLFunctionExtended
 		{
-			#region Implementation of ISQLFunction
-
 			// Since v5.3
 			[Obsolete("Use GetReturnType method instead.")]
 			public IType ReturnType(IType columnType, IMapping mapping)
@@ -586,9 +584,6 @@ namespace NHibernate.Dialect
 						" -1, 0)"
 					);
 			}
-
-			#endregion
 		}
-
 	}
 }

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using System.Text;
 using NHibernate.Dialect.Function;
+using NHibernate.Engine;
 using NHibernate.SqlCommand;
+using NHibernate.Type;
 using NHibernate.Util;
 
 namespace NHibernate.Dialect
@@ -109,7 +113,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));
 			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
-			RegisterFunction("locate", new SQLFunctionTemplate(NHibernateUtil.Int32, "instr(?2, ?1)") {MaxArgumentsCount = 2});
+			RegisterFunction("locate", new LocateFunction());
 
 			RegisterFunction("mod", new ModulusFunctionTemplate(false));
 
@@ -514,5 +518,77 @@ namespace NHibernate.Dialect
 				return true;
 			}
 		}
+		
+		[Serializable]
+		private class LocateFunction : ISQLFunction, ISQLFunctionExtended
+		{
+			#region Implementation of ISQLFunction
+
+			// Since v5.3
+			[Obsolete("Use GetReturnType method instead.")]
+			public IType ReturnType(IType columnType, IMapping mapping)
+			{
+				return NHibernateUtil.Int32;
+			}
+
+			/// <inheritdoc />
+			public IType GetReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+			{
+#pragma warning disable 618
+				return ReturnType(argumentTypes.FirstOrDefault(), mapping);
+#pragma warning restore 618
+			}
+
+			/// <inheritdoc />
+			public IType GetEffectiveReturnType(IEnumerable<IType> argumentTypes, IMapping mapping, bool throwOnError)
+			{
+				return GetReturnType(argumentTypes, mapping, throwOnError);
+			}
+
+			/// <inheritdoc />
+			public string Name => "instr";
+
+			public bool HasArguments => true;
+
+			public bool HasParenthesesIfNoArguments => true;
+
+			public SqlString Render(IList args, ISessionFactoryImplementor factory)
+			{
+				if (args.Count != 2 && args.Count != 3)
+				{
+					throw new QueryException("'locate' function takes 2 or 3 arguments. Provided count: " + args.Count);
+				}
+
+				if (args.Count == 2)
+				{
+					return new SqlString("instr(", args[1], ", ", args[0], ")");
+				}
+
+				var text = args[1];
+				var value = args[0];
+				var startIndex = args[2];
+				//ifnull(
+				//	nullif(
+				//		instr(substr(text, startIndex), value)
+				//		, 0)
+				//	+ startIndex -1
+				//, 0)
+				return
+					new SqlString(
+						"ifnull(nullif(instr(substr(",
+						text,
+						", ",
+						startIndex,
+						"), ",
+						value,
+						"), 0) + ",
+						startIndex,
+						" -1, 0)"
+					);
+			}
+
+			#endregion
+		}
+
 	}
 }

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -109,7 +109,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("trim", new AnsiTrimEmulationFunction());
 			RegisterFunction("replace", new StandardSafeSQLFunction("replace", NHibernateUtil.String, 3));
 			RegisterFunction("chr", new StandardSQLFunction("char", NHibernateUtil.Character));
-			RegisterFunction("locate", new StandardSQLFunction("instr",  NHibernateUtil.Int32));
+			RegisterFunction("locate", new SQLFunctionTemplate(NHibernateUtil.Int32, "instr(?2, ?1)") {MaxArgumentsCount = 2});
 
 			RegisterFunction("mod", new ModulusFunctionTemplate(false));
 


### PR DESCRIPTION
SQLite can support locate  as [`instr`](https://www.sqlitetutorial.net/sqlite-functions/sqlite-instr/) function since Release 3.7.15 on 2012-12-12.
`locate(text, value, startIndex)` is emulated via combination of `substr` and `instr`