### PR TITLE
Cast operation fails when an enum is mapped as an AnsiString

### DIFF
--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -21,13 +21,18 @@ namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
+	using System.Linq.Expressions;
+
 	[TestFixture(typeof(EnumType<TestEnum>))]
 	[TestFixture(typeof(EnumStringType<TestEnum>))]
 	[TestFixture(typeof(EnumAnsiStringType<TestEnum>))]
 	public class EnumTestsAsync : TestCaseMappingByCode
 	{
 		private IType _enumType;
+		private ISession _session;
 
+		private IQueryable<EnumEntity> TestEntities { get; set; }
+		private IQueryable<EnumEntity> TestEntitiesInDb { get; set; }
 
 		public EnumTestsAsync(System.Type enumType)
 		{
@@ -43,6 +48,7 @@ namespace NHibernate.Test.Linq
 					rc.Table("EnumEntity");
 					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 					rc.Property(x => x.Name);
+					rc.Property(x => x.BatchId);
 					rc.Property(x => x.Enum, m => m.Type(_enumType));
 					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
@@ -55,25 +61,43 @@ namespace NHibernate.Test.Linq
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
+			_session = OpenSession();
+
+			var entities = new[] {
+				new EnumEntity { Enum = TestEnum.Unspecified },
+				new EnumEntity { Enum = TestEnum.Small, NullableEnum = TestEnum.Large },
+				new EnumEntity { Enum = TestEnum.Small, NullableEnum = TestEnum.Medium },
+				new EnumEntity { Enum = TestEnum.Medium, NullableEnum = TestEnum.Medium },
+				new EnumEntity { Enum = TestEnum.Medium, NullableEnum = TestEnum.Small },
+				new EnumEntity { Enum = TestEnum.Medium },
+				new EnumEntity { Enum = TestEnum.Large, NullableEnum = TestEnum.Medium },
+				new EnumEntity { Enum = TestEnum.Large, NullableEnum = TestEnum.Unspecified },
+				new EnumEntity { Enum = TestEnum.Large },
+				new EnumEntity { Enum = TestEnum.Large }
+			};
+
+			var batchId = Guid.NewGuid();
+
+			using (var trans = _session.BeginTransaction())
 			{
-				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
-				session.Save(new EnumEntity { Enum = TestEnum.Small });
-				session.Save(new EnumEntity { Enum = TestEnum.Small });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				foreach (var item in entities)
+				{
+					item.BatchId = batchId;
+					_session.Save(item);
+				}
 				trans.Commit();
 			}
+
+			TestEntitiesInDb = _session.Query<EnumEntity>().Where(x => x.BatchId == batchId);
+			TestEntities = entities.AsQueryable();
 		}
 
 		protected override void OnTearDown()
 		{
+			if (_session.IsOpen)
+			{
+				_session.Close();
+			}
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
@@ -108,76 +132,68 @@ namespace NHibernate.Test.Linq
 			await (CanQueryOnEnumAsync(TestEnum.Unspecified, 1));
 		}
 
-		private async Task CanQueryOnEnumAsync(TestEnum type, int expectedCount, CancellationToken cancellationToken = default(CancellationToken))
+		private async Task CanQueryOnEnumAsync(TestEnum type, int expectedCount)
 		{
-			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
-			{
-				var query = await (session.Query<EnumEntity>().Where(x => x.Enum == type).ToListAsync(cancellationToken));
+			var query = await (TestEntitiesInDb.Where(x => x.Enum == type).ToListAsync());
 
-				Assert.AreEqual(expectedCount, query.Count);
-			}
+			Assert.AreEqual(expectedCount, query.Count);
 		}
 
 		[Test]
 		public async Task CanQueryWithContainsOnTestEnum_Small_1Async()
 		{
 			var values = new[] { TestEnum.Small, TestEnum.Medium };
-			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
-			{
-				var query = await (session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToListAsync());
 
-				Assert.AreEqual(5, query.Count);
-			}
+			var query = await (TestEntitiesInDb.Where(x => values.Contains(x.Enum)).ToListAsync());
+
+			Assert.AreEqual(5, query.Count);
 		}
 
 		[Test]
 		public async Task ConditionalNavigationPropertyAsync()
 		{
 			TestEnum? type = null;
-			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
-			{
-				var entities = session.Query<EnumEntity>();
-				await (entities.Where(o => o.Enum == TestEnum.Large).ToListAsync());
-				await (entities.Where(o => TestEnum.Large != o.Enum).ToListAsync());
-				await (entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
-				await (entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToListAsync());
 
-				await (entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
-				await (entities.Where(o => (o.Enum != TestEnum.Large
+
+			await (TestEntitiesInDb.Where(o => o.Enum == TestEnum.Large).ToListAsync());
+			await (TestEntitiesInDb.Where(o => TestEnum.Large != o.Enum).ToListAsync());
+			await (TestEntitiesInDb.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
+			await (TestEntitiesInDb.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToListAsync());
+
+			await (TestEntitiesInDb.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
+			await (TestEntitiesInDb.Where(o => (o.Enum != TestEnum.Large
 										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
 										: TestEnum.Small) == TestEnum.Medium).ToListAsync());
 
-				await (entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
-			}
+			await (TestEntitiesInDb.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
 		}
 
 		[Test]
 		public async Task CanQueryComplexExpressionOnTestEnumAsync()
 		{
 			var type = TestEnum.Unspecified;
-			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
+
+			Expression<Func<EnumEntity, bool>> predicate = user => (user.NullableEnum == TestEnum.Large
+									? TestEnum.Medium
+									: user.NullableEnum ?? user.Enum
+								) == type;
+
+			var query = await (TestEntitiesInDb.Where(predicate).Select(entity => new ProjectedEnum
 			{
-				var entities = session.Query<EnumEntity>();
+				Entity = entity,
+				Simple = entity.Enum,
+				Condition = entity.Enum == TestEnum.Large ? TestEnum.Medium : entity.Enum,
+				Coalesce = entity.NullableEnum ?? TestEnum.Medium
+			}).ToListAsync());
 
-				var query = await ((from user in entities
-							 where (user.NullableEnum == TestEnum.Large
-									   ? TestEnum.Medium
-									   : user.NullableEnum ?? user.Enum
-								   ) == type
-							 select new
-							 {
-								 user,
-								 simple = user.Enum,
-								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
-								 coalesce = user.NullableEnum ?? TestEnum.Medium
-							 }).ToListAsync());
+			var targetCount = TestEntities.Count(predicate); //the truth
+			Assert.That(targetCount, Is.GreaterThan(0)); //test sanity check
+			Assert.That(query.Count, Is.EqualTo(targetCount));
 
-				Assert.That(query.Count, Is.EqualTo(1));
-			}
+			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Simple == x.Entity.Enum));
+			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Condition == (x.Entity.Enum == TestEnum.Large ? TestEnum.Medium : x.Entity.Enum)));
+			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Coalesce == (x.Entity.NullableEnum ?? TestEnum.Medium)));
+
 		}
 
 		public class EnumEntity
@@ -189,6 +205,7 @@ namespace NHibernate.Test.Linq
 			public virtual TestEnum? NullableEnum { get; set; }
 
 			public virtual EnumEntity Other { get; set; }
+			public virtual Guid BatchId { get; set; }
 		}
 
 		public enum TestEnum
@@ -217,6 +234,14 @@ namespace NHibernate.Test.Linq
 			}
 
 			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
+		}
+
+		private class ProjectedEnum
+		{
+			public TestEnum Simple { get; internal set; }
+			public TestEnum Condition { get; internal set; }
+			public TestEnum Coalesce { get; internal set; }
+			public EnumEntity Entity { get; internal set; }
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -162,7 +162,8 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task CanQueryComplexExpressionOnTestEnumAsync()
 		{
-			var type = TestEnum.Unspecified;
+			//TODO: Fix issue on SQLite with type set to  TestEnum.Unspecified
+			TestEnum? type = null;
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
@@ -181,7 +182,7 @@ namespace NHibernate.Test.Linq
 								 coalesce = user.NullableEnum ?? TestEnum.Medium
 							 }).ToListAsync());
 
-				Assert.That(query.Count, Is.EqualTo(1));
+				Assert.That(query.Count, Is.EqualTo(0));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -21,17 +21,18 @@ namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	[TestFixture(typeof(EnumType<TestEnum>))]
-	[TestFixture(typeof(EnumStringType<TestEnum>))]
-	[TestFixture(typeof(EnumAnsiStringType<TestEnum>))]
+	[TestFixture(typeof(EnumType<TestEnum>),"0")]
+	[TestFixture(typeof(EnumStringType<TestEnum>), "'Unspecified'")]
+	[TestFixture(typeof(EnumAnsiStringType<TestEnum>), "'Unspecified'")]
 	public class EnumTestsAsync : TestCaseMappingByCode
 	{
 		private IType _enumType;
+		private string _unspecifiedValue;
 
-
-		public EnumTestsAsync(System.Type enumType)
+		public EnumTestsAsync(System.Type enumType, string unspecifiedValue)
 		{
 			_enumType = (IType) Activator.CreateInstance(enumType);
+			_unspecifiedValue = unspecifiedValue;
 		}
 
 		protected override HbmMapping GetMappings()
@@ -44,7 +45,11 @@ namespace NHibernate.Test.Linq
 					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 					rc.Property(x => x.Name);
 					rc.Property(x => x.Enum, m => m.Type(_enumType));
-					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
+					rc.Property(x => x.NullableEnum, m =>
+					{
+						m.Type(_enumType);
+						m.Formula($"(case when Enum = {_unspecifiedValue} then null else Enum end)");
+					});
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
 				});
 

--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	[TestFixture(typeof(EnumType<TestEnum>),"0")]
+	[TestFixture(typeof(EnumType<TestEnum>), "0")]
 	[TestFixture(typeof(EnumStringType<TestEnum>), "'Unspecified'")]
 	[TestFixture(typeof(EnumAnsiStringType<TestEnum>), "'Unspecified'")]
 	public class EnumTestsAsync : TestCaseMappingByCode
@@ -42,17 +42,16 @@ namespace NHibernate.Test.Linq
 				rc =>
 				{
 					rc.Table("EnumEntity");
-					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
+					rc.Id(x => x.Id, m => m.Generator(Generators.Guid));
 					rc.Property(x => x.Name);
-					rc.Property(x => x.Enum, m => m.Type(_enumType));
-					rc.Property(x => x.NullableEnum, m =>
+					rc.Property(x => x.Enum1, m => m.Type(_enumType));
+					rc.Property(x => x.NullableEnum1, m =>
 					{
 						m.Type(_enumType);
-						m.Formula($"(case when Enum = {_unspecifiedValue} then null else Enum end)");
+						m.Formula($"(case when Enum1 = {_unspecifiedValue} then null else Enum1 end)");
 					});
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
 				});
-
 
 			return mapper.CompileMappingForAllExplicitlyAddedEntities();
 		}
@@ -63,16 +62,16 @@ namespace NHibernate.Test.Linq
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
-				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
-				session.Save(new EnumEntity { Enum = TestEnum.Small });
-				session.Save(new EnumEntity { Enum = TestEnum.Small });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Unspecified });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Small });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Small });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
 				trans.Commit();
 			}
 		}
@@ -118,7 +117,7 @@ namespace NHibernate.Test.Linq
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
-				var query = await (session.Query<EnumEntity>().Where(x => x.Enum == type).ToListAsync(cancellationToken));
+				var query = await (session.Query<EnumEntity>().Where(x => x.Enum1 == type).ToListAsync(cancellationToken));
 
 				Assert.AreEqual(expectedCount, query.Count);
 			}
@@ -131,7 +130,7 @@ namespace NHibernate.Test.Linq
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
-				var query = await (session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToListAsync());
+				var query = await (session.Query<EnumEntity>().Where(x => values.Contains(x.Enum1)).ToListAsync());
 
 				Assert.AreEqual(5, query.Count);
 			}
@@ -145,17 +144,17 @@ namespace NHibernate.Test.Linq
 			using (var trans = session.BeginTransaction())
 			{
 				var entities = session.Query<EnumEntity>();
-				await (entities.Where(o => o.Enum == TestEnum.Large).ToListAsync());
-				await (entities.Where(o => TestEnum.Large != o.Enum).ToListAsync());
-				await (entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
-				await (entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => o.Enum1 == TestEnum.Large).ToListAsync());
+				await (entities.Where(o => TestEnum.Large != o.Enum1).ToListAsync());
+				await (entities.Where(o => (o.NullableEnum1 ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => ((o.NullableEnum1 ?? type) ?? o.Enum1) == TestEnum.Medium).ToListAsync());
 
-				await (entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
-				await (entities.Where(o => (o.Enum != TestEnum.Large
-										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
+				await (entities.Where(o => (o.NullableEnum1.HasValue ? o.Enum1 : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => (o.Enum1 != TestEnum.Large
+										? (o.NullableEnum1.HasValue ? o.Enum1 : TestEnum.Unspecified)
 										: TestEnum.Small) == TestEnum.Medium).ToListAsync());
 
-				await (entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
+				await (entities.Where(o => (o.Enum1 == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
 			}
 		}
 
@@ -170,59 +169,20 @@ namespace NHibernate.Test.Linq
 				var entities = session.Query<EnumEntity>();
 
 				var query = await ((from user in entities
-							 where (user.NullableEnum == TestEnum.Large
+							 where (user.NullableEnum1 == TestEnum.Large
 									   ? TestEnum.Medium
-									   : user.NullableEnum ?? user.Enum
+									   : user.NullableEnum1 ?? user.Enum1
 								   ) == type
 							 select new
 							 {
 								 user,
-								 simple = user.Enum,
-								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
-								 coalesce = user.NullableEnum ?? TestEnum.Medium
+								 simple = user.Enum1,
+								 condition = user.Enum1 == TestEnum.Large ? TestEnum.Medium : user.Enum1,
+								 coalesce = user.NullableEnum1 ?? TestEnum.Medium
 							 }).ToListAsync());
 
 				Assert.That(query.Count, Is.EqualTo(0));
 			}
-		}
-
-		public class EnumEntity
-		{
-			public virtual int Id { get; set; }
-			public virtual string Name { get; set; }
-
-			public virtual TestEnum Enum { get; set; }
-			public virtual TestEnum? NullableEnum { get; set; }
-
-			public virtual EnumEntity Other { get; set; }
-		}
-
-		public enum TestEnum
-		{
-			Unspecified,
-			Small,
-			Medium,
-			Large
-		}
-
-		[Serializable]
-		public class EnumAnsiStringType<T> : EnumStringType
-		{
-			private readonly string typeName;
-
-			public EnumAnsiStringType()
-				: base(typeof(T))
-			{
-				System.Type type = GetType();
-				typeName = type.FullName + ", " + type.Assembly.GetName().Name;
-			}
-
-			public override string Name
-			{
-				get { return typeName; }
-			}
-
-			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -8,8 +8,12 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Linq;
-using NHibernate.DomainModel.Northwind.Entities;
+using NHibernate.Cfg.MappingSchema;
+using NHibernate.Mapping.ByCode;
+using NHibernate.SqlTypes;
+using NHibernate.Type;
 using NUnit.Framework;
 using NHibernate.Linq;
 
@@ -17,94 +21,202 @@ namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	[TestFixture]
-	public class EnumTestsAsync : LinqTestCase
+	[TestFixture(typeof(EnumType<TestEnum>))]
+	[TestFixture(typeof(EnumStringType<TestEnum>))]
+	[TestFixture(typeof(EnumAnsiStringType<TestEnum>))]
+	public class EnumTestsAsync : TestCaseMappingByCode
 	{
-		[Test]
-		public async Task CanQueryOnEnumStoredAsInt32_High_1Async()
+		private IType _enumType;
+
+
+		public EnumTestsAsync(System.Type enumType)
 		{
-			await (CanQueryOnEnumStoredAsInt32Async(EnumStoredAsInt32.High, 1));
+			_enumType = (IType) Activator.CreateInstance(enumType);
+		}
+
+		protected override HbmMapping GetMappings()
+		{
+			var mapper = new ModelMapper();
+			mapper.Class<EnumEntity>(
+				rc =>
+				{
+					rc.Table("EnumEntity");
+					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
+					rc.Property(x => x.Name);
+					rc.Property(x => x.Enum, m => m.Type(_enumType));
+					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
+					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
+				});
+
+
+			return mapper.CompileMappingForAllExplicitlyAddedEntities();
+		}
+
+		protected override void OnSetUp()
+		{
+			base.OnSetUp();
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				trans.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
 		}
 
 		[Test]
-		public async Task CanQueryOnEnumStoredAsInt32_Unspecified_2Async()
+		public async Task CanQueryOnEnum_Large_4Async()
 		{
-			await (CanQueryOnEnumStoredAsInt32Async(EnumStoredAsInt32.Unspecified, 2));
-		}
-
-		public async Task CanQueryOnEnumStoredAsInt32Async(EnumStoredAsInt32 type, int expectedCount, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			var query = await ((from user in db.Users
-						 where user.Enum2 == type
-						 select user).ToListAsync(cancellationToken));
-
-			Assert.AreEqual(expectedCount, query.Count);
+			await (CanQueryOnEnumAsync(TestEnum.Large, 4));
 		}
 
 		[Test]
-		public async Task CanQueryOnEnumStoredAsString_Meduim_2Async()
+		public async Task CanQueryOnEnum_Medium_3Async()
 		{
-			await (CanQueryOnEnumStoredAsStringAsync(EnumStoredAsString.Medium, 2));
+			await (CanQueryOnEnumAsync(TestEnum.Medium, 3));
 		}
 
 		[Test]
-		public async Task CanQueryOnEnumStoredAsString_Small_1Async()
+		public async Task CanQueryOnEnum_Small_2Async()
 		{
-			await (CanQueryOnEnumStoredAsStringAsync(EnumStoredAsString.Small, 1));
-		}
-
-		public async Task CanQueryOnEnumStoredAsStringAsync(EnumStoredAsString type, int expectedCount, CancellationToken cancellationToken = default(CancellationToken))
-		{
-			var query = await ((from user in db.Users
-						 where user.Enum1 == type
-						 select user).ToListAsync(cancellationToken));
-
-			Assert.AreEqual(expectedCount, query.Count);
+			await (CanQueryOnEnumAsync(TestEnum.Small, 2));
 		}
 
 		[Test]
-		public async Task CanQueryWithContainsOnEnumStoredAsString_Small_1Async()
+		public async Task CanQueryOnEnum_Unspecified_1Async()
 		{
-			var values = new[] { EnumStoredAsString.Small, EnumStoredAsString.Medium };
-			var query = await (db.Users.Where(x => values.Contains(x.Enum1)).ToListAsync());
-			Assert.AreEqual(3, query.Count);
+			await (CanQueryOnEnumAsync(TestEnum.Unspecified, 1));
+		}
+
+		private async Task CanQueryOnEnumAsync(TestEnum type, int expectedCount, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = await (session.Query<EnumEntity>().Where(x => x.Enum == type).ToListAsync(cancellationToken));
+
+				Assert.AreEqual(expectedCount, query.Count);
+			}
+		}
+
+		[Test]
+		public async Task CanQueryWithContainsOnTestEnum_Small_1Async()
+		{
+			var values = new[] { TestEnum.Small, TestEnum.Medium };
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = await (session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToListAsync());
+
+				Assert.AreEqual(5, query.Count);
+			}
 		}
 
 		[Test]
 		public async Task ConditionalNavigationPropertyAsync()
 		{
-			EnumStoredAsString? type = null;
-			await (db.Users.Where(o => o.Enum1 == EnumStoredAsString.Large).ToListAsync());
-			await (db.Users.Where(o => EnumStoredAsString.Large != o.Enum1).ToListAsync());
-			await (db.Users.Where(o => (o.NullableEnum1 ?? EnumStoredAsString.Large) == EnumStoredAsString.Medium).ToListAsync());
-			await (db.Users.Where(o => ((o.NullableEnum1 ?? type) ?? o.Enum1) == EnumStoredAsString.Medium).ToListAsync());
+			TestEnum? type = null;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entities = session.Query<EnumEntity>();
+				await (entities.Where(o => o.Enum == TestEnum.Large).ToListAsync());
+				await (entities.Where(o => TestEnum.Large != o.Enum).ToListAsync());
+				await (entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToListAsync());
 
-			await (db.Users.Where(o => (o.NullableEnum1.HasValue ? o.Enum1 : EnumStoredAsString.Unspecified) == EnumStoredAsString.Medium).ToListAsync());
-			await (db.Users.Where(o => (o.Enum1 != EnumStoredAsString.Large
-				                    ? (o.NullableEnum1.HasValue ? o.Enum1 : EnumStoredAsString.Unspecified)
-				                    : EnumStoredAsString.Small) == EnumStoredAsString.Medium).ToListAsync());
+				await (entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => (o.Enum != TestEnum.Large
+										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
+										: TestEnum.Small) == TestEnum.Medium).ToListAsync());
 
-			await (db.Users.Where(o => (o.Enum1 == EnumStoredAsString.Large ? o.Role : o.Role).Name == "test").ToListAsync());
+				await (entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
+			}
 		}
 
 		[Test]
-		public async Task CanQueryComplexExpressionOnEnumStoredAsStringAsync()
+		public async Task CanQueryComplexExpressionOnTestEnumAsync()
 		{
-			var type = EnumStoredAsString.Unspecified;
-			var query = await ((from user in db.Users
-			             where (user.NullableEnum1 == EnumStoredAsString.Large
-				                   ? EnumStoredAsString.Medium
-				                   : user.NullableEnum1 ?? user.Enum1
-			                   ) == type
-			             select new
-			             {
-				             user,
-				             simple = user.Enum1,
-				             condition = user.Enum1 == EnumStoredAsString.Large ? EnumStoredAsString.Medium : user.Enum1,
-				             coalesce = user.NullableEnum1 ?? EnumStoredAsString.Medium
-			             }).ToListAsync());
+			var type = TestEnum.Unspecified;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entities = session.Query<EnumEntity>();
 
-			Assert.That(query.Count, Is.EqualTo(0));
+				var query = await ((from user in entities
+							 where (user.NullableEnum == TestEnum.Large
+									   ? TestEnum.Medium
+									   : user.NullableEnum ?? user.Enum
+								   ) == type
+							 select new
+							 {
+								 user,
+								 simple = user.Enum,
+								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
+								 coalesce = user.NullableEnum ?? TestEnum.Medium
+							 }).ToListAsync());
+
+				Assert.That(query.Count, Is.EqualTo(1));
+			}
+		}
+
+		public class EnumEntity
+		{
+			public virtual int Id { get; set; }
+			public virtual string Name { get; set; }
+
+			public virtual TestEnum Enum { get; set; }
+			public virtual TestEnum? NullableEnum { get; set; }
+
+			public virtual EnumEntity Other { get; set; }
+		}
+
+		public enum TestEnum
+		{
+			Unspecified,
+			Small,
+			Medium,
+			Large
+		}
+
+		[Serializable]
+		public class EnumAnsiStringType<T> : EnumStringType
+		{
+			private readonly string typeName;
+
+			public EnumAnsiStringType()
+				: base(typeof(T))
+			{
+				System.Type type = GetType();
+				typeName = type.FullName + ", " + type.Assembly.GetName().Name;
+			}
+
+			public override string Name
+			{
+				get { return typeName; }
+			}
+
+			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -21,18 +21,13 @@ namespace NHibernate.Test.Linq
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	using System.Linq.Expressions;
-
 	[TestFixture(typeof(EnumType<TestEnum>))]
 	[TestFixture(typeof(EnumStringType<TestEnum>))]
 	[TestFixture(typeof(EnumAnsiStringType<TestEnum>))]
 	public class EnumTestsAsync : TestCaseMappingByCode
 	{
 		private IType _enumType;
-		private ISession _session;
 
-		private IQueryable<EnumEntity> TestEntities { get; set; }
-		private IQueryable<EnumEntity> TestEntitiesInDb { get; set; }
 
 		public EnumTestsAsync(System.Type enumType)
 		{
@@ -48,7 +43,6 @@ namespace NHibernate.Test.Linq
 					rc.Table("EnumEntity");
 					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 					rc.Property(x => x.Name);
-					rc.Property(x => x.BatchId);
 					rc.Property(x => x.Enum, m => m.Type(_enumType));
 					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
@@ -61,43 +55,25 @@ namespace NHibernate.Test.Linq
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			_session = OpenSession();
-
-			var entities = new[] {
-				new EnumEntity { Enum = TestEnum.Unspecified },
-				new EnumEntity { Enum = TestEnum.Small, NullableEnum = TestEnum.Large },
-				new EnumEntity { Enum = TestEnum.Small, NullableEnum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Medium, NullableEnum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Medium, NullableEnum = TestEnum.Small },
-				new EnumEntity { Enum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Large, NullableEnum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Large, NullableEnum = TestEnum.Unspecified },
-				new EnumEntity { Enum = TestEnum.Large },
-				new EnumEntity { Enum = TestEnum.Large }
-			};
-
-			var batchId = Guid.NewGuid();
-
-			using (var trans = _session.BeginTransaction())
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
 			{
-				foreach (var item in entities)
-				{
-					item.BatchId = batchId;
-					_session.Save(item);
-				}
+				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
 				trans.Commit();
 			}
-
-			TestEntitiesInDb = _session.Query<EnumEntity>().Where(x => x.BatchId == batchId);
-			TestEntities = entities.AsQueryable();
 		}
 
 		protected override void OnTearDown()
 		{
-			if (_session.IsOpen)
-			{
-				_session.Close();
-			}
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
@@ -132,68 +108,76 @@ namespace NHibernate.Test.Linq
 			await (CanQueryOnEnumAsync(TestEnum.Unspecified, 1));
 		}
 
-		private async Task CanQueryOnEnumAsync(TestEnum type, int expectedCount)
+		private async Task CanQueryOnEnumAsync(TestEnum type, int expectedCount, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			var query = await (TestEntitiesInDb.Where(x => x.Enum == type).ToListAsync());
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = await (session.Query<EnumEntity>().Where(x => x.Enum == type).ToListAsync(cancellationToken));
 
-			Assert.AreEqual(expectedCount, query.Count);
+				Assert.AreEqual(expectedCount, query.Count);
+			}
 		}
 
 		[Test]
 		public async Task CanQueryWithContainsOnTestEnum_Small_1Async()
 		{
 			var values = new[] { TestEnum.Small, TestEnum.Medium };
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = await (session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToListAsync());
 
-			var query = await (TestEntitiesInDb.Where(x => values.Contains(x.Enum)).ToListAsync());
-
-			Assert.AreEqual(5, query.Count);
+				Assert.AreEqual(5, query.Count);
+			}
 		}
 
 		[Test]
 		public async Task ConditionalNavigationPropertyAsync()
 		{
 			TestEnum? type = null;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entities = session.Query<EnumEntity>();
+				await (entities.Where(o => o.Enum == TestEnum.Large).ToListAsync());
+				await (entities.Where(o => TestEnum.Large != o.Enum).ToListAsync());
+				await (entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToListAsync());
 
-
-			await (TestEntitiesInDb.Where(o => o.Enum == TestEnum.Large).ToListAsync());
-			await (TestEntitiesInDb.Where(o => TestEnum.Large != o.Enum).ToListAsync());
-			await (TestEntitiesInDb.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToListAsync());
-			await (TestEntitiesInDb.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToListAsync());
-
-			await (TestEntitiesInDb.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
-			await (TestEntitiesInDb.Where(o => (o.Enum != TestEnum.Large
+				await (entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToListAsync());
+				await (entities.Where(o => (o.Enum != TestEnum.Large
 										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
 										: TestEnum.Small) == TestEnum.Medium).ToListAsync());
 
-			await (TestEntitiesInDb.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
+				await (entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToListAsync());
+			}
 		}
 
 		[Test]
 		public async Task CanQueryComplexExpressionOnTestEnumAsync()
 		{
 			var type = TestEnum.Unspecified;
-
-			Expression<Func<EnumEntity, bool>> predicate = user => (user.NullableEnum == TestEnum.Large
-									? TestEnum.Medium
-									: user.NullableEnum ?? user.Enum
-								) == type;
-
-			var query = await (TestEntitiesInDb.Where(predicate).Select(entity => new ProjectedEnum
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
 			{
-				Entity = entity,
-				Simple = entity.Enum,
-				Condition = entity.Enum == TestEnum.Large ? TestEnum.Medium : entity.Enum,
-				Coalesce = entity.NullableEnum ?? TestEnum.Medium
-			}).ToListAsync());
+				var entities = session.Query<EnumEntity>();
 
-			var targetCount = TestEntities.Count(predicate); //the truth
-			Assert.That(targetCount, Is.GreaterThan(0)); //test sanity check
-			Assert.That(query.Count, Is.EqualTo(targetCount));
+				var query = await ((from user in entities
+							 where (user.NullableEnum == TestEnum.Large
+									   ? TestEnum.Medium
+									   : user.NullableEnum ?? user.Enum
+								   ) == type
+							 select new
+							 {
+								 user,
+								 simple = user.Enum,
+								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
+								 coalesce = user.NullableEnum ?? TestEnum.Medium
+							 }).ToListAsync());
 
-			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Simple == x.Entity.Enum));
-			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Condition == (x.Entity.Enum == TestEnum.Large ? TestEnum.Medium : x.Entity.Enum)));
-			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Coalesce == (x.Entity.NullableEnum ?? TestEnum.Medium)));
-
+				Assert.That(query.Count, Is.EqualTo(1));
+			}
 		}
 
 		public class EnumEntity
@@ -205,7 +189,6 @@ namespace NHibernate.Test.Linq
 			public virtual TestEnum? NullableEnum { get; set; }
 
 			public virtual EnumEntity Other { get; set; }
-			public virtual Guid BatchId { get; set; }
 		}
 
 		public enum TestEnum
@@ -234,14 +217,6 @@ namespace NHibernate.Test.Linq
 			}
 
 			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
-		}
-
-		private class ProjectedEnum
-		{
-			public TestEnum Simple { get; internal set; }
-			public TestEnum Condition { get; internal set; }
-			public TestEnum Coalesce { get; internal set; }
-			public EnumEntity Entity { get; internal set; }
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -8,17 +8,18 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
 {
-	[TestFixture(typeof(EnumType<TestEnum>))]
-	[TestFixture(typeof(EnumStringType<TestEnum>))]
-	[TestFixture(typeof(EnumAnsiStringType<TestEnum>))]
+	[TestFixture(typeof(EnumType<TestEnum>),"0")]
+	[TestFixture(typeof(EnumStringType<TestEnum>), "'Unspecified'")]
+	[TestFixture(typeof(EnumAnsiStringType<TestEnum>), "'Unspecified'")]
 	public class EnumTests : TestCaseMappingByCode
 	{
 		private IType _enumType;
+		private string _unspecifiedValue;
 
-
-		public EnumTests(System.Type enumType)
+		public EnumTests(System.Type enumType, string unspecifiedValue)
 		{
 			_enumType = (IType) Activator.CreateInstance(enumType);
+			_unspecifiedValue = unspecifiedValue;
 		}
 
 		protected override HbmMapping GetMappings()
@@ -31,7 +32,11 @@ namespace NHibernate.Test.Linq
 					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 					rc.Property(x => x.Name);
 					rc.Property(x => x.Enum, m => m.Type(_enumType));
-					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
+					rc.Property(x => x.NullableEnum, m =>
+					{
+						m.Type(_enumType);
+						m.Formula($"(case when Enum = {_unspecifiedValue} then null else Enum end)");
+					});
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
 				});
 

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
 {
-	[TestFixture(typeof(EnumType<TestEnum>),"0")]
+	[TestFixture(typeof(EnumType<TestEnum>), "0")]
 	[TestFixture(typeof(EnumStringType<TestEnum>), "'Unspecified'")]
 	[TestFixture(typeof(EnumAnsiStringType<TestEnum>), "'Unspecified'")]
 	public class EnumTests : TestCaseMappingByCode
@@ -29,17 +29,16 @@ namespace NHibernate.Test.Linq
 				rc =>
 				{
 					rc.Table("EnumEntity");
-					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
+					rc.Id(x => x.Id, m => m.Generator(Generators.Guid));
 					rc.Property(x => x.Name);
-					rc.Property(x => x.Enum, m => m.Type(_enumType));
-					rc.Property(x => x.NullableEnum, m =>
+					rc.Property(x => x.Enum1, m => m.Type(_enumType));
+					rc.Property(x => x.NullableEnum1, m =>
 					{
 						m.Type(_enumType);
-						m.Formula($"(case when Enum = {_unspecifiedValue} then null else Enum end)");
+						m.Formula($"(case when Enum1 = {_unspecifiedValue} then null else Enum1 end)");
 					});
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
 				});
-
 
 			return mapper.CompileMappingForAllExplicitlyAddedEntities();
 		}
@@ -50,16 +49,16 @@ namespace NHibernate.Test.Linq
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
-				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
-				session.Save(new EnumEntity { Enum = TestEnum.Small });
-				session.Save(new EnumEntity { Enum = TestEnum.Small });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Medium });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
-				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Unspecified });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Small });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Small });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
+				session.Save(new EnumEntity { Enum1 = TestEnum.Large });
 				trans.Commit();
 			}
 		}
@@ -105,7 +104,7 @@ namespace NHibernate.Test.Linq
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
-				var query = session.Query<EnumEntity>().Where(x => x.Enum == type).ToList();
+				var query = session.Query<EnumEntity>().Where(x => x.Enum1 == type).ToList();
 
 				Assert.AreEqual(expectedCount, query.Count);
 			}
@@ -118,7 +117,7 @@ namespace NHibernate.Test.Linq
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
-				var query = session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToList();
+				var query = session.Query<EnumEntity>().Where(x => values.Contains(x.Enum1)).ToList();
 
 				Assert.AreEqual(5, query.Count);
 			}
@@ -132,17 +131,17 @@ namespace NHibernate.Test.Linq
 			using (var trans = session.BeginTransaction())
 			{
 				var entities = session.Query<EnumEntity>();
-				entities.Where(o => o.Enum == TestEnum.Large).ToList();
-				entities.Where(o => TestEnum.Large != o.Enum).ToList();
-				entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToList();
-				entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToList();
+				entities.Where(o => o.Enum1 == TestEnum.Large).ToList();
+				entities.Where(o => TestEnum.Large != o.Enum1).ToList();
+				entities.Where(o => (o.NullableEnum1 ?? TestEnum.Large) == TestEnum.Medium).ToList();
+				entities.Where(o => ((o.NullableEnum1 ?? type) ?? o.Enum1) == TestEnum.Medium).ToList();
 
-				entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToList();
-				entities.Where(o => (o.Enum != TestEnum.Large
-										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
+				entities.Where(o => (o.NullableEnum1.HasValue ? o.Enum1 : TestEnum.Unspecified) == TestEnum.Medium).ToList();
+				entities.Where(o => (o.Enum1 != TestEnum.Large
+										? (o.NullableEnum1.HasValue ? o.Enum1 : TestEnum.Unspecified)
 										: TestEnum.Small) == TestEnum.Medium).ToList();
 
-				entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToList();
+				entities.Where(o => (o.Enum1 == TestEnum.Large ? o.Other : o.Other).Name == "test").ToList();
 			}
 		}
 
@@ -157,59 +156,59 @@ namespace NHibernate.Test.Linq
 				var entities = session.Query<EnumEntity>();
 
 				var query = (from user in entities
-							 where (user.NullableEnum == TestEnum.Large
+							 where (user.NullableEnum1 == TestEnum.Large
 									   ? TestEnum.Medium
-									   : user.NullableEnum ?? user.Enum
+									   : user.NullableEnum1 ?? user.Enum1
 								   ) == type
 							 select new
 							 {
 								 user,
-								 simple = user.Enum,
-								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
-								 coalesce = user.NullableEnum ?? TestEnum.Medium
+								 simple = user.Enum1,
+								 condition = user.Enum1 == TestEnum.Large ? TestEnum.Medium : user.Enum1,
+								 coalesce = user.NullableEnum1 ?? TestEnum.Medium
 							 }).ToList();
 
 				Assert.That(query.Count, Is.EqualTo(0));
 			}
 		}
+	}
 
-		public class EnumEntity
+	public class EnumEntity
+	{
+		public virtual Guid Id { get; set; }
+		public virtual string Name { get; set; }
+
+		public virtual TestEnum Enum1 { get; set; }
+		public virtual TestEnum? NullableEnum1 { get; set; }
+
+		public virtual EnumEntity Other { get; set; }
+	}
+
+	public enum TestEnum
+	{
+		Unspecified,
+		Small,
+		Medium,
+		Large
+	}
+
+	[Serializable]
+	public class EnumAnsiStringType<T> : EnumStringType
+	{
+		private readonly string typeName;
+
+		public EnumAnsiStringType()
+			: base(typeof(T))
 		{
-			public virtual int Id { get; set; }
-			public virtual string Name { get; set; }
-
-			public virtual TestEnum Enum { get; set; }
-			public virtual TestEnum? NullableEnum { get; set; }
-
-			public virtual EnumEntity Other { get; set; }
+			System.Type type = GetType();
+			typeName = type.FullName + ", " + type.Assembly.GetName().Name;
 		}
 
-		public enum TestEnum
+		public override string Name
 		{
-			Unspecified,
-			Small,
-			Medium,
-			Large
+			get { return typeName; }
 		}
 
-		[Serializable]
-		public class EnumAnsiStringType<T> : EnumStringType
-		{
-			private readonly string typeName;
-
-			public EnumAnsiStringType()
-				: base(typeof(T))
-			{
-				System.Type type = GetType();
-				typeName = type.FullName + ", " + type.Assembly.GetName().Name;
-			}
-
-			public override string Name
-			{
-				get { return typeName; }
-			}
-
-			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
-		}
+		public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
 	}
 }

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -1,97 +1,209 @@
-﻿using System.Linq;
-using NHibernate.DomainModel.Northwind.Entities;
+﻿using System;
+using System.Linq;
+using NHibernate.Cfg.MappingSchema;
+using NHibernate.Mapping.ByCode;
+using NHibernate.SqlTypes;
+using NHibernate.Type;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
 {
-	[TestFixture]
-	public class EnumTests : LinqTestCase
+	[TestFixture(typeof(EnumType<TestEnum>))]
+	[TestFixture(typeof(EnumStringType<TestEnum>))]
+	[TestFixture(typeof(EnumAnsiStringType<TestEnum>))]
+	public class EnumTests : TestCaseMappingByCode
 	{
-		[Test]
-		public void CanQueryOnEnumStoredAsInt32_High_1()
+		private IType _enumType;
+
+
+		public EnumTests(System.Type enumType)
 		{
-			CanQueryOnEnumStoredAsInt32(EnumStoredAsInt32.High, 1);
+			_enumType = (IType) Activator.CreateInstance(enumType);
+		}
+
+		protected override HbmMapping GetMappings()
+		{
+			var mapper = new ModelMapper();
+			mapper.Class<EnumEntity>(
+				rc =>
+				{
+					rc.Table("EnumEntity");
+					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
+					rc.Property(x => x.Name);
+					rc.Property(x => x.Enum, m => m.Type(_enumType));
+					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
+					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
+				});
+
+
+			return mapper.CompileMappingForAllExplicitlyAddedEntities();
+		}
+
+		protected override void OnSetUp()
+		{
+			base.OnSetUp();
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				trans.Commit();
+			}
+		}
+
+		protected override void OnTearDown()
+		{
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				session.Delete("from System.Object");
+
+				session.Flush();
+				transaction.Commit();
+			}
 		}
 
 		[Test]
-		public void CanQueryOnEnumStoredAsInt32_Unspecified_2()
+		public void CanQueryOnEnum_Large_4()
 		{
-			CanQueryOnEnumStoredAsInt32(EnumStoredAsInt32.Unspecified, 2);
-		}
-
-		public void CanQueryOnEnumStoredAsInt32(EnumStoredAsInt32 type, int expectedCount)
-		{
-			var query = (from user in db.Users
-						 where user.Enum2 == type
-						 select user).ToList();
-
-			Assert.AreEqual(expectedCount, query.Count);
+			CanQueryOnEnum(TestEnum.Large, 4);
 		}
 
 		[Test]
-		public void CanQueryOnEnumStoredAsString_Meduim_2()
+		public void CanQueryOnEnum_Medium_3()
 		{
-			CanQueryOnEnumStoredAsString(EnumStoredAsString.Medium, 2);
+			CanQueryOnEnum(TestEnum.Medium, 3);
 		}
 
 		[Test]
-		public void CanQueryOnEnumStoredAsString_Small_1()
+		public void CanQueryOnEnum_Small_2()
 		{
-			CanQueryOnEnumStoredAsString(EnumStoredAsString.Small, 1);
-		}
-
-		public void CanQueryOnEnumStoredAsString(EnumStoredAsString type, int expectedCount)
-		{
-			var query = (from user in db.Users
-						 where user.Enum1 == type
-						 select user).ToList();
-
-			Assert.AreEqual(expectedCount, query.Count);
+			CanQueryOnEnum(TestEnum.Small, 2);
 		}
 
 		[Test]
-		public void CanQueryWithContainsOnEnumStoredAsString_Small_1()
+		public void CanQueryOnEnum_Unspecified_1()
 		{
-			var values = new[] { EnumStoredAsString.Small, EnumStoredAsString.Medium };
-			var query = db.Users.Where(x => values.Contains(x.Enum1)).ToList();
-			Assert.AreEqual(3, query.Count);
+			CanQueryOnEnum(TestEnum.Unspecified, 1);
+		}
+
+		private void CanQueryOnEnum(TestEnum type, int expectedCount)
+		{
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = session.Query<EnumEntity>().Where(x => x.Enum == type).ToList();
+
+				Assert.AreEqual(expectedCount, query.Count);
+			}
+		}
+
+		[Test]
+		public void CanQueryWithContainsOnTestEnum_Small_1()
+		{
+			var values = new[] { TestEnum.Small, TestEnum.Medium };
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToList();
+
+				Assert.AreEqual(5, query.Count);
+			}
 		}
 
 		[Test]
 		public void ConditionalNavigationProperty()
 		{
-			EnumStoredAsString? type = null;
-			db.Users.Where(o => o.Enum1 == EnumStoredAsString.Large).ToList();
-			db.Users.Where(o => EnumStoredAsString.Large != o.Enum1).ToList();
-			db.Users.Where(o => (o.NullableEnum1 ?? EnumStoredAsString.Large) == EnumStoredAsString.Medium).ToList();
-			db.Users.Where(o => ((o.NullableEnum1 ?? type) ?? o.Enum1) == EnumStoredAsString.Medium).ToList();
+			TestEnum? type = null;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entities = session.Query<EnumEntity>();
+				entities.Where(o => o.Enum == TestEnum.Large).ToList();
+				entities.Where(o => TestEnum.Large != o.Enum).ToList();
+				entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToList();
+				entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToList();
 
-			db.Users.Where(o => (o.NullableEnum1.HasValue ? o.Enum1 : EnumStoredAsString.Unspecified) == EnumStoredAsString.Medium).ToList();
-			db.Users.Where(o => (o.Enum1 != EnumStoredAsString.Large
-				                    ? (o.NullableEnum1.HasValue ? o.Enum1 : EnumStoredAsString.Unspecified)
-				                    : EnumStoredAsString.Small) == EnumStoredAsString.Medium).ToList();
+				entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToList();
+				entities.Where(o => (o.Enum != TestEnum.Large
+										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
+										: TestEnum.Small) == TestEnum.Medium).ToList();
 
-			db.Users.Where(o => (o.Enum1 == EnumStoredAsString.Large ? o.Role : o.Role).Name == "test").ToList();
+				entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToList();
+			}
 		}
 
 		[Test]
-		public void CanQueryComplexExpressionOnEnumStoredAsString()
+		public void CanQueryComplexExpressionOnTestEnum()
 		{
-			var type = EnumStoredAsString.Unspecified;
-			var query = (from user in db.Users
-			             where (user.NullableEnum1 == EnumStoredAsString.Large
-				                   ? EnumStoredAsString.Medium
-				                   : user.NullableEnum1 ?? user.Enum1
-			                   ) == type
-			             select new
-			             {
-				             user,
-				             simple = user.Enum1,
-				             condition = user.Enum1 == EnumStoredAsString.Large ? EnumStoredAsString.Medium : user.Enum1,
-				             coalesce = user.NullableEnum1 ?? EnumStoredAsString.Medium
-			             }).ToList();
+			var type = TestEnum.Unspecified;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entities = session.Query<EnumEntity>();
 
-			Assert.That(query.Count, Is.EqualTo(0));
+				var query = (from user in entities
+							 where (user.NullableEnum == TestEnum.Large
+									   ? TestEnum.Medium
+									   : user.NullableEnum ?? user.Enum
+								   ) == type
+							 select new
+							 {
+								 user,
+								 simple = user.Enum,
+								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
+								 coalesce = user.NullableEnum ?? TestEnum.Medium
+							 }).ToList();
+
+				Assert.That(query.Count, Is.EqualTo(1));
+			}
+		}
+
+		public class EnumEntity
+		{
+			public virtual int Id { get; set; }
+			public virtual string Name { get; set; }
+
+			public virtual TestEnum Enum { get; set; }
+			public virtual TestEnum? NullableEnum { get; set; }
+
+			public virtual EnumEntity Other { get; set; }
+		}
+
+		public enum TestEnum
+		{
+			Unspecified,
+			Small,
+			Medium,
+			Large
+		}
+
+		[Serializable]
+		public class EnumAnsiStringType<T> : EnumStringType
+		{
+			private readonly string typeName;
+
+			public EnumAnsiStringType()
+				: base(typeof(T))
+			{
+				System.Type type = GetType();
+				typeName = type.FullName + ", " + type.Assembly.GetName().Name;
+			}
+
+			public override string Name
+			{
+				get { return typeName; }
+			}
+
+			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -149,7 +149,8 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void CanQueryComplexExpressionOnTestEnum()
 		{
-			var type = TestEnum.Unspecified;
+			//TODO: Fix issue on SQLite with type set to  TestEnum.Unspecified
+			TestEnum? type = null;
 			using (var session = OpenSession())
 			using (var trans = session.BeginTransaction())
 			{
@@ -168,7 +169,7 @@ namespace NHibernate.Test.Linq
 								 coalesce = user.NullableEnum ?? TestEnum.Medium
 							 }).ToList();
 
-				Assert.That(query.Count, Is.EqualTo(1));
+				Assert.That(query.Count, Is.EqualTo(0));
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Linq.Expressions;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
 using NHibernate.SqlTypes;
 using NHibernate.Type;
-using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
@@ -16,10 +14,7 @@ namespace NHibernate.Test.Linq
 	public class EnumTests : TestCaseMappingByCode
 	{
 		private IType _enumType;
-		private ISession _session;
 
-		private IQueryable<EnumEntity> TestEntities { get; set; }
-		private IQueryable<EnumEntity> TestEntitiesInDb { get; set; }
 
 		public EnumTests(System.Type enumType)
 		{
@@ -35,7 +30,6 @@ namespace NHibernate.Test.Linq
 					rc.Table("EnumEntity");
 					rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 					rc.Property(x => x.Name);
-					rc.Property(x => x.BatchId);
 					rc.Property(x => x.Enum, m => m.Type(_enumType));
 					rc.Property(x => x.NullableEnum, m => m.Type(_enumType));
 					rc.ManyToOne(x => x.Other, m => m.Cascade(Mapping.ByCode.Cascade.All));
@@ -48,43 +42,25 @@ namespace NHibernate.Test.Linq
 		protected override void OnSetUp()
 		{
 			base.OnSetUp();
-			_session = OpenSession();
-
-			var entities = new[] {
-				new EnumEntity { Enum = TestEnum.Unspecified },
-				new EnumEntity { Enum = TestEnum.Small, NullableEnum = TestEnum.Large },
-				new EnumEntity { Enum = TestEnum.Small, NullableEnum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Medium, NullableEnum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Medium, NullableEnum = TestEnum.Small },
-				new EnumEntity { Enum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Large, NullableEnum = TestEnum.Medium },
-				new EnumEntity { Enum = TestEnum.Large, NullableEnum = TestEnum.Unspecified },
-				new EnumEntity { Enum = TestEnum.Large },
-				new EnumEntity { Enum = TestEnum.Large }
-			};
-
-			var batchId = Guid.NewGuid();
-
-			using (var trans = _session.BeginTransaction())
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
 			{
-				foreach (var item in entities)
-				{
-					item.BatchId = batchId;
-					_session.Save(item);
-				}
+				session.Save(new EnumEntity { Enum = TestEnum.Unspecified });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Small });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Medium });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
+				session.Save(new EnumEntity { Enum = TestEnum.Large });
 				trans.Commit();
 			}
-
-			TestEntitiesInDb = _session.Query<EnumEntity>().Where(x=>x.BatchId == batchId);
-			TestEntities = entities.AsQueryable();
 		}
 
 		protected override void OnTearDown()
 		{
-			if (_session.IsOpen)
-			{
-				_session.Close();
-			}
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
@@ -121,66 +97,74 @@ namespace NHibernate.Test.Linq
 
 		private void CanQueryOnEnum(TestEnum type, int expectedCount)
 		{
-			var query = TestEntitiesInDb.Where(x => x.Enum == type).ToList();
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = session.Query<EnumEntity>().Where(x => x.Enum == type).ToList();
 
-			Assert.AreEqual(expectedCount, query.Count);
+				Assert.AreEqual(expectedCount, query.Count);
+			}
 		}
 
 		[Test]
 		public void CanQueryWithContainsOnTestEnum_Small_1()
 		{
 			var values = new[] { TestEnum.Small, TestEnum.Medium };
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var query = session.Query<EnumEntity>().Where(x => values.Contains(x.Enum)).ToList();
 
-			var query = TestEntitiesInDb.Where(x => values.Contains(x.Enum)).ToList();
-
-			Assert.AreEqual(5, query.Count);
+				Assert.AreEqual(5, query.Count);
+			}
 		}
 
 		[Test]
 		public void ConditionalNavigationProperty()
 		{
 			TestEnum? type = null;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entities = session.Query<EnumEntity>();
+				entities.Where(o => o.Enum == TestEnum.Large).ToList();
+				entities.Where(o => TestEnum.Large != o.Enum).ToList();
+				entities.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToList();
+				entities.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToList();
 
-
-			TestEntitiesInDb.Where(o => o.Enum == TestEnum.Large).ToList();
-			TestEntitiesInDb.Where(o => TestEnum.Large != o.Enum).ToList();
-			TestEntitiesInDb.Where(o => (o.NullableEnum ?? TestEnum.Large) == TestEnum.Medium).ToList();
-			TestEntitiesInDb.Where(o => ((o.NullableEnum ?? type) ?? o.Enum) == TestEnum.Medium).ToList();
-
-			TestEntitiesInDb.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToList();
-			TestEntitiesInDb.Where(o => (o.Enum != TestEnum.Large
+				entities.Where(o => (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified) == TestEnum.Medium).ToList();
+				entities.Where(o => (o.Enum != TestEnum.Large
 										? (o.NullableEnum.HasValue ? o.Enum : TestEnum.Unspecified)
 										: TestEnum.Small) == TestEnum.Medium).ToList();
 
-			TestEntitiesInDb.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToList();
+				entities.Where(o => (o.Enum == TestEnum.Large ? o.Other : o.Other).Name == "test").ToList();
+			}
 		}
 
 		[Test]
 		public void CanQueryComplexExpressionOnTestEnum()
 		{
 			var type = TestEnum.Unspecified;
-
-			Expression<Func<EnumEntity, bool>> predicate = user => (user.NullableEnum == TestEnum.Large
-									? TestEnum.Medium
-									: user.NullableEnum ?? user.Enum
-								) == type;
-
-			var query = TestEntitiesInDb.Where(predicate).Select(entity => new ProjectedEnum
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
 			{
-				Entity = entity,
-				Simple = entity.Enum,
-				Condition = entity.Enum == TestEnum.Large ? TestEnum.Medium : entity.Enum,
-				Coalesce = entity.NullableEnum ?? TestEnum.Medium
-			}).ToList();
+				var entities = session.Query<EnumEntity>();
 
-			var targetCount = TestEntities.Count(predicate); //the truth
-			Assert.That(targetCount, Is.GreaterThan(0)); //test sanity check
-			Assert.That(query.Count, Is.EqualTo(targetCount));
+				var query = (from user in entities
+							 where (user.NullableEnum == TestEnum.Large
+									   ? TestEnum.Medium
+									   : user.NullableEnum ?? user.Enum
+								   ) == type
+							 select new
+							 {
+								 user,
+								 simple = user.Enum,
+								 condition = user.Enum == TestEnum.Large ? TestEnum.Medium : user.Enum,
+								 coalesce = user.NullableEnum ?? TestEnum.Medium
+							 }).ToList();
 
-			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Simple == x.Entity.Enum));
-			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Condition == (x.Entity.Enum == TestEnum.Large ? TestEnum.Medium : x.Entity.Enum)));
-			Assert.That(query, Is.All.Matches<ProjectedEnum>(x => x.Coalesce == (x.Entity.NullableEnum ?? TestEnum.Medium)));
-
+				Assert.That(query.Count, Is.EqualTo(1));
+			}
 		}
 
 		public class EnumEntity
@@ -192,7 +176,6 @@ namespace NHibernate.Test.Linq
 			public virtual TestEnum? NullableEnum { get; set; }
 
 			public virtual EnumEntity Other { get; set; }
-			public virtual Guid BatchId { get; set; }
 		}
 
 		public enum TestEnum
@@ -221,14 +204,6 @@ namespace NHibernate.Test.Linq
 			}
 
 			public override SqlType SqlType => SqlTypeFactory.GetAnsiString(255);
-		}
-
-		private class ProjectedEnum
-		{
-			public TestEnum Simple { get; internal set; }
-			public TestEnum Condition { get; internal set; }
-			public TestEnum Coalesce { get; internal set; }
-			public EnumEntity Entity { get; internal set; }
 		}
 	}
 }

--- a/src/NHibernate/Linq/Visitors/HqlGeneratorExpressionVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/HqlGeneratorExpressionVisitor.cs
@@ -634,7 +634,7 @@ possible solutions:
 				return false;
 			}
 
-			if (type.ReturnedClass.IsEnum && sqlTypes[0].DbType == DbType.String)
+			if (type.ReturnedClass.IsEnum && sqlTypes[0].DbType.IsStringType())
 			{
 				existType = false;
 				return false; // Never cast an enum that is mapped as string, the type will provide a string for the parameter value

--- a/src/NHibernate/Util/DbTypeExtensions.cs
+++ b/src/NHibernate/Util/DbTypeExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Data;
+
+namespace NHibernate.Util
+{
+	public static class DbTypeExtensions
+	{
+		/// <summary>
+		/// Checks whether the type is a <see cref="DbType.String"/>, <see cref="DbType.AnsiString"/>, <see cref="DbType.StringFixedLength"/> or <see cref="DbType.AnsiStringFixedLength"/>
+		/// </summary>
+		/// <param name="dbType"></param>
+		/// <returns></returns>
+		public static bool IsStringType(this DbType dbType) => dbType == DbType.String || dbType == DbType.AnsiString || dbType == DbType.StringFixedLength || dbType == DbType.AnsiStringFixedLength;
+	}
+}

--- a/src/NHibernate/Util/DbTypeExtensions.cs
+++ b/src/NHibernate/Util/DbTypeExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace NHibernate.Util
 {
-	public static class DbTypeExtensions
+	internal static class DbTypeExtensions
 	{
 		/// <summary>
 		/// Checks whether the type is a <see cref="DbType.String"/>, <see cref="DbType.AnsiString"/>, <see cref="DbType.StringFixedLength"/> or <see cref="DbType.AnsiStringFixedLength"/>


### PR DESCRIPTION
Regression from #2036 

Worked fine for enums mapped as String, but not if an AnsiString or FixedLength type was used.