### PR TITLE
Change cascade style for DefaultDirtyCheckEventListener to persist to avoid flushing the session

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1413/FixtureByCode.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1413/FixtureByCode.cs
@@ -74,13 +74,12 @@ namespace NHibernate.Test.NHSpecificTest.GH1413
 			}
 		}
 
-		[Test]
-		[KnownBug("#1413")]
-		public async Task SessionIsDirtyShouldNotTriggerCascadeSavingAsync()
+		[Theory]
+		public async Task SessionIsDirtyShouldNotTriggerCascadeSavingAsync(bool beginTransaction)
 		{
 			Sfi.Statistics.IsStatisticsEnabled = true;
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (beginTransaction ? session.BeginTransaction() : null)
 			{
 				var parent = await (GetParentAsync(session));
 				var entityChild = new EntityChild

--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1413/FixtureByCode.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1413/FixtureByCode.cs
@@ -9,6 +9,7 @@
 
 
 using NHibernate.Cfg.MappingSchema;
+using NHibernate.Engine;
 using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
 
@@ -94,11 +95,14 @@ namespace NHibernate.Test.NHSpecificTest.GH1413
 				var isDirty = await (session.IsDirtyAsync());
 
 				Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(0), "Dirty has triggered an insert");
-				Assert.That(
-					entityChild.Id,
-					Is.EqualTo(0),
-					"Transient objects should not be saved by ISession.IsDirty() call (expected 0 as Id)");
 				Assert.That(isDirty, "ISession.IsDirty() call should return true.");
+				if (Dialect.SupportsIdentityColumns)
+				{
+					Assert.That(
+						entityChild.Id,
+						Is.EqualTo(0),
+						"Transient objects should not be saved by ISession.IsDirty() call (expected 0 as Id)");
+				}
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1413/FixtureByCode.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1413/FixtureByCode.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1413
 			var mapper = new ModelMapper();
 			mapper.Class<EntityParent>(rc =>
 			{
-				rc.Id(x => x.Id, m => m.Generator(Generators.Native));
+				rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 				rc.Property(x => x.Name);
 				rc.Bag(x => x.Children, m =>
 				{
@@ -39,7 +39,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1413
 
 			mapper.Class<EntityChild>(rc =>
 			{
-				rc.Id(x => x.Id, m => m.Generator(Generators.Native));
+				rc.Id(x => x.Id, m => m.Generator(Generators.Identity));
 				rc.Property(x => x.Name);
 			});
 

--- a/src/NHibernate.Test/NHSpecificTest/GH1413/FixtureByCode.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1413/FixtureByCode.cs
@@ -62,13 +62,12 @@ namespace NHibernate.Test.NHSpecificTest.GH1413
 			}
 		}
 
-		[Test]
-		[KnownBug("#1413")]
-		public void SessionIsDirtyShouldNotTriggerCascadeSaving()
+		[Theory]
+		public void SessionIsDirtyShouldNotTriggerCascadeSaving(bool beginTransaction)
 		{
 			Sfi.Statistics.IsStatisticsEnabled = true;
 			using (var session = OpenSession())
-			using (session.BeginTransaction())
+			using (beginTransaction ? session.BeginTransaction() : null)
 			{
 				var parent = GetParent(session);
 				var entityChild = new EntityChild

--- a/src/NHibernate/Async/Event/Default/DefaultDirtyCheckEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultDirtyCheckEventListener.cs
@@ -9,6 +9,8 @@
 
 
 using System;
+using NHibernate.Engine;
+using NHibernate.Util;
 
 namespace NHibernate.Event.Default
 {

--- a/src/NHibernate/Event/Default/DefaultDirtyCheckEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultDirtyCheckEventListener.cs
@@ -1,4 +1,6 @@
 using System;
+using NHibernate.Engine;
+using NHibernate.Util;
 
 namespace NHibernate.Event.Default
 {
@@ -10,6 +12,10 @@ namespace NHibernate.Event.Default
 	public partial class DefaultDirtyCheckEventListener : AbstractFlushingEventListener, IDirtyCheckEventListener
 	{
 		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(DefaultDirtyCheckEventListener));
+
+		protected override object Anything => IdentityMap.Instantiate(10);
+
+		protected override CascadingAction CascadingAction => CascadingAction.Persist;
 
 		public virtual void OnDirtyCheck(DirtyCheckEvent @event)
 		{


### PR DESCRIPTION
The default cascade for it was SaveUpdate (via base AbstractFlushingEventListener) which triggered
insertion of the entities with post-insert style ID generators (eg. identity). Persist on the other hand will
make sure that insertion of the entity is delyed until flush is called.

Related to #1413