### PR TITLE
Entity Joins are not polymorphic in hql

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
@@ -140,5 +140,13 @@ namespace NHibernate.Test.Linq.ByMethod
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 0 : 1));
 			}
 		}
+
+		[Test]
+		public async Task CanJoinOnEntityWithSubclassesAsync()
+		{
+			var result = await ((from o in db.Animals
+						from o2 in db.Animals.Where(x => x.BodyWeight > 50)
+						select new {o, o2}).Take(1).ToListAsync());
+		}
 	}
 }

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -129,5 +129,13 @@ namespace NHibernate.Test.Linq.ByMethod
 				Assert.That(GetTotalOccurrences(sql, "inner join"), Is.EqualTo(useCrossJoin ? 0 : 1));
 			}
 		}
+
+		[Test]
+		public void CanJoinOnEntityWithSubclasses()
+		{
+			var result = (from o in db.Animals
+						from o2 in db.Animals.Where(x => x.BodyWeight > 50)
+						select new {o, o2}).Take(1).ToList();
+		}
 	}
 }

--- a/src/NHibernate/Engine/JoinSequence.cs
+++ b/src/NHibernate/Engine/JoinSequence.cs
@@ -249,7 +249,7 @@ namespace NHibernate.Engine
 			return selector != null && selector.IncludeSubclasses(alias);
 		}
 
-		private void AddExtraJoins(JoinFragment joinFragment, string alias, IJoinable joinable, bool innerJoin)
+		private protected void AddExtraJoins(JoinFragment joinFragment, string alias, IJoinable joinable, bool innerJoin)
 		{
 			bool include = IsIncluded(alias);
 			joinFragment.AddJoins(joinable.FromJoinFragment(alias, innerJoin, include),

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/EntityJoinJoinSequenceImpl.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/EntityJoinJoinSequenceImpl.cs
@@ -41,6 +41,10 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 //				on.Append(" and ").Append(filters);
 //			}
 			joinFragment.AddJoin(_tableName, _tableAlias, Array.Empty<string>(), Array.Empty<string>(), _joinType, on);
+			if (includeExtraJoins)
+			{
+				AddExtraJoins(joinFragment, _tableAlias, _entityType.GetAssociatedJoinable(Factory), _joinType == JoinType.InnerJoin);
+			}
 			return joinFragment;
 		}
 	}


### PR DESCRIPTION
It's a regression since LINQ is now using entity joins

Missed that part when porting as in hibernate it's implemented using missing in NHibernate "table group join" feature - https://github.com/hibernate/hibernate-orm/commit/3d6f8eb0ff11adba1018c55fc978aa10ab297fdc
