### PR TITLE
Fix intermittent Firebird test errors

### DIFF
--- a/src/NHibernate.Test/TestCase.cs
+++ b/src/NHibernate.Test/TestCase.cs
@@ -303,6 +303,9 @@ namespace NHibernate.Test
 
 		public static void DropSchema(bool useStdOut, SchemaExport export, ISessionFactoryImplementor sfi, Func<DbConnection> getConnection = null)
 		{
+			using(var optionalConnection = getConnection?.Invoke())
+				export.Drop(useStdOut, true, optionalConnection);
+
 			if (sfi?.ConnectionProvider.Driver is FirebirdClientDriver fbDriver)
 			{
 				// Firebird will pool each connection created during the test and will marked as used any table
@@ -313,9 +316,6 @@ namespace NHibernate.Test
 				// Moved from NH1908 test case, contributed by Amro El-Fakharany.
 				fbDriver.ClearPool(null);
 			}
-
-			using(var optionalConnection = getConnection?.Invoke())
-				export.Drop(useStdOut, true, optionalConnection);
 		}
 
 		/// <summary>


### PR DESCRIPTION
I hope it fixes it everywhere. Tests shown on 14 Github Action runs no failed FB test:
https://github.com/bahusoid/nhibernate-core/actions/runs/914629949
https://github.com/bahusoid/nhibernate-core/actions/runs/914686728
https://github.com/bahusoid/nhibernate-core/runs/2765215509

Without this change CI sometime fails with errors like:

```sql
FirebirdSql.Data.FirebirdClient.FbException : unsuccessful metadata update
CREATE TABLE TESTENTITY failed
Table TESTENTITY already exists
```
See https://github.com/bahusoid/nhibernate-core/runs/2753973440?check_suite_focus=true#logs
https://ci.appveyor.com/project/nhibernate/nhibernate-core/builds/39434450/job/ici409t79f6kie1c/tests

Let's add it to 5.3 as it's still active branch to avoid annoying build restarts.