### PR TITLE
Fix AmbiguousMatchException in ClearPool with FirebirdClient 6.6.0 and above

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.3.0" />
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.6.0" />
     <PackageReference Include="Npgsql" Version="4.0.3" />
     <PackageReference Include="MySql.Data" Version="8.0.22" />
   </ItemGroup>

--- a/src/NHibernate/Driver/FirebirdClientDriver.cs
+++ b/src/NHibernate/Driver/FirebirdClientDriver.cs
@@ -160,8 +160,8 @@ namespace NHibernate.Driver
 				using (var clearConnection = CreateConnection())
 				{
 					var connectionType = clearConnection.GetType();
-					_clearPool = connectionType.GetMethod("ClearPool") ?? throw new InvalidOperationException("Unable to resolve ClearPool method.");
-					_clearAllPools = connectionType.GetMethod("ClearAllPools") ?? throw new InvalidOperationException("Unable to resolve ClearAllPools method.");
+					_clearPool = connectionType.GetMethod("ClearPool", new[] { connectionType }) ?? throw new InvalidOperationException("Unable to resolve ClearPool method.");
+					_clearAllPools = connectionType.GetMethod("ClearAllPools", Array.Empty<System.Type>()) ?? throw new InvalidOperationException("Unable to resolve ClearAllPools method.");
 				}
 			}
 


### PR DESCRIPTION
The addition of new ClearPool overload at https://github.com/FirebirdSQL/NETProvider/commit/f3a4949f52f42687e56f8acc34231cbed15548bb is breaking tests when updating to newer FB Client.