### PR TITLE
Fix parameters inside evaluatable expressions for Linq provider

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ParameterTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ParameterTests.cs
@@ -126,6 +126,23 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task UsingParameterInEvaluatableExpressionAsync()
+		{
+			var value = "test";
+			await (db.Orders.Where(o => string.Format("{0}", value) != o.ShippedTo).ToListAsync());
+			await (db.Orders.Where(o => $"{value}_" != o.ShippedTo).ToListAsync());
+			await (db.Orders.Where(o => string.Copy(value) != o.ShippedTo).ToListAsync());
+
+			var guid = Guid.Parse("2D7E6EB3-BD08-4A40-A4E7-5150F7895821");
+			await (db.Orders.Where(o => o.ShippedTo.Contains($"VALUE {guid}")).ToListAsync());
+
+			var names = new[] {"name"};
+			await (db.Users.Where(x => names.Length == 0 || names.Contains(x.Name)).ToListAsync());
+			names = new string[] { };
+			await (db.Users.Where(x => names.Length == 0 || names.Contains(x.Name)).ToListAsync());
+		}
+
+		[Test]
 		public async Task UsingNegateValueTypeParameterTwiceAsync()
 		{
 			var value = 1;

--- a/src/NHibernate.Test/Linq/ParameterTests.cs
+++ b/src/NHibernate.Test/Linq/ParameterTests.cs
@@ -114,6 +114,23 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void UsingParameterInEvaluatableExpression()
+		{
+			var value = "test";
+			db.Orders.Where(o => string.Format("{0}", value) != o.ShippedTo).ToList();
+			db.Orders.Where(o => $"{value}_" != o.ShippedTo).ToList();
+			db.Orders.Where(o => string.Copy(value) != o.ShippedTo).ToList();
+
+			var guid = Guid.Parse("2D7E6EB3-BD08-4A40-A4E7-5150F7895821");
+			db.Orders.Where(o => o.ShippedTo.Contains($"VALUE {guid}")).ToList();
+
+			var names = new[] {"name"};
+			db.Users.Where(x => names.Length == 0 || names.Contains(x.Name)).ToList();
+			names = new string[] { };
+			db.Users.Where(x => names.Length == 0 || names.Contains(x.Name)).ToList();
+		}
+
+		[Test]
 		public void ValidateMixingTwoParametersCacheKeys()
 		{
 			var value = 1;


### PR DESCRIPTION
This is a regression from #2335, where parameters inside evaluatable expressions that are not translatable to hql are not evaluated.

Fixes #2458 