### PR TITLE
Flatten AsQueryableResultOperator

### DIFF
--- a/src/NHibernate.Test/Async/Linq/WhereSubqueryTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereSubqueryTests.cs
@@ -328,6 +328,17 @@ namespace NHibernate.Test.Linq
 			Assert.That(query.Count, Is.EqualTo(2));
 		}
 
+		[Test(Description = "GH-2471")]
+		public async Task TimeSheetsWithStringContainsSubQueryWithAsQueryableAfterWhereAsync()
+		{
+			var query = await ((
+				from timesheet in db.Timesheets
+				where timesheet.Entries.Where(e => e.Comments != null).AsQueryable().Any(e => e.Comments.Contains("testing"))
+				select timesheet).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
 		[Test(Description = "NH-3002")]
 		public async Task HqlOrderLinesWithInnerJoinAndSubQueryAsync()
 		{

--- a/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
+++ b/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
@@ -372,6 +372,17 @@ namespace NHibernate.Test.Linq
 			Assert.That(query.Count, Is.EqualTo(2));
 		}
 
+		[Test(Description = "GH-2471")]
+		public void TimeSheetsWithStringContainsSubQueryWithAsQueryableAfterWhere()
+		{
+			var query = (
+				from timesheet in db.Timesheets
+				where timesheet.Entries.Where(e => e.Comments != null).AsQueryable().Any(e => e.Comments.Contains("testing"))
+				select timesheet).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
 		[Test(Description = "NH-3002")]
 		public void HqlOrderLinesWithInnerJoinAndSubQuery()
 		{

--- a/src/NHibernate/Linq/Visitors/SubQueryFromClauseFlattener.cs
+++ b/src/NHibernate/Linq/Visitors/SubQueryFromClauseFlattener.cs
@@ -4,6 +4,7 @@ using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ExpressionVisitors;
+using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.EagerFetching;
 
 namespace NHibernate.Linq.Visitors
@@ -15,7 +16,8 @@ namespace NHibernate.Linq.Visitors
 			typeof(LockResultOperator),
 			typeof(FetchLazyPropertiesResultOperator),
 			typeof(FetchOneRequest),
-			typeof(FetchManyRequest)
+			typeof(FetchManyRequest),
+			typeof(AsQueryableResultOperator)
 		};
 
 		public static void ReWrite(QueryModel queryModel)


### PR DESCRIPTION
Fixes #2471

It's one line fix. Let it go to 5.3.3