### PR TITLE
Fix possible test failure for SqlServer 2019

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1300/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1300/Fixture.cs
@@ -114,7 +114,9 @@ namespace NHibernate.Test.NHSpecificTest.GH1300
 
 				var sqlEx = ex.InnerException as SqlException;
 				Assert.That(sqlEx, Is.Not.Null);
-				Assert.That(sqlEx.Number, Is.EqualTo(8152));
+				// Error code is different if verbose truncation warning is enabled
+				// See details: https://www.brentozar.com/archive/2019/03/how-to-fix-the-error-string-or-binary-data-would-be-truncated/
+				Assert.That(sqlEx.Number, Is.EqualTo(8152).Or.EqualTo(2628));
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/GH1300/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1300/Fixture.cs
@@ -103,7 +103,9 @@ namespace NHibernate.Test.NHSpecificTest.GH1300
 
 				var sqlEx = ex.InnerException as SqlException;
 				Assert.That(sqlEx, Is.Not.Null);
-				Assert.That(sqlEx.Number, Is.EqualTo(8152));
+				// Error code is different if verbose truncation warning is enabled
+				// See details: https://www.brentozar.com/archive/2019/03/how-to-fix-the-error-string-or-binary-data-would-be-truncated/
+				Assert.That(sqlEx.Number, Is.EqualTo(8152).Or.EqualTo(2628));
 			}
 		}
 


### PR DESCRIPTION
Apparently latest SQL Server 2019 has enabled "verbose truncation warning" by default. Which gives more detailed exception and changes error code: 
"2628 – String or binary data would be truncated in table ‘[TableName]’, column ‘[ColumnName]’. Truncated value: ‘[Value]’."
vs old
"8152 -String or binary data would be truncated"
