### PR TITLE
Upgrade AsyncGenerator to 0.19.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpasyncgenerator.tool": {
+      "version": "0.19.1",
+      "commands": [
+        "async-generator"
+      ]
+    }
+  }
+}

--- a/ShowBuildMenu.sh
+++ b/ShowBuildMenu.sh
@@ -178,34 +178,13 @@ testRun(){
 }
 
 generateAsync(){
-	dotnet restore ./src/NHibernate.sln
-
-	getAsyncGeneratorPath
 	cd src
-	dotnet ../"$async_generator_path"
+	dotnet tool restore
+	dotnet restore ./NHibernate.sln
+	dotnet async-generator
 	cd ..
 
 	mainMenu
-}
-
-getAsyncGeneratorPath(){
-	if [ "$async_generator_path" ]
-	then
-		return
-	fi
-
-	cd Tools
-
-	async_generator_version="$(cat packages.csproj | grep Include=\"CSharpAsyncGenerator.CommandLine | cut -d\" -f4)"
-	async_generator_path="csharpasyncgenerator.commandline/$async_generator_version/tools"
-
-	if [ ! -d $async_generator_path ]
-	then
-		dotnet restore "./packages.csproj" --packages .
-	fi
-
-	async_generator_path="Tools/$async_generator_path/netcoreapp2.1/AsyncGenerator.CommandLine.dll"
-	cd ..
 }
 
 mainMenu() {

--- a/Tools/packages.csproj
+++ b/Tools/packages.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="CSharpAsyncGenerator.CommandLine" Version="0.19.1" />
     <PackageReference Include="vswhere" Version="2.1.4" />
     <PackageReference Include="NUnit.Console" Version="3.10.0" />
     <PackageReference Include="GitReleaseManager" Version="0.11.0" />

--- a/Tools/packages.csproj
+++ b/Tools/packages.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="CSharpAsyncGenerator.CommandLine" Version="0.18.2" />
+    <PackageReference Include="CSharpAsyncGenerator.CommandLine" Version="0.19.1" />
     <PackageReference Include="vswhere" Version="2.1.4" />
     <PackageReference Include="NUnit.Console" Version="3.10.0" />
     <PackageReference Include="GitReleaseManager" Version="0.11.0" />

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -47,30 +47,13 @@
 		<property name="tools.dir" value="${root.dir}/Tools"/>
 	</target>
 
-	<target name="common.tools-restore" depends="common.init common.get-dotnet-version">
+	<target name="common.tools-restore" depends="common.init">
 		<exec workingdir="${root.dir}" program="dotnet" verbose="true">
 			<arg line="tool restore" />
 		</exec> 
 		<exec workingdir="${root.dir}/Tools" program="dotnet" verbose="true">
 			<arg line="restore ./packages.csproj --packages ." />
 		</exec> 
-	</target>
-
-	<target name="common.get-dotnet-version">
-		<property name="dotnet.version.file" value="${root.dir}/Tools/dotnet.version" />
-		<exec workingdir="${root.dir}/Tools" program="dotnet" output="${dotnet.version.file}">
-			<arg line="--version" />
-		</exec>
-		<loadfile file="${dotnet.version.file}" property="dotnet.version.content" />
-		<delete file="${dotnet.version.file}" />
-		<echo message="dotnet version: ${string::trim(dotnet.version.content)}" />
-		<if test="${string::index-of(dotnet.version.content, '-') == -1}">
-			<property name="dotnet.version" value="${version::parse(string::trim(dotnet.version.content))}" />
-		</if>
-		<!-- For preview versions we have to substring until - character. Example: 5.0.100-preview.2.20176.6  -->
-		<if test="${string::index-of(dotnet.version.content, '-') != -1}">
-			<property name="dotnet.version" value="${version::parse(string::trim(string::substring(dotnet.version.content, 0, string::index-of(dotnet.version.content, '-'))))}" />
-		</if>
 	</target>
 
 </project>

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -48,6 +48,9 @@
 	</target>
 
 	<target name="common.tools-restore" depends="common.init common.get-dotnet-version">
+		<exec workingdir="${root.dir}" program="dotnet" verbose="true">
+			<arg line="tool restore" />
+		</exec> 
 		<exec workingdir="${root.dir}/Tools" program="dotnet" verbose="true">
 			<arg line="restore ./packages.csproj --packages ." />
 		</exec> 

--- a/build-common/common.xml
+++ b/build-common/common.xml
@@ -47,10 +47,27 @@
 		<property name="tools.dir" value="${root.dir}/Tools"/>
 	</target>
 
-	<target name="common.tools-restore" depends="common.init">
+	<target name="common.tools-restore" depends="common.init common.get-dotnet-version">
 		<exec workingdir="${root.dir}/Tools" program="dotnet" verbose="true">
 			<arg line="restore ./packages.csproj --packages ." />
 		</exec> 
+	</target>
+
+	<target name="common.get-dotnet-version">
+		<property name="dotnet.version.file" value="${root.dir}/Tools/dotnet.version" />
+		<exec workingdir="${root.dir}/Tools" program="dotnet" output="${dotnet.version.file}">
+			<arg line="--version" />
+		</exec>
+		<loadfile file="${dotnet.version.file}" property="dotnet.version.content" />
+		<delete file="${dotnet.version.file}" />
+		<echo message="dotnet version: ${string::trim(dotnet.version.content)}" />
+		<if test="${string::index-of(dotnet.version.content, '-') == -1}">
+			<property name="dotnet.version" value="${version::parse(string::trim(dotnet.version.content))}" />
+		</if>
+		<!-- For preview versions we have to substring until - character. Example: 5.0.100-preview.2.20176.6  -->
+		<if test="${string::index-of(dotnet.version.content, '-') != -1}">
+			<property name="dotnet.version" value="${version::parse(string::trim(string::substring(dotnet.version.content, 0, string::index-of(dotnet.version.content, '-'))))}" />
+		</if>
 	</target>
 
 </project>

--- a/default.build
+++ b/default.build
@@ -67,7 +67,13 @@
 	<target name="find-async-generator-console">
 		<property name="tool.id" value="CSharpAsyncGenerator.CommandLine" />
 		<call target="get-tool-info" />
-		<property name="async-generator-console"  value="${tool.path}tools/netcoreapp2.1/AsyncGenerator.CommandLine.dll" />
+		<property name="async-generator-console" value="${tool.path}tools/netcoreapp2.1/AsyncGenerator.CommandLine.dll" />
+		<if test="${version::get-major(version::parse(dotnet.version)) == 3}">
+			<property name="async-generator-console" value="${tool.path}tools/netcoreapp3.1/AsyncGenerator.CommandLine.dll" />
+		</if>
+		<if test="${version::get-major(version::parse(dotnet.version)) >= 5}">
+			<property name="async-generator-console" value="${tool.path}tools/net5.0/AsyncGenerator.CommandLine.dll" />
+		</if>
 	</target>
 
 	<target name="generate-async" depends="solution-restore find-async-generator-console">

--- a/default.build
+++ b/default.build
@@ -64,21 +64,9 @@
 		<property name="tool.path" value="${tools.dir}/${tool.id}/${tool.version}/" />
 	</target>
 
-	<target name="find-async-generator-console">
-		<property name="tool.id" value="CSharpAsyncGenerator.CommandLine" />
-		<call target="get-tool-info" />
-		<property name="async-generator-console" value="${tool.path}tools/netcoreapp2.1/AsyncGenerator.CommandLine.dll" />
-		<if test="${version::get-major(version::parse(dotnet.version)) == 3}">
-			<property name="async-generator-console" value="${tool.path}tools/netcoreapp3.1/AsyncGenerator.CommandLine.dll" />
-		</if>
-		<if test="${version::get-major(version::parse(dotnet.version)) >= 5}">
-			<property name="async-generator-console" value="${tool.path}tools/net5.0/AsyncGenerator.CommandLine.dll" />
-		</if>
-	</target>
-
-	<target name="generate-async" depends="solution-restore find-async-generator-console">
+	<target name="generate-async" depends="solution-restore">
 		<exec workingdir="${root.dir}/src" program="dotnet" verbose="true">
-			<arg line=".${async-generator-console}" />
+			<arg line="async-generator" />
 		</exec> 
 	</target>
 


### PR DESCRIPTION
With this upgrade we can now generate async code also with .NET Core 3.1 and 5.0. Based on the installed .NET Core version, the appropriate async generator binaries will be used, so the `global.json` won't be needed anymore.