### PR TITLE
Fix possible issue with logging for Linq Readonly tests

### DIFF
--- a/src/NHibernate.Test/Linq/LinqReadonlyTestsContext.cs
+++ b/src/NHibernate.Test/Linq/LinqReadonlyTestsContext.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace NHibernate.Test.Linq
 {
 	[SetUpFixture]
-	public class LinqReadonlyTestsContext
+	public class LinqReadonlyTestsContext : TestsContextBase
 	{
 		/// <summary>
 		/// Assembly to load mapping files from

--- a/src/NHibernate.Test/TestsContext.cs
+++ b/src/NHibernate.Test/TestsContext.cs
@@ -1,34 +1,14 @@
 ﻿using NUnit.Framework;
-using System.Configuration;
-using System.Reflection;
-using log4net;
-using log4net.Config;
-using NHibernate.Cfg;
 
 namespace NHibernate.Test
 {
 	[SetUpFixture]
-	public class TestsContext
+	public class TestsContext : TestsContextBase
 	{
-		private static readonly Assembly TestAssembly = typeof(TestsContext).Assembly;
-
 		[OneTimeSetUp]
 		public void RunBeforeAnyTests()
 		{
-			ConfigureLog4Net();
-
-			//When .NET Core App 2.0 tests run from VS/VSTest the entry assembly is "testhost.dll"
-			//so we need to explicitly load the configuration
-			if (Assembly.GetEntryAssembly() != null)
-			{
-				ConfigurationProvider.Current = new SystemConfigurationProvider(ConfigurationManager.OpenExeConfiguration(TestAssembly.Location));
-			}
-		}
-
-		private static void ConfigureLog4Net()
-		{
-			using (var log4NetXml = TestAssembly.GetManifestResourceStream("NHibernate.Test.log4net.xml"))
-				XmlConfigurator.Configure(LogManager.GetRepository(TestAssembly), log4NetXml);
+			//Everything is done in TestsContextBase static ctor 
 		}
 	}
 }

--- a/src/NHibernate.Test/TestsContextBase.cs
+++ b/src/NHibernate.Test/TestsContextBase.cs
@@ -1,0 +1,31 @@
+using System.Configuration;
+using System.Reflection;
+using log4net;
+using log4net.Config;
+using NHibernate.Cfg;
+
+namespace NHibernate.Test
+{
+	public abstract class TestsContextBase
+	{
+		private static readonly Assembly TestAssembly = typeof(TestsContextBase).Assembly;
+
+		static TestsContextBase()
+		{
+			ConfigureLog4Net();
+
+			//When .NET Core App 2.0 tests run from VS/VSTest the entry assembly is "testhost.dll"
+			//so we need to explicitly load the configuration
+			if (Assembly.GetEntryAssembly() != null)
+			{
+				ConfigurationProvider.Current = new SystemConfigurationProvider(ConfigurationManager.OpenExeConfiguration(TestAssembly.Location));
+			}
+		}
+
+		private static void ConfigureLog4Net()
+		{
+			using (var log4NetXml = TestAssembly.GetManifestResourceStream("NHibernate.Test.log4net.xml"))
+				XmlConfigurator.Configure(LogManager.GetRepository(TestAssembly), log4NetXml);
+		}
+	}
+}


### PR DESCRIPTION
We need to make sure that logic from TestsContext is executed before any others set up fixtures