### PR TITLE
Fix InvalidCastException for Future Criteria with aliased fetches

### DIFF
--- a/src/NHibernate.Test/Async/Criteria/SelectModeTest/SelectModeTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/SelectModeTest/SelectModeTest.cs
@@ -480,6 +480,72 @@ namespace NHibernate.Test.Criteria.SelectModeTest
 			}
 		}
 
+		//GH-2440
+		[Test]
+		public async Task FetchWithAliasedJoinFutureAsync()
+		{
+			using (var session = OpenSession())
+			{
+				EntityComplex alias = null;
+				EntitySimpleChild child1 = null;
+				var list = (await (session.QueryOver<EntityComplex>(() => alias)
+								.Where(ec => ec.Id == _parentEntityComplexId)
+								.JoinQueryOver(() => alias.Child1, () => child1)
+								.Fetch(SelectMode.Fetch, () => alias.ChildrenList)
+								.TransformUsing(Transformers.DistinctRootEntity)
+								.Future()
+								.GetEnumerableAsync()))
+								.ToList();
+
+				var childList = list[0].ChildrenList;
+				Assert.That(list[0].ChildrenList.Count, Is.GreaterThan(1));
+				Assert.That(list[0].ChildrenList, Is.EqualTo(list[0].ChildrenList.OrderByDescending(c => c.OrderIdx)), "wrong order");
+			}
+		}
+
+		//GH-2440
+		[Test]
+		public async Task CacheableFetchWithAliasedJoinFutureAsync()
+		{
+			using (var session = OpenSession())
+			{
+				EntityComplex alias = null;
+				EntitySimpleChild child1 = null;
+				var list = (await (session.QueryOver<EntityComplex>(() => alias)
+								.Where(ec => ec.Id == _parentEntityComplexId)
+								.JoinQueryOver(() => alias.Child1, () => child1)
+								.Fetch(SelectMode.Fetch, () => alias.ChildrenList)
+								.TransformUsing(Transformers.DistinctRootEntity)
+								.Cacheable()
+								.Future()
+								.GetEnumerableAsync()))
+								.ToList();
+				EntityComplex value = null;
+				Assert.DoesNotThrow(() => value = list[0]);
+				Assert.That(value, Is.Not.Null);
+			}
+
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex alias = null;
+				EntitySimpleChild child1 = null;
+				var list = session.QueryOver<EntityComplex>(() => alias)
+								.Where(ec => ec.Id == _parentEntityComplexId)
+								.JoinQueryOver(() => alias.Child1, () => child1)
+								.Fetch(SelectMode.Fetch, () => alias.ChildrenList)
+								.TransformUsing(Transformers.DistinctRootEntity)
+								.Cacheable()
+								.Future()
+								.ToList();
+				EntityComplex value = null;
+				Assert.DoesNotThrow(() => value = list[0]);
+				Assert.That(value, Is.Not.Null);
+
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(0), "Query is expected to be retrieved from cache");
+			}
+		}
+
 		[Test, Obsolete]
 		public async Task FetchModeEagerForLazyAsync()
 		{

--- a/src/NHibernate.Test/Criteria/SelectModeTest/SelectModeTest.cs
+++ b/src/NHibernate.Test/Criteria/SelectModeTest/SelectModeTest.cs
@@ -511,6 +511,72 @@ namespace NHibernate.Test.Criteria.SelectModeTest
 			}
 		}
 
+		//GH-2440
+		[Test]
+		public void FetchWithAliasedJoinFuture()
+		{
+			using (var session = OpenSession())
+			{
+				EntityComplex alias = null;
+				EntitySimpleChild child1 = null;
+				var list = session.QueryOver<EntityComplex>(() => alias)
+								.Where(ec => ec.Id == _parentEntityComplexId)
+								.JoinQueryOver(() => alias.Child1, () => child1)
+								.Fetch(SelectMode.Fetch, () => alias.ChildrenList)
+								.TransformUsing(Transformers.DistinctRootEntity)
+								.Future()
+								.GetEnumerable()
+								.ToList();
+
+				var childList = list[0].ChildrenList;
+				Assert.That(list[0].ChildrenList.Count, Is.GreaterThan(1));
+				Assert.That(list[0].ChildrenList, Is.EqualTo(list[0].ChildrenList.OrderByDescending(c => c.OrderIdx)), "wrong order");
+			}
+		}
+
+		//GH-2440
+		[Test]
+		public void CacheableFetchWithAliasedJoinFuture()
+		{
+			using (var session = OpenSession())
+			{
+				EntityComplex alias = null;
+				EntitySimpleChild child1 = null;
+				var list = session.QueryOver<EntityComplex>(() => alias)
+								.Where(ec => ec.Id == _parentEntityComplexId)
+								.JoinQueryOver(() => alias.Child1, () => child1)
+								.Fetch(SelectMode.Fetch, () => alias.ChildrenList)
+								.TransformUsing(Transformers.DistinctRootEntity)
+								.Cacheable()
+								.Future()
+								.GetEnumerable()
+								.ToList();
+				EntityComplex value = null;
+				Assert.DoesNotThrow(() => value = list[0]);
+				Assert.That(value, Is.Not.Null);
+			}
+
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex alias = null;
+				EntitySimpleChild child1 = null;
+				var list = session.QueryOver<EntityComplex>(() => alias)
+								.Where(ec => ec.Id == _parentEntityComplexId)
+								.JoinQueryOver(() => alias.Child1, () => child1)
+								.Fetch(SelectMode.Fetch, () => alias.ChildrenList)
+								.TransformUsing(Transformers.DistinctRootEntity)
+								.Cacheable()
+								.Future()
+								.ToList();
+				EntityComplex value = null;
+				Assert.DoesNotThrow(() => value = list[0]);
+				Assert.That(value, Is.Not.Null);
+
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(0), "Query is expected to be retrieved from cache");
+			}
+		}
+
 		[Test, Obsolete]
 		public void FetchModeEagerForLazy()
 		{

--- a/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Async/Multi/QueryBatchItemBase.cs
@@ -76,7 +76,7 @@ namespace NHibernate.Multi
 					var lockModeArray = loader.GetLockModes(queryParameters.LockModes);
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
-					var queryCacheBuilder = new QueryCacheResultBuilder(loader);
+					var queryCacheBuilder = queryInfo.IsCacheable ? new QueryCacheResultBuilder(loader) : null;
 					var cacheBatcher = queryInfo.CacheBatcher;
 					var ownCacheBatcher = cacheBatcher == null;
 					if (ownCacheBatcher)

--- a/src/NHibernate/Multi/QueryBatchItemBase.cs
+++ b/src/NHibernate/Multi/QueryBatchItemBase.cs
@@ -222,7 +222,7 @@ namespace NHibernate.Multi
 					var lockModeArray = loader.GetLockModes(queryParameters.LockModes);
 					var optionalObjectKey = Loader.Loader.GetOptionalObjectKey(queryParameters, Session);
 					var tmpResults = new List<object>();
-					var queryCacheBuilder = new QueryCacheResultBuilder(loader);
+					var queryCacheBuilder = queryInfo.IsCacheable ? new QueryCacheResultBuilder(loader) : null;
 					var cacheBatcher = queryInfo.CacheBatcher;
 					var ownCacheBatcher = cacheBatcher == null;
 					if (ownCacheBatcher)


### PR DESCRIPTION
Fixes #2440
`QueryCacheResultBuilder` should not be used for not cacheable queries.