### PR TITLE
Add Oracle to Git Hub Actions

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -16,6 +16,8 @@ jobs:
             CONNECTION_STRING: "DataSource=localhost;Database=nhibernate;User=SYSDBA;Password=nhibernate;charset=utf8;"
           - DB: MySQL
             CONNECTION_STRING: "Server=localhost;Uid=root;Password=nhibernate;Database=nhibernate;Old Guids=True;"
+          - DB: Oracle
+            CONNECTION_STRING: "User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XEPDB1)))"
           - DB: SQLite
     runs-on: ubuntu-latest
     continue-on-error: ${{matrix.ALLOW_FAILURE == true}}
@@ -44,6 +46,11 @@ jobs:
       if: matrix.DB == 'Firebird'
       run: |
         docker run --name firebird -e EnableWireCrypt=true -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e ISC_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d jacobalberty/firebird:v3.0
+
+    - name: Set up Oracle
+      if: matrix.DB == 'Oracle'
+      run: |
+        docker run -d -p 1521:1521 -e APP_USER=nhibernate -e APP_USER_PASSWORD=nhibernate -e ORACLE_PASSWORD=nhibernate gvenzl/oracle-xe:18-slim
 
     - uses: actions/checkout@v2
     - name: Setup .NET

--- a/psake.ps1
+++ b/psake.ps1
@@ -64,8 +64,9 @@ Task Set-Configuration {
             'dialect' = 'NHibernate.Dialect.MsSql2012Dialect'
         };
         'Oracle' = @{
-			'connection.driver_class' = 'NHibernate.Driver.OracleManagedDataClientDriver';
-            'dialect' = 'NHibernate.Dialect.Oracle12cDialect'
+            'connection.connection_string' = 'User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XEPDB1)))';
+            'connection.driver_class' = 'NHibernate.Driver.OracleManagedDataClientDriver';
+            'dialect' = 'NHibernate.Dialect.Oracle10gDialect'
         }
     }
     #Settings for current build

--- a/psake.ps1
+++ b/psake.ps1
@@ -62,6 +62,10 @@ Task Set-Configuration {
         'SqlServer2012' = @{
             'connection.connection_string' = 'Server=(local)\SQL2017;User ID=sa;Password=Password12!;initial catalog=nhibernate;';
             'dialect' = 'NHibernate.Dialect.MsSql2012Dialect'
+        };
+        'Oracle' = @{
+			'connection.driver_class' = 'NHibernate.Driver.OracleManagedDataClientDriver';
+            'dialect' = 'NHibernate.Dialect.Oracle12cDialect'
         }
     }
     #Settings for current build

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1171/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1171/Fixture.cs
@@ -24,7 +24,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1171
 				// Firebird has issues with comments containing apostrophes
 				!(dialect is FirebirdDialect)
 				// GH-2853: Oracle client bug: throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
-				&& !(dialect is Oracle10gDialect);
+				&& !(dialect is Oracle8iDialect);
 		}
 
 		protected override void Configure(NHibernate.Cfg.Configuration configuration)

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1171/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1171/Fixture.cs
@@ -21,7 +21,12 @@ namespace NHibernate.Test.NHSpecificTest.NH1171
 		protected override bool AppliesTo(Dialect.Dialect dialect)
 		{
 			// Firebird has issues with comments containing apostrophes
-			return !(dialect is FirebirdDialect);
+			return !(dialect is FirebirdDialect)
+#if !NETFX
+					//Oracle Core client throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
+					&& !(dialect is Oracle10gDialect)
+#endif
+				;
 		}
 
 		protected override void Configure(NHibernate.Cfg.Configuration configuration)

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1171/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1171/Fixture.cs
@@ -20,13 +20,11 @@ namespace NHibernate.Test.NHSpecificTest.NH1171
 	{
 		protected override bool AppliesTo(Dialect.Dialect dialect)
 		{
-			// Firebird has issues with comments containing apostrophes
-			return !(dialect is FirebirdDialect)
-#if !NETFX
-					//Oracle Core client throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
-					&& !(dialect is Oracle10gDialect)
-#endif
-				;
+			return
+				// Firebird has issues with comments containing apostrophes
+				!(dialect is FirebirdDialect)
+				// GH-2853: Oracle client bug: throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
+				&& !(dialect is Oracle10gDialect);
 		}
 
 		protected override void Configure(NHibernate.Cfg.Configuration configuration)

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1693/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1693/Fixture.cs
@@ -49,7 +49,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1693
 			using (var tx = session.BeginTransaction())
 			{
 				var q1 =
-					"from Invoice i where i.Mode='a' and i.Category=:cat and not exists (from Invoice i2 where i2.Mode='a' and i2.Category=:cat and i2.Num=i.Num+1)";
+					"from Invoice i where i.Mode='a' and i.Category=:cat and not exists (from Invoice i2 where i2.Mode='a' and i2.Category=:cat and i2.Num=i.Num+1) order by i.Num";
 				var list = await (session.CreateQuery(q1)
 					.SetParameter("cat", 10)
 					.ListAsync<Invoice>());
@@ -70,7 +70,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1693
 				session.EnableFilter("modeFilter").SetParameter("currentMode", "a");
 
 				var q1 =
-					"from Invoice i where i.Category=:cat and not exists (from Invoice i2 where i2.Category=:cat and i2.Num=i.Num+1)";
+					"from Invoice i where i.Category=:cat and not exists (from Invoice i2 where i2.Category=:cat and i2.Num=i.Num+1) order by i.Num";
 				var list = await (session.CreateQuery(q1)
 					.SetParameter("cat", 10)
 					.ListAsync<Invoice>());

--- a/src/NHibernate.Test/Async/Tools/hbm2ddl/SchemaMetadataUpdaterTest/SchemaMetadataUpdaterFixture.cs
+++ b/src/NHibernate.Test/Async/Tools/hbm2ddl/SchemaMetadataUpdaterTest/SchemaMetadataUpdaterFixture.cs
@@ -254,7 +254,7 @@ namespace NHibernate.Test.Tools.hbm2ddl.SchemaMetadataUpdaterTest
 			// Test uses the default dialect driver, which will not accept Odbc or OleDb connection strings.
 			if (typeof(OdbcDriver).IsAssignableFrom(driverClass) || typeof(OleDbDriver).IsAssignableFrom(driverClass))
 				Assert.Ignore("Test is not compatible with OleDb or ODBC driver connection strings");
-			var configuredDialect = Dialect.Dialect.GetDialect();
+			var configuredDialect = Dialect.Dialect.GetDialect(configuration.Properties);
 			if(!configuredDialect.DefaultProperties.ContainsKey(Environment.ConnectionDriver))
 			{
 				Assert.Ignore(GetType() + " does not apply to " + configuredDialect);

--- a/src/NHibernate.Test/NHSpecificTest/NH1171/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1171/Fixture.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1171
 				// Firebird has issues with comments containing apostrophes
 				!(dialect is FirebirdDialect)
 				// GH-2853: Oracle client bug: throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
-				&& !(dialect is Oracle10gDialect);
+				&& !(dialect is Oracle8iDialect);
 		}
 
 		protected override void Configure(NHibernate.Cfg.Configuration configuration)

--- a/src/NHibernate.Test/NHSpecificTest/NH1171/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1171/Fixture.cs
@@ -9,13 +9,11 @@ namespace NHibernate.Test.NHSpecificTest.NH1171
 	{
 		protected override bool AppliesTo(Dialect.Dialect dialect)
 		{
-			// Firebird has issues with comments containing apostrophes
-			return !(dialect is FirebirdDialect)
-#if !NETFX
-					//Oracle Core client throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
-					&& !(dialect is Oracle10gDialect)
-#endif
-				;
+			return
+				// Firebird has issues with comments containing apostrophes
+				!(dialect is FirebirdDialect)
+				// GH-2853: Oracle client bug: throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
+				&& !(dialect is Oracle10gDialect);
 		}
 
 		protected override void Configure(NHibernate.Cfg.Configuration configuration)

--- a/src/NHibernate.Test/NHSpecificTest/NH1171/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1171/Fixture.cs
@@ -10,7 +10,12 @@ namespace NHibernate.Test.NHSpecificTest.NH1171
 		protected override bool AppliesTo(Dialect.Dialect dialect)
 		{
 			// Firebird has issues with comments containing apostrophes
-			return !(dialect is FirebirdDialect);
+			return !(dialect is FirebirdDialect)
+#if !NETFX
+					//Oracle Core client throws Oracle.ManagedDataAccess.Client.OracleException : ORA-01008: not all variables bound
+					&& !(dialect is Oracle10gDialect)
+#endif
+				;
 		}
 
 		protected override void Configure(NHibernate.Cfg.Configuration configuration)

--- a/src/NHibernate.Test/NHSpecificTest/NH1693/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1693/Fixture.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1693
 			using (var tx = session.BeginTransaction())
 			{
 				var q1 =
-					"from Invoice i where i.Mode='a' and i.Category=:cat and not exists (from Invoice i2 where i2.Mode='a' and i2.Category=:cat and i2.Num=i.Num+1)";
+					"from Invoice i where i.Mode='a' and i.Category=:cat and not exists (from Invoice i2 where i2.Mode='a' and i2.Category=:cat and i2.Num=i.Num+1) order by i.Num";
 				var list = session.CreateQuery(q1)
 					.SetParameter("cat", 10)
 					.List<Invoice>();
@@ -59,7 +59,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1693
 				session.EnableFilter("modeFilter").SetParameter("currentMode", "a");
 
 				var q1 =
-					"from Invoice i where i.Category=:cat and not exists (from Invoice i2 where i2.Category=:cat and i2.Num=i.Num+1)";
+					"from Invoice i where i.Category=:cat and not exists (from Invoice i2 where i2.Category=:cat and i2.Num=i.Num+1) order by i.Num";
 				var list = session.CreateQuery(q1)
 					.SetParameter("cat", 10)
 					.List<Invoice>();

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -74,7 +74,7 @@
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Data.OracleClient" />
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />
+    <PackageReference Include="Oracle.ManagedDataAccess" Version="19.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <PackageReference Include="System.CodeDom" Version="4.7.0" />

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -74,7 +74,7 @@
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Data.OracleClient" />
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="19.1.0" />
+    <PackageReference Include="Oracle.ManagedDataAccess" Version="19.11.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <PackageReference Include="System.CodeDom" Version="4.7.0" />

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -80,6 +80,7 @@
     <PackageReference Include="System.CodeDom" Version="4.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.Data.OracleClient" Version="1.0.8" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.110" />
     <PackageReference Include="System.Data.Odbc" Version="4.7.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="NUnitLite" Version="3.13.2" />

--- a/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/SchemaMetadataUpdaterFixture.cs
+++ b/src/NHibernate.Test/Tools/hbm2ddl/SchemaMetadataUpdaterTest/SchemaMetadataUpdaterFixture.cs
@@ -259,7 +259,7 @@ namespace NHibernate.Test.Tools.hbm2ddl.SchemaMetadataUpdaterTest
 			// Test uses the default dialect driver, which will not accept Odbc or OleDb connection strings.
 			if (typeof(OdbcDriver).IsAssignableFrom(driverClass) || typeof(OleDbDriver).IsAssignableFrom(driverClass))
 				Assert.Ignore("Test is not compatible with OleDb or ODBC driver connection strings");
-			var configuredDialect = Dialect.Dialect.GetDialect();
+			var configuredDialect = Dialect.Dialect.GetDialect(configuration.Properties);
 			if(!configuredDialect.DefaultProperties.ContainsKey(Environment.ConnectionDriver))
 			{
 				Assert.Ignore(GetType() + " does not apply to " + configuredDialect);


### PR DESCRIPTION
DB: Oracle 18c (18.4.0) [docker image](https://hub.docker.com/r/gvenzl/oracle-xe)
Client: Oracle.ManagedDataAccess.Core Version="2.19.110" (3.x doesn't support .net standard 2.0)
Dialect: NHibernate.Dialect.Oracle10gDialect (newer Oracle12cDialect dialect gives some failed tests)

NH1171 tests are skipped as it's Oracle client bug (also present in recent [NETFX libs](https://stackoverflow.com/questions/7493028/ora-01008-not-all-variables-bound-they-are-bound/30982945#comment80845483_7542670)) - added https://github.com/nhibernate/nhibernate-core/issues/2853 for tracking

P.S. Oracle teamcity tests take [40 minutes ](https://teamcity.jetbrains.com/viewLog.html?buildId=3540988&buildTypeId=bt1099) to finish. Doesn't look right -  if I remember correctly it was about [20 minutes](https://github.com/nhibernate/nhibernate-core/pull/1517#pullrequestreview-87775763) some months/years back. I wonder if #1511 is a culprit - added https://github.com/nhibernate/nhibernate-core/issues/2854