### PR TITLE
Update GitReleaseManager

### DIFF
--- a/ReleaseProcedure.txt
+++ b/ReleaseProcedure.txt
@@ -8,7 +8,7 @@ These are the tasks typically needed to create an official NHibernate release.
     (change x.x.x by its current version in tools).
     By example:
 
-Tools\gitreleasemanager\0.7.0\tools\GitReleaseManager.exe create -o nhibernate -r nhibernate-core -m 5.1 -u username -p password
+Tools\gitreleasemanager\0.11.0\tools\GitReleaseManager.exe create -o nhibernate -r nhibernate-core -m 5.3 --token yourGitHubTokenWithRepoScope
 
     (Adjust the -m milestone parameter above, and add "-c branchname" if
     releasing another branch than master)

--- a/Tools/packages.csproj
+++ b/Tools/packages.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="CSharpAsyncGenerator.CommandLine" Version="0.18.2" />
     <PackageReference Include="vswhere" Version="2.1.4" />
     <PackageReference Include="NUnit.Console" Version="3.10.0" />
-    <PackageReference Include="GitReleaseManager" Version="0.7.0" />
+    <PackageReference Include="GitReleaseManager" Version="0.11.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Authenticating through a password is deprecated and will be dropped. GitReleaseManager needs to be upgraded in order to authenticate through a token.