### PR TITLE
Default value for CancellationToken in IQueryBatch.GetResultAsync 

### DIFF
--- a/src/AsyncGenerator.yml
+++ b/src/AsyncGenerator.yml
@@ -287,6 +287,7 @@ methodRules:
   - containingType: NHibernate.Linq.DmlExtensionMethods
   - containingType: NHibernate.Linq.InsertBuilder<TSource, TTarget>
   - containingType: NHibernate.Linq.UpdateBuilder<TSource>
+  - containingType: NHibernate.Multi.IQueryBatch 
   name: PubliclyExposedType
 - filters:
   - hasAttributeName: ObsoleteAttribute

--- a/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
@@ -1112,7 +1112,7 @@ namespace NHibernate.Test.CacheTest
 
 				using (var t = s.BeginTransaction())
 				{
-					await (queries.ExecuteAsync(CancellationToken.None));
+					await (queries.ExecuteAsync());
 					await (t.CommitAsync());
 				}
 
@@ -1127,24 +1127,24 @@ namespace NHibernate.Test.CacheTest
 				// Run a second time, to test the query cache
 				using (var t = s.BeginTransaction())
 				{
-					await (queries.ExecuteAsync(CancellationToken.None));
+					await (queries.ExecuteAsync());
 					await (t.CommitAsync());
 				}
 
 				Assert.That(
-					await (queries.GetResultAsync<ReadOnly>(0, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadOnly>(0)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadOnly.Name)).EqualTo(name1), "q1");
 				Assert.That(
-					await (queries.GetResultAsync<ReadOnly>(1, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadOnly>(1)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadOnly.Name)).EqualTo(name2), "q2");
 				Assert.That(
-					await (queries.GetResultAsync<ReadWrite>(2, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadWrite>(2)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadWrite.Name)).EqualTo(name3), "q3");
 				Assert.That(
-					await (queries.GetResultAsync<ReadWrite>(3, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadWrite>(3)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadWrite.Name)).EqualTo(name4), "q4");
 				Assert.That(
-					await (queries.GetResultAsync<ReadOnly>(4, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadOnly>(4)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadOnly.Name)).EqualTo(name5), "q5");
 
 				Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(2), "cache GetMany secondExecution");
@@ -1174,24 +1174,24 @@ namespace NHibernate.Test.CacheTest
 				// Run a third time, to re-test the query cache
 				using (var t = s.BeginTransaction())
 				{
-					await (queries.ExecuteAsync(CancellationToken.None));
+					await (queries.ExecuteAsync());
 					await (t.CommitAsync());
 				}
 
 				Assert.That(
-					await (queries.GetResultAsync<ReadOnly>(0, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadOnly>(0)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadOnly.Name)).EqualTo(name1), "q1 after update");
 				Assert.That(
-					await (queries.GetResultAsync<ReadOnly>(1, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadOnly>(1)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadOnly.Name)).EqualTo(name2), "q2 after update");
 				Assert.That(
-					await (queries.GetResultAsync<ReadWrite>(2, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadWrite>(2)),
 					Has.Count.EqualTo(0), "q3 after update");
 				Assert.That(
-					await (queries.GetResultAsync<ReadWrite>(3, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadWrite>(3)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadWrite.Name)).EqualTo(name4), "q4 after update");
 				Assert.That(
-					await (queries.GetResultAsync<ReadOnly>(4, CancellationToken.None)),
+					await (queries.GetResultAsync<ReadOnly>(4)),
 					Has.Count.EqualTo(1).And.One.Property(nameof(ReadOnly.Name)).EqualTo(name5), "q5 after update");
 
 				Assert.That(cache.GetMultipleCalls, Has.Count.EqualTo(3), "cache GetMany thirdExecution");

--- a/src/NHibernate.Test/Async/Criteria/Lambda/IntegrationFixture.cs
+++ b/src/NHibernate.Test/Async/Criteria/Lambda/IntegrationFixture.cs
@@ -428,8 +428,8 @@ namespace NHibernate.Test.Criteria.Lambda
 					 .Add("page", query)
 					 .Add<int>("count", query.ToRowCountQuery());
 
-				var pageResults = await (multiQuery.GetResultAsync<Person>("page", CancellationToken.None));
-				var countResults = await (multiQuery.GetResultAsync<int>("count", CancellationToken.None));
+				var pageResults = await (multiQuery.GetResultAsync<Person>("page"));
+				var countResults = await (multiQuery.GetResultAsync<int>("count"));
 
 				Assert.That(pageResults.Count, Is.EqualTo(1));
 				Assert.That(pageResults[0].Name, Is.EqualTo("Name 3"));
@@ -451,8 +451,8 @@ namespace NHibernate.Test.Criteria.Lambda
 					 .Add("page", query)
 					 .Add<int>("count", query.ToRowCountQuery());
 
-				var pageResults = await (multiCriteria.GetResultAsync<Person>("page", CancellationToken.None));
-				var countResults = await (multiCriteria.GetResultAsync<int>("count", CancellationToken.None));
+				var pageResults = await (multiCriteria.GetResultAsync<Person>("page"));
+				var countResults = await (multiCriteria.GetResultAsync<int>("count"));
 
 				Assert.That(pageResults.Count, Is.EqualTo(1));
 				Assert.That(pageResults[0].Name, Is.EqualTo("Name 3"));

--- a/src/NHibernate.Test/Async/Futures/QueryBatchFixture.cs
+++ b/src/NHibernate.Test/Async/Futures/QueryBatchFixture.cs
@@ -22,7 +22,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.Futures
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class QueryBatchFixtureAsync : TestCaseMappingByCode
 	{
@@ -81,10 +80,10 @@ namespace NHibernate.Test.Futures
 
 				using (var sqlLog = new SqlLogSpy())
 				{
-					await (batch.GetResultAsync<int>(0, CancellationToken.None));
-					await (batch.GetResultAsync<EntityComplex>("queryOver", CancellationToken.None));
-					await (batch.GetResultAsync<EntityComplex>(2, CancellationToken.None));
-					await (batch.GetResultAsync<EntitySimpleChild>("sql", CancellationToken.None));
+					await (batch.GetResultAsync<int>(0));
+					await (batch.GetResultAsync<EntityComplex>("queryOver"));
+					await (batch.GetResultAsync<EntityComplex>(2));
+					await (batch.GetResultAsync<EntitySimpleChild>("sql"));
 					if (SupportsMultipleQueries)
 						Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1));
 				}
@@ -142,7 +141,7 @@ namespace NHibernate.Test.Futures
 
 				batch.Add(q1);
 				batch.Add(session.Query<EntityComplex>().Fetch(c => c.ChildrenList));
-				await (batch.ExecuteAsync(CancellationToken.None));
+				await (batch.ExecuteAsync());
 
 				var parent = await (session.LoadAsync<EntityComplex>(_parentId));
 				Assert.That(NHibernateUtil.IsInitialized(parent), Is.True);
@@ -162,7 +161,7 @@ namespace NHibernate.Test.Futures
 				int count = 0;
 				batch.Add(session.Query<EntityComplex>().WithOptions(o => o.SetCacheable(true)), r => results = r);
 				batch.Add(session.Query<EntityComplex>().WithOptions(o => o.SetCacheable(true)), ec => ec.Count(), r => count = r);
-				await (batch.ExecuteAsync(CancellationToken.None));
+				await (batch.ExecuteAsync());
 
 				Assert.That(results, Is.Not.Null);
 				Assert.That(count, Is.GreaterThan(0));
@@ -177,7 +176,7 @@ namespace NHibernate.Test.Futures
 				batch.Add(session.Query<EntityComplex>().WithOptions(o => o.SetCacheable(true)), r => results = r);
 				batch.Add(session.Query<EntityComplex>().WithOptions(o => o.SetCacheable(true)), ec => ec.Count(), r => count = r);
 
-				await (batch.ExecuteAsync(CancellationToken.None));
+				await (batch.ExecuteAsync());
 
 				Assert.That(results, Is.Not.Null);
 				Assert.That(count, Is.GreaterThan(0));

--- a/src/NHibernate.Test/Async/NHSpecificTest/DataReaderWrapperTest/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/DataReaderWrapperTest/Fixture.cs
@@ -16,7 +16,6 @@ using NHibernate.Multi;
 namespace NHibernate.Test.NHSpecificTest.DataReaderWrapperTest
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -71,7 +70,7 @@ namespace NHibernate.Test.NHSpecificTest.DataReaderWrapperTest
 				var crit = s.CreateCriteria(typeof (TheEntity));
 				var multi = s.CreateQueryBatch();
 				multi.Add<TheEntity>(crit);
-				var res = await (multi.GetResultAsync<TheEntity>(0, CancellationToken.None));
+				var res = await (multi.GetResultAsync<TheEntity>(0));
 				Assert.That(res.Count, Is.EqualTo(1));
 			}
 		}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1253/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1253/Fixture.cs
@@ -15,7 +15,6 @@ using NHibernate.Multi;
 namespace NHibernate.Test.NHSpecificTest.NH1253
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -119,7 +118,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1253
 				await (s.CreateQueryBatch()
 				 .Add<Car>(q1)
 				 .Add<Car>(q2)
-				 .ExecuteAsync(CancellationToken.None));
+				 .ExecuteAsync());
 
 				await (tx.CommitAsync());
 			}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1508/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1508/Fixture.cs
@@ -15,7 +15,6 @@ using NHibernate.Multi;
 namespace NHibernate.Test.NHSpecificTest.NH1508
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -81,7 +80,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1508
 				var q = session
 				        .CreateQueryBatch()
 				        .Add<Document>(sqlQuery);
-				await (q.ExecuteAsync(CancellationToken.None));
+				await (q.ExecuteAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1609/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1609/Fixture.cs
@@ -86,9 +86,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1609
 					session.CreateCriteria(typeof (EntityB)).Add(Restrictions.Eq("A.Id", a1.Id)).Add(Restrictions.Eq("C.Id", c.Id)).
 					        SetFirstResult(0).SetMaxResults(1));
 
-				Assert.That(await (multi.GetResultAsync<EntityA>(0, CancellationToken.None)), Has.Count.EqualTo(1));
-				Assert.That(await (multi.GetResultAsync<EntityA>(1, CancellationToken.None)), Has.Count.EqualTo(1));
-				Assert.That(await (multi.GetResultAsync<EntityB>(2, CancellationToken.None)), Has.Count.EqualTo(1));
+				Assert.That(await (multi.GetResultAsync<EntityA>(0)), Has.Count.EqualTo(1));
+				Assert.That(await (multi.GetResultAsync<EntityA>(1)), Has.Count.EqualTo(1));
+				Assert.That(await (multi.GetResultAsync<EntityB>(2)), Has.Count.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1836/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1836/Fixture.cs
@@ -18,7 +18,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH1836
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -70,7 +69,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1836
 				                                 .SetResultTransformer(Transformers.AliasToBean(typeof(EntityDTO))));
 
 				Assert.That(multiQuery.Execute, Throws.Nothing);
-				var results = await (multiQuery.GetResultAsync<EntityDTO>(0, CancellationToken.None));
+				var results = await (multiQuery.GetResultAsync<EntityDTO>(0));
 				Assert.That(results.First(), Is.TypeOf<EntityDTO>().And.Property("EntityId").EqualTo(1));
 				await (t.CommitAsync());
 			}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1869/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1869/Fixture.cs
@@ -107,8 +107,8 @@ namespace NHibernate.Test.NHSpecificTest.NH1869
 			using (var session = Sfi.OpenSession())
 			{
 				var result = await (GetResultWithQueryBatchAsync(session));
-				Assert.That(await (result.GetResultAsync<NodeKeyword>(0, CancellationToken.None)), Has.Count.EqualTo(1));
-				Assert.That(await (result.GetResultAsync<NodeKeyword>(1, CancellationToken.None)), Has.Count.EqualTo(1));
+				Assert.That(await (result.GetResultAsync<NodeKeyword>(0)), Has.Count.EqualTo(1));
+				Assert.That(await (result.GetResultAsync<NodeKeyword>(1)), Has.Count.EqualTo(1));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2195/SQLiteMultiCriteriaTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2195/SQLiteMultiCriteriaTest.cs
@@ -20,7 +20,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH2195
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class SQLiteMultiCriteriaTestAsync : BugTestCase
 	{
@@ -173,8 +172,8 @@ namespace NHibernate.Test.NHSpecificTest.NH2195
 				multi.Add<DomainClass>(criteriaWithPagination);
 				multi.Add<long>(criteriaWithRowCount);
 
-				var numResults = (await (multi.GetResultAsync<long>(1, CancellationToken.None))).Single();
-				var list = await (multi.GetResultAsync<DomainClass>(0, CancellationToken.None));
+				var numResults = (await (multi.GetResultAsync<long>(1))).Single();
+				var list = await (multi.GetResultAsync<DomainClass>(0));
 
 				Assert.That(numResults, Is.EqualTo(2));
 				Assert.That(list.Count, Is.EqualTo(1));
@@ -198,8 +197,8 @@ namespace NHibernate.Test.NHSpecificTest.NH2195
 				multi.Add<DomainClass>(criteriaWithPagination);
 				multi.Add<long>(criteriaWithRowCount);
 
-				var numResults = (await (multi.GetResultAsync<long>(1, CancellationToken.None))).Single();
-				var list = await (multi.GetResultAsync<DomainClass>(0, CancellationToken.None));
+				var numResults = (await (multi.GetResultAsync<long>(1))).Single();
+				var list = await (multi.GetResultAsync<DomainClass>(0));
 
 				Assert.That(numResults, Is.EqualTo(2));
 				Assert.That(list.Count, Is.EqualTo(1));

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2201/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2201/Fixture.cs
@@ -16,7 +16,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH2201
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -78,8 +77,8 @@ namespace NHibernate.Test.NHSpecificTest.NH2201
 					 .Add<Parent>(s.CreateCriteria<Parent>())
 					 .Add<Parent>(s.CreateCriteria<Parent>());
 
-				var result1 = await (multi.GetResultAsync<Parent>(0, CancellationToken.None));
-				var result2 = await (multi.GetResultAsync<Parent>(1, CancellationToken.None));
+				var result1 = await (multi.GetResultAsync<Parent>(0));
+				var result2 = await (multi.GetResultAsync<Parent>(1));
 
 				Assert.That(result1.Count, Is.EqualTo(2));
 				Assert.That(result2.Count, Is.EqualTo(2));

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2959/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2959/Fixture.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH2959
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -89,7 +88,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2959
 			{
 				var results = await (session.CreateQueryBatch()
 				                     .Add<BaseEntity>(session.CreateCriteria(typeof(BaseEntity)))
-				                     .GetResultAsync<BaseEntity>(0, CancellationToken.None));
+				                     .GetResultAsync<BaseEntity>(0));
 
 				Assert.That(results, Has.Count.EqualTo(2));
 			}
@@ -103,7 +102,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2959
 			{
 				var results = await (session.CreateQueryBatch()
 				                     .Add<BaseEntity>(session.CreateQuery("from " + typeof(BaseEntity).FullName))
-				                     .GetResultAsync<BaseEntity>(0, CancellationToken.None));
+				                     .GetResultAsync<BaseEntity>(0));
 
 				Assert.That(results, Has.Count.EqualTo(2));
 			}

--- a/src/NHibernate.Test/Async/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/SqlConverterAndMultiQuery/Fixture.cs
@@ -18,7 +18,6 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class FixtureAsync : BugTestCase
 	{
@@ -76,7 +75,7 @@ namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 				var multi = s.CreateQueryBatch();
 				multi.Add<int>(s.CreateQuery(hqlQuery));
 				s.Connection.Close();
-				Assert.ThrowsAsync<UnitTestException>(() => multi.ExecuteAsync(CancellationToken.None));
+				Assert.ThrowsAsync<UnitTestException>(() => multi.ExecuteAsync());
 			}
 		}
 
@@ -118,7 +117,7 @@ namespace NHibernate.Test.NHSpecificTest.SqlConverterAndMultiQuery
 				var multi = s.CreateQueryBatch();
 				multi.Add<ClassA>(s.CreateCriteria(typeof(ClassA)));
 				s.Connection.Close();
-				Assert.ThrowsAsync<UnitTestException>(() => multi.ExecuteAsync(CancellationToken.None));
+				Assert.ThrowsAsync<UnitTestException>(() => multi.ExecuteAsync());
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/Pagination/CustomDialectFixture.cs
+++ b/src/NHibernate.Test/Async/Pagination/CustomDialectFixture.cs
@@ -23,7 +23,6 @@ using Environment = NHibernate.Cfg.Environment;
 namespace NHibernate.Test.Pagination
 {
 	using System.Threading.Tasks;
-	using System.Threading;
 	[TestFixture]
 	public class CustomDialectFixtureAsync : TestCase
 	{
@@ -153,7 +152,7 @@ namespace NHibernate.Test.Pagination
 						  .SetFirstResult(1)
 						  .SetMaxResults(2));
 
-				var points = await (query.GetResultAsync<DataPoint>(0, CancellationToken.None));
+				var points = await (query.GetResultAsync<DataPoint>(0));
 
 				Assert.That(points.Count, Is.EqualTo(2));
 				Assert.That(points[0].X, Is.EqualTo(7d));

--- a/src/NHibernate.Test/Async/QueryTest/QueryBatchFixture.cs
+++ b/src/NHibernate.Test/Async/QueryTest/QueryBatchFixture.cs
@@ -78,12 +78,12 @@ namespace NHibernate.Test.QueryTest
 				var queries = s.CreateQueryBatch()
 				               .Add<Item>(getItems)
 				               .Add<int>(countItems);
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				var fromDb = items.First();
 				Assert.That(fromDb.Id, Is.EqualTo(1));
 				Assert.That(fromDb.Name, Is.EqualTo("foo"));
 
-				var count = (await (queries.GetResultAsync<int>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<int>(1))).Single();
 				Assert.That(count, Is.EqualTo(1));
 
 				await (transaction.CommitAsync());
@@ -109,11 +109,11 @@ namespace NHibernate.Test.QueryTest
 				var queries = s.CreateQueryBatch()
 				               .Add<Item>(getItems)
 				               .Add<int>(countItems);
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				var fromDb = items.First();
 				Assert.That(fromDb.Id, Is.EqualTo(1));
 
-				var count = (await (queries.GetResultAsync<int>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<int>(1))).Single();
 				Assert.That(count, Is.EqualTo(1));
 			}
 		}
@@ -176,9 +176,9 @@ namespace NHibernate.Test.QueryTest
 				               .Add<int>(
 					               CriteriaTransformer
 						               .Clone(criteria).SetProjection(Projections.RowCount()).SetCacheable(true));
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				Assert.That(items.Count, Is.EqualTo(89));
-				var count = (await (queries.GetResultAsync<int>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<int>(1))).Single();
 				Assert.That(count, Is.EqualTo(99));
 			}
 
@@ -191,12 +191,12 @@ namespace NHibernate.Test.QueryTest
 				               .Add<int>(
 					               CriteriaTransformer
 						               .Clone(criteria).SetProjection(Projections.RowCount()).SetCacheable(true));
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				Assert.That(
 					items.Count,
 					Is.EqualTo(79),
 					"Should have gotten different result here, because the paging is different");
-				var count = (await (queries.GetResultAsync<int>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<int>(1))).Single();
 				Assert.That(count, Is.EqualTo(99));
 			}
 		}
@@ -218,9 +218,9 @@ namespace NHibernate.Test.QueryTest
 				               .Add<int>(
 					               CriteriaTransformer.Clone(criteria)
 					                                  .SetProjection(Projections.RowCount()));
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				Assert.That(items.Count, Is.EqualTo(89));
-				var count = (await (queries.GetResultAsync<int>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<int>(1))).Single();
 				Assert.That(count, Is.EqualTo(99));
 			}
 		}
@@ -248,11 +248,11 @@ namespace NHibernate.Test.QueryTest
 					               CriteriaTransformer.Clone(criteria)
 					                                  .SetProjection(Projections.RowCount()));
 
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				var fromDb = items.First();
 				Assert.That(fromDb.Id, Is.EqualTo(1));
 
-				var count = (await (queries.GetResultAsync<int>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<int>(1))).Single();
 				Assert.That(count, Is.EqualTo(1));
 			}
 		}
@@ -274,8 +274,8 @@ namespace NHibernate.Test.QueryTest
 				multiCriteria.Add<Item>("firstCriteria", firstCriteria);
 				multiCriteria.Add<Item>("secondCriteria", secondCriteria);
 
-				var secondResult = await (multiCriteria.GetResultAsync<Item>("secondCriteria", CancellationToken.None));
-				var firstResult = await (multiCriteria.GetResultAsync<Item>("firstCriteria", CancellationToken.None));
+				var secondResult = await (multiCriteria.GetResultAsync<Item>("secondCriteria"));
+				var firstResult = await (multiCriteria.GetResultAsync<Item>("firstCriteria"));
 
 				Assert.That(secondResult.Count, Is.GreaterThan(firstResult.Count));
 			}
@@ -298,8 +298,8 @@ namespace NHibernate.Test.QueryTest
 				multiCriteria.Add<Item>("firstCriteria", firstCriteria);
 				multiCriteria.Add<Item>("secondCriteria", secondCriteria);
 
-				var secondResult = await (multiCriteria.GetResultAsync<Item>("secondCriteria", CancellationToken.None));
-				var firstResult = await (multiCriteria.GetResultAsync<Item>("firstCriteria", CancellationToken.None));
+				var secondResult = await (multiCriteria.GetResultAsync<Item>("secondCriteria"));
+				var firstResult = await (multiCriteria.GetResultAsync<Item>("firstCriteria"));
 
 				Assert.That(secondResult.Count, Is.GreaterThan(firstResult.Count));
 			}
@@ -317,7 +317,7 @@ namespace NHibernate.Test.QueryTest
 				                      .SetResultTransformer(transformer);
 				var multiCriteria = session.CreateQueryBatch()
 				                           .Add<object[]>(criteria);
-				await (multiCriteria.GetResultAsync<object[]>(0, CancellationToken.None));
+				await (multiCriteria.GetResultAsync<object[]>(0));
 
 				Assert.That(transformer.WasTransformTupleCalled, Is.True, "Transform Tuple was not called");
 				Assert.That(transformer.WasTransformListCalled, Is.True, "Transform List was not called");
@@ -356,7 +356,7 @@ namespace NHibernate.Test.QueryTest
 
 				for (var i = 0; i < 12; i++)
 				{
-					Assert.That((await (multi.GetResultAsync<Item>(i, CancellationToken.None))).Count, Is.EqualTo(1));
+					Assert.That((await (multi.GetResultAsync<Item>(i))).Count, Is.EqualTo(1));
 				}
 			}
 		}
@@ -380,7 +380,7 @@ namespace NHibernate.Test.QueryTest
 				await (s.DeleteAsync(p1));
 				var multi = s.CreateQueryBatch();
 				multi.Add<int>(s.QueryOver<Item>().ToRowCountQuery());
-				var count = (await (multi.GetResultAsync<int>(0, CancellationToken.None))).Single();
+				var count = (await (multi.GetResultAsync<int>(0))).Single();
 				await (tx.CommitAsync());
 
 				Assert.That(count, Is.EqualTo(0), "Session wasn't auto flushed.");
@@ -441,9 +441,9 @@ namespace NHibernate.Test.QueryTest
 					                  s.CreateQuery("select count(*) from Item i where i.Id > ?")
 					                   .SetInt32(0, 50)
 					                   .SetCacheable(true));
-				var items = await (multiQuery.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (multiQuery.GetResultAsync<Item>(0));
 				Assert.That(items.Count, Is.EqualTo(89));
-				var count = (await (multiQuery.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (multiQuery.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(99L));
 			}
 
@@ -459,12 +459,12 @@ namespace NHibernate.Test.QueryTest
 					                  s.CreateQuery("select count(*) from Item i where i.Id > ?")
 					                   .SetInt32(0, 50)
 					                   .SetCacheable(true));
-				var items = await (multiQuery.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (multiQuery.GetResultAsync<Item>(0));
 				Assert.That(
 					items.Count,
 					Is.EqualTo(79),
 					"Should have gotten different result here, because the paging is different");
-				var count = (await (multiQuery.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (multiQuery.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(99L));
 			}
 		}
@@ -499,9 +499,9 @@ namespace NHibernate.Test.QueryTest
 				var queries = s.CreateQueryBatch()
 				               .Add<Item>(getItems)
 				               .Add<long>(countItems);
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				Assert.That(items.Count, Is.EqualTo(89));
-				var count = (await (queries.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(99L));
 			}
 		}
@@ -530,10 +530,10 @@ namespace NHibernate.Test.QueryTest
 						                "items",
 						                new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
 
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				Assert.That(items.First().Id, Is.EqualTo(1));
 
-				var count = (await (queries.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(1L));
 			}
 		}
@@ -556,11 +556,11 @@ namespace NHibernate.Test.QueryTest
 				var queries = s.CreateQueryBatch()
 				               .Add<Item>(getItems)
 				               .Add<long>(countItems);
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				var fromDb = items.First();
 				Assert.That(fromDb.Id, Is.EqualTo(1));
 
-				var count = (await (queries.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(1L));
 			}
 		}
@@ -581,8 +581,8 @@ namespace NHibernate.Test.QueryTest
 
 				multiQuery.Add<Item>("first", firstQuery).Add<Item>("second", secondQuery);
 
-				var secondResult = await (multiQuery.GetResultAsync<Item>("second", CancellationToken.None));
-				var firstResult = await (multiQuery.GetResultAsync<Item>("first", CancellationToken.None));
+				var secondResult = await (multiQuery.GetResultAsync<Item>("second"));
+				var firstResult = await (multiQuery.GetResultAsync<Item>("first"));
 
 				Assert.That(secondResult.Count, Is.GreaterThan(firstResult.Count));
 			}
@@ -600,7 +600,7 @@ namespace NHibernate.Test.QueryTest
 				                      .SetResultTransformer(transformer);
 				await (session.CreateQueryBatch()
 				       .Add<object[]>(criteria)
-				       .GetResultAsync<object[]>(0, CancellationToken.None));
+				       .GetResultAsync<object[]>(0));
 
 				Assert.That(transformer.WasTransformTupleCalled, Is.True, "Transform Tuple was not called");
 				Assert.That(transformer.WasTransformListCalled, Is.True, "Transform List was not called");
@@ -642,7 +642,7 @@ namespace NHibernate.Test.QueryTest
 					                  s.CreateSQLQuery("select * from ITEM where Id in (:ids)")
 					                   .AddEntity(typeof(Item)))
 				                  .Add<Item>(s.CreateQuery("from Item i where i.Id in (:ids2)"));
-				var e = Assert.ThrowsAsync<QueryException>(() => multiQuery.ExecuteAsync(CancellationToken.None));
+				var e = Assert.ThrowsAsync<QueryException>(() => multiQuery.ExecuteAsync());
 				Assert.That(
 					e.Message,
 					Is.EqualTo(
@@ -681,7 +681,7 @@ namespace NHibernate.Test.QueryTest
 				 .Add<Item>(
 					 s.CreateQuery("from Item i where i.Id = :id2")
 					  .SetInt32("id2", 5))
-				 .ExecuteAsync(CancellationToken.None));
+				 .ExecuteAsync());
 			}
 		}
 
@@ -703,9 +703,9 @@ namespace NHibernate.Test.QueryTest
 					                   .SetInt32(0, 50)
 					                   .SetCacheable(true));
 
-				var items = await (multiQuery.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (multiQuery.GetResultAsync<Item>(0));
 				Assert.That(items.Count, Is.EqualTo(89));
-				var count = (await (multiQuery.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (multiQuery.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(99L));
 			}
 
@@ -722,12 +722,12 @@ namespace NHibernate.Test.QueryTest
 					                   .AddScalar("itemCount", NHibernateUtil.Int64)
 					                   .SetInt32(0, 50)
 					                   .SetCacheable(true));
-				var items = await (multiQuery.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (multiQuery.GetResultAsync<Item>(0));
 				Assert.That(
 					items.Count,
 					Is.EqualTo(79),
 					"Should have gotten different result here, because the paging is different");
-				var count = (await (multiQuery.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (multiQuery.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(99L));
 			}
 		}
@@ -763,9 +763,9 @@ namespace NHibernate.Test.QueryTest
 				var queries = s.CreateQueryBatch()
 				               .Add<Item>(getItems)
 				               .Add<long>(countItems);
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				Assert.That(items.Count, Is.EqualTo(89));
-				var count = (await (queries.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(99L));
 			}
 		}
@@ -794,11 +794,11 @@ namespace NHibernate.Test.QueryTest
 					                     "items",
 					                     new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
 
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				var fromDb = items.First();
 				Assert.That(fromDb.Id, Is.EqualTo(1));
 
-				var count = (await (queries.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(1L));
 			}
 		}
@@ -821,11 +821,11 @@ namespace NHibernate.Test.QueryTest
 				var queries = s.CreateQueryBatch()
 				               .Add<Item>(getItems)
 				               .Add<long>(countItems);
-				var items = await (queries.GetResultAsync<Item>(0, CancellationToken.None));
+				var items = await (queries.GetResultAsync<Item>(0));
 				var fromDb = items.First();
 				Assert.That(fromDb.Id, Is.EqualTo(1));
 
-				var count = (await (queries.GetResultAsync<long>(1, CancellationToken.None))).Single();
+				var count = (await (queries.GetResultAsync<long>(1))).Single();
 				Assert.That(count, Is.EqualTo(1L));
 			}
 		}
@@ -847,8 +847,8 @@ namespace NHibernate.Test.QueryTest
 
 				multiQuery.Add<Item>("first", firstQuery).Add<Item>("second", secondQuery);
 
-				var secondResult = await (multiQuery.GetResultAsync<Item>("second", CancellationToken.None));
-				var firstResult = await (multiQuery.GetResultAsync<Item>("first", CancellationToken.None));
+				var secondResult = await (multiQuery.GetResultAsync<Item>("second"));
+				var firstResult = await (multiQuery.GetResultAsync<Item>("first"));
 
 				Assert.That(secondResult.Count, Is.GreaterThan(firstResult.Count));
 			}
@@ -867,7 +867,7 @@ namespace NHibernate.Test.QueryTest
 				                   .SetResultTransformer(transformer);
 				await (session.CreateQueryBatch()
 				       .Add<object[]>(query)
-				       .GetResultAsync<object[]>(0, CancellationToken.None));
+				       .GetResultAsync<object[]>(0));
 
 				Assert.That(transformer.WasTransformTupleCalled, Is.True, "Transform Tuple was not called");
 				Assert.That(transformer.WasTransformListCalled, Is.True, "Transform List was not called");
@@ -889,7 +889,7 @@ namespace NHibernate.Test.QueryTest
 				multiCriteria.Add<Item>("firstCriteria", firstCriteria);
 
 				Assert.That(
-					() => multiCriteria.GetResultAsync<Item>("unknownKey", CancellationToken.None),
+					() => multiCriteria.GetResultAsync<Item>("unknownKey"),
 					Throws.InstanceOf<KeyNotFoundException>());
 			}
 		}

--- a/src/NHibernate.Test/Async/Stats/StatsFixture.cs
+++ b/src/NHibernate.Test/Async/Stats/StatsFixture.cs
@@ -275,7 +275,7 @@ namespace NHibernate.Test.Stats
 					await (s.CreateQueryBatch()
 					 .Add<Country>(s.CreateQuery("from Country"))
 					 .Add<Continent>(s.CreateQuery("from Continent"))
-					 .ExecuteAsync(CancellationToken.None));
+					 .ExecuteAsync());
 				}
 				Assert.That(stats.QueryExecutionCount, Is.EqualTo(1));
 
@@ -285,7 +285,7 @@ namespace NHibernate.Test.Stats
 					await (s.CreateQueryBatch()
 					 .Add<Country>(DetachedCriteria.For<Country>())
 					 .Add<Continent>(DetachedCriteria.For<Continent>())
-					 .ExecuteAsync(CancellationToken.None));
+					 .ExecuteAsync());
 				}
 				Assert.That(stats.QueryExecutionCount, Is.EqualTo(1));
 			}

--- a/src/NHibernate/Async/Multi/IQueryBatch.cs
+++ b/src/NHibernate/Async/Multi/IQueryBatch.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Multi
 		/// Executes the batch.
 		/// </summary>
 		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
-		Task ExecuteAsync(CancellationToken cancellationToken);
+		Task ExecuteAsync(CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Gets a query result, triggering execution of the batch if it was not already executed.
@@ -32,7 +32,7 @@ namespace NHibernate.Multi
 		/// <returns>A query result.</returns>
 		/// <remarks><paramref name="queryIndex"/> is <c>0</c> based and matches the order in which queries have been
 		/// added into the batch.</remarks>
-		Task<IList<TResult>> GetResultAsync<TResult>(int queryIndex, CancellationToken cancellationToken);
+		Task<IList<TResult>> GetResultAsync<TResult>(int queryIndex, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Gets a query result, triggering execution of the batch if it was not already executed.
@@ -41,6 +41,6 @@ namespace NHibernate.Multi
 		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
 		/// <typeparam name="TResult">The type of the result elements of the query.</typeparam>
 		/// <returns>A query result.</returns>
-		Task<IList<TResult>> GetResultAsync<TResult>(string querykey, CancellationToken cancellationToken);
+		Task<IList<TResult>> GetResultAsync<TResult>(string querykey, CancellationToken cancellationToken = default(CancellationToken));
 	}
 }

--- a/src/NHibernate/Async/Multi/QueryBatch.cs
+++ b/src/NHibernate/Async/Multi/QueryBatch.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Multi
 		}
 
 		/// <inheritdoc />
-		public Task<IList<TResult>> GetResultAsync<TResult>(int queryIndex, CancellationToken cancellationToken)
+		public Task<IList<TResult>> GetResultAsync<TResult>(int queryIndex, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (cancellationToken.IsCancellationRequested)
 			{
@@ -87,7 +87,7 @@ namespace NHibernate.Multi
 		}
 
 		/// <inheritdoc />
-		public Task<IList<TResult>> GetResultAsync<TResult>(string querykey, CancellationToken cancellationToken)
+		public Task<IList<TResult>> GetResultAsync<TResult>(string querykey, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (cancellationToken.IsCancellationRequested)
 			{

--- a/src/NHibernate/Async/Multi/QueryBatch.cs
+++ b/src/NHibernate/Async/Multi/QueryBatch.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Multi
 	{
 
 		/// <inheritdoc />
-		public async Task ExecuteAsync(CancellationToken cancellationToken)
+		public async Task ExecuteAsync(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			if (_queries.Count == 0)


### PR DESCRIPTION
I'd like to propose default value of second parameter in function `IQueryBatch.GetResultAsync` to be `default(CancellationToken)`. This would be consistent with the rest of async functions `SingleOrDefaultAsync, ListAsync` and `RowCountAsync`, where in each and every case this is the default value for cancellation. 

To my best knowledge this should be nonbreaking change. Due to triviality I don't think any tests are required here.