### PR TITLE
Fix NRE in SchemaUpdate and SchemaExport Execute method for collection mappings

### DIFF
--- a/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/HeavyEntity.cs
+++ b/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/HeavyEntity.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace NHibernate.Test.Tools.hbm2ddl.SchemaMetadataUpdaterTest
 {
 	public class Order
@@ -8,5 +10,13 @@ namespace NHibernate.Test.Tools.hbm2ddl.SchemaMetadataUpdaterTest
 		public string Column { get; set; }
 		public string Name { get; set; }
 		public string Abracadabra { get; set; }
+		public ISet<OrderRow> Rows { get; set; }
+	}
+
+	public class OrderRow
+	{
+		public int Id { get; set; }
+		public Order Order { get; set; }
+		public string Name { get; set; }
 	}
 }

--- a/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/HeavyEntity.hbm.xml
+++ b/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/HeavyEntity.hbm.xml
@@ -4,16 +4,27 @@
 				   assembly="NHibernate.Test"
 				   default-lazy="false">
 
-	<class name="Order">
-		<id type="int">
-			<generator class="native"/>
-		</id>
-		<property name="Select"/>
-		<property name="From"/>
-		<property name="And"/>
-		<property name="Column"/>
-		<property name="Name"/>
-		<property name="Abracadabra"/>
-	</class>
+  <class name="Order">
+    <id type="int">
+      <generator class="native"/>
+    </id>
+    <property name="Select"/>
+    <property name="From"/>
+    <property name="And"/>
+    <property name="Column"/>
+    <property name="Name"/>
+    <property name="Abracadabra"/>
+    <set name="Rows" cascade="none">
+      <key column="Order"/>
+      <one-to-many class="OrderRow" />
+    </set>
+  </class>
+  <class name="OrderRow">
+    <id name="Id">
+      <generator class="native"/>
+    </id>
+    <property name="Name"/>
+    <many-to-one name="Order" column="Order" not-null="true"/>
+  </class>
 
 </hibernate-mapping>

--- a/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/Order.cs
+++ b/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/Order.cs
@@ -12,11 +12,4 @@ namespace NHibernate.Test.Tools.hbm2ddl.SchemaMetadataUpdaterTest
 		public string Abracadabra { get; set; }
 		public ISet<OrderRow> Rows { get; set; }
 	}
-
-	public class OrderRow
-	{
-		public int Id { get; set; }
-		public Order Order { get; set; }
-		public string Name { get; set; }
-	}
 }

--- a/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/OrderRow.cs
+++ b/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/OrderRow.cs
@@ -1,0 +1,9 @@
+namespace NHibernate.Test.Tools.hbm2ddl.SchemaMetadataUpdaterTest
+{
+	public class OrderRow
+	{
+		public int Id { get; set; }
+		public Order Order { get; set; }
+		public string Name { get; set; }
+	}
+}

--- a/src/NHibernate/Tool/hbm2ddl/SchemaMetadataUpdater.cs
+++ b/src/NHibernate/Tool/hbm2ddl/SchemaMetadataUpdater.cs
@@ -55,6 +55,8 @@ namespace NHibernate.Tool.hbm2ddl
 
 		public static void QuoteTableAndColumns(Configuration configuration, Dialect.Dialect dialect)
 		{
+			// We have to build the mappings in order to quote collection mappings that use a second pass command to be fully initialized
+			configuration.BuildMappings();
 			foreach (var cm in configuration.ClassMappings)
 			{
 				QuoteTable(cm.Table, dialect);


### PR DESCRIPTION
Fixes the regression made by #2149, where a NRE is thrown when calling `SchemaExport.Execute` and `SchemaUpdate.Execute` method before `Configuration.SecondPassCompile` method is called, which is required for mapped collections that use a `SecondPassCommand` to be fully initialized. The issue is not present in current tests, because `Configuration.BuildSessionFactory`, which calls `Configuration.SecondPassCompile` method, is called before `SchemaExport.Execute` method.