### PR TITLE
Replace casting with NodeType checks in Criteria ExpressionProcessor

### DIFF
--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -461,9 +461,12 @@ namespace NHibernate.Impl
 
 		private static System.Type FindMemberType(Expression expression)
 		{
-			if (expression.NodeType == ExpressionType.Call)
+			switch (expression.NodeType)
 			{
-				return ((MethodCallExpression) expression).Method.ReturnType;
+				case ExpressionType.MemberAccess:
+					return expression.Type;
+				case ExpressionType.Call:
+					return ((MethodCallExpression) expression).Method.ReturnType;
 			}
 
 			var unwrapExpression = UnwrapConvertExpression(expression);
@@ -472,7 +475,10 @@ namespace NHibernate.Impl
 				return FindMemberType(unwrapExpression);
 			}
 
-			return expression.Type;
+			if(expression is UnaryExpression || expression is BinaryExpression)
+				return expression.Type;
+
+			throw new ArgumentException("Could not determine member type from " + expression, nameof(expression));
 		}
 
 		private static bool IsMemberExpression(Expression expression)

--- a/src/NHibernate/Impl/ExpressionProcessor.cs
+++ b/src/NHibernate/Impl/ExpressionProcessor.cs
@@ -479,7 +479,7 @@ namespace NHibernate.Impl
 				return FindMemberType(unwrapExpression);
 			}
 
-			if(expression is UnaryExpression || expression is BinaryExpression)
+			if (expression is UnaryExpression || expression is BinaryExpression)
 				return expression.Type;
 
 			throw new ArgumentException("Could not determine member type from " + expression, nameof(expression));


### PR DESCRIPTION
Single check (`is/as` cast vs `NodeType` with direct cast)  is around 11% faster when casting is failed and 3% percent slower for successful casting case.

