### PR TITLE
Set the rolledBack flag when disposing active transactions

### DIFF
--- a/src/NHibernate/Async/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Async/Transaction/AdoTransaction.cs
@@ -177,10 +177,12 @@ namespace NHibernate.Transaction
 						log.Debug("DbTransaction disposed.");
 					}
 
-					if (IsActive && session != null)
+					if (IsActive)
 					{
 						// Assume we are rolled back
-						await (AfterTransactionCompletionAsync(false, cancellationToken)).ConfigureAwait(false);
+						rolledBack = true;
+						if (session != null)
+							await (AfterTransactionCompletionAsync(false, cancellationToken)).ConfigureAwait(false);
 					}
 					// nothing for Finalizer to do - so tell the GC to ignore it
 					GC.SuppressFinalize(this);

--- a/src/NHibernate/Transaction/AdoTransaction.cs
+++ b/src/NHibernate/Transaction/AdoTransaction.cs
@@ -383,10 +383,12 @@ namespace NHibernate.Transaction
 						log.Debug("DbTransaction disposed.");
 					}
 
-					if (IsActive && session != null)
+					if (IsActive)
 					{
 						// Assume we are rolled back
-						AfterTransactionCompletion(false);
+						rolledBack = true;
+						if (session != null)
+							AfterTransactionCompletion(false);
 					}
 					// nothing for Finalizer to do - so tell the GC to ignore it
 					GC.SuppressFinalize(this);


### PR DESCRIPTION
This is a slight improvement related to #2696. When disposing an active transaction, the underlying `DbTransaction` is disposed. Most implementations if not all trigger a rollback in such case, so we should flag the transaction has having been rollbacked.

(As it seems the opener obtains disposed transactions with `IsActive` being still `true`, I do not think it will fix his case, because the current code base as I read it does not allow such a situation in normal circumstances (without an exception occurring during disposal, while having explicitly disposed the transaction).)