### PR TITLE
Avoid lambda compilation for member access expressions in LINQ

### DIFF
--- a/src/NHibernate/Linq/Visitors/NhPartialEvaluatingExpressionVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/NhPartialEvaluatingExpressionVisitor.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using NHibernate.Collection;
 using NHibernate.Engine;
 using NHibernate.Impl;
@@ -145,7 +146,14 @@ namespace NHibernate.Linq.Visitors
 				return constantExpression;
 			}
 
-			return Expression.Constant(ExpressionProcessor.FindValue(subtree), subtree.Type);
+			try
+			{
+				return Expression.Constant(ExpressionProcessor.FindValue(subtree), subtree.Type);
+			}
+			catch (TargetInvocationException ex)
+			{
+				throw ReflectHelper.UnwrapTargetInvocationException(ex);
+			}
 		}
 
 		#region NH additions

--- a/src/NHibernate/Linq/Visitors/NhPartialEvaluatingExpressionVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/NhPartialEvaluatingExpressionVisitor.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using NHibernate.Collection;
 using NHibernate.Engine;
+using NHibernate.Impl;
 using NHibernate.Linq.Functions;
 using NHibernate.Util;
 using Remotion.Linq.Parsing;
@@ -143,14 +144,8 @@ namespace NHibernate.Linq.Visitors
 
 				return constantExpression;
 			}
-			else
-			{
-				Expression<Func<object>> lambdaWithoutParameters = Expression.Lambda<Func<object>>(Expression.Convert(subtree, typeof(object)));
-				var compiledLambda = lambdaWithoutParameters.Compile();
 
-				object value = compiledLambda();
-				return Expression.Constant(value, subtree.Type);
-			}
+			return Expression.Constant(ExpressionProcessor.FindValue(subtree), subtree.Type);
 		}
 
 		#region NH additions


### PR DESCRIPTION
Fixes #2947 

Also see #2448 for details and benchmarks.