### PR TITLE
Fetch all lazy properties when entity is already loaded fails

### DIFF
--- a/src/NHibernate.Test/Async/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/Async/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -945,6 +945,26 @@ namespace NHibernate.Test.FetchLazyProperties
 			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Formula"), Is.True);
 		}
 
+		[TestCase(true)]
+		[TestCase(false)]
+		public async Task TestFetchAllPropertiesAfterEntityIsInitializedAsync(bool readOnly)
+		{
+			Person person;
+			using(var s = OpenSession())
+			using(var tx = s.BeginTransaction())
+			{
+				person = await (s.CreateQuery("from Person where Id = 1").SetReadOnly(readOnly).UniqueResultAsync<Person>());
+				var image = person.Image;
+				person = await (s.CreateQuery("from Person fetch all properties where Id = 1").SetReadOnly(readOnly).UniqueResultAsync<Person>());
+
+				await (tx.CommitAsync());
+			}
+
+			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Image"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Address"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Formula"), Is.True);
+		}
+
 		[Test]
 		public async Task TestHqlCrossJoinFetchFormulaAsync()
 		{

--- a/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -934,6 +934,26 @@ namespace NHibernate.Test.FetchLazyProperties
 			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Formula"), Is.True);
 		}
 
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestFetchAllPropertiesAfterEntityIsInitialized(bool readOnly)
+		{
+			Person person;
+			using(var s = OpenSession())
+			using(var tx = s.BeginTransaction())
+			{
+				person = s.CreateQuery("from Person where Id = 1").SetReadOnly(readOnly).UniqueResult<Person>();
+				var image = person.Image;
+				person = s.CreateQuery("from Person fetch all properties where Id = 1").SetReadOnly(readOnly).UniqueResult<Person>();
+
+				tx.Commit();
+			}
+
+			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Image"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Address"), Is.True);
+			Assert.That(NHibernateUtil.IsPropertyInitialized(person, "Formula"), Is.True);
+		}
+
 		[Test]
 		public void TestHqlCrossJoinFetchFormula()
 		{

--- a/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Async/Persister/Entity/AbstractEntityPersister.cs
@@ -87,7 +87,12 @@ namespace NHibernate.Persister.Entity
 				int[] lazyIndexes;
 				if (allLazyProperties)
 				{
-					lazyIndexes = indexes = lazyPropertyNumbers;
+					indexes = lazyPropertyNumbers;
+					lazyIndexes = new int[lazyPropertyNumbers.Length];
+					for(var i = 0; i < lazyIndexes.Length; i++)
+					{
+						lazyIndexes[i] = i;
+					}
 				}
 				else
 				{

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1408,7 +1408,6 @@ namespace NHibernate.Persister.Entity
 			{
 				throw new HibernateException($"Entity is not associated with the session: {id}");
 			}
-
 		
 			var lazyProperties = allLazyProperties ? LazyProperties.ToArray() : uninitializedLazyProperties;
 			var metadata = InstrumentationMetadata.LazyPropertiesMetadata;
@@ -1420,7 +1419,6 @@ namespace NHibernate.Persister.Entity
 				indexes[i] = descriptor.PropertyIndex;
 				lazyIndexes[i] = descriptor.LazyIndex;
 			}
-		
 
 			var values = Hydrate(rs, id, entity, suffixedPropertyColumns, null, true, indexes, session);
 			for (var i = 0; i < lazyIndexes.Length; i++)

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1409,24 +1409,18 @@ namespace NHibernate.Persister.Entity
 				throw new HibernateException($"Entity is not associated with the session: {id}");
 			}
 
-			int[] indexes;
-			int[] lazyIndexes;
-			if (allLazyProperties)
+		
+			var lazyProperties = allLazyProperties ? LazyProperties.ToArray() : uninitializedLazyProperties;
+			var metadata = InstrumentationMetadata.LazyPropertiesMetadata;
+			var indexes = new int[lazyProperties.Length];
+			var lazyIndexes = new int[lazyProperties.Length];
+			for (var i = 0; i < lazyProperties.Length; i++)
 			{
-				lazyIndexes = indexes = lazyPropertyNumbers;
+				var descriptor = metadata.GetLazyPropertyDescriptor(lazyProperties[i]);
+				indexes[i] = descriptor.PropertyIndex;
+				lazyIndexes[i] = descriptor.LazyIndex;
 			}
-			else
-			{
-				var metadata = InstrumentationMetadata.LazyPropertiesMetadata;
-				indexes = new int[uninitializedLazyProperties.Length];
-				lazyIndexes = new int[uninitializedLazyProperties.Length];
-				for (var i = 0; i < uninitializedLazyProperties.Length; i++)
-				{
-					var descriptor = metadata.GetLazyPropertyDescriptor(uninitializedLazyProperties[i]);
-					indexes[i] = descriptor.PropertyIndex;
-					lazyIndexes[i] = descriptor.LazyIndex;
-				}
-			}
+		
 
 			var values = Hydrate(rs, id, entity, suffixedPropertyColumns, null, true, indexes, session);
 			for (var i = 0; i < lazyIndexes.Length; i++)

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1432,6 +1432,7 @@ namespace NHibernate.Persister.Entity
 					lazyIndexes[i] = descriptor.LazyIndex;
 				}
 			}
+
 			var values = Hydrate(rs, id, entity, suffixedPropertyColumns, null, true, indexes, session);
 			for (var i = 0; i < lazyIndexes.Length; i++)
 			{

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1408,18 +1408,31 @@ namespace NHibernate.Persister.Entity
 			{
 				throw new HibernateException($"Entity is not associated with the session: {id}");
 			}
-		
-			var lazyProperties = allLazyProperties ? LazyProperties.ToArray() : uninitializedLazyProperties;
-			var metadata = InstrumentationMetadata.LazyPropertiesMetadata;
-			var indexes = new int[lazyProperties.Length];
-			var lazyIndexes = new int[lazyProperties.Length];
-			for (var i = 0; i < lazyProperties.Length; i++)
-			{
-				var descriptor = metadata.GetLazyPropertyDescriptor(lazyProperties[i]);
-				indexes[i] = descriptor.PropertyIndex;
-				lazyIndexes[i] = descriptor.LazyIndex;
-			}
 
+			int[] indexes;
+			int[] lazyIndexes;
+			if (allLazyProperties)
+			{
+				indexes = lazyPropertyNumbers;
+				lazyIndexes = new int[lazyPropertyNumbers.Length];
+				for(var i = 0; i < lazyIndexes.Length; i++)
+				{
+					lazyIndexes[i] = i;
+				}
+			}
+			else
+			{
+				var metadata = InstrumentationMetadata.LazyPropertiesMetadata;
+				indexes = new int[uninitializedLazyProperties.Length];
+				lazyIndexes = new int[uninitializedLazyProperties.Length];
+				for(var i = 0; i < uninitializedLazyProperties.Length; i++)
+				{
+					var descriptor = metadata.GetLazyPropertyDescriptor(uninitializedLazyProperties[i]);
+					indexes[i] = descriptor.PropertyIndex;
+					lazyIndexes[i] = descriptor.LazyIndex;
+				}
+			}
+			
 			var values = Hydrate(rs, id, entity, suffixedPropertyColumns, null, true, indexes, session);
 			for (var i = 0; i < lazyIndexes.Length; i++)
 			{

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1432,7 +1432,6 @@ namespace NHibernate.Persister.Entity
 					lazyIndexes[i] = descriptor.LazyIndex;
 				}
 			}
-			
 			var values = Hydrate(rs, id, entity, suffixedPropertyColumns, null, true, indexes, session);
 			for (var i = 0; i < lazyIndexes.Length; i++)
 			{

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -1425,7 +1425,7 @@ namespace NHibernate.Persister.Entity
 				var metadata = InstrumentationMetadata.LazyPropertiesMetadata;
 				indexes = new int[uninitializedLazyProperties.Length];
 				lazyIndexes = new int[uninitializedLazyProperties.Length];
-				for(var i = 0; i < uninitializedLazyProperties.Length; i++)
+				for (var i = 0; i < uninitializedLazyProperties.Length; i++)
 				{
 					var descriptor = metadata.GetLazyPropertyDescriptor(uninitializedLazyProperties[i]);
 					indexes[i] = descriptor.PropertyIndex;


### PR DESCRIPTION
Fix for the new test `TestFetchAllPropertiesAfterEntityIsInitialized` in `FetchLazyPropertiesFixture`.

Prior to this fix, the second query below would fail:
```
Person person;
using(var s = OpenSession())
{
    person = s.CreateQuery("from Person where Id = 1").UniqueResult<Person>();
    var image = person.Image;
    person = s.CreateQuery("from Person fetch all properties where Id = 1").UniqueResult<Person>();
}
```
The problem was with the `indexes` and `lazyIndexes` arrays in  `InitializeLazyProperties()` of `AbstractEntityPersister` when `allLazyProperties` was `true`. This could, in turn, cause `IndexOutOfRangeException` or `InvalidCastException`. 