### PR TITLE
Fix parameter detection for Equals and CompareTo methods for Linq provider

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/GH2437/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH2437/Fixture.cs
@@ -86,6 +86,18 @@ namespace NHibernate.Test.NHSpecificTest.GH2437
 		}
 
 		[Test]
+		public async Task Get_DateCustomType_NullableDateValueEqualsMethodAsync()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var sessions = await (session.Query<UserSession>().Where(x => x.OpenDate.Value.Equals(DateTime.Now)).ToListAsync());
+
+				Assert.That(sessions, Has.Count.EqualTo(10));
+			}
+		}
+
+		[Test]
 		public async Task Get_DateTimeCustomType_NullableDateValueEqualsAsync()
 		{
 			using (var session = OpenSession())

--- a/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
+++ b/src/NHibernate.Test/Linq/ParameterTypeLocatorTests.cs
@@ -85,6 +85,21 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void EqualsMethodStringTest()
+		{
+			AssertResults(
+				new Dictionary<string, Predicate<IType>>
+				{
+					{"\"London\"", o => o is StringType stringType && stringType.SqlType.Length == 15}
+				},
+				db.Orders.Where(o => o.ShippingAddress.City.Equals("London")),
+				db.Orders.Where(o => "London".Equals(o.ShippingAddress.City)),
+				db.Orders.Where(o => string.Equals("London", o.ShippingAddress.City)),
+				db.Orders.Where(o => string.Equals(o.ShippingAddress.City, "London"))
+			);
+		}
+
+		[Test]
 		public void ContainsStringEnumTest()
 		{
 			var values = new[] {EnumStoredAsString.Small};
@@ -155,6 +170,22 @@ namespace NHibernate.Test.Linq
 				},
 				db.Orders.Where(o => o.ShippingAddress.City == "London"),
 				db.Orders.Where(o => "London" == o.ShippingAddress.City)
+			);
+		}
+
+		[Test]
+		public void CompareToStringTest()
+		{
+			AssertResults(
+				new Dictionary<string, Predicate<IType>>
+				{
+					{"1", o => o is Int32Type},
+					{"\"London\"", o => o is StringType stringType && stringType.SqlType.Length == 15}
+				},
+				db.Orders.Where(o => o.ShippingAddress.City.CompareTo("London") > 1),
+				db.Orders.Where(o => "London".CompareTo(o.ShippingAddress.City) > 1),
+				db.Orders.Where(o => string.Compare("London", o.ShippingAddress.City) > 1),
+				db.Orders.Where(o => string.Compare(o.ShippingAddress.City, "London") > 1)
 			);
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/GH2437/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH2437/Fixture.cs
@@ -74,6 +74,18 @@ namespace NHibernate.Test.NHSpecificTest.GH2437
 		}
 
 		[Test]
+		public void Get_DateCustomType_NullableDateValueEqualsMethod()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var sessions = session.Query<UserSession>().Where(x => x.OpenDate.Value.Equals(DateTime.Now)).ToList();
+
+				Assert.That(sessions, Has.Count.EqualTo(10));
+			}
+		}
+
+		[Test]
 		public void Get_DateTimeCustomType_NullableDateValueEquals()
 		{
 			using (var session = OpenSession())

--- a/src/NHibernate/Linq/Functions/EqualsGenerator.cs
+++ b/src/NHibernate/Linq/Functions/EqualsGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -10,57 +11,59 @@ namespace NHibernate.Linq.Functions
 {
 	public class EqualsGenerator : BaseHqlGeneratorForMethod
 	{
+		internal static HashSet<MethodInfo> Methods = new HashSet<MethodInfo>
+		{
+			ReflectHelper.FastGetMethod(string.Equals, default(string), default(string)),
+			ReflectHelper.GetMethodDefinition<string>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<char>(x => x.Equals(x)),
+
+			ReflectHelper.GetMethodDefinition<sbyte>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<byte>(x => x.Equals(x)),
+
+			ReflectHelper.GetMethodDefinition<short>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<ushort>(x => x.Equals(x)),
+
+			ReflectHelper.GetMethodDefinition<int>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<uint>(x => x.Equals(x)),
+
+			ReflectHelper.GetMethodDefinition<long>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<ulong>(x => x.Equals(x)),
+
+			ReflectHelper.GetMethodDefinition<float>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<double>(x => x.Equals(x)),
+
+			ReflectHelper.FastGetMethod(decimal.Equals, default(decimal), default(decimal)),
+			ReflectHelper.GetMethodDefinition<decimal>(x => x.Equals(x)),
+
+			ReflectHelper.GetMethodDefinition<Guid>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<DateTime>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<DateTimeOffset>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<TimeSpan>(x => x.Equals(x)),
+			ReflectHelper.GetMethodDefinition<bool>(x => x.Equals(default(bool))),
+
+			ReflectHelper.GetMethodDefinition<IEquatable<string>>(x => x.Equals(default(string))),
+			ReflectHelper.GetMethodDefinition<IEquatable<char>>(x => x.Equals(default(char))),
+			ReflectHelper.GetMethodDefinition<IEquatable<sbyte>>(x => x.Equals(default(sbyte))),
+			ReflectHelper.GetMethodDefinition<IEquatable<byte>>(x => x.Equals(default(byte))),
+			ReflectHelper.GetMethodDefinition<IEquatable<short>>(x => x.Equals(default(short))),
+			ReflectHelper.GetMethodDefinition<IEquatable<ushort>>(x => x.Equals(default(ushort))),
+			ReflectHelper.GetMethodDefinition<IEquatable<int>>(x => x.Equals(default(int))),
+			ReflectHelper.GetMethodDefinition<IEquatable<uint>>(x => x.Equals(default(uint))),
+			ReflectHelper.GetMethodDefinition<IEquatable<long>>(x => x.Equals(default(long))),
+			ReflectHelper.GetMethodDefinition<IEquatable<ulong>>(x => x.Equals(default(ulong))),
+			ReflectHelper.GetMethodDefinition<IEquatable<float>>(x => x.Equals(default(float))),
+			ReflectHelper.GetMethodDefinition<IEquatable<double>>(x => x.Equals(default(double))),
+			ReflectHelper.GetMethodDefinition<IEquatable<decimal>>(x => x.Equals(default(decimal))),
+			ReflectHelper.GetMethodDefinition<IEquatable<Guid>>(x => x.Equals(default(Guid))),
+			ReflectHelper.GetMethodDefinition<IEquatable<DateTime>>(x => x.Equals(default(DateTime))),
+			ReflectHelper.GetMethodDefinition<IEquatable<DateTimeOffset>>(x => x.Equals(default(DateTimeOffset))),
+			ReflectHelper.GetMethodDefinition<IEquatable<TimeSpan>>(x => x.Equals(default(TimeSpan))),
+			ReflectHelper.GetMethodDefinition<IEquatable<bool>>(x => x.Equals(default(bool)))
+		};
+
 		public EqualsGenerator()
 		{
-			SupportedMethods = new[]
-				{
-					ReflectHelper.FastGetMethod(string.Equals, default(string), default(string)),
-					ReflectHelper.GetMethodDefinition<string>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<char>(x => x.Equals(x)),
-
-					ReflectHelper.GetMethodDefinition<sbyte>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<byte>(x => x.Equals(x)),
-
-					ReflectHelper.GetMethodDefinition<short>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<ushort>(x => x.Equals(x)),
-
-					ReflectHelper.GetMethodDefinition<int>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<uint>(x => x.Equals(x)),
-
-					ReflectHelper.GetMethodDefinition<long>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<ulong>(x => x.Equals(x)),
-
-					ReflectHelper.GetMethodDefinition<float>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<double>(x => x.Equals(x)),
-					
-					ReflectHelper.FastGetMethod(decimal.Equals, default(decimal), default(decimal)),
-					ReflectHelper.GetMethodDefinition<decimal>(x => x.Equals(x)),
-
-					ReflectHelper.GetMethodDefinition<Guid>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<DateTime>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<DateTimeOffset>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<TimeSpan>(x => x.Equals(x)),
-					ReflectHelper.GetMethodDefinition<bool>(x => x.Equals(default(bool))),
-
-					ReflectHelper.GetMethodDefinition<IEquatable<string>>(x => x.Equals(default(string))),
-					ReflectHelper.GetMethodDefinition<IEquatable<char>>(x => x.Equals(default(char))),
-					ReflectHelper.GetMethodDefinition<IEquatable<sbyte>>(x => x.Equals(default(sbyte))),
-					ReflectHelper.GetMethodDefinition<IEquatable<byte>>(x => x.Equals(default(byte))),
-					ReflectHelper.GetMethodDefinition<IEquatable<short>>(x => x.Equals(default(short))),
-					ReflectHelper.GetMethodDefinition<IEquatable<ushort>>(x => x.Equals(default(ushort))),
-					ReflectHelper.GetMethodDefinition<IEquatable<int>>(x => x.Equals(default(int))),
-					ReflectHelper.GetMethodDefinition<IEquatable<uint>>(x => x.Equals(default(uint))),
-					ReflectHelper.GetMethodDefinition<IEquatable<long>>(x => x.Equals(default(long))),
-					ReflectHelper.GetMethodDefinition<IEquatable<ulong>>(x => x.Equals(default(ulong))),
-					ReflectHelper.GetMethodDefinition<IEquatable<float>>(x => x.Equals(default(float))),
-					ReflectHelper.GetMethodDefinition<IEquatable<double>>(x => x.Equals(default(double))),
-					ReflectHelper.GetMethodDefinition<IEquatable<decimal>>(x => x.Equals(default(decimal))),
-					ReflectHelper.GetMethodDefinition<IEquatable<Guid>>(x => x.Equals(default(Guid))),
-					ReflectHelper.GetMethodDefinition<IEquatable<DateTime>>(x => x.Equals(default(DateTime))),
-					ReflectHelper.GetMethodDefinition<IEquatable<DateTimeOffset>>(x => x.Equals(default(DateTimeOffset))),
-					ReflectHelper.GetMethodDefinition<IEquatable<TimeSpan>>(x => x.Equals(default(TimeSpan))),
-					ReflectHelper.GetMethodDefinition<IEquatable<bool>>(x => x.Equals(default(bool)))
-				};
+			SupportedMethods = Methods;
 		}
 
 		public override bool AllowsNullableReturnType(MethodInfo method) => false;

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -3,6 +3,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Linq.Expressions;
 using NHibernate.Engine;
+using NHibernate.Linq.Functions;
 using NHibernate.Param;
 using NHibernate.Persister.Collection;
 using NHibernate.Type;
@@ -213,6 +214,17 @@ namespace NHibernate.Linq.Visitors
 					return _removeMappedAsCalls
 						? rawParameter
 						: node;
+				}
+
+				if (EqualsGenerator.Methods.Contains(node.Method) || CompareGenerator.IsCompareMethod(node.Method))
+				{
+					node = (MethodCallExpression) base.VisitMethodCall(node);
+					var left = Unwrap(node.Method.IsStatic ? node.Arguments[0] : node.Object);
+					var right = Unwrap(node.Method.IsStatic ? node.Arguments[1] : node.Arguments[0]);
+					AddRelatedExpression(node, left, right);
+					AddRelatedExpression(node, right, left);
+
+					return node;
 				}
 
 				return base.VisitMethodCall(node);


### PR DESCRIPTION
Fix another regression from #2365, where `Equals` and `CompareTo` were forgot to be added in the logic of detecting parameter types.

Related #2483