### PR TITLE
Support internal entity classes by proxy factory

### DIFF
--- a/src/NHibernate.Test/StaticProxyTest/StaticProxyFactoryFixture.cs
+++ b/src/NHibernate.Test/StaticProxyTest/StaticProxyFactoryFixture.cs
@@ -37,6 +37,13 @@ namespace NHibernate.Test.StaticProxyTest
 			public virtual int Id { get; set; }
 		}
 
+		[Serializable]
+		internal class InternalTestClass
+		{
+			int Id { get; set; }
+			string Name { get; set; }
+		}
+
 		public interface IPublic
 		{
 			int Id { get; set; }
@@ -517,6 +524,32 @@ namespace NHibernate.Test.StaticProxyTest
 					Assert.That(proxy, Is.Not.Null);
 					Assert.That(proxy, Is.InstanceOf<IPublic>());
 					Assert.That(proxy, Is.InstanceOf<AbstractTestClass>());
+#if NETFX
+				});
+#endif
+		}
+		
+		[Test]
+		public void VerifyProxyForInternalClass()
+		{
+			var factory = new StaticProxyFactory();
+			factory.PostInstantiate(
+				typeof(InternalTestClass).FullName,
+				typeof(InternalTestClass),
+				new HashSet<System.Type> { typeof(INHibernateProxy) },
+				null, null, null, true);
+
+#if NETFX
+			VerifyGeneratedAssembly(
+				() =>
+				{
+#endif
+					var proxy = factory.GetProxy(1, null);
+					Assert.That(proxy, Is.Not.Null);
+					Assert.That(proxy, Is.InstanceOf<InternalTestClass>());
+
+					Assert.That(factory.GetFieldInterceptionProxy(), Is.InstanceOf<InternalTestClass>());
+
 #if NETFX
 				});
 #endif

--- a/src/NHibernate/Proxy/FieldInterceptorProxyBuilder.cs
+++ b/src/NHibernate/Proxy/FieldInterceptorProxyBuilder.cs
@@ -56,6 +56,11 @@ namespace NHibernate.Proxy
 			var name = new AssemblyName(assemblyName);
 
 			var assemblyBuilder = ProxyBuilderHelper.DefineDynamicAssembly(AppDomain.CurrentDomain, name);
+
+#if NETFX || NETCOREAPP2_0
+			if (!baseType.IsVisible)
+				ProxyBuilderHelper.GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, baseType.Assembly.GetName().Name);
+#endif
 			var moduleBuilder = ProxyBuilderHelper.DefineDynamicModule(assemblyBuilder, moduleName);
 
 			const TypeAttributes typeAttributes = TypeAttributes.AutoClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.BeforeFieldInit;

--- a/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
+++ b/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
@@ -78,14 +78,12 @@ namespace NHibernate.Proxy
 
 #if NETFX || NETCOREAPP2_0
 			var assemblyNamesToIgnoreAccessCheck =
-				interfaces.Where(i => !i.IsVisible)
-				          .Select(i => i.Assembly.GetName().Name)
-				          .Distinct();
+				new[] {baseType}
+					.Concat(interfaces).Where(i => !i.IsVisible)
+					.Select(i => i.Assembly.GetName().Name)
+					.Distinct();
 			foreach (var a in assemblyNamesToIgnoreAccessCheck)
 				ProxyBuilderHelper.GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, a);
-
-			if (!baseType.IsVisible && !baseType.IsInterface)
-				ProxyBuilderHelper.GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, baseType.Assembly.GetName().Name);
 #else
 			interfaces.RemoveWhere(i => !i.IsVisible);
 #endif

--- a/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
+++ b/src/NHibernate/Proxy/NHibernateProxyBuilder.cs
@@ -83,6 +83,9 @@ namespace NHibernate.Proxy
 				          .Distinct();
 			foreach (var a in assemblyNamesToIgnoreAccessCheck)
 				ProxyBuilderHelper.GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, a);
+
+			if (!baseType.IsVisible && !baseType.IsInterface)
+				ProxyBuilderHelper.GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, baseType.Assembly.GetName().Name);
 #else
 			interfaces.RemoveWhere(i => !i.IsVisible);
 #endif


### PR DESCRIPTION
We do support proxy for internal interfaces since https://github.com/nhibernate/nhibernate-core/pull/1814
So not supporting internal classes looks like omission to me