### PR TITLE
Criteria API - Added support for Full-Text Search in SQL Server & SQLite

### DIFF
--- a/src/NHibernate/Criterion/ContainsExpression.cs
+++ b/src/NHibernate/Criterion/ContainsExpression.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Dialect;
+using NHibernate.Engine;
+using NHibernate.SqlCommand;
+using NHibernate.Util;
+
+namespace NHibernate.Criterion
+{
+	public class ContainsExpression : AbstractCriterion
+	{
+		private readonly object value;
+		private readonly IProjection projection;
+		private readonly TypedValue typedValue;
+		private readonly bool freetext;
+
+		public ContainsExpression(IProjection projection, object value, bool freetext)
+		{
+			this.projection = projection;
+			this.value = value;
+			typedValue = new TypedValue(NHibernateUtil.String, this.value, false);
+			this.freetext = freetext;
+		}
+
+		public ContainsExpression(string propertyName, object value, bool freetext)
+			: this(Projections.Property(propertyName), value, freetext)
+		{
+		}
+
+		public override SqlString ToSqlString(ICriteria criteria, ICriteriaQuery criteriaQuery)
+		{
+			var columns = CriterionUtil.GetColumnNamesAsSqlStringParts(projection, criteriaQuery, criteria);
+			var value = criteriaQuery.NewQueryParameter(typedValue).Single();
+			var arguments = new[] { columns[0], value };
+			var functionName = GetFunctionName(criteriaQuery);
+
+			var dialectFunction = criteriaQuery.Factory.SQLFunctionRegistry.FindSQLFunction(functionName);
+			if (dialectFunction == null)
+			{
+				throw new HibernateException(string.Format("The current dialect '{0}' doesn't support the function: '{1}'",
+					criteriaQuery.Factory.Dialect, functionName));
+			}
+			return dialectFunction.Render(arguments, criteriaQuery.Factory);
+		}
+
+		private string GetFunctionName(ICriteriaQuery criteriaQuery)
+		{
+			var dialect = criteriaQuery.Factory.Dialect;
+
+			if (dialect is MsSql2000Dialect)
+				return freetext ? "freetext" : "contains";
+
+			if (dialect is SQLiteDialect)
+				return "match";
+
+			return "contains";
+		}
+
+		public override TypedValue[] GetTypedValues(ICriteria criteria, ICriteriaQuery criteriaQuery)
+		{
+			return new TypedValue[] { typedValue };
+		}
+
+		public override IProjection[] GetProjections()
+		{
+			if (projection != null)
+			{
+				return new IProjection[] { projection };
+			}
+			return null;
+		}
+
+		/// <summary></summary>
+		public override string ToString()
+		{
+			return projection + " contains/freetext " + value;
+		}
+	}
+}

--- a/src/NHibernate/Criterion/ContainsExpression.cs
+++ b/src/NHibernate/Criterion/ContainsExpression.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using NHibernate.Dialect;
 using NHibernate.Engine;
 using NHibernate.SqlCommand;
-using NHibernate.Util;
 
 namespace NHibernate.Criterion
 {
+	[Serializable]
 	public class ContainsExpression : AbstractCriterion
 	{
 		private readonly object value;

--- a/src/NHibernate/Criterion/FullTextContainsExpression.cs
+++ b/src/NHibernate/Criterion/FullTextContainsExpression.cs
@@ -59,7 +59,7 @@ namespace NHibernate.Criterion
 		/// <summary></summary>
 		public override string ToString()
 		{
-			return projection + " contains/freetext " + value;
+			return projection + " full-text-contains " + value;
 		}
 	}
 }

--- a/src/NHibernate/Criterion/FullTextContainsExpression.cs
+++ b/src/NHibernate/Criterion/FullTextContainsExpression.cs
@@ -7,20 +7,20 @@ using NHibernate.SqlCommand;
 namespace NHibernate.Criterion
 {
 	[Serializable]
-	public class ContainsExpression : AbstractCriterion
+	public class FullTextContainsExpression : AbstractCriterion
 	{
 		private readonly object value;
 		private readonly IProjection projection;
 		private readonly TypedValue typedValue;
 
-		public ContainsExpression(IProjection projection, object value)
+		public FullTextContainsExpression(IProjection projection, object value)
 		{
 			this.projection = projection;
 			this.value = value;
 			typedValue = new TypedValue(NHibernateUtil.String, this.value, false);
 		}
 
-		public ContainsExpression(string propertyName, object value)
+		public FullTextContainsExpression(string propertyName, object value)
 			: this(Projections.Property(propertyName), value)
 		{
 		}

--- a/src/NHibernate/Criterion/Restrictions.cs
+++ b/src/NHibernate/Criterion/Restrictions.cs
@@ -141,14 +141,14 @@ namespace NHibernate.Criterion
 			return new InsensitiveLikeExpression(projection, value);
 		}
 
-		public static AbstractCriterion Contains(string propertyName, string value)
+		public static AbstractCriterion FullTextContains(string propertyName, string value)
 		{
-			return new ContainsExpression(propertyName, value);
+			return new FullTextContainsExpression(propertyName, value);
 		}
 
-		public static AbstractCriterion Contains(IProjection projection, string value)
+		public static AbstractCriterion FullTextContains(IProjection projection, string value)
 		{
-			return new ContainsExpression(projection, value);
+			return new FullTextContainsExpression(projection, value);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Criterion/Restrictions.cs
+++ b/src/NHibernate/Criterion/Restrictions.cs
@@ -141,14 +141,14 @@ namespace NHibernate.Criterion
 			return new InsensitiveLikeExpression(projection, value);
 		}
 
-		public static AbstractCriterion Contains(string propertyName, string value, bool freetext = false)
+		public static AbstractCriterion Contains(string propertyName, string value)
 		{
-			return new ContainsExpression(propertyName, value, freetext);
+			return new ContainsExpression(propertyName, value);
 		}
 
-		public static AbstractCriterion Contains(IProjection projection, string value, bool freetext = false)
+		public static AbstractCriterion Contains(IProjection projection, string value)
 		{
-			return new ContainsExpression(projection, value, freetext);
+			return new ContainsExpression(projection, value);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Criterion/Restrictions.cs
+++ b/src/NHibernate/Criterion/Restrictions.cs
@@ -141,6 +141,16 @@ namespace NHibernate.Criterion
 			return new InsensitiveLikeExpression(projection, value);
 		}
 
+		public static AbstractCriterion Contains(string propertyName, string value, bool freetext = false)
+		{
+			return new ContainsExpression(propertyName, value, freetext);
+		}
+
+		public static AbstractCriterion Contains(IProjection projection, string value, bool freetext = false)
+		{
+			return new ContainsExpression(projection, value, freetext);
+		}
+
 		/// <summary>
 		/// Apply a "greater than" constraint to the named property
 		/// </summary>

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -2542,6 +2542,11 @@ namespace NHibernate.Dialect
 			get { return "lower"; }
 		}
 
+		public virtual string FullTextSearchFunction
+		{
+			get { return string.Empty; }
+		}
+
 		// 18 is the smallest of all dialects we handle.
 		/// <summary>
 		/// The maximum length a SQL alias can have.

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -746,6 +746,11 @@ namespace NHibernate.Dialect
 			get { return true; }
 		}
 
+		public override string FullTextSearchFunction
+		{
+			get { return "contains"; }
+		}
+
 		// Was 30 in "earlier version", without telling to which version the document apply.
 		// https://msdn.microsoft.com/en-us/library/ms191240.aspx#Anchor_3
 		/// <inheritdoc />

--- a/src/NHibernate/Dialect/MsSql2000Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2000Dialect.cs
@@ -365,6 +365,9 @@ namespace NHibernate.Dialect
 			RegisterFunction("extract", new SQLFunctionTemplate(NHibernateUtil.Int32, "datepart(?1, ?3)"));
 
 			RegisterFunction("new_uuid", new NoArgSQLFunction("newid", NHibernateUtil.Guid));
+
+			RegisterFunction("contains", new StandardSQLFunction("contains"));
+			RegisterFunction("freetext", new StandardSQLFunction("freetext")); 
 		}
 
 		protected virtual void RegisterGuidTypeMapping()

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -143,6 +143,8 @@ namespace NHibernate.Dialect
 				new SQLFunctionTemplate(
 					NHibernateUtil.Double,
 					"(cast(random() as real) / 4611686018427387904 / 4 + 0.5)"));
+
+			RegisterFunction("match", new SQLFunctionTemplate(null, "?1 match ?2")); 
 		}
 
 		public override void Configure(IDictionary<string, string> settings)

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -508,6 +508,11 @@ namespace NHibernate.Dialect
 		/// <inheritdoc />
 		public override int MaxAliasLength => 128;
 
+		public override string FullTextSearchFunction
+		{
+			get { return "match"; }
+		}
+
 		// Since v5.3
 		[Obsolete("This class has no usage in NHibernate anymore and will be removed in a future version. Use or extend CastFunction instead.")]
 		[Serializable]


### PR DESCRIPTION
Verified in production as well, against SQL Server.
The SQLite bit was only tested as far as to see the generated SQL, to verify the abstraction.