### PR TITLE
Fix Linq failure on null parameter value

### DIFF
--- a/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Async/Linq/LinqQuerySamples.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using NHibernate.Linq;
 
@@ -1369,6 +1370,20 @@ namespace NHibernate.Test.Linq
 				var sql = sqlSpy.GetWholeLog();
 				Assert.That(GetTotalOccurrences(sql, "left outer join"), Is.EqualTo(2));
 			}
+		}
+
+		[Test]
+		public void ReplaceFunctionWithNullArgumentAsync()
+		{
+			var query = from e in db.Employees
+			            select e.FirstName.Replace(e.LastName, null);
+			List<string> results = null;
+			Assert.That(
+				async () =>
+				{
+					results = await (query.ToListAsync());
+				}, Throws.Nothing, "Expected REPLACE(FirstName, LastName, NULL) to be supported");
+			Assert.That(results, Is.Not.Null);
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/LinqQuerySamples.cs
+++ b/src/NHibernate.Test/Linq/LinqQuerySamples.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Linq
@@ -1954,6 +1955,20 @@ namespace NHibernate.Test.Linq
 			Assert.AreEqual(809, q.Length);
 
 			Assert.That(!q.Any(orderid => withNullShippingDate.Contains(orderid)));
+		}
+
+		[Test]
+		public void ReplaceFunctionWithNullArgument()
+		{
+			var query = from e in db.Employees
+			            select e.FirstName.Replace(e.LastName, null);
+			List<string> results = null;
+			Assert.That(
+				() =>
+				{
+					results = query.ToList();
+				}, Throws.Nothing, "Expected REPLACE(FirstName, LastName, NULL) to be supported");
+			Assert.That(results, Is.Not.Null);
 		}
 	}
 

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -156,7 +156,7 @@ namespace NHibernate.Linq.Visitors
 				return candidateType;
 			}
 
-			if (visitor.NotGuessableConstants.Contains(constantExpression))
+			if (visitor.NotGuessableConstants.Contains(constantExpression) && constantExpression.Value != null)
 			{
 				return null;
 			}


### PR DESCRIPTION
HQL is ill equipped for guessing types of null parameters.
We should keep doing that on Linq side.

Fix #2833