### PR TITLE
Avoid NRE in cache strategies

### DIFF
--- a/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", key);
 			}
 
-			var result = await (InternalCache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
+			var result = await (_this.Cache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug(result != null ? "Cache hit: {0}" : "Cache miss: {0}", key);
@@ -49,7 +49,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
 
-			var results = await (InternalCache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
+			var results = await (_this.Cache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache hit: {0}", string.Join(",", keys.Where((k, i) => results != null)));
@@ -85,7 +85,7 @@ namespace NHibernate.Cache
 				}
 			}
 
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			var skipKeyIndexes = new HashSet<int>();
 			if (checkKeys.Any())
 			{
@@ -138,7 +138,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			if (minimalPut && await (cache.GetAsync(key, cancellationToken)).ConfigureAwait(false) != null)
 			{
 				if (log.IsDebugEnabled())
@@ -186,7 +186,7 @@ namespace NHibernate.Cache
 				{
 					log.Debug("Removing: {0}", key);
 				}
-				return InternalCache.RemoveAsync(key, cancellationToken);
+				return _this.Cache.RemoveAsync(key, cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -206,7 +206,7 @@ namespace NHibernate.Cache
 				{
 					log.Debug("Clearing");
 				}
-				return InternalCache.ClearAsync(cancellationToken);
+				return _this.Cache.ClearAsync(cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -229,7 +229,7 @@ namespace NHibernate.Cache
 				{
 					log.Debug("Invalidating: {0}", key);
 				}
-				return InternalCache.RemoveAsync(key, cancellationToken);
+				return _this.Cache.RemoveAsync(key, cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -263,7 +263,7 @@ namespace NHibernate.Cache
 					log.Debug("Invalidating (again): {0}", key);
 				}
 
-				return InternalCache.RemoveAsync(key, cancellationToken);
+				return _this.Cache.RemoveAsync(key, cancellationToken);
 			}
 			catch (Exception ex)
 			{

--- a/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,6 +27,7 @@ namespace NHibernate.Cache
 		public async Task<object> GetAsync(CacheKey key, long txTimestamp, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
+			CheckCache();
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache lookup: {0}", key);
@@ -43,6 +45,7 @@ namespace NHibernate.Cache
 		public async Task<object[]> GetManyAsync(CacheKey[] keys, long timestamp, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
+			CheckCache();
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
@@ -72,6 +75,8 @@ namespace NHibernate.Cache
 				// MinValue means cache is disabled
 				return result;
 			}
+
+			CheckCache();
 
 			var checkKeys = new List<object>();
 			var checkKeyIndexes = new List<int>();
@@ -135,6 +140,8 @@ namespace NHibernate.Cache
 				return false;
 			}
 
+			CheckCache();
+
 			if (minimalPut && await (Cache.GetAsync(key, cancellationToken)).ConfigureAwait(false) != null)
 			{
 				if (log.IsDebugEnabled())
@@ -164,7 +171,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromResult<ISoftLock>(Lock(key, version));
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				return Task.FromException<ISoftLock>(ex);
 			}
@@ -178,13 +185,14 @@ namespace NHibernate.Cache
 			}
 			try
 			{
+				CheckCache();
 				if (log.IsDebugEnabled())
 				{
 					log.Debug("Removing: {0}", key);
 				}
 				return Cache.RemoveAsync(key, cancellationToken);
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				return Task.FromException<object>(ex);
 			}
@@ -198,13 +206,14 @@ namespace NHibernate.Cache
 			}
 			try
 			{
+				CheckCache();
 				if (log.IsDebugEnabled())
 				{
 					log.Debug("Clearing");
 				}
 				return Cache.ClearAsync(cancellationToken);
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				return Task.FromException<object>(ex);
 			}
@@ -221,13 +230,14 @@ namespace NHibernate.Cache
 			}
 			try
 			{
+				CheckCache();
 				if (log.IsDebugEnabled())
 				{
 					log.Debug("Invalidating: {0}", key);
 				}
 				return Cache.RemoveAsync(key, cancellationToken);
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				return Task.FromException<object>(ex);
 			}
@@ -254,6 +264,7 @@ namespace NHibernate.Cache
 			}
 			try
 			{
+				CheckCache();
 				if (log.IsDebugEnabled())
 				{
 					log.Debug("Invalidating (again): {0}", key);
@@ -261,7 +272,7 @@ namespace NHibernate.Cache
 
 				return Cache.RemoveAsync(key, cancellationToken);
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				return Task.FromException<object>(ex);
 			}
@@ -290,7 +301,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromResult<bool>(AfterInsert(key, value, version));
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				return Task.FromException<bool>(ex);
 			}

--- a/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/NonstrictReadWriteCache.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", key);
 			}
 
-			var result = await (_this.Cache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
+			var result = await (InternalCache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug(result != null ? "Cache hit: {0}" : "Cache miss: {0}", key);
@@ -49,7 +49,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
 
-			var results = await (_this.Cache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
+			var results = await (InternalCache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache hit: {0}", string.Join(",", keys.Where((k, i) => results != null)));
@@ -85,7 +85,7 @@ namespace NHibernate.Cache
 				}
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			var skipKeyIndexes = new HashSet<int>();
 			if (checkKeys.Any())
 			{
@@ -138,7 +138,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			if (minimalPut && await (cache.GetAsync(key, cancellationToken)).ConfigureAwait(false) != null)
 			{
 				if (log.IsDebugEnabled())
@@ -186,7 +186,7 @@ namespace NHibernate.Cache
 				{
 					log.Debug("Removing: {0}", key);
 				}
-				return _this.Cache.RemoveAsync(key, cancellationToken);
+				return InternalCache.RemoveAsync(key, cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -206,7 +206,7 @@ namespace NHibernate.Cache
 				{
 					log.Debug("Clearing");
 				}
-				return _this.Cache.ClearAsync(cancellationToken);
+				return InternalCache.ClearAsync(cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -229,7 +229,7 @@ namespace NHibernate.Cache
 				{
 					log.Debug("Invalidating: {0}", key);
 				}
-				return _this.Cache.RemoveAsync(key, cancellationToken);
+				return InternalCache.RemoveAsync(key, cancellationToken);
 			}
 			catch (Exception ex)
 			{
@@ -263,7 +263,7 @@ namespace NHibernate.Cache
 					log.Debug("Invalidating (again): {0}", key);
 				}
 
-				return _this.Cache.RemoveAsync(key, cancellationToken);
+				return InternalCache.RemoveAsync(key, cancellationToken);
 			}
 			catch (Exception ex)
 			{

--- a/src/NHibernate/Async/Cache/ReadOnlyCache.cs
+++ b/src/NHibernate/Async/Cache/ReadOnlyCache.cs
@@ -24,7 +24,7 @@ namespace NHibernate.Cache
 		public async Task<object> GetAsync(CacheKey key, long timestamp, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var result = await (InternalCache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
+			var result = await (_this.Cache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug(result != null ? "Cache hit: {0}" : "Cache miss: {0}", key);
@@ -41,7 +41,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
 
-			var results = await (InternalCache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
+			var results = await (_this.Cache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache hit: {0}", string.Join(",", keys.Where((k, i) => results[i] != null)));
@@ -93,7 +93,7 @@ namespace NHibernate.Cache
 				}
 			}
 
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			var skipKeyIndexes = new HashSet<int>();
 			if (checkKeys.Any())
 			{
@@ -143,7 +143,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			if (minimalPut && await (cache.GetAsync(key, cancellationToken)).ConfigureAwait(false) != null)
 			{
 				if (log.IsDebugEnabled())
@@ -186,7 +186,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return InternalCache.ClearAsync(cancellationToken);
+			return _this.Cache.ClearAsync(cancellationToken);
 		}
 
 		public Task RemoveAsync(CacheKey key, CancellationToken cancellationToken)
@@ -195,7 +195,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return InternalCache.RemoveAsync(key, cancellationToken);
+			return _this.Cache.RemoveAsync(key, cancellationToken);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Async/Cache/ReadOnlyCache.cs
+++ b/src/NHibernate/Async/Cache/ReadOnlyCache.cs
@@ -24,7 +24,7 @@ namespace NHibernate.Cache
 		public async Task<object> GetAsync(CacheKey key, long timestamp, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var result = await (_this.Cache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
+			var result = await (InternalCache.GetAsync(key, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug(result != null ? "Cache hit: {0}" : "Cache miss: {0}", key);
@@ -41,7 +41,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
 
-			var results = await (_this.Cache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
+			var results = await (InternalCache.GetManyAsync(keys, cancellationToken)).ConfigureAwait(false);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache hit: {0}", string.Join(",", keys.Where((k, i) => results[i] != null)));
@@ -93,7 +93,7 @@ namespace NHibernate.Cache
 				}
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			var skipKeyIndexes = new HashSet<int>();
 			if (checkKeys.Any())
 			{
@@ -143,7 +143,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			if (minimalPut && await (cache.GetAsync(key, cancellationToken)).ConfigureAwait(false) != null)
 			{
 				if (log.IsDebugEnabled())
@@ -186,7 +186,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return _this.Cache.ClearAsync(cancellationToken);
+			return InternalCache.ClearAsync(cancellationToken);
 		}
 
 		public Task RemoveAsync(CacheKey key, CancellationToken cancellationToken)
@@ -195,7 +195,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return _this.Cache.RemoveAsync(key, cancellationToken);
+			return InternalCache.RemoveAsync(key, cancellationToken);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Async/Cache/ReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/ReadWriteCache.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Cache
 		public async Task<object> GetAsync(CacheKey key, long txTimestamp, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.ReadLockAsync()).ConfigureAwait(false))
 			{
@@ -72,7 +72,7 @@ namespace NHibernate.Cache
 			{
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			var result = new object[keys.Length];
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.ReadLockAsync()).ConfigureAwait(false))
@@ -97,7 +97,7 @@ namespace NHibernate.Cache
 		public async Task<ISoftLock> LockAsync(CacheKey key, object version, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -143,7 +143,7 @@ namespace NHibernate.Cache
 				return result;
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -215,7 +215,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -269,7 +269,7 @@ namespace NHibernate.Cache
 			try
 			{
 				//decrement the lock
-				var cache = _this.Cache;
+				var cache = InternalCache;
 				@lock.Unlock(cache.NextTimestamp());
 				return cache.PutAsync(key, @lock, cancellationToken);
 			}
@@ -282,7 +282,7 @@ namespace NHibernate.Cache
 		public async Task ReleaseAsync(CacheKey key, ISoftLock clientLock, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -320,7 +320,7 @@ namespace NHibernate.Cache
 			try
 			{
 				log.Warn("An item was expired by the cache while it was locked (increase your cache timeout): {0}", key);
-				var cache = _this.Cache;
+				var cache = InternalCache;
 				long ts = cache.NextTimestamp() + cache.Timeout;
 				// create new lock that times out immediately
 				CacheLock @lock = CacheLock.Create(ts, NextLockId(), null);
@@ -339,7 +339,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return _this.Cache.ClearAsync(cancellationToken);
+			return InternalCache.ClearAsync(cancellationToken);
 		}
 
 		public Task RemoveAsync(CacheKey key, CancellationToken cancellationToken)
@@ -348,7 +348,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return _this.Cache.RemoveAsync(key, cancellationToken);
+			return InternalCache.RemoveAsync(key, cancellationToken);
 		}
 
 		/// <summary>
@@ -358,7 +358,7 @@ namespace NHibernate.Cache
 		public async Task<bool> AfterUpdateAsync(CacheKey key, object value, object version, ISoftLock clientLock, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -407,7 +407,7 @@ namespace NHibernate.Cache
 		public async Task<bool> AfterInsertAsync(CacheKey key, object value, object version, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{

--- a/src/NHibernate/Async/Cache/ReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/ReadWriteCache.cs
@@ -269,8 +269,9 @@ namespace NHibernate.Cache
 			try
 			{
 				//decrement the lock
-				@lock.Unlock(InternalCache.NextTimestamp());
-				return InternalCache.PutAsync(key, @lock, cancellationToken);
+				var cache = InternalCache;
+				@lock.Unlock(cache.NextTimestamp());
+				return cache.PutAsync(key, @lock, cancellationToken);
 			}
 			catch (Exception ex)
 			{

--- a/src/NHibernate/Async/Cache/ReadWriteCache.cs
+++ b/src/NHibernate/Async/Cache/ReadWriteCache.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Cache
 		public async Task<object> GetAsync(CacheKey key, long txTimestamp, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.ReadLockAsync()).ConfigureAwait(false))
 			{
@@ -72,7 +72,7 @@ namespace NHibernate.Cache
 			{
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			var result = new object[keys.Length];
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.ReadLockAsync()).ConfigureAwait(false))
@@ -97,7 +97,7 @@ namespace NHibernate.Cache
 		public async Task<ISoftLock> LockAsync(CacheKey key, object version, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -143,7 +143,7 @@ namespace NHibernate.Cache
 				return result;
 			}
 
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -215,7 +215,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -269,7 +269,7 @@ namespace NHibernate.Cache
 			try
 			{
 				//decrement the lock
-				var cache = InternalCache;
+				var cache = _this.Cache;
 				@lock.Unlock(cache.NextTimestamp());
 				return cache.PutAsync(key, @lock, cancellationToken);
 			}
@@ -282,7 +282,7 @@ namespace NHibernate.Cache
 		public async Task ReleaseAsync(CacheKey key, ISoftLock clientLock, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -320,7 +320,7 @@ namespace NHibernate.Cache
 			try
 			{
 				log.Warn("An item was expired by the cache while it was locked (increase your cache timeout): {0}", key);
-				var cache = InternalCache;
+				var cache = _this.Cache;
 				long ts = cache.NextTimestamp() + cache.Timeout;
 				// create new lock that times out immediately
 				CacheLock @lock = CacheLock.Create(ts, NextLockId(), null);
@@ -339,7 +339,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return InternalCache.ClearAsync(cancellationToken);
+			return _this.Cache.ClearAsync(cancellationToken);
 		}
 
 		public Task RemoveAsync(CacheKey key, CancellationToken cancellationToken)
@@ -348,7 +348,7 @@ namespace NHibernate.Cache
 			{
 				return Task.FromCanceled<object>(cancellationToken);
 			}
-			return InternalCache.RemoveAsync(key, cancellationToken);
+			return _this.Cache.RemoveAsync(key, cancellationToken);
 		}
 
 		/// <summary>
@@ -358,7 +358,7 @@ namespace NHibernate.Cache
 		public async Task<bool> AfterUpdateAsync(CacheKey key, object value, object version, ISoftLock clientLock, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{
@@ -407,7 +407,7 @@ namespace NHibernate.Cache
 		public async Task<bool> AfterInsertAsync(CacheKey key, object value, object version, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var cache = InternalCache;
+			var cache = _this.Cache;
 			cancellationToken.ThrowIfCancellationRequested();
 			using (await (_asyncReaderWriterLock.WriteLockAsync()).ConfigureAwait(false))
 			{

--- a/src/NHibernate/Cache/CacheFactory.cs
+++ b/src/NHibernate/Cache/CacheFactory.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Cache
 		public static ICacheConcurrencyStrategy CreateCache(string usage, CacheBase cache)
 		{
 			if (log.IsDebugEnabled())
-				log.Debug("cache for: {0} usage strategy: {1}", cache.RegionName, usage);
+				log.Debug("cache for: {0} usage strategy: {1}", cache?.RegionName, usage);
 
 			ICacheConcurrencyStrategy ccs;
 			switch (usage)

--- a/src/NHibernate/Cache/NonstrictReadWriteCache.cs
+++ b/src/NHibernate/Cache/NonstrictReadWriteCache.cs
@@ -47,7 +47,6 @@ namespace NHibernate.Cache
 					throw new InvalidOperationException(_isDestroyed ? "The cache has already been destroyed" : "The concrete cache is not defined");
 				return _cache;
 			}
-			set => _cache = value;
 		}
 
 		// 6.0 TODO: remove

--- a/src/NHibernate/Cache/ReadOnlyCache.cs
+++ b/src/NHibernate/Cache/ReadOnlyCache.cs
@@ -13,18 +13,8 @@ namespace NHibernate.Cache
 	{
 		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(ReadOnlyCache));
 
-		// 6.0 TODO : remove
-		private readonly IBatchableCacheConcurrencyStrategy _this;
 		private CacheBase _cache;
 		private bool _isDestroyed;
-
-		/// <summary>
-		/// Default constructor.
-		/// </summary>
-		public ReadOnlyCache()
-		{
-			_this = this;
-		}
 
 		/// <summary>
 		/// Gets the cache region name.
@@ -43,8 +33,8 @@ namespace NHibernate.Cache
 			set { _cache = value?.AsCacheBase(); }
 		}
 
-		// 6.0 TODO: implement implicitly
-		CacheBase IBatchableCacheConcurrencyStrategy.Cache
+		// 6.0 TODO: Rename to Cache and make public (possible breaking change for reader when null).
+		private CacheBase InternalCache
 		{
 			get
 			{
@@ -52,12 +42,18 @@ namespace NHibernate.Cache
 					throw new InvalidOperationException(_isDestroyed ? "The cache has already been destroyed" : "The concrete cache is not defined");
 				return _cache;
 			}
+		}
+
+		// 6.0 TODO: remove
+		CacheBase IBatchableCacheConcurrencyStrategy.Cache
+		{
+			get => _cache;
 			set => _cache = value;
 		}
 
 		public object Get(CacheKey key, long timestamp)
 		{
-			var result = _this.Cache.Get(key);
+			var result = InternalCache.Get(key);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug(result != null ? "Cache hit: {0}" : "Cache miss: {0}", key);
@@ -73,7 +69,7 @@ namespace NHibernate.Cache
 				log.Debug("Cache lookup: {0}", string.Join(",", keys.AsEnumerable()));
 			}
 
-			var results = _this.Cache.GetMany(keys);
+			var results = InternalCache.GetMany(keys);
 			if (log.IsDebugEnabled())
 			{
 				log.Debug("Cache hit: {0}", string.Join(",", keys.Where((k, i) => results[i] != null)));
@@ -114,7 +110,7 @@ namespace NHibernate.Cache
 				}
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			var skipKeyIndexes = new HashSet<int>();
 			if (checkKeys.Any())
 			{
@@ -163,7 +159,7 @@ namespace NHibernate.Cache
 				return false;
 			}
 
-			var cache = _this.Cache;
+			var cache = InternalCache;
 			if (minimalPut && cache.Get(key) != null)
 			{
 				if (log.IsDebugEnabled())
@@ -190,12 +186,12 @@ namespace NHibernate.Cache
 
 		public void Clear()
 		{
-			_this.Cache.Clear();
+			InternalCache.Clear();
 		}
 
 		public void Remove(CacheKey key)
 		{
-			_this.Cache.Remove(key);
+			InternalCache.Remove(key);
 		}
 
 		public void Destroy()

--- a/src/NHibernate/Cache/ReadOnlyCache.cs
+++ b/src/NHibernate/Cache/ReadOnlyCache.cs
@@ -42,7 +42,6 @@ namespace NHibernate.Cache
 					throw new InvalidOperationException(_isDestroyed ? "The cache has already been destroyed" : "The concrete cache is not defined");
 				return _cache;
 			}
-			set => _cache = value;
 		}
 
 		// 6.0 TODO: remove

--- a/src/NHibernate/Cache/ReadWriteCache.cs
+++ b/src/NHibernate/Cache/ReadWriteCache.cs
@@ -66,7 +66,6 @@ namespace NHibernate.Cache
 					throw new InvalidOperationException(_isDestroyed ? "The cache has already been destroyed" : "The concrete cache is not defined");
 				return _cache;
 			}
-			set => _cache = value;
 		}
 
 		// 6.0 TODO: remove

--- a/src/NHibernate/Cache/ReadWriteCache.cs
+++ b/src/NHibernate/Cache/ReadWriteCache.cs
@@ -344,8 +344,9 @@ namespace NHibernate.Cache
 		private void DecrementLock(object key, CacheLock @lock)
 		{
 			//decrement the lock
-			@lock.Unlock(InternalCache.NextTimestamp());
-			InternalCache.Put(key, @lock);
+			var cache = InternalCache;
+			@lock.Unlock(cache.NextTimestamp());
+			cache.Put(key, @lock);
 		}
 
 		public void Release(CacheKey key, ISoftLock clientLock)


### PR DESCRIPTION
This fixes a regression from #1480, where destroying the externally supplied and shared cache has been replaced by setting it to null.

Related: #2530.

But this change causes further usages of the cache to cause null reference exceptions, instead of meaningful errors.

This PR is in my opinion the most correct minimal fix.

Another option could be to just remove the line setting the cache to null, effectively causing `Destroy` to be no-op. But this would mean letting the user use "destroyed" caches, which seems a bit wrong. And in the case of read-write caches, other failures would occur due to some internal object being disposed.