### PR TITLE
Fix Oracle binary floating point setting

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/AverageTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/AverageTests.cs
@@ -22,29 +22,6 @@ namespace NHibernate.Test.Linq.ByMethod
 		[Test]
 		public async Task CanGetAverageOfIntegersAsDoubleAsync()
 		{
-			// TODO 6.0: Enable test for Oracle once nhibernate.oracle.use_binary_floating_point_types is set to true
-			if (Dialect is Oracle8iDialect)
-			{
-				// The point of this test is to verify that LINQ's Average over an
-				// integer columns yields a non-integer result, even on databases
-				// where the corresponding avg() will yield a return type equal to
-				// the input type. This means the LINQ provider must generate HQL
-				// that cast the input to double inside the call to avg(). This works
-				// fine on most databases, but Oracle causes trouble.
-				//
-				// The dialect maps double to "DOUBLE PRECISION" on Oracle, which
-				// on Oracle has larger precision than C#'s double. When such
-				// values are returned, ODP.NET will convert it to .Net decimal, which
-				// has lower precision and thus causes an overflow exception.
-				//
-				// Some argue that this is a flaw in ODP.NET, others have created
-				// local dialects that use e.g. BINARY_DOUBLE instead, which more
-				// closely matches C#'s IEEE 745 double, see e.g. HHH-1961 and
-				// serveral blogs.
-
-				Assert.Ignore("Not supported on Oracle due to casting/overflow issues.");
-			}
-
 			//NH-2429
 			var average = await (db.Products.AverageAsync(x => x.UnitsOnOrder));
 

--- a/src/NHibernate.Test/Linq/ByMethod/AverageTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/AverageTests.cs
@@ -10,29 +10,6 @@ namespace NHibernate.Test.Linq.ByMethod
 		[Test]
 		public void CanGetAverageOfIntegersAsDouble()
 		{
-			// TODO 6.0: Enable test for Oracle once nhibernate.oracle.use_binary_floating_point_types is set to true
-			if (Dialect is Oracle8iDialect)
-			{
-				// The point of this test is to verify that LINQ's Average over an
-				// integer columns yields a non-integer result, even on databases
-				// where the corresponding avg() will yield a return type equal to
-				// the input type. This means the LINQ provider must generate HQL
-				// that cast the input to double inside the call to avg(). This works
-				// fine on most databases, but Oracle causes trouble.
-				//
-				// The dialect maps double to "DOUBLE PRECISION" on Oracle, which
-				// on Oracle has larger precision than C#'s double. When such
-				// values are returned, ODP.NET will convert it to .Net decimal, which
-				// has lower precision and thus causes an overflow exception.
-				//
-				// Some argue that this is a flaw in ODP.NET, others have created
-				// local dialects that use e.g. BINARY_DOUBLE instead, which more
-				// closely matches C#'s IEEE 745 double, see e.g. HHH-1961 and
-				// serveral blogs.
-
-				Assert.Ignore("Not supported on Oracle due to casting/overflow issues.");
-			}
-
 			//NH-2429
 			var average = db.Products.Average(x => x.UnitsOnOrder);
 

--- a/src/NHibernate/Dialect/Oracle10gDialect.cs
+++ b/src/NHibernate/Dialect/Oracle10gDialect.cs
@@ -26,12 +26,12 @@ namespace NHibernate.Dialect
 
 		public override void Configure(IDictionary<string, string> settings)
 		{
-			base.Configure(settings);
-
 			_useBinaryFloatingPointTypes = PropertiesHelper.GetBoolean(
 				Environment.OracleUseBinaryFloatingPointTypes,
 				settings,
 				false);
+
+			base.Configure(settings);
 		}
 
 		// Avoid registering weighted double type when using binary floating point types


### PR DESCRIPTION
Fix for the setting introduced by #2349. I was testing the mentioned PR with `CanGetAverageOfIntegersAsDouble` method, but I didn't noticed that it works even without having the setting enabled.