### PR TITLE
Fix iconUrl warning

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -27,6 +27,7 @@
 
     <PackageProjectUrl>http://nhibernate.info</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/nhibernate/nhibernate-core/master/logo/NHibernate-NuGet.png</PackageIconUrl>
+    <PackageIcon>NHibernate-NuGet.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
     <PackageReleaseNotes Condition="'$(VersionSuffix)' == ''">https://github.com/nhibernate/nhibernate-core/blob/$(VersionPrefix)/releasenotes.txt</PackageReleaseNotes>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -77,5 +77,6 @@
     <Content Include="../../LICENSE.txt">
       <PackagePath>./NHibernate.license.txt</PackagePath>
     </Content>
+    <None Include="../../logo/NHibernate-NuGet.png" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix the `iconUrl` warning occurring on NuGet push.
See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packageiconurl