### PR TITLE
Add spaces around concat operator

### DIFF
--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -101,7 +101,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("cast", new CastFunction());
 			RegisterFunction("transparentcast", new TransparentCastFunction());
 			RegisterFunction("extract", new AnsiExtractFunction());
-			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", "||", ")"));
+			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", " || ", ")"));
 
 			// the syntax of current_timestamp is extracted from H3.2 tests 
 			// - test\hql\ASTParserLoadingTest.java


### PR DESCRIPTION
Some dialects (DB2 for example) are confused by the concat operator without spaces. So let's just tweak it.

I did consider overriding only DB2Dialect but I think it is more beneficial if applied to all dialects.