### PR TITLE
Remove persistent collections Equals/GetHashCode overrides

### DIFF
--- a/src/NHibernate/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericList.cs
@@ -238,23 +238,6 @@ namespace NHibernate.Collection.Generic
 			return entry != null;
 		}
 
-		public override bool Equals(object obj)
-		{
-			var that = obj as ICollection<T>;
-			if (that == null)
-			{
-				return false;
-			}
-			Read();
-			return CollectionHelper.SequenceEquals(WrappedList, that);
-		}
-
-		public override int GetHashCode()
-		{
-			Read();
-			return WrappedList.GetHashCode();
-		}
-
 		#region IList Members
 
 		int IList.Add(object value)

--- a/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
@@ -230,23 +230,6 @@ namespace NHibernate.Collection.Generic
 			return sn[((KeyValuePair<TKey, TValue>)entry).Key];
 		}
 
-		public override bool Equals(object other)
-		{
-			var that = other as IDictionary<TKey, TValue>;
-			if (that == null)
-			{
-				return false;
-			}
-			Read();
-			return CollectionHelper.DictionaryEquals(WrappedMap, that);
-		}
-
-		public override int GetHashCode()
-		{
-			Read();
-			return WrappedMap.GetHashCode();
-		}
-
 		public override bool EntryExists(object entry, int i)
 		{
 			return WrappedMap.ContainsKey(((KeyValuePair<TKey, TValue>)entry).Key);

--- a/src/NHibernate/Collection/Generic/PersistentGenericSet.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericSet.cs
@@ -277,23 +277,6 @@ namespace NHibernate.Collection.Generic
 			throw new NotSupportedException("Sets don't support updating by element");
 		}
 
-		public override bool Equals(object other)
-		{
-			var that = other as ISet<T>;
-			if (that == null)
-			{
-				return false;
-			}
-			Read();
-			return WrappedSet.SequenceEqual(that);
-		}
-
-		public override int GetHashCode()
-		{
-			Read();
-			return WrappedSet.GetHashCode();
-		}
-
 		public override bool EntryExists(object entry, int i)
 		{
 			return true;


### PR DESCRIPTION
To make behavior consistent with standard collections.
Related to #2457