### PR TITLE
Fixes #2614

### DIFF
--- a/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
@@ -78,7 +78,7 @@ namespace NHibernate.Engine.Query
 					for (int x = 0; x < size; x++)
 					{
 						object result = tmp[x];
-						if (distinction.Add(result))
+						if (!distinction.Add(result))
 						{
 							continue;
 						}

--- a/src/NHibernate/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Engine/Query/HQLQueryPlan.cs
@@ -128,7 +128,7 @@ namespace NHibernate.Engine.Query
 					for (int x = 0; x < size; x++)
 					{
 						object result = tmp[x];
-						if (distinction.Add(result))
+						if (!distinction.Add(result))
 						{
 							continue;
 						}


### PR DESCRIPTION
Results from the query should be skipped if they are already in the
ISet distinction thus if distinction.Add is false. Currently, they are
only added if they have been there before.

Signed-off-by: csharper2010