### PR TITLE
Fix Queryable.Contains method for Linq provider

### DIFF
--- a/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
@@ -36,6 +36,18 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task CanExecuteContainsAsync()
+		{
+			var user = await (db.Users.FirstOrDefaultAsync());
+			var result = db.Users.Contains(user);
+			Assert.That(result, Is.True);
+
+			user = new User("test", DateTime.Now);
+			result = db.Users.Contains(user);
+			Assert.That(result, Is.False);
+		}
+
+		[Test]
 		public async Task CanExecuteCountWithOrderByArgumentsAsync()
 		{
 			var query = db.Users.OrderBy(u => u.Name);

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3850/MainFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3850/MainFixture.cs
@@ -187,6 +187,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			}
 		}
 
+		[Test]
+		public async Task ContainsBBaseAsync()
+		{
+			using (var session = OpenSession())
+			{
+				var item = await (session.Query<DomainClassBExtendedByA>().FirstAsync(dc => dc.Name == SearchName1));
+				var result = session.Query<DomainClassBExtendedByA>().Contains(item);
+				Assert.That(result, Is.True);
+			}
+		}
+
 		// Non-reg case
 		[Test]
 		public async Task AnyCBaseAsync()
@@ -213,6 +224,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			}
 		}
 
+		[Test]
+		public async Task ContainsCBaseAsync()
+		{
+			using (var session = OpenSession())
+			{
+				var item = await (session.Query<DomainClassCExtendedByD>().FirstAsync(dc => dc.Name == SearchName1));
+				var result = session.Query<DomainClassCExtendedByD>().Contains(item);
+				Assert.That(result, Is.True);
+			}
+		}
+
 		// Non-reg case
 		[Test]
 		public async Task AnyEAsync()
@@ -236,6 +258,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 				Assert.That(result, Is.True);
 				result = await (session.Query<DomainClassE>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == SearchName1)).GetValueAsync());
 				Assert.That(result, Is.True, "Future");
+			}
+		}
+
+		[Test]
+		public async Task ContainsEAsync()
+		{
+			using (var session = OpenSession())
+			{
+				var item = await (session.Query<DomainClassE>().FirstAsync(dc => dc.Name == SearchName1));
+				var result = session.Query<DomainClassE>().Contains(item);
+				Assert.That(result, Is.True);
 			}
 		}
 
@@ -288,6 +321,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 				Assert.That(result, Is.True);
 				result = await (session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == SearchName1)).GetValueAsync());
 				Assert.That(result, Is.True, "Future");
+			}
+		}
+
+		[Test]
+		public async Task ContainsGBaseAsync()
+		{
+			using (var session = OpenSession())
+			{
+				var item = await (session.Query<DomainClassGExtendedByH>().FirstAsync(dc => dc.Name == SearchName1));
+				var result = session.Query<DomainClassGExtendedByH>().Contains(item);
+				Assert.That(result, Is.True);
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Linq/MethodCallTests.cs
@@ -24,6 +24,18 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void CanExecuteContains()
+		{
+			var user = db.Users.FirstOrDefault();
+			var result = db.Users.Contains(user);
+			Assert.That(result, Is.True);
+
+			user = new User("test", DateTime.Now);
+			result = db.Users.Contains(user);
+			Assert.That(result, Is.False);
+		}
+
+		[Test]
 		public void CanExecuteCountWithOrderByArguments()
 		{
 			var query = db.Users.OrderBy(u => u.Name);

--- a/src/NHibernate.Test/NHSpecificTest/NH3850/MainFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3850/MainFixture.cs
@@ -194,6 +194,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			}
 		}
 
+		[Test]
+		public void ContainsBBase()
+		{
+			using (var session = OpenSession())
+			{
+				var item = session.Query<DomainClassBExtendedByA>().First(dc => dc.Name == SearchName1);
+				var result = session.Query<DomainClassBExtendedByA>().Contains(item);
+				Assert.That(result, Is.True);
+			}
+		}
+
 		// Non-reg case
 		[Test]
 		public void AnyCBase()
@@ -217,6 +228,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 				Assert.That(result, Is.True);
 				result = session.Query<DomainClassCExtendedByD>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == SearchName1)).Value;
 				Assert.That(result, Is.True, "Future");
+			}
+		}
+
+		[Test]
+		public void ContainsCBase()
+		{
+			using (var session = OpenSession())
+			{
+				var item = session.Query<DomainClassCExtendedByD>().First(dc => dc.Name == SearchName1);
+				var result = session.Query<DomainClassCExtendedByD>().Contains(item);
+				Assert.That(result, Is.True);
 			}
 		}
 
@@ -246,6 +268,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			}
 		}
 
+		[Test]
+		public void ContainsE()
+		{
+			using (var session = OpenSession())
+			{
+				var item = session.Query<DomainClassE>().First(dc => dc.Name == SearchName1);
+				var result = session.Query<DomainClassE>().Contains(item);
+				Assert.That(result, Is.True);
+			}
+		}
+
 		// Non-reg case
 		[Test]
 		public void AnyF()
@@ -272,6 +305,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 			}
 		}
 
+		[Test]
+		public void ContainsF()
+		{
+			using (var session = OpenSession())
+			{
+				var item = new DomainClassF() {Id = -1};
+				var result = session.Query<DomainClassF>().Contains(item);
+				Assert.That(result, Is.False);
+			}
+		}
+
 		// Non-reg case
 		[Test]
 		public void AnyGBase()
@@ -295,6 +339,17 @@ namespace NHibernate.Test.NHSpecificTest.NH3850
 				Assert.That(result, Is.True);
 				result = session.Query<DomainClassGExtendedByH>().ToFutureValue(qdc => qdc.Any(dc => dc.Name == SearchName1)).Value;
 				Assert.That(result, Is.True, "Future");
+			}
+		}
+
+		[Test]
+		public void ContainsGBase()
+		{
+			using (var session = OpenSession())
+			{
+				var item = session.Query<DomainClassGExtendedByH>().First(dc => dc.Name == SearchName1);
+				var result = session.Query<DomainClassGExtendedByH>().Contains(item);
+				Assert.That(result, Is.True);
 			}
 		}
 

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAny.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessAny.cs
@@ -11,6 +11,11 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 	{
 		public void Process(AnyResultOperator anyOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree)
 		{
+			Process(tree);
+		}
+
+		internal static void Process(IntermediateHqlTree tree)
+		{
 			if (tree.IsRoot)
 			{
 				tree.AddTakeClause(tree.TreeBuilder.Constant(1));
@@ -24,7 +29,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 			}
 			else
 			{
-				tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery)tree.Root));
+				tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery) tree.Root));
 			}
 		}
 	}

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessContains.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessContains.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using NHibernate.Hql.Ast;
 using Remotion.Linq.Clauses.ResultOperators;
 
@@ -37,7 +40,19 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 					tree.AddWhereClause(tree.TreeBuilder.Equality(
 						tree.TreeBuilder.Ident(GetFromAlias(tree.Root).AstNode.Text),
 						itemExpression));
-					tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery)tree.Root));
+					if (tree.IsRoot)
+					{
+						tree.AddTakeClause(tree.TreeBuilder.Constant(1));
+						Expression<Func<IEnumerable<object>, bool>> x = l => l.Any();
+						tree.AddListTransformer(x);
+
+						Expression<Func<IEnumerable<bool>, bool>> px = l => l.Any(r => r);
+						tree.AddPostExecuteTransformer(px);
+					}
+					else
+					{
+						tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery) tree.Root));
+					}
 				}
 				else
 				{

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessContains.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessContains.cs
@@ -40,19 +40,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 					tree.AddWhereClause(tree.TreeBuilder.Equality(
 						tree.TreeBuilder.Ident(GetFromAlias(tree.Root).AstNode.Text),
 						itemExpression));
-					if (tree.IsRoot)
-					{
-						tree.AddTakeClause(tree.TreeBuilder.Constant(1));
-						Expression<Func<IEnumerable<object>, bool>> x = l => l.Any();
-						tree.AddListTransformer(x);
-
-						Expression<Func<IEnumerable<bool>, bool>> px = l => l.Any(r => r);
-						tree.AddPostExecuteTransformer(px);
-					}
-					else
-					{
-						tree.SetRoot(tree.TreeBuilder.Exists((HqlQuery) tree.Root));
-					}
+					ProcessAny.Process(tree);
 				}
 				else
 				{


### PR DESCRIPTION
I think this is a regression from #568, but I am not sure.

Fixes #2544

Should we backport it also to `5.2.x`, `5.1.x` and `5.0.x`?