### PR TITLE
Remove OrderByClause from query models with Contains, All and Any result operators

### DIFF
--- a/src/NHibernate.Test/Async/Linq/WhereSubqueryTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereSubqueryTests.cs
@@ -487,6 +487,21 @@ where c.Order.Customer.CustomerId = 'VINET'
 			Assert.That(productsNotInLargestOrders.Count, Is.EqualTo(49), nameof(productsNotInLargestOrders));
 		}
 
+		[Test]
+		public async Task OrdersWithSubquery11AAsync()
+		{
+			var ordersQuery = db.Orders
+			                    .OrderByDescending(x => x.OrderLines.Count).ThenBy(x => x.OrderId);
+
+			var orderLineQuery = ordersQuery.SelectMany(x => x.OrderLines);
+			var productsNotInLargestOrders = await (db.Products
+			                                   .Where(x => orderLineQuery.All(p => p.Product != x))
+			                                   .OrderBy(x => x.ProductId)
+			                                   .ToListAsync());
+
+			Assert.That(productsNotInLargestOrders.Count, Is.EqualTo(0), nameof(productsNotInLargestOrders));
+		}
+
 		[Test(Description = "NH-2654")]
 		public async Task CategoriesWithDiscountedProductsAsync()
 		{

--- a/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
+++ b/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
@@ -621,9 +621,6 @@ where c.Order.Customer.CustomerId = 'VINET'
 		[Test]
 		public void OrdersWithSubquery11A()
 		{
-			//if (Dialect is MsSqlCeDialect)
-			//	Assert.Ignore("MS SQL CE does not support sorting on a subquery.");
-
 			var ordersQuery = db.Orders
 			                    .OrderByDescending(x => x.OrderLines.Count).ThenBy(x => x.OrderId);
 

--- a/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
+++ b/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
@@ -534,6 +534,25 @@ where c.Order.Customer.CustomerId = 'VINET'
 			Assert.That(orderLines.Count, Is.EqualTo(6), nameof(orderLines));
 		}
 
+		[Test]
+		public void OrdersWithSubquery9A()
+		{
+			var ordersQuery = db.Orders
+			                    .Where(x => x.Employee.EmployeeId > 5)
+			                    .OrderBy(x => x.OrderId);
+
+			var orderLinesFuture = db.OrderLines
+			                         .Where(x => ordersQuery.Any(o => o == x.Order))
+			                         .OrderBy(x => x.Id)
+			                         .ToFuture();
+
+			var orders = ordersQuery.ToFuture().ToList();
+			var orderLines = orderLinesFuture.ToList();
+
+			Assert.That(orders.Count, Is.EqualTo(286), nameof(orders));
+			Assert.That(orderLines.Count, Is.EqualTo(711), nameof(orderLines));
+		}
+
 		[Test(Description = "GH2479")]
 		public void OrdersWithSubquery10()
 		{
@@ -558,6 +577,26 @@ where c.Order.Customer.CustomerId = 'VINET'
 			Assert.That(products.Count, Is.EqualTo(6), nameof(products));
 		}
 
+		[Test]
+		public void OrdersWithSubquery10A()
+		{
+			var ordersQuery = db.Orders
+			                    .Where(x => x.Employee.EmployeeId > 5)
+			                    .OrderBy(x => x.OrderId);
+
+			var productsQuery = ordersQuery.SelectMany(x => x.OrderLines).Select(x => x.Product);
+			var productsFuture = db.Products
+			                       .Where(x => productsQuery.Contains(x))
+			                       .OrderBy(x => x.ProductId)
+			                       .ToFuture();
+
+			var orders = ordersQuery.ToFuture().ToList();
+			var products = productsFuture.ToList();
+
+			Assert.That(orders.Count, Is.EqualTo(286), nameof(orders));
+			Assert.That(orders.Count, Is.EqualTo(286), nameof(orders));
+		}
+
 		[Test(Description = "GH2479")]
 		public void OrdersWithSubquery11()
 		{
@@ -577,6 +616,24 @@ where c.Order.Customer.CustomerId = 'VINET'
 			                                   .ToList();
 
 			Assert.That(productsNotInLargestOrders.Count, Is.EqualTo(49), nameof(productsNotInLargestOrders));
+		}
+
+		[Test]
+		public void OrdersWithSubquery11A()
+		{
+			//if (Dialect is MsSqlCeDialect)
+			//	Assert.Ignore("MS SQL CE does not support sorting on a subquery.");
+
+			var ordersQuery = db.Orders
+			                    .OrderByDescending(x => x.OrderLines.Count).ThenBy(x => x.OrderId);
+
+			var orderLineQuery = ordersQuery.SelectMany(x => x.OrderLines);
+			var productsNotInLargestOrders = db.Products
+			                                   .Where(x => orderLineQuery.All(p => p.Product != x))
+			                                   .OrderBy(x => x.ProductId)
+			                                   .ToList();
+
+			Assert.That(productsNotInLargestOrders.Count, Is.EqualTo(0), nameof(productsNotInLargestOrders));
 		}
 
 		[Test(Description = "NH-2654")]

--- a/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
+++ b/src/NHibernate.Test/Linq/WhereSubqueryTests.cs
@@ -519,7 +519,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 
 			var ordersQuery = db.Orders
 			                    .Where(x => x.Employee.EmployeeId > 5)
-			                    .OrderBy(x => x.OrderId)
+			                    .OrderByDescending(x => x.OrderId)
 			                    .Take(2);
 
 			var orderLinesFuture = db.OrderLines
@@ -531,7 +531,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 			var orderLines = orderLinesFuture.ToList();
 
 			Assert.That(orders.Count, Is.EqualTo(2), nameof(orders));
-			Assert.That(orderLines.Count, Is.EqualTo(6), nameof(orderLines));
+			Assert.That(orderLines.Count, Is.EqualTo(4), nameof(orderLines));
 		}
 
 		[Test]
@@ -539,7 +539,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 		{
 			var ordersQuery = db.Orders
 			                    .Where(x => x.Employee.EmployeeId > 5)
-			                    .OrderBy(x => x.OrderId);
+			                    .OrderByDescending(x => x.OrderId);
 
 			var orderLinesFuture = db.OrderLines
 			                         .Where(x => ordersQuery.Any(o => o == x.Order))
@@ -561,7 +561,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 
 			var ordersQuery = db.Orders
 			                    .Where(x => x.Employee.EmployeeId > 5)
-			                    .OrderBy(x => x.OrderId)
+			                    .OrderByDescending(x => x.OrderId)
 			                    .Take(2);
 
 			var productsQuery = ordersQuery.SelectMany(x => x.OrderLines).Select(x => x.Product);
@@ -574,7 +574,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 			var products = productsFuture.ToList();
 
 			Assert.That(orders.Count, Is.EqualTo(2), nameof(orders));
-			Assert.That(products.Count, Is.EqualTo(6), nameof(products));
+			Assert.That(products.Count, Is.EqualTo(4), nameof(products));
 		}
 
 		[Test]
@@ -582,7 +582,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 		{
 			var ordersQuery = db.Orders
 			                    .Where(x => x.Employee.EmployeeId > 5)
-			                    .OrderBy(x => x.OrderId);
+			                    .OrderByDescending(x => x.OrderId);
 
 			var productsQuery = ordersQuery.SelectMany(x => x.OrderLines).Select(x => x.Product);
 			var productsFuture = db.Products
@@ -594,7 +594,7 @@ where c.Order.Customer.CustomerId = 'VINET'
 			var products = productsFuture.ToList();
 
 			Assert.That(orders.Count, Is.EqualTo(286), nameof(orders));
-			Assert.That(orders.Count, Is.EqualTo(286), nameof(orders));
+			Assert.That(products.Count, Is.EqualTo(77), nameof(products));
 		}
 
 		[Test(Description = "GH2479")]

--- a/src/NHibernate/Linq/GroupBy/PagingRewriter.cs
+++ b/src/NHibernate/Linq/GroupBy/PagingRewriter.cs
@@ -53,8 +53,7 @@ namespace NHibernate.Linq.GroupBy
 				var where = new WhereClause(new SubQueryExpression(newSubQueryModel));
 				queryModel.BodyClauses.Add(where);
 
-				if (!queryModel.BodyClauses.OfType<OrderByClause>().Any() && 
-					!(queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators.All(x => x is AnyResultOperator || x is ContainsResultOperator || x is AllResultOperator)))
+				if (!queryModel.BodyClauses.OfType<OrderByClause>().Any())
 				{
 					var orderByClauses = subQueryModel.BodyClauses.OfType<OrderByClause>();
 					foreach (var orderByClause in orderByClauses)

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -21,9 +21,13 @@ namespace NHibernate.Linq.ReWriters
 
 		public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
 		{
-			if (resultOperator is CountResultOperator || resultOperator is LongCountResultOperator)
+			if (resultOperator is CountResultOperator || 
+			    resultOperator is LongCountResultOperator || 
+			    resultOperator is ContainsResultOperator ||
+			    resultOperator is AnyResultOperator ||
+			    resultOperator is AllResultOperator)
 			{
-				// For count operators, we can remove any order-by result operators
+				// For these operators, we can remove any order-by result operators
 				var bodyClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
 				foreach (var orderby in bodyClauses)
 				{

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Linq.ReWriters
 			    resultOperator is AnyResultOperator ||
 			    resultOperator is AllResultOperator)
 			{
-				// For these operators, we can remove any order-by result operators
+				// For these operators, we can remove any order-by clause
 				var bodyClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
 				foreach (var orderby in bodyClauses)
 				{

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -16,14 +16,16 @@ namespace NHibernate.Linq.ReWriters
 		{
 			var rewriter = new RemoveUnnecessaryBodyOperators();
 
-			if (queryModel.ResultOperators.All(
-				r => r is ContainsResultOperator || r is AnyResultOperator || r is AllResultOperator))
+			if (queryModel.ResultOperators.Count == 1 &&
+				queryModel.ResultOperators.All(
+					r => r is ContainsResultOperator || r is AnyResultOperator || r is AllResultOperator))
 			{
 				// For these operators, we can remove any order-by clause
-				var bodyClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
-				foreach (var orderby in bodyClauses)
+				var bodyClauses = queryModel.BodyClauses;
+				for (int i = bodyClauses.Count - 1; i >= 0; i--)
 				{
-					queryModel.BodyClauses.Remove(orderby);
+					if (bodyClauses[i] is OrderByClause)
+						bodyClauses.RemoveAt(i);
 				}
 			}
 

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -16,18 +16,25 @@ namespace NHibernate.Linq.ReWriters
 		{
 			var rewriter = new RemoveUnnecessaryBodyOperators();
 
+			if (queryModel.ResultOperators.All(
+				r => r is ContainsResultOperator || r is AnyResultOperator || r is AllResultOperator))
+			{
+				// For these operators, we can remove any order-by clause
+				var bodyClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
+				foreach (var orderby in bodyClauses)
+				{
+					queryModel.BodyClauses.Remove(orderby);
+				}
+			}
+
 			rewriter.VisitQueryModel(queryModel);
 		}
 
 		public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
 		{
-			if (resultOperator is CountResultOperator || 
-			    resultOperator is LongCountResultOperator || 
-			    resultOperator is ContainsResultOperator ||
-			    resultOperator is AnyResultOperator ||
-			    resultOperator is AllResultOperator)
+			if (resultOperator is CountResultOperator || resultOperator is LongCountResultOperator)
 			{
-				// For these operators, we can remove any order-by clause
+				// For count operators, we can remove any order-by clause
 				var bodyClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
 				foreach (var orderby in bodyClauses)
 				{

--- a/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
+++ b/src/NHibernate/Linq/ReWriters/RemoveUnnecessaryBodyOperators.cs
@@ -16,9 +16,14 @@ namespace NHibernate.Linq.ReWriters
 		{
 			var rewriter = new RemoveUnnecessaryBodyOperators();
 
+			rewriter.VisitQueryModel(queryModel);
+		}
+
+		internal static void RemoveUnnecessaryOrderByClauses(QueryModel queryModel)
+		{
 			if (queryModel.ResultOperators.Count == 1 &&
-				queryModel.ResultOperators.All(
-					r => r is ContainsResultOperator || r is AnyResultOperator || r is AllResultOperator))
+			    queryModel.ResultOperators.All(
+				    r => r is ContainsResultOperator || r is AnyResultOperator || r is AllResultOperator))
 			{
 				// For these operators, we can remove any order-by clause
 				var bodyClauses = queryModel.BodyClauses;
@@ -28,8 +33,6 @@ namespace NHibernate.Linq.ReWriters
 						bodyClauses.RemoveAt(i);
 				}
 			}
-
-			rewriter.VisitQueryModel(queryModel);
 		}
 
 		public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)

--- a/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
@@ -65,6 +65,9 @@ namespace NHibernate.Linq.Visitors
 			// Rewrite paging
 			PagingRewriter.ReWrite(queryModel);
 
+			//Remove unnecessary order-by clauses
+			RemoveUnnecessaryBodyOperators.RemoveUnnecessaryOrderByClauses(queryModel);
+
 			// Flatten pointless subqueries
 			QueryReferenceExpressionFlattener.ReWrite(queryModel);
 


### PR DESCRIPTION
Improvement for an unwanted behavior found on #2480 