### PR TITLE
Fix detecting parameter type for Contains method for Linq provider

### DIFF
--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -63,6 +63,14 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task CanQueryWithContainsOnEnumStoredAsString_Small_1Async()
+		{
+			var values = new[] { EnumStoredAsString.Small, EnumStoredAsString.Medium };
+			var query = await (db.Users.Where(x => values.Contains(x.Enum1)).ToListAsync());
+			Assert.AreEqual(3, query.Count);
+		}
+
+		[Test]
 		public async Task ConditionalNavigationPropertyAsync()
 		{
 			EnumStoredAsString? type = null;

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -50,6 +50,14 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void CanQueryWithContainsOnEnumStoredAsString_Small_1()
+		{
+			var values = new[] { EnumStoredAsString.Small, EnumStoredAsString.Medium };
+			var query = db.Users.Where(x => values.Contains(x.Enum1)).ToList();
+			Assert.AreEqual(3, query.Count);
+		}
+
+		[Test]
 		public void ConditionalNavigationProperty()
 		{
 			EnumStoredAsString? type = null;

--- a/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
+++ b/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
@@ -85,6 +85,22 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void ContainsStringEnumTest()
+		{
+			var values = new[] {EnumStoredAsString.Small};
+			AssertResults(
+				new Dictionary<string, Predicate<IType>>
+				{
+					{"value(NHibernate.DomainModel.Northwind.Entities.EnumStoredAsString[])", o => o is EnumStoredAsStringType}
+				},
+				db.Users.Where(o => values.Contains(o.Enum1)),
+				db.Users.Where(o => values.Contains(o.NullableEnum1.Value)),
+				db.Users.Where(o => values.Contains(o.Name == o.Name ? o.Enum1 : o.NullableEnum1.Value)),
+				db.Timesheets.Where(o => o.Users.Any(u => values.Contains(u.Enum1)))
+			);
+		}
+
+		[Test]
 		public void EqualStringEnumTestWithFetch()
 		{
 			AssertResults(

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -1,12 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 using System.Linq.Expressions;
 using NHibernate.Engine;
 using NHibernate.Param;
 using NHibernate.Type;
 using NHibernate.Util;
 using Remotion.Linq;
+using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Parsing;
 
 namespace NHibernate.Linq.Visitors
@@ -219,14 +222,35 @@ namespace NHibernate.Linq.Visitors
 				return node;
 			}
 
-			public override Expression Visit(Expression node)
+			protected override Expression VisitSubQuery(SubQueryExpression node)
 			{
-				if (node is SubQueryExpression subQueryExpression)
+				// ReLinq wraps all ResultOperatorExpressionNodeBase into a SubQueryExpression. In case of
+				// ContainsResultOperator where the constant expression is dislocated from the related expression,
+				// we have to manually link the related expressions.
+				var containsOperator = node.QueryModel.ResultOperators.OfType<ContainsResultOperator>().FirstOrDefault();
+				if (containsOperator != null &&
+				    node.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression querySourceReference &&
+				    querySourceReference.ReferencedQuerySource is MainFromClause mainFromClause &&
+				    mainFromClause.FromExpression is ConstantExpression constantExpression)
 				{
-					subQueryExpression.QueryModel.TransformExpressions(Visit);
+					VisitConstant(constantExpression);
+					AddRelatedExpression(constantExpression, Unwrap(Visit(containsOperator.Item)));
+					// Copy all found MemberExpressions to the constant expression
+					// (e.g. values.Contains(o.Name != o.Name2 ? o.Enum1 : o.Enum2) -> copy o.Enum1 and o.Enum2)
+					if (RelatedExpressions.TryGetValue(containsOperator.Item, out var set))
+					{
+						foreach (var nestedMemberExpression in set)
+						{
+							AddRelatedExpression(constantExpression, nestedMemberExpression);
+						}
+					}
+				}
+				else
+				{
+					node.QueryModel.TransformExpressions(Visit);
 				}
 
-				return base.Visit(node);
+				return node;
 			}
 
 			private void VisitAssign(Expression leftNode, Expression rightNode)

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -227,8 +227,8 @@ namespace NHibernate.Linq.Visitors
 				// ReLinq wraps all ResultOperatorExpressionNodeBase into a SubQueryExpression. In case of
 				// ContainsResultOperator where the constant expression is dislocated from the related expression,
 				// we have to manually link the related expressions.
-				var containsOperator = node.QueryModel.ResultOperators.OfType<ContainsResultOperator>().FirstOrDefault();
-				if (containsOperator != null &&
+				if (node.QueryModel.ResultOperators.Count == 1 &&
+				    node.QueryModel.ResultOperators[0] is ContainsResultOperator containsOperator &&
 				    node.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression querySourceReference &&
 				    querySourceReference.ReferencedQuerySource is MainFromClause mainFromClause &&
 				    mainFromClause.FromExpression is ConstantExpression constantExpression)


### PR DESCRIPTION
This is a regression from #2365, where `Contains` method which is transformed into `ContainsResultOperator` on pre-transform was not handled correctly by `QueryModel.TransformExpressions`. `ContainsResultOperator` is a special result operator that unfortunately has to be manually handled.

Fixes: #2453