### PR TITLE
Fix intermittent Firebird test errors

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.3.0" />
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.6.0" />
     <PackageReference Include="Npgsql" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(NhNetFx)">

--- a/src/NHibernate/Driver/FirebirdClientDriver.cs
+++ b/src/NHibernate/Driver/FirebirdClientDriver.cs
@@ -160,8 +160,8 @@ namespace NHibernate.Driver
 				using (var clearConnection = CreateConnection())
 				{
 					var connectionType = clearConnection.GetType();
-					_clearPool = connectionType.GetMethod("ClearPool") ?? throw new InvalidOperationException("Unable to resolve ClearPool method.");
-					_clearAllPools = connectionType.GetMethod("ClearAllPools") ?? throw new InvalidOperationException("Unable to resolve ClearAllPools method.");
+					_clearPool = connectionType.GetMethod("ClearPool", new[] { connectionType }) ?? throw new InvalidOperationException("Unable to resolve ClearPool method.");
+					_clearAllPools = connectionType.GetMethod("ClearAllPools", Array.Empty<System.Type>()) ?? throw new InvalidOperationException("Unable to resolve ClearAllPools method.");
 				}
 			}
 


### PR DESCRIPTION
Backport #2758 to avoid  annoying Firebird build restarts. It looks like simple version bump fixes CI intermittent test errors.

Without this change CI sometime fails with errors like:

```sql
FirebirdSql.Data.FirebirdClient.FbException : unsuccessful metadata update
CREATE TABLE TESTENTITY failed
Table TESTENTITY already exists
```

Tested with 10 jobs on github and appveyor:
https://github.com/bahusoid/nhibernate-core/actions/runs/916004229
https://ci.appveyor.com/project/nhibernate/nhibernate-core/builds/39499777

