### PR TITLE
WIP Fix nullable entity comparison with null

### DIFF
--- a/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
@@ -16,8 +16,9 @@ namespace NHibernate.Test.Hql.EntityJoinHqlTestEntities
 	{
 		public virtual Guid Id { get; set; }
 		public virtual string Name { get; set; }
+		public virtual NullableOwner Parent { get; set; }
 	}
-	
+
 	public class PropRefEntity
 	{
 		public virtual Guid Id { get; set; }

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -409,9 +409,15 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			}
 			else
 			{
-				comparisonWithNullableEntity = (Walker.IsComparativeExpressionClause && entityType.IsNullable);
-				joinIsNeeded = generateJoin || (Walker.IsInSelect && !Walker.IsInCase) || (Walker.IsInFrom && !Walker.IsComparativeExpressionClause)
-				               || comparisonWithNullableEntity;
+				if (Walker.IsComparativeExpressionClause && entityType.IsNullable)
+				{
+					joinIsNeeded = comparisonWithNullableEntity = true;
+					_joinType = JoinType.LeftOuterJoin;
+				}
+				else
+				{
+					joinIsNeeded = generateJoin || (Walker.IsInSelect && !Walker.IsInCase) || (Walker.IsInFrom && !Walker.IsComparativeExpressionClause);
+				}
 			}
 
 			if ( joinIsNeeded ) 
@@ -517,7 +523,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				// If this is an implied join in a from element, then use the impled join type which is part of the
 				// tree parser's state (set by the gramamar actions).
 				JoinSequence joinSequence = SessionFactoryHelper
-					.CreateJoinSequence( impliedJoin, propertyType, tableAlias, _joinType, joinColumns );
+					.CreateJoinSequence(_joinType != JoinType.LeftOuterJoin && impliedJoin, propertyType, tableAlias, _joinType, joinColumns);
 
 				var factory = new FromElementFactory(
 						currentFromClause,

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -414,7 +414,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				{
 					joinIsNeeded = comparisonWithNullableEntity = true;
 
-					//TODO: Fix this hack. We should always left join here. Skip left join for nullable entity if query contains implicit joins. We currently don't support such queries (see OneToOneCompositeQueryCompareWithJoin)
+					//TODO: Fix this hack. Ideally we should always left join here. Skip left join for nullable entity if query contains implicit joins. We currently don't support left joins for such queries (see OneToOneCompositeQueryCompareWithJoinOrIsNull)
 					var fromJoins = ASTUtil.CollectChildren<FromElement>(Walker.CurrentFromClause, x => x is FromElement fe && !fe.IsImplied && fe.Type == HqlSqlWalker.FROM_FRAGMENT);
 					if(fromJoins.Count == 1)
 						_joinType = JoinType.LeftOuterJoin;

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Antlr.Runtime;
 
 using NHibernate.Engine;
@@ -412,7 +413,11 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				if (Walker.IsComparativeExpressionClause && entityType.IsNullable)
 				{
 					joinIsNeeded = comparisonWithNullableEntity = true;
-					_joinType = JoinType.LeftOuterJoin;
+
+					//TODO: Fix this hack. We should always left join here. Skip left join for nullable entity if query contains implicit joins. We currently don't support such queries (see OneToOneCompositeQueryCompareWithJoin)
+					var fromJoins = ASTUtil.CollectChildren<FromElement>(Walker.CurrentFromClause, x => x is FromElement fe && !fe.IsImplied && fe.Type == HqlSqlWalker.FROM_FRAGMENT);
+					if(fromJoins.Count == 1)
+						_joinType = JoinType.LeftOuterJoin;
 				}
 				else
 				{


### PR DESCRIPTION
Apparently fix made in #2081 wasn't enough as implicit joins were generated for comparisons like `where entity.OneToOne is null`. It should be left join instead...

Fixes #2611