### PR TITLE
Enable named parameters on DB2CoreDriver

### DIFF
--- a/src/NHibernate/Driver/DB2CoreDriver.cs
+++ b/src/NHibernate/Driver/DB2CoreDriver.cs
@@ -1,3 +1,6 @@
+using System.Data.Common;
+using NHibernate.SqlTypes;
+
 namespace NHibernate.Driver
 {
 	/// <summary>
@@ -7,6 +10,18 @@ namespace NHibernate.Driver
 	{		
 		public DB2CoreDriver() : base("IBM.Data.DB2.Core")
 		{
+		}
+		
+		public override bool UseNamedPrefixInSql => true;
+
+		public override bool UseNamedPrefixInParameter => true;
+
+		public override string NamedPrefix => "@";
+
+		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
+		{
+			dbParam.ParameterName = FormatNameForParameter(name);
+			base.InitializeParameter(dbParam, name, sqlType);
 		}
 	}
 }


### PR DESCRIPTION
Checked on [IBM.Data.DB2.Core 1.2.2.100](https://www.nuget.org/packages/IBM.Data.DB2.Core/1.2.2.100)

--- 

How to run:

```sh
 docker run -d --name db2 --privileged -p 50000:50000 -e LICENSE=accept -e DBNAME=nhdb -e DB2INST1_PASSWORD=nhibernate ibmcom/db2
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<hibernate-configuration  xmlns="urn:nhibernate-configuration-2.2" >
	<session-factory name="NHibernate.Test">
		<property name="connection.driver_class">NHibernate.Driver.DB2CoreDriver</property>
		<property name="connection.connection_string">
			Server=localhost:50000;Database=nhdb;UID=db2inst1;PWD=nhibernate;Max Pool Size=100;Min Pool Size=10;
		</property>
		<property name="dialect">NHibernate.Dialect.DB2Dialect</property>
		<property name="show_sql">true</property>
	</session-factory>
</hibernate-configuration>

```