### PR TITLE
Fix joining with an inherited property from another table for Linq provider

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
@@ -148,5 +148,13 @@ namespace NHibernate.Test.Linq.ByMethod
 						from o2 in db.Animals.Where(x => x.BodyWeight > 50)
 						select new {o, o2}).Take(1).ToListAsync());
 		}
+
+		[Test(Description = "GH-2580")]
+		public async Task CanInnerJoinOnSubclassWithBaseTableReferenceInOnClauseAsync()
+		{
+			var result = await ((from o in db.Animals
+			              join o2 in db.Mammals on o.BodyWeight equals o2.BodyWeight
+			              select new { o, o2 }).Take(1).ToListAsync());
+		}
 	}
 }

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -137,5 +137,13 @@ namespace NHibernate.Test.Linq.ByMethod
 						from o2 in db.Animals.Where(x => x.BodyWeight > 50)
 						select new {o, o2}).Take(1).ToList();
 		}
+
+		[Test(Description = "GH-2580")]
+		public void CanInnerJoinOnSubclassWithBaseTableReferenceInOnClause()
+		{
+			var result = (from o in db.Animals
+			              join o2 in db.Mammals on o.BodyWeight equals o2.BodyWeight
+			              select new { o, o2 }).Take(1).ToList();
+		}
 	}
 }


### PR DESCRIPTION
Fix for a regression made by #2327. When merging into master only the test cases should be merged as #2361 makes this fix obsolete.

Fixes #2580