### PR TITLE
Fix possible ArgumentNullException when provider is unable to open a connection

### DIFF
--- a/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs
+++ b/src/NHibernate/Tool/hbm2ddl/SchemaExport.cs
@@ -468,7 +468,11 @@ namespace NHibernate.Tool.hbm2ddl
 			{
 				if (connectionProvider != null)
 				{
-					connectionProvider.CloseConnection(connection);
+					if (connection != null)
+					{
+						connectionProvider.CloseConnection(connection);
+					}
+
 					connectionProvider.Dispose();
 				}
 			}


### PR DESCRIPTION
`SchemaExport` fails with `ArgumentNullException` if connection has not been opened. 