### PR TITLE
Throw entity not mapped exception for entity join in hql if possible

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -794,7 +794,8 @@ namespace NHibernate.Hql.Ast.ANTLR
 			if (path.Type == IDENT)
 			{
 				var pathIdentNode = (IdentNode) path;
-				return SessionFactoryHelper.FindQueryableUsingImports(pathIdentNode.Path);
+				//Until IDENT node is not expected for implicit join path we can throw on not found persister
+				return (IQueryable) SessionFactoryHelper.RequireClassPersister(pathIdentNode.Path);
 			}
 			else if (path.Type == DOT)
 			{

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -794,7 +794,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 			if (path.Type == IDENT)
 			{
 				var pathIdentNode = (IdentNode) path;
-				//Until IDENT node is not expected for implicit join path we can throw on not found persister
+				// Since IDENT node is not expected for implicit join path, we can throw on not found persister
 				return (IQueryable) SessionFactoryHelper.RequireClassPersister(pathIdentNode.Path);
 			}
 			else if (path.Type == DOT)


### PR DESCRIPTION
Consider it as regression as correct exception was thrown from LINQ in 5.2 (with implicit join) and to avoid reporting issues like https://github.com/nhibernate/nhibernate-core/issues/2478
