### PR TITLE
Fix possible ERROR log when parsing join in hql

### DIFF
--- a/src/NHibernate.Test/Associations/OneToOneFixture.cs
+++ b/src/NHibernate.Test/Associations/OneToOneFixture.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
 using NHibernate.Test.Associations.OneToOneFixtureEntities;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Associations
@@ -127,19 +128,22 @@ namespace NHibernate.Test.Associations
 				Assert.That(loadedEntity, Is.Not.Null);
 			}
 		}
-		
+
 		//GH-2064
 		[Test]
 		public void OneToOneCompositeQuerySelectProjection()
 		{
+			using(var logSpy = new LogSpy(typeof(ReflectHelper)))
 			using (var session = OpenSession())
 			{
 				var loadedProjection = session.Query<Parent>().Select(x => new {x.OneToOneComp, x.Key}).FirstOrDefault();
 
 				Assert.That(loadedProjection.OneToOneComp, Is.Not.Null);
+				// GH-2855 Error is logged
+				Assert.That(logSpy.GetWholeLog(), Is.Empty);
 			}
 		}
-		
+
 		//NH-3178 (GH-1125)
 		[Test]
 		public void OneToOneQueryOverSelectProjection()

--- a/src/NHibernate.Test/Async/Associations/OneToOneFixture.cs
+++ b/src/NHibernate.Test/Async/Associations/OneToOneFixture.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using NHibernate.Cfg.MappingSchema;
 using NHibernate.Mapping.ByCode;
 using NHibernate.Test.Associations.OneToOneFixtureEntities;
+using NHibernate.Util;
 using NUnit.Framework;
 using NHibernate.Linq;
 
@@ -139,19 +140,22 @@ namespace NHibernate.Test.Associations
 				Assert.That(loadedEntity, Is.Not.Null);
 			}
 		}
-		
+
 		//GH-2064
 		[Test]
 		public async Task OneToOneCompositeQuerySelectProjectionAsync()
 		{
+			using(var logSpy = new LogSpy(typeof(ReflectHelper)))
 			using (var session = OpenSession())
 			{
 				var loadedProjection = await (session.Query<Parent>().Select(x => new {x.OneToOneComp, x.Key}).FirstOrDefaultAsync());
 
 				Assert.That(loadedProjection.OneToOneComp, Is.Not.Null);
+				// GH-2855 Error is logged
+				Assert.That(logSpy.GetWholeLog(), Is.Empty);
 			}
 		}
-		
+
 		//NH-3178 (GH-1125)
 		[Test]
 		public async Task OneToOneQueryOverSelectProjectionAsync()

--- a/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
@@ -26,7 +26,7 @@ namespace NHibernate.Test.Hql
 	[TestFixture]
 	public class EntityJoinHqlTestAsync : TestCaseMappingByCode
 	{
-		private const string _customEntityName = "CustomEntityName";
+		private const string _customEntityName = "CustomEntityName.Test";
 		private EntityWithCompositeId _entityWithCompositeId;
 		private EntityWithNoAssociation _noAssociation;
 		private EntityCustomEntityName _entityWithCustomEntityName;
@@ -42,6 +42,46 @@ namespace NHibernate.Test.Hql
 					.CreateQuery("select ex " +
 						"from EntityWithNoAssociation root " +
 						"left join EntityComplex ex with root.Complex1Id = ex.Id")
+						.SetMaxResults(1)
+					.UniqueResultAsync<EntityComplex>());
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
+		public async Task CanJoinNotAssociatedEntityFullNameAsync()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				await (session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						$"left join {typeof(EntityComplex).FullName} ex with root.Complex1Id = ex.Id")
+						.SetMaxResults(1)
+					.UniqueResultAsync<EntityComplex>());
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
+		public async Task CanJoinNotAssociatedInterfaceFullNameAsync()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				await (session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						$"left join {typeof(IEntityComplex).FullName} ex with root.Complex1Id = ex.Id")
 						.SetMaxResults(1)
 					.UniqueResultAsync<EntityComplex>());
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Test.Hql
 	[TestFixture]
 	public class EntityJoinHqlTest : TestCaseMappingByCode
 	{
-		private const string _customEntityName = "CustomEntityName";
+		private const string _customEntityName = "CustomEntityName.Test";
 		private EntityWithCompositeId _entityWithCompositeId;
 		private EntityWithNoAssociation _noAssociation;
 		private EntityCustomEntityName _entityWithCustomEntityName;
@@ -30,6 +30,46 @@ namespace NHibernate.Test.Hql
 					.CreateQuery("select ex " +
 						"from EntityWithNoAssociation root " +
 						"left join EntityComplex ex with root.Complex1Id = ex.Id")
+						.SetMaxResults(1)
+					.UniqueResult<EntityComplex>();
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
+		public void CanJoinNotAssociatedEntityFullName()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						$"left join {typeof(EntityComplex).FullName} ex with root.Complex1Id = ex.Id")
+						.SetMaxResults(1)
+					.UniqueResult<EntityComplex>();
+
+				Assert.That(entityComplex, Is.Not.Null);
+				Assert.That(NHibernateUtil.IsInitialized(entityComplex), Is.True);
+				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");
+			}
+		}
+
+		[Test]
+		public void CanJoinNotAssociatedInterfaceFullName()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			using (var session = OpenSession())
+			{
+				EntityComplex entityComplex = 
+				session
+					.CreateQuery("select ex " +
+						"from EntityWithNoAssociation root " +
+						$"left join {typeof(IEntityComplex).FullName} ex with root.Complex1Id = ex.Id")
 						.SetMaxResults(1)
 					.UniqueResult<EntityComplex>();
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTestEntities.cs
@@ -2,7 +2,17 @@
 
 namespace NHibernate.Test.Hql.EntityJoinHqlTestEntities
 {
-	public class EntityComplex
+	public interface IEntityComplex
+	{
+		Guid Id { get; set; }
+		int Version { get; set; }
+		string Name { get; set; }
+		string LazyProp { get; set; }
+		EntityComplex SameTypeChild { get; set; }
+		EntityComplex SameTypeChild2 { get; set; }
+	}
+
+	public class EntityComplex : IEntityComplex
 	{
 		public virtual Guid Id { get; set; }
 		public virtual int Version { get; set; }

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -124,6 +124,8 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			set { _propertyPath = value; }
 		}
 
+		internal bool SkipSemiResolve { get; set; }
+
 		public override void SetScalarColumnText(int i)
 		{
 			string[] sqlColumns = GetColumns();
@@ -200,7 +202,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			// this might be a Java constant.
 			if ( propertyType == null ) 
 			{
-				if ( parent == null ) 
+				if (parent == null && !SkipSemiResolve)
 				{
 					Walker.LiteralProcessor.LookupConstant( this );
 				}


### PR DESCRIPTION
Regression from #2810

Fix tries to process node as implicit join first (as `GetImplementors` required for entity join caches results, and we want to avoid caching query parts representing implicit join)

Fixes #2855 