### PR TITLE
Make Render method virtual for Cast function

### DIFF
--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -54,7 +54,7 @@ namespace NHibernate.Dialect.Function
 			get { return true; }
 		}
 
-		public SqlString Render(IList args, ISessionFactoryImplementor factory)
+		public virtual SqlString Render(IList args, ISessionFactoryImplementor factory)
 		{
 			if (args.Count != 2)
 			{
@@ -87,13 +87,13 @@ namespace NHibernate.Dialect.Function
 				throw new QueryException(string.Format("invalid Hibernate type for cast(): type {0} not found", typeName));
 			}
 
-			//TODO 6.0: Remove pragma block with its content
+			// TODO 6.0: Remove pragma block with its content
 #pragma warning disable 618
 			if (!CastingIsRequired(sqlType))
 				return new SqlString("(", args[0], ")");
 #pragma warning restore 618
 
-			return Render(args, sqlType, factory);
+			return Render(args[0], sqlType, factory);
 		}
 
 		#endregion
@@ -108,13 +108,13 @@ namespace NHibernate.Dialect.Function
 		/// <summary>
 		/// Renders the SQL fragment representing the SQL cast.
 		/// </summary>
-		/// <param name="args">The cast arguments.</param>
+		/// <param name="expression">The cast argument.</param>
 		/// <param name="sqlType">The SQL type to cast to.</param>
 		/// <param name="factory">The session factory.</param>
 		/// <returns>A SQL fragment.</returns>
-		protected virtual SqlString Render(IList args, string sqlType, ISessionFactoryImplementor factory)
+		protected virtual SqlString Render(object expression, string sqlType, ISessionFactoryImplementor factory)
 		{
-			return new SqlString("cast(", args[0], " as ", sqlType, ")");
+			return new SqlString("cast(", expression, " as ", sqlType, ")");
 		}
 
 		#region IFunctionGrammar Members

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -87,11 +87,13 @@ namespace NHibernate.Dialect.Function
 				throw new QueryException(string.Format("invalid Hibernate type for cast(): type {0} not found", typeName));
 			}
 
+			//TODO 6.0: Remove pragma block with its content
 #pragma warning disable 618
-			return CastingIsRequired(sqlType)
+			if (!CastingIsRequired(sqlType))
+				return new SqlString("(", args[0], ")");
 #pragma warning restore 618
-				? Render(args, sqlType, factory)
-				: new SqlString("(", args[0], ")");
+
+			return Render(args, sqlType, factory);
 		}
 
 		#endregion

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -87,11 +87,17 @@ namespace NHibernate.Dialect.Function
 				throw new QueryException(string.Format("invalid Hibernate type for cast(): type {0} not found", typeName));
 			}
 
-			return CastingIsRequired(sqlType) ? Render(args, sqlType, factory) : new SqlString("(", args[0], ")");
+#pragma warning disable 618
+			return CastingIsRequired(sqlType)
+#pragma warning restore 618
+				? Render(args, sqlType, factory)
+				: new SqlString("(", args[0], ")");
 		}
 
 		#endregion
 
+		// Since v5.3
+		[Obsolete("This method has no usages and will be removed in a future version")]
 		protected virtual bool CastingIsRequired(string sqlType)
 		{
 			return true;

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -87,14 +87,7 @@ namespace NHibernate.Dialect.Function
 				throw new QueryException(string.Format("invalid Hibernate type for cast(): type {0} not found", typeName));
 			}
 
-			if (CastingIsRequired(sqlType))
-			{
-				return new SqlString("cast(", args[0], " as ", sqlType, ")");
-			}
-			else
-			{
-				return new SqlString("(", args[0], ")");
-			}
+			return CastingIsRequired(sqlType) ? Render(args, sqlType, factory) : new SqlString("(", args[0], ")");
 		}
 
 		#endregion
@@ -102,6 +95,11 @@ namespace NHibernate.Dialect.Function
 		protected virtual bool CastingIsRequired(string sqlType)
 		{
 			return true;
+		}
+
+		protected virtual SqlString Render(IList args, string sqlType, ISessionFactoryImplementor factory)
+		{
+			return new SqlString("cast(", args[0], " as ", sqlType, ")");
 		}
 
 		#region IFunctionGrammar Members

--- a/src/NHibernate/Dialect/Function/CastFunction.cs
+++ b/src/NHibernate/Dialect/Function/CastFunction.cs
@@ -105,6 +105,13 @@ namespace NHibernate.Dialect.Function
 			return true;
 		}
 
+		/// <summary>
+		/// Renders the SQL fragment representing the SQL cast.
+		/// </summary>
+		/// <param name="args">The cast arguments.</param>
+		/// <param name="sqlType">The SQL type to cast to.</param>
+		/// <param name="factory">The session factory.</param>
+		/// <returns>A SQL fragment.</returns>
 		protected virtual SqlString Render(IList args, string sqlType, ISessionFactoryImplementor factory)
 		{
 			return new SqlString("cast(", args[0], " as ", sqlType, ")");

--- a/src/NHibernate/Dialect/Function/TransparentCastFunction.cs
+++ b/src/NHibernate/Dialect/Function/TransparentCastFunction.cs
@@ -18,6 +18,13 @@ namespace NHibernate.Dialect.Function
 			return false;
 		}
 
+		/// <summary>
+		/// Renders the SQL fragment representing the casted expression without actually casting it.
+		/// </summary>
+		/// <param name="args">The cast arguments.</param>
+		/// <param name="sqlType">The SQL type to cast to, ignored for rendering.</param>
+		/// <param name="factory">The session factory.</param>
+		/// <returns>A SQL fragment.</returns>
 		protected override SqlString Render(IList args, string sqlType, ISessionFactoryImplementor factory)
 		{
 			return new SqlString("(", args[0], ")");

--- a/src/NHibernate/Dialect/Function/TransparentCastFunction.cs
+++ b/src/NHibernate/Dialect/Function/TransparentCastFunction.cs
@@ -21,13 +21,13 @@ namespace NHibernate.Dialect.Function
 		/// <summary>
 		/// Renders the SQL fragment representing the casted expression without actually casting it.
 		/// </summary>
-		/// <param name="args">The cast arguments.</param>
+		/// <param name="expression">The cast argument.</param>
 		/// <param name="sqlType">The SQL type to cast to, ignored for rendering.</param>
 		/// <param name="factory">The session factory.</param>
 		/// <returns>A SQL fragment.</returns>
-		protected override SqlString Render(IList args, string sqlType, ISessionFactoryImplementor factory)
+		protected override SqlString Render(object expression, string sqlType, ISessionFactoryImplementor factory)
 		{
-			return new SqlString("(", args[0], ")");
+			return new SqlString("(", expression, ")");
 		}
 	}
 }

--- a/src/NHibernate/Dialect/Function/TransparentCastFunction.cs
+++ b/src/NHibernate/Dialect/Function/TransparentCastFunction.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using NHibernate.Engine;
+using NHibernate.SqlCommand;
 
 namespace NHibernate.Dialect.Function
 {
@@ -8,9 +11,16 @@ namespace NHibernate.Dialect.Function
 	[Serializable]
 	public class TransparentCastFunction : CastFunction
 	{
+		// Since v5.3
+		[Obsolete("This method has no usages and will be removed in a future version")]
 		protected override bool CastingIsRequired(string sqlType)
 		{
 			return false;
+		}
+
+		protected override SqlString Render(IList args, string sqlType, ISessionFactoryImplementor factory)
+		{
+			return new SqlString("(", args[0], ")");
 		}
 	}
 }

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -510,6 +510,8 @@ namespace NHibernate.Dialect
 		[Serializable]
 		protected class SQLiteCastFunction : CastFunction
 		{
+			// Since v5.3
+			[Obsolete("This method has no usages and will be removed in a future version")]
 			protected override bool CastingIsRequired(string sqlType)
 			{
 				if (StringHelper.ContainsCaseInsensitive(sqlType, "date") ||


### PR DESCRIPTION
In order to override it in case the dialect does not support cast function.

Fixes #2404 

