### PR TITLE
Fix detecting parameter types in subqueries for Linq provider

### DIFF
--- a/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
+++ b/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
@@ -93,7 +93,10 @@ namespace NHibernate.Test.Linq
 					{"3", o => o is EnumStoredAsStringType}
 				},
 				db.Users.Fetch(o => o.Role).ThenFetch(o => o.ParentRole).Where(o => o.Enum1 == EnumStoredAsString.Large),
-				db.Users.Fetch(o => o.Role).ThenFetch(o => o.ParentRole).Where(o => EnumStoredAsString.Large == o.Enum1)
+				db.Users.Fetch(o => o.Role).ThenFetch(o => o.ParentRole).Where(o => EnumStoredAsString.Large == o.Enum1),
+				db.Timesheets.SelectMany(o => o.Users).Fetch(o => o.Role).Where(o => EnumStoredAsString.Large == o.Enum1),
+				db.Timesheets.FetchMany(o => o.Users).SelectMany(o => o.Users).Where(o => EnumStoredAsString.Large == o.Enum1),
+				db.Timesheets.FetchMany(o => o.Users).Where(o => o.Users.Any(u => EnumStoredAsString.Large == u.Enum1))
 			);
 		}
 
@@ -106,7 +109,8 @@ namespace NHibernate.Test.Linq
 					{"3", o => o is EnumStoredAsStringType}
 				},
 				db.Users.Where(o => db.Users.Any(u => u.Enum1 == EnumStoredAsString.Large)),
-				db.Users.Where(o => db.Users.Any(u => EnumStoredAsString.Large == u.Enum1))
+				db.Users.Where(o => db.Users.Any(u => EnumStoredAsString.Large == u.Enum1)),
+				db.Timesheets.Where(o => o.Users.Any(u => EnumStoredAsString.Large == u.Enum1))
 			);
 		}
 

--- a/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
+++ b/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
@@ -85,6 +85,47 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void EqualStringEnumTestWithFetch()
+		{
+			AssertResults(
+				new Dictionary<string, Predicate<IType>>
+				{
+					{"3", o => o is EnumStoredAsStringType}
+				},
+				db.Users.Fetch(o => o.Role).ThenFetch(o => o.ParentRole).Where(o => o.Enum1 == EnumStoredAsString.Large),
+				db.Users.Fetch(o => o.Role).ThenFetch(o => o.ParentRole).Where(o => EnumStoredAsString.Large == o.Enum1)
+			);
+		}
+
+		[Test]
+		public void EqualStringEnumTestWithSubQuery()
+		{
+			AssertResults(
+				new Dictionary<string, Predicate<IType>>
+				{
+					{"3", o => o is EnumStoredAsStringType}
+				},
+				db.Users.Where(o => db.Users.Any(u => u.Enum1 == EnumStoredAsString.Large)),
+				db.Users.Where(o => db.Users.Any(u => EnumStoredAsString.Large == u.Enum1))
+			);
+		}
+
+		[Test]
+		public void EqualStringEnumTestWithMaxSubQuery()
+		{
+			AssertResults(
+				new Dictionary<string, Predicate<IType>>
+				{
+					{"3", o => o is EnumStoredAsStringType}
+				},
+				db.Users.Fetch(o => o.Role).Where(o => db.Users.Max(u => u.Enum1 == EnumStoredAsString.Large ? u.Id : -u.Id) == o.Id),
+				db.Users.Fetch(o => o.Role).Where(o => db.Users.Max(u => EnumStoredAsString.Large == u.Enum1 ? u.Id : -u.Id) == o.Id),
+				db.Users.Where(o => db.Users.Max(u => u.Enum1 == EnumStoredAsString.Large ? u.Id : -u.Id) == o.Id),
+				db.Users.Where(o => db.Users.Max(u => EnumStoredAsString.Large == u.Enum1 ? u.Id : -u.Id) == o.Id)
+			);
+		}
+
+		[Test]
 		public void EqualStringTest()
 		{
 			AssertResults(

--- a/src/NHibernate/Util/ExpressionsHelper.cs
+++ b/src/NHibernate/Util/ExpressionsHelper.cs
@@ -714,6 +714,12 @@ namespace NHibernate.Util
 				return node;
 			}
 
+			protected override Expression VisitSubQuery(SubQueryExpression expression)
+			{
+				expression.QueryModel.TransformExpressions(base.Visit);
+				return expression;
+			}
+
 			protected override Expression VisitUnary(UnaryExpression node)
 			{
 				// Store only the outermost cast, when there are multiple casts for the same member

--- a/src/NHibernate/Util/ExpressionsHelper.cs
+++ b/src/NHibernate/Util/ExpressionsHelper.cs
@@ -716,7 +716,7 @@ namespace NHibernate.Util
 
 			protected override Expression VisitSubQuery(SubQueryExpression expression)
 			{
-				expression.QueryModel.TransformExpressions(base.Visit);
+				base.Visit(expression.QueryModel.SelectClause.Selector);
 				return expression;
 			}
 


### PR DESCRIPTION
Fix a regression from #2036, where subqueries were not traversed when detecting expression types.

Fixes #2439