### PR TITLE
Optimize PersistentGenericBag.EqualsSnapshot

### DIFF
--- a/src/NHibernate.Test/Async/GenericTest/BagGeneric/BagGenericFixture.cs
+++ b/src/NHibernate.Test/Async/GenericTest/BagGeneric/BagGenericFixture.cs
@@ -8,14 +8,16 @@
 //------------------------------------------------------------------------------
 
 
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
+using NHibernate.Collection;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.GenericTest.BagGeneric
 {
 	using System.Threading.Tasks;
+	using System.Threading;
 	[TestFixture]
 	public class BagGenericFixtureAsync : TestCase
 	{
@@ -72,6 +74,51 @@ namespace NHibernate.Test.GenericTest.BagGeneric
 			Assert.AreEqual( 3, a.Items.Count, "3 items in the bag now" );
 			await (s.FlushAsync());
 			s.Close();
+		}
+
+		[Test]
+		public async Task EqualsSnapshotAsync()
+		{
+			var a = new A {Name = "first generic type"};
+			var i0 = new B {Name = "1"};
+			var i4 = new B {Name = "4"};
+			a.Items = new List<B>
+			{
+				i0,
+				i0,
+				new B {Name = "2"},
+				new B {Name = "3"},
+				i4,
+				i4,
+			};
+			var lastIdx = a.Items.Count - 1;
+			using (var s = OpenSession())
+			{
+				await (s.SaveAsync(a));
+				await (s.FlushAsync());
+				var collection = (IPersistentCollection) a.Items;
+				var collectionPersister = Sfi.GetCollectionPersister(collection.Role);
+
+				a.Items[0] = i4;
+				Assert.Multiple(
+					async () =>
+					{
+						Assert.That(await (collection.EqualsSnapshotAsync(collectionPersister, CancellationToken.None)), Is.False, "modify first collection element");
+
+						a.Items[lastIdx] = i0;
+						Assert.That(await (collection.EqualsSnapshotAsync(collectionPersister, CancellationToken.None)), Is.True, "swap elements in collection");
+
+						a.Items[0] = i0;
+						a.Items[lastIdx] = i0;
+						Assert.That(await (collection.EqualsSnapshotAsync(collectionPersister, CancellationToken.None)), Is.False, "modify last collection element");
+
+						a.Items[lastIdx] = i4;
+						var reversed = a.Items.Reverse().ToArray();
+						a.Items.Clear();
+						ArrayHelper.AddAll(a.Items, reversed);
+						Assert.That(await (collection.EqualsSnapshotAsync(collectionPersister, CancellationToken.None)), Is.True, "reverse collection elements");
+					});
+			}
 		}
 
 		[Test]

--- a/src/NHibernate.Test/GenericTest/BagGeneric/BagGenericFixture.cs
+++ b/src/NHibernate.Test/GenericTest/BagGeneric/BagGenericFixture.cs
@@ -1,6 +1,7 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
+using NHibernate.Collection;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.GenericTest.BagGeneric
@@ -61,6 +62,51 @@ namespace NHibernate.Test.GenericTest.BagGeneric
 			Assert.AreEqual( 3, a.Items.Count, "3 items in the bag now" );
 			s.Flush();
 			s.Close();
+		}
+
+		[Test]
+		public void EqualsSnapshot()
+		{
+			var a = new A {Name = "first generic type"};
+			var i0 = new B {Name = "1"};
+			var i4 = new B {Name = "4"};
+			a.Items = new List<B>
+			{
+				i0,
+				i0,
+				new B {Name = "2"},
+				new B {Name = "3"},
+				i4,
+				i4,
+			};
+			var lastIdx = a.Items.Count - 1;
+			using (var s = OpenSession())
+			{
+				s.Save(a);
+				s.Flush();
+				var collection = (IPersistentCollection) a.Items;
+				var collectionPersister = Sfi.GetCollectionPersister(collection.Role);
+
+				a.Items[0] = i4;
+				Assert.Multiple(
+					() =>
+					{
+						Assert.That(collection.EqualsSnapshot(collectionPersister), Is.False, "modify first collection element");
+
+						a.Items[lastIdx] = i0;
+						Assert.That(collection.EqualsSnapshot(collectionPersister), Is.True, "swap elements in collection");
+
+						a.Items[0] = i0;
+						a.Items[lastIdx] = i0;
+						Assert.That(collection.EqualsSnapshot(collectionPersister), Is.False, "modify last collection element");
+
+						a.Items[lastIdx] = i4;
+						var reversed = a.Items.Reverse().ToArray();
+						a.Items.Clear();
+						ArrayHelper.AddAll(a.Items, reversed);
+						Assert.That(collection.EqualsSnapshot(collectionPersister), Is.True, "reverse collection elements");
+					});
+			}
 		}
 
 		[Test]

--- a/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
@@ -295,12 +295,15 @@ namespace NHibernate.Collection.Generic
 				return false;
 			}
 
-			foreach (var elt in _gbag)
+			for (var i = 0; i < _gbag.Count; i++)
 			{
-				if (CountOccurrences(elt, _gbag, elementType) != CountOccurrences(elt, sn, elementType))
-				{
+				if(elementType.IsSame(_gbag[i], sn[i]))
+					continue;
+
+				var elt = _gbag[i];
+				var countInSnapshot = CountOccurrences(elt, sn, elementType);
+				if (countInSnapshot == 0 || CountOccurrences(elt, _gbag, elementType) != countInSnapshot)
 					return false;
-				}
 			}
 
 			return true;

--- a/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
@@ -297,7 +297,7 @@ namespace NHibernate.Collection.Generic
 
 			for (var i = 0; i < _gbag.Count; i++)
 			{
-				if(elementType.IsSame(_gbag[i], sn[i]))
+				if (elementType.IsSame(_gbag[i], sn[i]))
 					continue;
 
 				var elt = _gbag[i];

--- a/src/NHibernate/Engine/CollectionEntry.cs
+++ b/src/NHibernate/Engine/CollectionEntry.cs
@@ -264,7 +264,7 @@ namespace NHibernate.Engine
 
 			if (forceDirty)
 			{
-				collection.Dirty();
+				throw new HibernateException("Found test where it's used...");
 			}
 		}
 

--- a/src/NHibernate/Engine/CollectionEntry.cs
+++ b/src/NHibernate/Engine/CollectionEntry.cs
@@ -264,7 +264,7 @@ namespace NHibernate.Engine
 
 			if (forceDirty)
 			{
-				throw new HibernateException("Found test where it's used...");
+				collection.Dirty();
 			}
 		}
 


### PR DESCRIPTION
Added tests directly calling `EqualsSnapshot` to verify it works correctly.

Notes: This check is called when NHibernate detects cases when underlying collection can be modified directly in user code and not via `IPersistenCollection` wrapper, for instance array mappings and `PersistentArryaHolder`.
For bags it's executed if new instance is created with bag then flushed (so `List<Entity>` become `PersistentGenericBag`).  Check is executed for all additional flushes in this session as theoretically user can still have instance of original bag `List<Entity>` not wrapped in `PersistentGenericBag` that can be modified directly