### PR TITLE
Use BestGuessEntityName instead of GuessEntityName

### DIFF
--- a/src/NHibernate/Impl/SessionImpl.cs
+++ b/src/NHibernate/Impl/SessionImpl.cs
@@ -2370,7 +2370,7 @@ namespace NHibernate.Impl
 			{
 				if (entityName == null)
 				{
-					return Factory.GetEntityPersister(GuessEntityName(obj));
+					return Factory.GetEntityPersister(BestGuessEntityName(obj));
 				}
 				else
 				{


### PR DESCRIPTION
GuessEntityName fails to retrieve the EntityName of *ProxyFieldInterceptor.
Switch to use BestGuessEntityName instead since it already handles this case.