### PR TITLE
Improve CriteriaAssertFixture

### DIFF
--- a/src/NHibernate.Test/Criteria/Lambda/CriteriaAssertFixture.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/CriteriaAssertFixture.cs
@@ -12,28 +12,16 @@ namespace NHibernate.Test.Criteria.Lambda
 	{
 		private void AssertCriteriaAreNotEqual(ICriteria expected, ICriteria actual)
 		{
-			try
-			{
-				AssertCriteriaAreEqual(expected, actual);
-				Assert.Fail("No exception thrown");
-			}
-			catch
-			{
-				Assert.Pass();
-			}
+			Assert.Throws<AssertionException>(
+				() => { AssertCriteriaAreEqual(expected, actual); },
+				"No exception thrown");
 		}
 
 		private void AssertCriteriaAreNotEqual(DetachedCriteria expected, DetachedCriteria actual)
 		{
-			try
-			{
-				AssertCriteriaAreEqual(expected, actual);
-				Assert.Fail("No exception thrown");
-			}
-			catch
-			{
-				Assert.Pass();
-			}
+			Assert.Throws<AssertionException>(
+				() => { AssertCriteriaAreEqual(expected, actual); },
+				"No exception thrown");
 		}
 
 		[Test]


### PR DESCRIPTION
The reason for this change is that the ReSharper unit test runner was reporting these tests as failures when the `AssertCriteriaAreEqual` are expected to fail.

The `try`/`catch` along with a `Assert.pass()` wasn't enough.  `Assert.Throws` does behave correctly.