### PR TITLE
Fix parameter caching for Linq provider

### DIFF
--- a/src/NHibernate.Test/Linq/ConstantTest.cs
+++ b/src/NHibernate.Test/Linq/ConstantTest.cs
@@ -121,6 +121,22 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void ConstantNonCachedInMemberInitExpressionWithCondition()
+		{
+			var shipper1 = GetShipper(1);
+			var shipper2 = GetShipper(2);
+
+			Assert.That(shipper1.Number, Is.EqualTo(1));
+			Assert.That(shipper2.Number, Is.EqualTo(2));
+		}
+
+		private ShipperDto GetShipper(int id)
+		{
+			return db.Shippers.Where(o => o.ShipperId == id)
+			         .Select(o => new ShipperDto {Number = id, CompanyName = o.CompanyName}).Single();
+		}
+
+		[Test]
 		public void ConstantInNewArrayExpression()
 		{
 			var c1 = (from c in db.Categories

--- a/src/NHibernate/Linq/NhLinqExpression.cs
+++ b/src/NHibernate/Linq/NhLinqExpression.cs
@@ -101,7 +101,7 @@ namespace NHibernate.Linq
 
 			ParameterDescriptors = requiredHqlParameters.AsReadOnly();
 
-			CanCachePlan = CanCachePlan &&
+			CanCachePlan = CanCachePlan && visitorParameters.CanCachePlan &&
 				// If some constants do not have matching HQL parameters, their values from first query will
 				// be embedded in the plan and reused for subsequent queries: do not cache the plan.
 				!ParameterValuesByName

--- a/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using NHibernate.Engine;
 using NHibernate.Linq.Functions;
 using NHibernate.Linq.Expressions;
+using NHibernate.Param;
 using NHibernate.Util;
 using Remotion.Linq.Parsing;
 
@@ -17,6 +18,7 @@ namespace NHibernate.Linq.Visitors
 	{
 		private readonly ILinqToHqlGeneratorsRegistry _functionRegistry;
 		private readonly ISessionFactoryImplementor _sessionFactory;
+		private readonly VisitorParameters _parameters;
 
 		/// <summary>
 		/// The expression parts that can be converted to pure HQL.
@@ -38,6 +40,7 @@ namespace NHibernate.Linq.Visitors
 		{
 			_functionRegistry = parameters.SessionFactory.Settings.LinqToHqlGeneratorsRegistry;
 			_sessionFactory = parameters.SessionFactory;
+			_parameters = parameters;
 		}
 
 		internal Expression Nominate(Expression expression)
@@ -152,6 +155,11 @@ namespace NHibernate.Linq.Visitors
 			// Constants will only be evaluated in HQL if they're inside a method call
 			if (expression.NodeType == ExpressionType.Constant)
 			{
+				if (!projectConstantsInHql && _parameters.ConstantToParameterMap.ContainsKey((ConstantExpression)expression))
+				{
+					_parameters.CanCachePlan = false;
+				}
+
 				return projectConstantsInHql;
 			}
 

--- a/src/NHibernate/Linq/Visitors/VisitorParameters.cs
+++ b/src/NHibernate/Linq/Visitors/VisitorParameters.cs
@@ -23,6 +23,8 @@ namespace NHibernate.Linq.Visitors
 
 		public QueryMode RootQueryMode { get; }
 
+		internal bool CanCachePlan { get; set; } = true;
+
 		public VisitorParameters(
 			ISessionFactoryImplementor sessionFactory, 
 			IDictionary<ConstantExpression, NamedParameter> constantToParameterMap, 


### PR DESCRIPTION
Fix for a regression made by #2335.

Reported by @jeremycampbellaustin in [this comment](https://github.com/nhibernate/nhibernate-core/issues/1330#issuecomment-686618840)
