### PR TITLE
Allow specifying the size of the query plan cache

### DIFF
--- a/src/NHibernate.Test/CfgTest/SettingsFactoryFixture.cs
+++ b/src/NHibernate.Test/CfgTest/SettingsFactoryFixture.cs
@@ -49,7 +49,6 @@ namespace NHibernate.Test.CfgTest
 		{
 			public SettingsTestCaseData(string key, string value, Func<Settings, object> settingsProp) : base(key, value, settingsProp)
 			{
-
 			}
 		}
 	}

--- a/src/NHibernate.Test/CfgTest/SettingsFactoryFixture.cs
+++ b/src/NHibernate.Test/CfgTest/SettingsFactoryFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NHibernate.Cfg;
 using NUnit.Framework;
@@ -11,12 +12,45 @@ namespace NHibernate.Test.CfgTest
 		public void DefaultValueForKeyWords()
 		{
 			var properties = new Dictionary<string, string>
-			                 	{
-			                 		{"dialect", typeof (Dialect.MsSql2005Dialect).FullName}
-			                 	};
+			{
+				{"dialect", typeof (Dialect.MsSql2005Dialect).FullName}
+			};
 			var settings = new SettingsFactory().BuildSettings(properties);
 			Assert.That(settings.IsKeywordsImportEnabled);
 			Assert.That(!settings.IsAutoQuoteEnabled);
+		}
+
+		[Test,TestCaseSource(nameof(TestCases))]
+		public object ReadsSettingsCorrectly(string key, string value, Func<Settings,object> settingsProp)
+		{
+			//Dialect needed to prevent exception
+			var properties = new Dictionary<string, string>
+			{
+				{"dialect", typeof (Dialect.MsSql2005Dialect).FullName}
+			};
+
+			properties[key] = value;
+
+			var settings = new SettingsFactory().BuildSettings(properties);
+			
+			return settingsProp(settings);
+		}
+
+		public static IEnumerable<TestCaseData> TestCases
+		{
+			get
+			{
+				yield return new SettingsTestCaseData("query.plan_cache_max_size", "256", x => x.QueryPlanCacheMaxSize).Returns(256);
+				yield return new SettingsTestCaseData("query.plan_parameter_metadata_max_size", "512", x => x.QueryPlanCacheParameterMetadataMaxSize).Returns(512);
+			}
+		}
+
+		private class SettingsTestCaseData : TestCaseData
+		{
+			public SettingsTestCaseData(string key, string value, Func<Settings, object> settingsProp) : base(key, value, settingsProp)
+			{
+
+			}
 		}
 	}
 }

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using NHibernate.Bytecode;
 using NHibernate.Cfg.ConfigurationSchema;
 using NHibernate.Engine;
+using NHibernate.Engine.Query;
 using NHibernate.Linq;
 using NHibernate.Linq.Visitors;
 using NHibernate.MultiTenancy;
@@ -395,6 +396,30 @@ namespace NHibernate.Cfg
 		/// Connection provider for given multi-tenancy strategy. Class name implementing IMultiTenancyConnectionProvider.
 		/// </summary>
 		public const string MultiTenancyConnectionProvider = "multi_tenancy.connection_provider";
+
+		/// <summary>
+		/// The maximum number of entries including:
+		/// <list>
+		/// <item>
+		///	<see cref="HQLQueryPlan"/>
+		/// </item>
+		/// <item>
+		/// <see cref="NativeSQLQueryPlan"/>
+		/// </item>
+		/// <item>
+		/// <see cref="FilterQueryPlan"/>
+		/// </item>
+		/// </list>
+		/// 
+		/// maintained by <see cref="QueryPlanCache"/>. Default is 128.
+		/// </summary>
+		public const string QueryPlanCacheMaxSize = "query.plan_cache_max_size";
+
+		/// <summary>
+		/// The maximum number of <see cref="ParameterMetadata"/> maintained
+		/// by <see cref="QueryPlanCache"/>. Default is 128.
+		/// </summary>
+		public const string QueryPlanCacheParameterMetadataMaxSize = "query.plan_parameter_metadata_max_size";
 
 		private static IBytecodeProvider BytecodeProviderInstance;
 		private static bool EnableReflectionOptimizer;

--- a/src/NHibernate/Cfg/Settings.cs
+++ b/src/NHibernate/Cfg/Settings.cs
@@ -212,5 +212,7 @@ namespace NHibernate.Cfg
 		public MultiTenancyStrategy MultiTenancyStrategy { get; internal set; }
 
 		public IMultiTenancyConnectionProvider MultiTenancyConnectionProvider { get; internal set; }
+		public int QueryPlanCacheParameterMetadataMaxSize { get; internal set; }
+		public int QueryPlanCacheMaxSize { get; internal set; }
 	}
 }

--- a/src/NHibernate/Cfg/SettingsFactory.cs
+++ b/src/NHibernate/Cfg/SettingsFactory.cs
@@ -7,6 +7,7 @@ using NHibernate.AdoNet.Util;
 using NHibernate.Cache;
 using NHibernate.Connection;
 using NHibernate.Dialect;
+using NHibernate.Engine.Query;
 using NHibernate.Exceptions;
 using NHibernate.Hql;
 using NHibernate.Linq;
@@ -318,6 +319,10 @@ namespace NHibernate.Cfg
 			{
 				settings.LinqPreTransformer = NhRelinqQueryParser.CreatePreTransformer(settings.PreTransformerRegistrar);
 			}
+
+			//QueryPlanCache:
+			settings.QueryPlanCacheParameterMetadataMaxSize = PropertiesHelper.GetInt32(Environment.QueryPlanCacheParameterMetadataMaxSize, properties, QueryPlanCache.DefaultParameterMetadataMaxCount); 
+			settings.QueryPlanCacheMaxSize = PropertiesHelper.GetInt32(Environment.QueryPlanCacheMaxSize, properties, QueryPlanCache.DefaultQueryPlanMaxCount);
 
 			// NHibernate-specific:
 			settings.IsolationLevel = isolation;

--- a/src/NHibernate/Engine/Query/QueryPlanCache.cs
+++ b/src/NHibernate/Engine/Query/QueryPlanCache.cs
@@ -23,14 +23,20 @@ namespace NHibernate.Engine.Query
 		// unnecessary cache entries.
 		// Used solely for caching param metadata for native-sql queries, see
 		// getSQLParameterMetadata() for a discussion as to why...
-		private readonly SimpleMRUCache sqlParamMetadataCache = new SimpleMRUCache();
+		private readonly SimpleMRUCache sqlParamMetadataCache;
 
 		// the cache of the actual plans...
-		private readonly SoftLimitMRUCache planCache = new SoftLimitMRUCache(128);
+		private readonly SoftLimitMRUCache planCache;
+		
+		internal const int DefaultParameterMetadataMaxCount = 128;
+		internal const int DefaultQueryPlanMaxCount = 128;
 
 		public QueryPlanCache(ISessionFactoryImplementor factory)
 		{
 			this.factory = factory;
+
+			sqlParamMetadataCache = new SimpleMRUCache(factory.Settings.QueryPlanCacheParameterMetadataMaxSize);
+			planCache = new SoftLimitMRUCache(factory.Settings.QueryPlanCacheMaxSize);
 		}
 
 		public ParameterMetadata GetSQLParameterMetadata(string query)

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -181,12 +181,15 @@ namespace NHibernate.Impl
 
 		public SessionFactoryImpl(Configuration cfg, IMapping mapping, Settings settings, EventListeners listeners)
 		{
+			this.settings = settings;
+
 			Init();
+			
 			log.Info("building session factory");
 
 			properties = new Dictionary<string, string>(cfg.Properties);
 			interceptor = cfg.Interceptor;
-			this.settings = settings;
+			
 			sqlFunctionRegistry = new SQLFunctionRegistry(settings.Dialect, cfg.SqlFunctions);
 			eventListeners = listeners;
 			filters = new Dictionary<string, FilterDefinition>(cfg.FilterDefinitions);

--- a/src/NHibernate/nhibernate-configuration.xsd
+++ b/src/NHibernate/nhibernate-configuration.xsd
@@ -122,6 +122,8 @@
 										<xs:enumeration value="query.factory_class" />
 										<xs:enumeration value="query.linq_provider_class" />
 										<xs:enumeration value="query.imports" />
+										<xs:enumeration value="query.plan_parameter_metadata_max_size" />
+										<xs:enumeration value="query.plan_cache_max_size" />
 										<xs:enumeration value="hbm2ddl.auto" />
 										<xs:enumeration value="hbm2ddl.keywords" />
 										<xs:enumeration value="hbm2ddl.throw_on_update">


### PR DESCRIPTION
Implemented "query.plan_cache_max_size" and "query.plan_parameter_metadata_max_size" from Hibernate.