### PR TITLE
Fix null check for component with 4+ properties in hql

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3634/Connection.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/Connection.cs
@@ -5,5 +5,6 @@
 		public virtual string ConnectionType { get; set; }
 		public virtual string Address { get; set; }
 		public virtual string PortName { get; set; }
+		public virtual string PortName2 { get; set; }
 	}
 }

--- a/src/NHibernate.Test/NHSpecificTest/NH3634/PersonMapper.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3634/PersonMapper.cs
@@ -19,6 +19,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3634
 					m.Property(c => c.ConnectionType, mapper => mapper.NotNullable(true)); 
 					m.Property(c => c.Address, mapper => mapper.NotNullable(false));
 					m.Property(c => c.PortName, mapper => mapper.NotNullable(false));
+					m.Property(c => c.PortName2, mapper => mapper.NotNullable(false));
 				});
 		}
 	}

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/AbstractNullnessCheckNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/AbstractNullnessCheckNode.cs
@@ -75,20 +75,26 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			{
 				if ( i == 1 )
 				{
-					container.AddChildren(
-						ASTFactory.CreateNode(comparisonType, comparisonText,
-							ASTFactory.CreateNode(HqlSqlWalker.SQL_TOKEN, mutationTexts[0])),
-						ASTFactory.CreateNode(comparisonType, comparisonText,
-							ASTFactory.CreateNode(HqlSqlWalker.SQL_TOKEN, mutationTexts[1])));
+					var op1 = ASTFactory.CreateNode(comparisonType, comparisonText);
+					var operand1 = ASTFactory.CreateNode(HqlSqlWalker.SQL_TOKEN, mutationTexts[0]);
+					op1.SetFirstChild(operand1);
+					container.SetFirstChild(op1);
+
+					var op2 = ASTFactory.CreateNode(comparisonType, comparisonText);
+					var operand2 = ASTFactory.CreateNode(HqlSqlWalker.SQL_TOKEN, mutationTexts[1]);
+					op2.SetFirstChild(operand2);
+					op1.AddSibling(op2);
 				}
 				else 
 				{
-					container.AddChildren(
-						ASTFactory.CreateNode(expansionConnectorType, expansionConnectorText),
-						ASTFactory.CreateNode(comparisonType, comparisonText,
-							ASTFactory.CreateNode(HqlSqlWalker.SQL_TOKEN, mutationTexts[i])));
+					var operand = ASTFactory.CreateNode(HqlSqlWalker.SQL_TOKEN, mutationTexts[i]);
+					var op = ASTFactory.CreateNode(comparisonType, comparisonText);
+					op.SetFirstChild(operand);
 
-					container = GetChild(0);
+					var newContainer = ASTFactory.CreateNode(expansionConnectorType, expansionConnectorText);
+					container.SetFirstChild(newContainer);
+					newContainer.AddSibling(op);
+					container = newContainer;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2822 

Just ported hibernate version https://github.com/hibernate/hibernate-orm/blob/ee55768587abc2893d26fca1915ac32e86242fa2/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/AbstractNullnessCheckNode.java#L72-L88