### PR TITLE
Remove no longer needed alias substitution for filtered many-to-many collection in hql

### DIFF
--- a/src/NHibernate/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Loader/Hql/QueryLoader.cs
@@ -203,11 +203,6 @@ namespace NHibernate.Loader.Hql
 			get { return _collectionPersisters; }
 		}
 
-		protected override IDictionary<string, string[]> GetCollectionUserProvidedAlias(int index)
-		{
-			return null;
-		}
-
 		private void Initialize(SelectClause selectClause)
 		{
 			IList<FromElement> fromElementList = selectClause.FromElementsForLoad;

--- a/src/NHibernate/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Loader/Hql/QueryLoader.cs
@@ -45,7 +45,6 @@ namespace NHibernate.Loader.Hql
 		private int _selectLength;
 		private LockMode[] _defaultLockModes;
 		private ISet<ICollectionPersister> _uncacheableCollectionPersisters;
-		private Dictionary<string, string[]>[] _collectionUserProvidedAliases;
 		private IReadOnlyDictionary<int, int> _entityByResultTypeDic;
 
 		public QueryLoader(QueryTranslatorImpl queryTranslator, ISessionFactoryImplementor factory, SelectClause selectClause)
@@ -206,7 +205,7 @@ namespace NHibernate.Loader.Hql
 
 		protected override IDictionary<string, string[]> GetCollectionUserProvidedAlias(int index)
 		{
-			return _collectionUserProvidedAliases?[index];
+			return null;
 		}
 
 		private void Initialize(SelectClause selectClause)
@@ -229,8 +228,6 @@ namespace NHibernate.Loader.Hql
 				_collectionPersisters = new IQueryableCollection[length];
 				_collectionOwners = new int[length];
 				_collectionSuffixes = new string[length];
-				if (collectionFromElements.Any(qc => qc.QueryableCollection.IsManyToMany))
-					_collectionUserProvidedAliases = new Dictionary<string, string[]>[length];
 
 				for (int i = 0; i < length; i++)
 				{
@@ -278,24 +275,6 @@ namespace NHibernate.Loader.Hql
 				if (_includeInSelect[i])
 				{
 					_selectLength++;
-				}
-
-				if (collectionFromElements != null && element.IsFetch && element.QueryableCollection?.IsManyToMany == true
-					&& element.QueryableCollection.IsManyToManyFiltered(_queryTranslator.EnabledFilters))
-				{
-					var collectionIndex = collectionFromElements.IndexOf(element);
-
-					if (collectionIndex >= 0)
-					{
-						// When many-to-many is filtered we need to populate collection from element persister and not from bridge table.
-						// As bridge table will contain not-null values for filtered elements
-						// So do alias substitution for collection persister with element persister
-						// See test TestFilteredLinqQuery for details
-						_collectionUserProvidedAliases[collectionIndex] = new Dictionary<string, string[]>
-						{
-							{CollectionPersister.PropElement, _entityPersisters[i].GetIdentifierAliases(Suffixes[i])}
-						};
-					}
 				}
 
 				_owners[i] = -1; //by default

--- a/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/AbstractCollectionPersister.cs
@@ -1380,7 +1380,9 @@ namespace NHibernate.Persister.Collection
 
 			return buffer.ToString();
 		}
-		
+
+		// Since 5.4
+		[Obsolete("This method has no more usages and will be removed in a future version.")]
 		public bool IsManyToManyFiltered(IDictionary<string, IFilter> enabledFilters)
 		{
 			return IsManyToMany && (manyToManyWhereString != null || manyToManyFilterHelper.IsAffectedBy(enabledFilters));

--- a/src/NHibernate/Persister/Collection/ICollectionPersister.cs
+++ b/src/NHibernate/Persister/Collection/ICollectionPersister.cs
@@ -305,18 +305,5 @@ namespace NHibernate.Persister.Collection
 
 			return 1;
 		}
-
-		/// <summary>
-		/// Is this persister has enabled many-to-many filter or has many-to-many where clause
-		/// </summary>
-		internal static bool IsManyToManyFiltered(this ICollectionPersister persister, IDictionary<string, IFilter> enabledFilters)
-		{
-			if (persister is AbstractCollectionPersister acp)
-			{
-				return acp.IsManyToManyFiltered(enabledFilters);
-			}
-
-			return persister.IsManyToMany && !string.IsNullOrEmpty(persister.GetManyToManyFilterFragment("x", enabledFilters));
-		}
 	}
 }


### PR DESCRIPTION
Partial undo of https://github.com/nhibernate/nhibernate-core/commit/c4b806cae771fa2229a66a6e2d0ad239635d0f08
as no longer needed with table group joins https://github.com/nhibernate/nhibernate-core/commit/bc1484c76e962f51eaa65e0a178a9cc95488d3cf

Test case: TestFilteredLinqQuery