### PR TITLE
Simplify single alias retrieval for SimpleProjections

### DIFF
--- a/src/NHibernate.Test/Criteria/AddNumberProjection.cs
+++ b/src/NHibernate.Test/Criteria/AddNumberProjection.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Test.Criteria
 				.Add(" + ")
 				.Add(criteriaQuery.NewQueryParameter(typedValue).Single())
 				.Add(") as ")
-				.Add(GetColumnAlias(0, 0 ))
+				.Add(GetColumnAlias(0))
 				.ToSqlString();
 		}
 

--- a/src/NHibernate.Test/Criteria/AddNumberProjection.cs
+++ b/src/NHibernate.Test/Criteria/AddNumberProjection.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Test.Criteria
 				.Add(" + ")
 				.Add(criteriaQuery.NewQueryParameter(typedValue).Single())
 				.Add(") as ")
-				.Add(GetColumnAliases(0, criteria, criteriaQuery)[0])
+				.Add(GetColumnAlias(0, 0 ))
 				.ToSqlString();
 		}
 

--- a/src/NHibernate/Criterion/AvgProjection.cs
+++ b/src/NHibernate/Criterion/AvgProjection.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Criterion
 				sql.Add(criteriaQuery.GetColumn(criteria, propertyName));
 			}
 			sql.Add(" as ").Add(sqlType).Add(")");
-			sql.Add(") as ").Add(GetColumnAliases(loc, criteria, criteriaQuery)[0]);
+			sql.Add(") as ").Add(GetColumnAlias(loc, 0));
 			return sql.ToSqlString();
 		}
 

--- a/src/NHibernate/Criterion/AvgProjection.cs
+++ b/src/NHibernate/Criterion/AvgProjection.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Criterion
 				sql.Add(criteriaQuery.GetColumn(criteria, propertyName));
 			}
 			sql.Add(" as ").Add(sqlType).Add(")");
-			sql.Add(") as ").Add(GetColumnAlias(loc, 0));
+			sql.Add(") as ").Add(GetColumnAlias(loc));
 			return sql.ToSqlString();
 		}
 

--- a/src/NHibernate/Criterion/CastProjection.cs
+++ b/src/NHibernate/Criterion/CastProjection.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Criterion
 			string sqlType = factory.Dialect.GetCastTypeName(sqlTypeCodes[0]);
 			var val = CriterionUtil.GetColumnNameAsSqlStringPart(projection, criteriaQuery, criteria);
 
-			return new SqlString("cast( ", val, " as ", sqlType, ") as ", GetColumnAlias(position, 0));
+			return new SqlString("cast( ", val, " as ", sqlType, ") as ", GetColumnAlias(position));
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/CastProjection.cs
+++ b/src/NHibernate/Criterion/CastProjection.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Criterion
 			string sqlType = factory.Dialect.GetCastTypeName(sqlTypeCodes[0]);
 			var val = CriterionUtil.GetColumnNameAsSqlStringPart(projection, criteriaQuery, criteria);
 
-			return new SqlString("cast( ", val, " as ", sqlType, ") as ", GetColumnAliases(position, criteria, criteriaQuery)[0]);
+			return new SqlString("cast( ", val, " as ", sqlType, ") as ", GetColumnAlias(position, 0));
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/ConditionalProjection.cs
+++ b/src/NHibernate/Criterion/ConditionalProjection.cs
@@ -48,7 +48,7 @@ namespace NHibernate.Criterion
 			var ifTrue = CriterionUtil.GetColumnNameAsSqlStringPart(whenTrue, criteriaQuery, criteria);
 			var ifFalse = CriterionUtil.GetColumnNameAsSqlStringPart(whenFalse, criteriaQuery, criteria);
 			return new SqlString("(case when ", condition, " then ", ifTrue, " else ", ifFalse, " end) as ",
-			                     GetColumnAliases(position, criteria, criteriaQuery)[0]);
+			                     GetColumnAlias(position, 0));
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/ConditionalProjection.cs
+++ b/src/NHibernate/Criterion/ConditionalProjection.cs
@@ -48,7 +48,7 @@ namespace NHibernate.Criterion
 			var ifTrue = CriterionUtil.GetColumnNameAsSqlStringPart(whenTrue, criteriaQuery, criteria);
 			var ifFalse = CriterionUtil.GetColumnNameAsSqlStringPart(whenFalse, criteriaQuery, criteria);
 			return new SqlString("(case when ", condition, " then ", ifTrue, " else ", ifFalse, " end) as ",
-			                     GetColumnAlias(position, 0));
+			                     GetColumnAlias(position));
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/ConstantProjection.cs
+++ b/src/NHibernate/Criterion/ConstantProjection.cs
@@ -45,7 +45,7 @@ namespace NHibernate.Criterion
 			return new SqlString(
 				criteriaQuery.NewQueryParameter(TypedValue).Single(),
 				" as ",
-				GetColumnAliases(position, criteria, criteriaQuery)[0]);
+				GetColumnAlias(position, 0));
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/ConstantProjection.cs
+++ b/src/NHibernate/Criterion/ConstantProjection.cs
@@ -45,7 +45,7 @@ namespace NHibernate.Criterion
 			return new SqlString(
 				criteriaQuery.NewQueryParameter(TypedValue).Single(),
 				" as ",
-				GetColumnAlias(position, 0));
+				GetColumnAlias(position));
 		}
 
 		public override IType[] GetTypes(ICriteria criteria, ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/SimpleProjection.cs
+++ b/src/NHibernate/Criterion/SimpleProjection.cs
@@ -26,11 +26,18 @@ namespace NHibernate.Criterion
 			return null;
 		}
 
+		// Since v5.3
+		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
 		public virtual string[] GetColumnAliases(int loc)
 		{
-			return new string[] {"y" + loc + "_"};
+			return new[] {GetColumnAlias(loc, 0)};
 		}
-		
+
+		public virtual string GetColumnAlias(int position, int columnIndex)
+		{
+			return "y" + (position + columnIndex) + "_";
+		}
+
 		public string[] GetColumnAliases(string alias, int position, ICriteria criteria, ICriteriaQuery criteriaQuery)
 		{
 			return GetColumnAliases(alias, position);
@@ -42,12 +49,11 @@ namespace NHibernate.Criterion
 			string[] aliases = new string[numColumns];
 			for (int i = 0; i < numColumns; i++) 
 			{
-				aliases[i] = "y" + position + "_";
-				position++;
+				aliases[i] = GetColumnAlias(position, i);
 			}
 			return aliases;
 		}
-		
+
 		public virtual string[] Aliases
 		{
 			get { return new String[1]; }

--- a/src/NHibernate/Criterion/SimpleProjection.cs
+++ b/src/NHibernate/Criterion/SimpleProjection.cs
@@ -26,16 +26,16 @@ namespace NHibernate.Criterion
 			return null;
 		}
 
-		// Since v5.3
+		// Since v5.4
 		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
 		public virtual string[] GetColumnAliases(int loc)
 		{
-			return new[] {GetColumnAlias(loc, 0)};
+			return new[] {GetColumnAlias(loc)};
 		}
 
-		public virtual string GetColumnAlias(int position, int columnIndex)
+		protected string GetColumnAlias(int position)
 		{
-			return "y" + (position + columnIndex) + "_";
+			return "y" + position + "_";
 		}
 
 		public string[] GetColumnAliases(string alias, int position, ICriteria criteria, ICriteriaQuery criteriaQuery)
@@ -47,9 +47,9 @@ namespace NHibernate.Criterion
 		{
 			int numColumns = this.GetColumnCount(criteria, criteriaQuery);
 			string[] aliases = new string[numColumns];
-			for (int i = 0; i < numColumns; i++) 
+			for (int i = 0; i < numColumns; i++)
 			{
-				aliases[i] = GetColumnAlias(position, i);
+				aliases[i] = GetColumnAlias(position + i);
 			}
 			return aliases;
 		}

--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -89,7 +89,7 @@ namespace NHibernate.Criterion
 			return new SqlString(
 				sqlFunction.Render(arguments, criteriaQuery.Factory),
 				" as ",
-				GetColumnAliases(position, criteria, criteriaQuery)[0]);
+				GetColumnAlias(position, 0));
 		}
 
 		private ISQLFunction GetFunction(ICriteriaQuery criteriaQuery)

--- a/src/NHibernate/Criterion/SqlFunctionProjection.cs
+++ b/src/NHibernate/Criterion/SqlFunctionProjection.cs
@@ -89,7 +89,7 @@ namespace NHibernate.Criterion
 			return new SqlString(
 				sqlFunction.Render(arguments, criteriaQuery.Factory),
 				" as ",
-				GetColumnAlias(position, 0));
+				GetColumnAlias(position));
 		}
 
 		private ISQLFunction GetFunction(ICriteriaQuery criteriaQuery)


### PR DESCRIPTION
There is no need to parse projection just to retrieve single alias for projections based on `SimpleProjection`.
See https://github.com/nhibernate/nhibernate-core/pull/2455#issuecomment-664922877