### PR TITLE
Add special case for constants contained within Convert nodes (#2642) 

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ParameterTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ParameterTests.cs
@@ -617,6 +617,64 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task UsingParameterWithImplicitOperatorAsync()
+		{
+			var id = new GuidImplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502CF}"));
+			Assert.That(await (db.Shippers.Where(o => o.Reference == id).ToListAsync()), Has.Count.EqualTo(1));
+
+			id = new GuidImplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502FF}"));
+			Assert.That(await (db.Shippers.Where(o => o.Reference == id).ToListAsync()), Is.Empty);
+
+			await (AssertTotalParametersAsync(
+				db.Shippers.Where(o => o.Reference == id && id == o.Reference),
+				1));
+		}
+
+		private struct GuidImplicitWrapper
+		{
+			public readonly Guid Id;
+
+			public GuidImplicitWrapper(Guid id)
+			{
+				Id = id;
+			}
+
+			public static implicit operator Guid(GuidImplicitWrapper idWrapper)
+			{
+				return idWrapper.Id;
+			}
+		}
+
+		[Test]
+		public async Task UsingParameterWithExplicitOperatorAsync()
+		{
+			var id = new GuidExplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502CF}"));
+			Assert.That(await (db.Shippers.Where(o => o.Reference == (Guid) id).ToListAsync()), Has.Count.EqualTo(1));
+
+			id = new GuidExplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502FF}"));
+			Assert.That(await (db.Shippers.Where(o => o.Reference == (Guid) id).ToListAsync()), Is.Empty);
+
+			await (AssertTotalParametersAsync(
+				db.Shippers.Where(o => o.Reference == (Guid) id && (Guid) id == o.Reference),
+				1));
+		}
+
+		private struct GuidExplicitWrapper
+		{
+			public readonly Guid Id;
+
+			public GuidExplicitWrapper(Guid id)
+			{
+				Id = id;
+			}
+
+			public static explicit operator Guid(GuidExplicitWrapper idWrapper)
+			{
+				return idWrapper.Id;
+			}
+		}
+
+		[Test]
 		public async Task UsingParameterOnSelectorsAsync()
 		{
 			var user = new User() {Id = 1};

--- a/src/NHibernate.Test/Linq/ParameterTests.cs
+++ b/src/NHibernate.Test/Linq/ParameterTests.cs
@@ -605,6 +605,64 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void UsingParameterWithImplicitOperator()
+		{
+			var id = new GuidImplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502CF}"));
+			Assert.That(db.Shippers.Where(o => o.Reference == id).ToList(), Has.Count.EqualTo(1));
+
+			id = new GuidImplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502FF}"));
+			Assert.That(db.Shippers.Where(o => o.Reference == id).ToList(), Is.Empty);
+
+			AssertTotalParameters(
+				db.Shippers.Where(o => o.Reference == id && id == o.Reference),
+				1);
+		}
+
+		private struct GuidImplicitWrapper
+		{
+			public readonly Guid Id;
+
+			public GuidImplicitWrapper(Guid id)
+			{
+				Id = id;
+			}
+
+			public static implicit operator Guid(GuidImplicitWrapper idWrapper)
+			{
+				return idWrapper.Id;
+			}
+		}
+
+		[Test]
+		public void UsingParameterWithExplicitOperator()
+		{
+			var id = new GuidExplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502CF}"));
+			Assert.That(db.Shippers.Where(o => o.Reference == (Guid) id).ToList(), Has.Count.EqualTo(1));
+
+			id = new GuidExplicitWrapper(new Guid("{356E4A7E-B027-4321-BA40-E2677E6502FF}"));
+			Assert.That(db.Shippers.Where(o => o.Reference == (Guid) id).ToList(), Is.Empty);
+
+			AssertTotalParameters(
+				db.Shippers.Where(o => o.Reference == (Guid) id && (Guid) id == o.Reference),
+				1);
+		}
+
+		private struct GuidExplicitWrapper
+		{
+			public readonly Guid Id;
+
+			public GuidExplicitWrapper(Guid id)
+			{
+				Id = id;
+			}
+
+			public static explicit operator Guid(GuidExplicitWrapper idWrapper)
+			{
+				return idWrapper.Id;
+			}
+		}
+
+		[Test]
 		public void UsingParameterOnSelectors()
 		{
 			var user = new User() {Id = 1};

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -849,19 +849,6 @@ namespace NHibernate.Test.Linq
 			Assert.That(result.SerialNumber, Is.EqualTo("1121"));
 		}
 
-		[Test(Description = "GH-2642")]
-		public void CanUseImplicitCastOperatorToGuid()
-		{
-			var id = new GuidWrapper(new Guid("{01234567-abcd-abcd-abcd-0123456789ab}"));
-
-			var query = session.Query<Shipper>().Where(a => a.Reference == id);
-
-			Assert.DoesNotThrow(() =>
-			{
-				var _ = query.ToList();
-			});
-		}
-
 		private static List<object[]> CanUseCompareInQueryDataSource()
 		{
 			return new List<object[]>
@@ -902,21 +889,6 @@ namespace NHibernate.Test.Linq
 				{
 					expression, expectedCount, expectCase
 				};
-		}
-
-		private struct GuidWrapper
-		{
-			public readonly Guid Id;
-
-			public GuidWrapper(Guid id)
-			{
-				Id = id;
-			}
-
-			public static implicit operator Guid(GuidWrapper idWrapper)
-			{
-				return idWrapper.Id;
-			}
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -849,6 +849,19 @@ namespace NHibernate.Test.Linq
 			Assert.That(result.SerialNumber, Is.EqualTo("1121"));
 		}
 
+		[Test(Description = "GH-2642")]
+		public void CanUseImplicitCastOperatorToGuid()
+		{
+			var id = new GuidWrapper(new Guid("{01234567-abcd-abcd-abcd-0123456789ab}"));
+
+			var query = session.Query<Shipper>().Where(a => a.Reference == id);
+
+			Assert.DoesNotThrow(() =>
+			{
+				var _ = query.ToList();
+			});
+		}
+
 		private static List<object[]> CanUseCompareInQueryDataSource()
 		{
 			return new List<object[]>
@@ -889,6 +902,21 @@ namespace NHibernate.Test.Linq
 				{
 					expression, expectedCount, expectCase
 				};
+		}
+
+		private struct GuidWrapper
+		{
+			public readonly Guid Id;
+
+			public GuidWrapper(Guid id)
+			{
+				Id = id;
+			}
+
+			public static implicit operator Guid(GuidWrapper idWrapper)
+			{
+				return idWrapper.Id;
+			}
 		}
 	}
 }

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -146,7 +146,9 @@ namespace NHibernate.Linq.Visitors
 			// If we have an expression like "Convert(<constant>)" we no not want to lose the conversion operation
 			// because it might be necessary if the types are incompatible with each other, which might happen if
 			// the expression uses an implicitly or explicitly defined cast operator.
-			if (node.NodeType == ExpressionType.Convert && node.Operand is ConstantExpression constantExpression)
+			if (node.NodeType == ExpressionType.Convert &&
+			    node.Method != null && // The implicit/explicit operator method
+				node.Operand is ConstantExpression constantExpression)
 			{
 				// Instead of getting constantExpression.Value, we override the value by compiling and executing this subtree,
 				// performing the cast.

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -143,7 +143,7 @@ namespace NHibernate.Linq.Visitors
 
 		protected override Expression VisitUnary(UnaryExpression node)
 		{
-			// If we have an expression like "Convert(<constant>)" we no not want to lose the conversion operation
+			// If we have an expression like "Convert(<constant>)" we do not want to lose the conversion operation
 			// because it might be necessary if the types are incompatible with each other, which might happen if
 			// the expression uses an implicitly or explicitly defined cast operator.
 			if (node.NodeType == ExpressionType.Convert &&

--- a/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/ExpressionParameterVisitor.cs
@@ -148,7 +148,7 @@ namespace NHibernate.Linq.Visitors
 			// the expression uses an implicitly or explicitly defined cast operator.
 			if (node.NodeType == ExpressionType.Convert &&
 			    node.Method != null && // The implicit/explicit operator method
-				node.Operand is ConstantExpression constantExpression)
+			    node.Operand is ConstantExpression constantExpression)
 			{
 				// Instead of getting constantExpression.Value, we override the value by compiling and executing this subtree,
 				// performing the cast.


### PR DESCRIPTION
Test case and fix for issue #2642 

- Extracted `AddConstantExpressionParameter` method, added an extra parameter to "override" the value instead of always using `expression.Value`
- Added a special case for a constant contained within a "Convert" node. Instead of using the constant value, evaluate the node so the conversion is performed correctly.

Tested with SQL Server and PostgreSQL.