### PR TITLE
Add Projections.Select in Criteria

### DIFF
--- a/src/NHibernate/Criterion/Lambda/QueryOverProjectionBuilder.cs
+++ b/src/NHibernate/Criterion/Lambda/QueryOverProjectionBuilder.cs
@@ -177,7 +177,7 @@ namespace NHibernate.Criterion.Lambda
 		/// </summary>
 		public QueryOverProjectionBuilder<T> Select(Expression<Func<T, object>> expression)
 		{
-			PushProjection(Projections.Expression(expression));
+			PushProjection(Projections.Select(expression));
 			return this;
 		}
 
@@ -186,7 +186,7 @@ namespace NHibernate.Criterion.Lambda
 		/// </summary>
 		public QueryOverProjectionBuilder<T> Select(Expression<Func<object>> expression)
 		{
-			PushProjection(Projections.Expression(expression));
+			PushProjection(Projections.Select(expression));
 			return this;
 		}
 

--- a/src/NHibernate/Criterion/Lambda/QueryOverProjectionBuilder.cs
+++ b/src/NHibernate/Criterion/Lambda/QueryOverProjectionBuilder.cs
@@ -177,7 +177,7 @@ namespace NHibernate.Criterion.Lambda
 		/// </summary>
 		public QueryOverProjectionBuilder<T> Select(Expression<Func<T, object>> expression)
 		{
-			PushProjection(ExpressionProcessor.FindMemberProjection(expression.Body).AsProjection());
+			PushProjection(Projections.Expression(expression));
 			return this;
 		}
 
@@ -186,7 +186,7 @@ namespace NHibernate.Criterion.Lambda
 		/// </summary>
 		public QueryOverProjectionBuilder<T> Select(Expression<Func<object>> expression)
 		{
-			PushProjection(ExpressionProcessor.FindMemberProjection(expression.Body).AsProjection());
+			PushProjection(Projections.Expression(expression));
 			return this;
 		}
 

--- a/src/NHibernate/Criterion/Projections.cs
+++ b/src/NHibernate/Criterion/Projections.cs
@@ -523,7 +523,7 @@ namespace NHibernate.Criterion
 		/// <summary>
 		/// Projects given lambda expression
 		/// </summary>
-		public static IProjection Expression(Expression<Func<object>> expression)
+		public static IProjection Select(Expression<Func<object>> expression)
 		{
 			return ExpressionProcessor.FindMemberProjection(expression.Body).AsProjection();
 		}
@@ -531,7 +531,7 @@ namespace NHibernate.Criterion
 		/// <summary>
 		/// Projects given lambda expression
 		/// </summary>
-		public static IProjection Expression<TEntity>(Expression<Func<TEntity, object>> expression)
+		public static IProjection Select<TEntity>(Expression<Func<TEntity, object>> expression)
 		{
 			return ExpressionProcessor.FindMemberProjection(expression.Body).AsProjection();
 		}

--- a/src/NHibernate/Criterion/Projections.cs
+++ b/src/NHibernate/Criterion/Projections.cs
@@ -520,6 +520,22 @@ namespace NHibernate.Criterion
 			throw QueryOver.GetDirectUsageException();
 		}
 
+		/// <summary>
+		/// Projects given lambda expression
+		/// </summary>
+		public static IProjection Expression(Expression<Func<object>> expression)
+		{
+			return ExpressionProcessor.FindMemberProjection(expression.Body).AsProjection();
+		}
+
+		/// <summary>
+		/// Projects given lambda expression
+		/// </summary>
+		public static IProjection Expression<TEntity>(Expression<Func<TEntity, object>> expression)
+		{
+			return ExpressionProcessor.FindMemberProjection(expression.Body).AsProjection();
+		}
+
 		internal static IProjection ProcessConcat(MethodCallExpression methodCallExpression)
 		{
 			NewArrayExpression args = (NewArrayExpression)methodCallExpression.Arguments[0];

--- a/src/NHibernate/Criterion/QueryOver.cs
+++ b/src/NHibernate/Criterion/QueryOver.cs
@@ -9,6 +9,7 @@ using NHibernate.Impl;
 using NHibernate.Loader;
 using NHibernate.SqlCommand;
 using NHibernate.Transform;
+using NHibernate.Util;
 
 namespace NHibernate.Criterion
 {
@@ -404,12 +405,7 @@ namespace NHibernate.Criterion
 
 		public QueryOver<TRoot,TSubType> Select(params Expression<Func<TRoot, object>>[] projections)
 		{
-			List<IProjection> projectionList = new List<IProjection>();
-
-			foreach (var projection in projections)
-				projectionList.Add(ExpressionProcessor.FindMemberProjection(projection.Body).AsProjection());
-
-			criteria.SetProjection(projectionList.ToArray());
+			criteria.SetProjection(projections.ToArray(x => Projections.Expression(x)));
 			return this;
 		}
 

--- a/src/NHibernate/Criterion/QueryOver.cs
+++ b/src/NHibernate/Criterion/QueryOver.cs
@@ -405,7 +405,7 @@ namespace NHibernate.Criterion
 
 		public QueryOver<TRoot,TSubType> Select(params Expression<Func<TRoot, object>>[] projections)
 		{
-			criteria.SetProjection(projections.ToArray(x => Projections.Expression(x)));
+			criteria.SetProjection(projections.ToArray(x => Projections.Select(x)));
 			return this;
 		}
 


### PR DESCRIPTION
Expression projections are exposed in `QueryOver` via `Select` method but it should also be exposed as plain `Criteria` projections