### PR TITLE
Fix asymmetrical SqlType.Equals

### DIFF
--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeWithLengthFixture.cs
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeWithLengthFixture.cs
@@ -68,16 +68,16 @@ namespace NHibernate.Test.TypesTest
 			var propertyType25 = Sfi.GetClassMetadata(typeof(ChangeDefaultTypeClass))
 								.GetPropertyType(nameof(ChangeDefaultTypeClass.StringTypeLengthInType25));
 			Assert.That(
-				propertyType25,
-				Is.EqualTo(_testDefaultStringType));
+				propertyType25.GetType(),
+				Is.EqualTo(_testDefaultStringType.GetType()));
 			Assert.That(propertyType25.SqlTypes(Sfi)[0].Length, Is.EqualTo(25));
 			
 			var propertyType20 = Sfi.GetClassMetadata(typeof(ChangeDefaultTypeClass))
 								.GetPropertyType(nameof(ChangeDefaultTypeClass.StringTypeExplicitLength20));
 			
 			Assert.That(
-				propertyType20,
-				Is.EqualTo(_testDefaultStringType));
+				propertyType20.GetType(),
+				Is.EqualTo(_testDefaultStringType.GetType()));
 			Assert.That(propertyType20.SqlTypes(Sfi)[0].Length, Is.EqualTo(20));
 		}
 

--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeWithPrecisionFixture.cs
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeWithPrecisionFixture.cs
@@ -78,8 +78,8 @@ namespace NHibernate.Test.TypesTest
 									.GetPropertyType(nameof(ChangeDefaultTypeClass.CurrencyTypePrecisionInType5And2));
 			
 			Assert.That(
-				propertyType2,
-				Is.EqualTo(_testDefaultType));
+				propertyType2.GetType(),
+				Is.EqualTo(_testDefaultType.GetType()));
 			Assert.That(propertyType2.SqlTypes(Sfi)[0].Precision, Is.EqualTo(5));
 			Assert.That(propertyType2.SqlTypes(Sfi)[0].Scale, Is.EqualTo(2));
 		}

--- a/src/NHibernate.Test/TypesTest/ChangeDefaultTypeWithPrecisionFixture.cs
+++ b/src/NHibernate.Test/TypesTest/ChangeDefaultTypeWithPrecisionFixture.cs
@@ -69,8 +69,8 @@ namespace NHibernate.Test.TypesTest
 			var propertyType1 = Sfi.GetClassMetadata(typeof(ChangeDefaultTypeClass))
 									.GetPropertyType(nameof(ChangeDefaultTypeClass.CurrencyTypeExplicitPrecision6And3));
 			Assert.That(
-				propertyType1,
-				Is.EqualTo(_testDefaultType));
+				propertyType1.GetType(),
+				Is.EqualTo(_testDefaultType.GetType()));
 			Assert.That(propertyType1.SqlTypes(Sfi)[0].Precision, Is.EqualTo(6));
 			Assert.That(propertyType1.SqlTypes(Sfi)[0].Scale, Is.EqualTo(3));
 			

--- a/src/NHibernate/SqlTypes/SqlType.cs
+++ b/src/NHibernate/SqlTypes/SqlType.cs
@@ -143,13 +143,13 @@ namespace NHibernate.SqlTypes
 			if (ScaleDefined != rhsSqlType.ScaleDefined)
 				return false;
 
-			if (LengthDefined && Length != rhsSqlType.Length)
+			if (Length != rhsSqlType.Length)
 				return false;
 
-			if (PrecisionDefined && Precision != rhsSqlType.Precision)
+			if (Precision != rhsSqlType.Precision)
 				return false;
 
-			if (ScaleDefined && Scale != rhsSqlType.Scale)
+			if (Scale != rhsSqlType.Scale)
 				return false;
 
 			return true;

--- a/src/NHibernate/SqlTypes/SqlType.cs
+++ b/src/NHibernate/SqlTypes/SqlType.cs
@@ -21,7 +21,7 @@ namespace NHibernate.SqlTypes
 	/// </p>
 	/// </remarks>
 	[Serializable]
-	public class SqlType
+	public class SqlType : IEquatable<SqlType>
 	{
 		private readonly DbType dbType;
 		private readonly int length;
@@ -125,24 +125,34 @@ namespace NHibernate.SqlTypes
 
 		public bool Equals(SqlType rhsSqlType)
 		{
-			if (rhsSqlType == null)
-			{
-				return false;
-			}
+			if (ReferenceEquals(this, rhsSqlType))
+				return true;
 
-			if (LengthDefined)
-			{
-				return (DbType.Equals(rhsSqlType.DbType)) && (Length == rhsSqlType.Length);
-			}
-			if (PrecisionDefined)
-			{
-				return (DbType.Equals(rhsSqlType.DbType)) && (Precision == rhsSqlType.Precision) && (Scale == rhsSqlType.Scale);
-			}
-			if (ScaleDefined)
-			{
-				return DbType.Equals(rhsSqlType.DbType) && Scale == rhsSqlType.Scale;
-			}
-			return (DbType.Equals(rhsSqlType.DbType));
+			if (rhsSqlType == null)
+				return false;
+
+			if (DbType != rhsSqlType.DbType)
+				return false;
+
+			if (LengthDefined != rhsSqlType.LengthDefined)
+				return false;
+
+			if (PrecisionDefined != rhsSqlType.PrecisionDefined)
+				return false;
+
+			if (ScaleDefined != rhsSqlType.ScaleDefined)
+				return false;
+
+			if (LengthDefined && Length != rhsSqlType.Length)
+				return false;
+
+			if (PrecisionDefined && Precision != rhsSqlType.Precision)
+				return false;
+
+			if (ScaleDefined && Scale != rhsSqlType.Scale)
+				return false;
+
+			return true;
 		}
 
 		public override string ToString()


### PR DESCRIPTION
Fixed equality issue described in https://github.com/nhibernate/nhibernate-core/issues/1180#issuecomment-664946300

Now it's strict check that returns true only in case of full object equality. Maybe should go as possible breaking change?