### PR TITLE
Fix parameter detection when using GroupBy method for Linq provider

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/GroupByHavingTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/GroupByHavingTests.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Linq;
+using NHibernate.DomainModel.Northwind.Entities;
 using NUnit.Framework;
 using NHibernate.Linq;
 
@@ -146,6 +147,46 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.That(orderCounts, Has.Count.EqualTo(28));
 			var hornRow = orderCounts.Single(row => row.CompanyName == "Around the Horn");
 			Assert.That(hornRow.OrderCount, Is.EqualTo(13));
+		}
+
+		[Test]
+		public async Task HavingWithStringEnumParameterAsync()
+		{
+			await (db.Users
+			  .GroupBy(p => p.Enum1)
+			  .Where(g => g.Key == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new StringEnumGroup {Enum = p.Enum1})
+			  .Where(g => g.Key.Enum == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new[] {p.Enum1})
+			  .Where(g => g.Key[0] == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new {p.Enum1})
+			  .Where(g => g.Key.Enum1 == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new {Test = new {Test2 = p.Enum1}})
+			  .Where(g => g.Key.Test.Test2 == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new {Test = new[] {p.Enum1}})
+			  .Where(g => g.Key.Test[0] == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToListAsync());
+		}
+
+		private class StringEnumGroup
+		{
+			public EnumStoredAsString Enum { get; set; }
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/GroupByTests.cs
@@ -383,6 +383,40 @@ namespace NHibernate.Test.Linq.ByMethod
 		}
 
 		[Test]
+		public async Task GroupByWithStringEnumParameterAsync()
+		{
+			await (db.Users
+			  .GroupBy(p => p.Enum1)
+			  .Select(g => g.Key == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new StringEnumGroup {Enum = p.Enum1})
+			  .Select(g => g.Key.Enum == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new[] {p.Enum1})
+			  .Select(g => g.Key[0] == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new {p.Enum1})
+			  .Select(g => g.Key.Enum1 == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new {Test = new {Test2 = p.Enum1}})
+			  .Select(g => g.Key.Test.Test2 == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToListAsync());
+			await (db.Users
+			  .GroupBy(p => new {Test = new[] {p.Enum1}})
+			  .Select(g => g.Key.Test[0] == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToListAsync());
+		}
+
+		private class StringEnumGroup
+		{
+			public EnumStoredAsString Enum { get; set; }
+		}
+
+		[Test]
 		public async Task SelectFirstElementFromProductsGroupedByUnitPriceAsync()
 		{
 			//NH-3180

--- a/src/NHibernate.Test/Linq/ByMethod/GroupByHavingTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GroupByHavingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using NHibernate.DomainModel.Northwind.Entities;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq.ByMethod
@@ -134,6 +135,46 @@ namespace NHibernate.Test.Linq.ByMethod
 			Assert.That(orderCounts, Has.Count.EqualTo(28));
 			var hornRow = orderCounts.Single(row => row.CompanyName == "Around the Horn");
 			Assert.That(hornRow.OrderCount, Is.EqualTo(13));
+		}
+
+		[Test]
+		public void HavingWithStringEnumParameter()
+		{
+			db.Users
+			  .GroupBy(p => p.Enum1)
+			  .Where(g => g.Key == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new StringEnumGroup {Enum = p.Enum1})
+			  .Where(g => g.Key.Enum == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new[] {p.Enum1})
+			  .Where(g => g.Key[0] == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new {p.Enum1})
+			  .Where(g => g.Key.Enum1 == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new {Test = new {Test2 = p.Enum1}})
+			  .Where(g => g.Key.Test.Test2 == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new {Test = new[] {p.Enum1}})
+			  .Where(g => g.Key.Test[0] == EnumStoredAsString.Large)
+			  .Select(g => g.Count())
+			  .ToList();
+		}
+
+		private class StringEnumGroup
+		{
+			public EnumStoredAsString Enum { get; set; }
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GroupByTests.cs
@@ -372,6 +372,40 @@ namespace NHibernate.Test.Linq.ByMethod
 		}
 
 		[Test]
+		public void GroupByWithStringEnumParameter()
+		{
+			db.Users
+			  .GroupBy(p => p.Enum1)
+			  .Select(g => g.Key == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new StringEnumGroup {Enum = p.Enum1})
+			  .Select(g => g.Key.Enum == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new[] {p.Enum1})
+			  .Select(g => g.Key[0] == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new {p.Enum1})
+			  .Select(g => g.Key.Enum1 == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new {Test = new {Test2 = p.Enum1}})
+			  .Select(g => g.Key.Test.Test2 == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToList();
+			db.Users
+			  .GroupBy(p => new {Test = new[] {p.Enum1}})
+			  .Select(g => g.Key.Test[0] == EnumStoredAsString.Large ? g.Sum(o => o.Id) : 0)
+			  .ToList();
+		}
+
+		private class StringEnumGroup
+		{
+			public EnumStoredAsString Enum { get; set; }
+		}
+
+		[Test]
 		public void SelectFirstElementFromProductsGroupedByUnitPrice()
 		{
 			//NH-3180

--- a/src/NHibernate/Linq/ExpressionExtensions.cs
+++ b/src/NHibernate/Linq/ExpressionExtensions.cs
@@ -15,6 +15,23 @@ namespace NHibernate.Linq
 					 expression.Member.DeclaringType.IsGenericType && expression.Member.DeclaringType.GetGenericTypeDefinition() == typeof(IGrouping<,>);
 		}
 
+		internal static bool TryGetGroupResultOperator(this MemberExpression keyExpression, out GroupResultOperator groupBy)
+		{
+			if (keyExpression.IsGroupingKey() &&
+				keyExpression.Expression is QuerySourceReferenceExpression querySource &&
+				querySource.ReferencedQuerySource is MainFromClause fromClause &&
+				fromClause.FromExpression is SubQueryExpression query)
+			{
+				groupBy = query.QueryModel.ResultOperators
+				               .OfType<GroupResultOperator>()
+				               .FirstOrDefault(o => o.KeySelector.Type == keyExpression.Type);
+				return groupBy != null;
+			}
+
+			groupBy = null;
+			return false;
+		}
+
 		public static bool IsGroupingKeyOf(this MemberExpression expression,GroupResultOperator groupBy)
 		{
 			if (!expression.IsGroupingKey())

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -343,6 +343,7 @@ namespace NHibernate.Linq.Visitors
 			private void AddRelatedExpression(Expression node, Expression left, Expression right)
 			{
 				if (left.NodeType == ExpressionType.MemberAccess ||
+					left.NodeType == ExpressionType.ArrayIndex || // e.g. group.Key[0] == variable
 					IsDynamicMember(left) ||
 					left is QuerySourceReferenceExpression)
 				{


### PR DESCRIPTION
Fix a regression from #2365, where expressions containing a grouping key were not correctly traversed.

Fixes #2693