### PR TITLE
Remove locks from UpdateTimestampsCache

### DIFF
--- a/src/NHibernate/Cache/UpdateTimestampsCache.cs
+++ b/src/NHibernate/Cache/UpdateTimestampsCache.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-
 using NHibernate.Cfg;
 using NHibernate.Util;
 
@@ -19,7 +17,6 @@ namespace NHibernate.Cache
 	{
 		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(UpdateTimestampsCache));
 		private readonly CacheBase _updateTimestamps;
-		private readonly AsyncReaderWriterLock _asyncReaderWriterLock = new AsyncReaderWriterLock();
 
 		public virtual void Clear()
 		{
@@ -60,13 +57,10 @@ namespace NHibernate.Cache
 			if (spaces.Count == 0)
 				return;
 
-			using (_asyncReaderWriterLock.WriteLock())
-			{
-				//TODO: to handle concurrent writes correctly, this should return a Lock to the client
-				var ts = _updateTimestamps.NextTimestamp() + _updateTimestamps.Timeout;
-				SetSpacesTimestamp(spaces, ts);
-				//TODO: return new Lock(ts);
-			}
+			//TODO: to handle concurrent writes correctly, this should return a Lock to the client
+			var ts = _updateTimestamps.NextTimestamp() + _updateTimestamps.Timeout;
+			SetSpacesTimestamp(spaces, ts);
+			//TODO: return new Lock(ts);
 		}
 
 		//Since v5.1
@@ -82,15 +76,12 @@ namespace NHibernate.Cache
 			if (spaces.Count == 0)
 				return;
 
-			using (_asyncReaderWriterLock.WriteLock())
-			{
-				//TODO: to handle concurrent writes correctly, the client should pass in a Lock
-				long ts = _updateTimestamps.NextTimestamp();
-				//TODO: if lock.getTimestamp().equals(ts)
-				if (log.IsDebugEnabled())
-					log.Debug("Invalidating spaces [{0}]", StringHelper.CollectionToString(spaces));
-				SetSpacesTimestamp(spaces, ts);
-			}
+			//TODO: to handle concurrent writes correctly, the client should pass in a Lock
+			long ts = _updateTimestamps.NextTimestamp();
+			//TODO: if lock.getTimestamp().equals(ts)
+			if (log.IsDebugEnabled())
+				log.Debug("Invalidating spaces [{0}]", StringHelper.CollectionToString(spaces));
+			SetSpacesTimestamp(spaces, ts);
 		}
 
 		private void SetSpacesTimestamp(IReadOnlyCollection<string> spaces, long ts)
@@ -105,11 +96,8 @@ namespace NHibernate.Cache
 			if (spaces.Count == 0)
 				return true;
 
-			using (_asyncReaderWriterLock.ReadLock())
-			{
-				var lastUpdates = _updateTimestamps.GetMany(spaces.ToArray<object>());
-				return lastUpdates.All(lastUpdate => !IsOutdated(lastUpdate as long?, timestamp));
-			}
+			var lastUpdates = _updateTimestamps.GetMany(spaces.ToArray<object>());
+			return lastUpdates.All(lastUpdate => !IsOutdated(lastUpdate as long?, timestamp));
 		}
 
 		public virtual bool[] AreUpToDate(ISet<string>[] spaces, long[] timestamps)
@@ -128,23 +116,20 @@ namespace NHibernate.Cache
 
 			var keys = allSpaces.ToArray<object>();
 
-			using (_asyncReaderWriterLock.ReadLock())
+			var index = 0;
+			var lastUpdatesBySpace =
+				_updateTimestamps
+					.GetMany(keys)
+					.ToDictionary(u => keys[index++], u => u as long?);
+
+			var results = new bool[spaces.Length];
+			for (var i = 0; i < spaces.Length; i++)
 			{
-				var index = 0;
-				var lastUpdatesBySpace =
-					_updateTimestamps
-						.GetMany(keys)
-						.ToDictionary(u => keys[index++], u => u as long?);
-
-				var results = new bool[spaces.Length];
-				for (var i = 0; i < spaces.Length; i++)
-				{
-					var timestamp = timestamps[i];
-					results[i] = spaces[i].All(space => !IsOutdated(lastUpdatesBySpace[space], timestamp));
-				}
-
-				return results;
+				var timestamp = timestamps[i];
+				results[i] = spaces[i].All(space => !IsOutdated(lastUpdatesBySpace[space], timestamp));
 			}
+
+			return results;
 		}
 
 		// Since v5.3
@@ -153,7 +138,6 @@ namespace NHibernate.Cache
 		{
 			// The cache is externally provided and may be shared. Destroying the cache is
 			// not the responsibility of this class.
-			_asyncReaderWriterLock.Dispose();
 		}
 
 		private static bool IsOutdated(long? lastUpdate, long timestamp)


### PR DESCRIPTION
See #2735

> Hibernate has done [it] a [long time ago](https://github.com/hibernate/hibernate-orm/commit/f85e9247e918c1ddb2b76a6e870f6ad730020788) to improve performance. 

Possible breaking change: 
> In theory the read/write locking prevents that `IsUpToDate` would return stale data, but that holds true only when one instance of the application is running. In case multiple application instances are running then `IsUpToDate` may return stale data due to another application instance writing data at the same time. So we could remove the locking entirely as Hiberanate did or add a configuration setting for disabling it.

_Originally posted by @maca88 in https://github.com/nhibernate/nhibernate-core/issues/2735#issuecomment-826136231_