### PR TITLE
Fix NoViableAltException in delete query

### DIFF
--- a/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Text.RegularExpressions;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
@@ -230,6 +231,21 @@ namespace NHibernate.Test.Hql
 
 				Assert.That(Regex.Matches(sqlLog.GetWholeLog(), "PropRefEntity").Count, Is.EqualTo(1));
 				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test(Description = "GH-2688")]
+		public async Task NullableManyToOneDeleteQueryAsync()
+		{
+			using (var session = OpenSession())
+			{
+				await (session
+					.CreateQuery(
+						"delete "
+						+ "from NullableOwner ex "
+						+ "where ex.ManyToOne.id = :id"
+					).SetParameter("id", Guid.Empty)
+					.ExecuteUpdateAsync());
 			}
 		}
 
@@ -515,6 +531,7 @@ namespace NHibernate.Test.Hql
 							m.ForeignKey("none");
 							m.NotFound(NotFoundMode.Ignore);
 						});
+					rc.ManyToOne(e => e.ManyToOne, m => m.NotFound(NotFoundMode.Ignore));
 				});
 
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
 using NHibernate.Test.Hql.EntityJoinHqlTestEntities;
@@ -219,6 +220,21 @@ namespace NHibernate.Test.Hql
 
 				Assert.That(Regex.Matches(sqlLog.GetWholeLog(), "PropRefEntity").Count, Is.EqualTo(1));
 				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test(Description = "GH-2688")]
+		public void NullableManyToOneDeleteQuery()
+		{
+			using (var session = OpenSession())
+			{
+				session
+					.CreateQuery(
+						"delete "
+						+ "from NullableOwner ex "
+						+ "where ex.ManyToOne.id = :id"
+					).SetParameter("id", Guid.Empty)
+					.ExecuteUpdate();
 			}
 		}
 
@@ -520,6 +536,7 @@ namespace NHibernate.Test.Hql
 							m.ForeignKey("none");
 							m.NotFound(NotFoundMode.Ignore);
 						});
+					rc.ManyToOne(e => e.ManyToOne, m => m.NotFound(NotFoundMode.Ignore));
 				});
 
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
@@ -31,6 +31,7 @@ namespace NHibernate.Test.Hql.EntityJoinHqlTestEntities
 		public virtual string Name { get; set; }
 		public virtual OneToOneEntity OneToOne { get; set; }
 		public virtual PropRefEntity PropRef { get; set; }
+		public virtual OneToOneEntity ManyToOne { get; set; }
 	}
 
 	public class EntityWithCompositeId

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -386,7 +386,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			string property = _propertyName;
 			bool joinIsNeeded;
 
-			//For nullable entity comparisons we always need to add join (like not constrained one-to-one or not-found ignore associations) 
+			//For nullable entity comparisons we always need to add join (like not constrained one-to-one or not-found ignore associations)
+			//NOTE: This fix is not fully correct. It doesn't work for comparisons with null (where e.OneToOneProp is null)
+			// as by default implicit join is generated and to work propelry left join is required (see GH-2611)
 			bool comparisonWithNullableEntity = false;
 
 			if ( IsDotNode( parent ) ) 
@@ -396,7 +398,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				// entity's PK (because 'our' table would know the FK).
 				parentAsDotNode = ( DotNode ) parent;
 				property = parentAsDotNode._propertyName;
-				joinIsNeeded = generateJoin && (entityType.IsNullable || !IsReferenceToPrimaryKey( parentAsDotNode._propertyName, entityType ));
+				joinIsNeeded = generateJoin && ((Walker.IsSelectStatement && entityType.IsNullable) || !IsReferenceToPrimaryKey( parentAsDotNode._propertyName, entityType ));
 			}
 			else if ( ! Walker.IsSelectStatement ) 
 			{


### PR DESCRIPTION
Fixes #2688
Regression after #2081

Though the real issue here -  `NoViableAltException`  exception is thrown for delete queries with implied joins. So query like `"delete from BasketItem where Product.Name = :name"` will throw on 5.x too. 