### PR TITLE
Fix nullable entity comparison with null and implicit/cross joins

### DIFF
--- a/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
@@ -344,10 +344,11 @@ namespace NHibernate.Test.Hql
 				var withValidManyToOneList = await (session.Query<NullableOwner>().Where(x => x.ManyToOne != null).Select(x => new {x.Name, ManyToOneId = (Guid?) x.ManyToOne.Id}).ToListAsync());
 				var withValidManyToOneList2 = await (session.CreateQuery("from NullableOwner ex where not ex.ManyToOne is null").ListAsync<NullableOwner>());
 				var withNullManyToOneList = await (session.Query<NullableOwner>().Where(x => x.ManyToOne == null).ToListAsync());
-				var withNullManyToOneJoinedList = await ((from x in session.Query<NullableOwner>()
-													from x2 in session.Query<NullableOwner>()
-													where x == x2 && x.ManyToOne == null && x.OneToOne.Name == null
-													select x2).ToListAsync());
+				var withNullManyToOneJoinedList =
+					await ((from x in session.Query<NullableOwner>()
+							from x2 in session.Query<NullableOwner>()
+							where x == x2 && x.ManyToOne == null && x.OneToOne.Name == null
+							select x2).ToListAsync());
 				Assert.That(fullList.Count, Is.EqualTo(2));
 				Assert.That(withValidManyToOneList.Count, Is.EqualTo(0));
 				Assert.That(withValidManyToOneList2.Count, Is.EqualTo(0));

--- a/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Async/Hql/EntityJoinHqlTest.cs
@@ -344,10 +344,15 @@ namespace NHibernate.Test.Hql
 				var withValidManyToOneList = await (session.Query<NullableOwner>().Where(x => x.ManyToOne != null).Select(x => new {x.Name, ManyToOneId = (Guid?) x.ManyToOne.Id}).ToListAsync());
 				var withValidManyToOneList2 = await (session.CreateQuery("from NullableOwner ex where not ex.ManyToOne is null").ListAsync<NullableOwner>());
 				var withNullManyToOneList = await (session.Query<NullableOwner>().Where(x => x.ManyToOne == null).ToListAsync());
+				var withNullManyToOneJoinedList = await ((from x in session.Query<NullableOwner>()
+													from x2 in session.Query<NullableOwner>()
+													where x == x2 && x.ManyToOne == null && x.OneToOne.Name == null
+													select x2).ToListAsync());
 				Assert.That(fullList.Count, Is.EqualTo(2));
 				Assert.That(withValidManyToOneList.Count, Is.EqualTo(0));
 				Assert.That(withValidManyToOneList2.Count, Is.EqualTo(0));
 				Assert.That(withNullManyToOneList.Count, Is.EqualTo(2));
+				Assert.That(withNullManyToOneJoinedList.Count, Is.EqualTo(2));
 			}
 		}
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -332,10 +332,15 @@ namespace NHibernate.Test.Hql
 				var withValidManyToOneList = session.Query<NullableOwner>().Where(x => x.ManyToOne != null).Select(x => new {x.Name, ManyToOneId = (Guid?) x.ManyToOne.Id}).ToList();
 				var withValidManyToOneList2 = session.CreateQuery("from NullableOwner ex where not ex.ManyToOne is null").List<NullableOwner>();
 				var withNullManyToOneList = session.Query<NullableOwner>().Where(x => x.ManyToOne == null).ToList();
+				var withNullManyToOneJoinedList = (from x in session.Query<NullableOwner>()
+													from x2 in session.Query<NullableOwner>()
+													where x == x2 && x.ManyToOne == null && x.OneToOne.Name == null
+													select x2).ToList();
 				Assert.That(fullList.Count, Is.EqualTo(2));
 				Assert.That(withValidManyToOneList.Count, Is.EqualTo(0));
 				Assert.That(withValidManyToOneList2.Count, Is.EqualTo(0));
 				Assert.That(withNullManyToOneList.Count, Is.EqualTo(2));
+				Assert.That(withNullManyToOneJoinedList.Count, Is.EqualTo(2));
 			}
 		}
 

--- a/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
+++ b/src/NHibernate.Test/Hql/EntityJoinHqlTest.cs
@@ -332,10 +332,11 @@ namespace NHibernate.Test.Hql
 				var withValidManyToOneList = session.Query<NullableOwner>().Where(x => x.ManyToOne != null).Select(x => new {x.Name, ManyToOneId = (Guid?) x.ManyToOne.Id}).ToList();
 				var withValidManyToOneList2 = session.CreateQuery("from NullableOwner ex where not ex.ManyToOne is null").List<NullableOwner>();
 				var withNullManyToOneList = session.Query<NullableOwner>().Where(x => x.ManyToOne == null).ToList();
-				var withNullManyToOneJoinedList = (from x in session.Query<NullableOwner>()
-													from x2 in session.Query<NullableOwner>()
-													where x == x2 && x.ManyToOne == null && x.OneToOne.Name == null
-													select x2).ToList();
+				var withNullManyToOneJoinedList =
+					(from x in session.Query<NullableOwner>()
+					from x2 in session.Query<NullableOwner>()
+					where x == x2 && x.ManyToOne == null && x.OneToOne.Name == null
+					select x2).ToList();
 				Assert.That(fullList.Count, Is.EqualTo(2));
 				Assert.That(withValidManyToOneList.Count, Is.EqualTo(0));
 				Assert.That(withValidManyToOneList2.Count, Is.EqualTo(0));

--- a/src/NHibernate/Hql/Ast/ANTLR/SqlGenerator.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/SqlGenerator.cs
@@ -229,8 +229,15 @@ namespace NHibernate.Hql.Ast.ANTLR
 			}
 			else
 			{
-				// these are just two unrelated table references
-				Out(", ");
+				if (right.JoinSequence?.IsThetaStyle == false && right.JoinSequence.JoinCount != 0)
+				{
+					Out(" ");
+				}
+				else
+				{
+					// these are just two unrelated table references
+					Out(", ");
+				}
 			}
 		}
 


### PR DESCRIPTION
One more adjustment is required in https://github.com/nhibernate/nhibernate-core/pull/2889 to handle properly queries with other joins present.

It might confuse our SqlGenereator and make it generate invalid SQL like:

``` sql
, left join Entity e... -- left join starts with coma
```