### PR TITLE
Allow entity not found delegate to handle when an entity is not found

### DIFF
--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -78,7 +78,7 @@ namespace NHibernate.Impl
 	{
 		#region Default entity not found delegate
 
-		internal class DefaultEntityNotFoundDelegate : IEntityNotFoundDelegate
+		internal class DefaultEntityNotFoundDelegate : IEntityNotFoundDelegate, IEntityNotFoundPropertyDelegate
 		{
 			#region IEntityNotFoundDelegate Members
 

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -78,7 +78,7 @@ namespace NHibernate.Impl
 	{
 		#region Default entity not found delegate
 
-		internal class DefaultEntityNotFoundDelegate : IEntityNotFoundDelegate, IEntityNotFoundPropertyDelegate
+		internal class DefaultEntityNotFoundDelegate : IEntityNotFoundDelegate, IEntityNotFoundByUniqueKeyDelegate
 		{
 			#region IEntityNotFoundDelegate Members
 

--- a/src/NHibernate/Proxy/IEntityNotFoundDelegate.cs
+++ b/src/NHibernate/Proxy/IEntityNotFoundDelegate.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Proxy
 			string propertyName,
 			object key)
 		{
-			if (interceptor is Impl.SessionFactoryImpl.DefaultEntityNotFoundDelegate x)
+			if (interceptor is IEntityNotFoundPropertyDelegate x)
 			{
 				x.HandleEntityNotFound(entityName, propertyName, key);
 				return;
@@ -26,6 +26,14 @@ namespace NHibernate.Proxy
 		}
 	}
 
+	/// <summary> 
+	/// Delegate to handle the scenario of an entity not found by a specified id and property. 
+	/// </summary>
+	public interface IEntityNotFoundPropertyDelegate
+	{
+		void HandleEntityNotFound(string entityName, string propertyName, object key);
+	}
+	
 	/// <summary> 
 	/// Delegate to handle the scenario of an entity not found by a specified id. 
 	/// </summary>

--- a/src/NHibernate/Proxy/IEntityNotFoundDelegate.cs
+++ b/src/NHibernate/Proxy/IEntityNotFoundDelegate.cs
@@ -16,7 +16,7 @@ namespace NHibernate.Proxy
 			string propertyName,
 			object key)
 		{
-			if (interceptor is IEntityNotFoundPropertyDelegate x)
+			if (interceptor is IEntityNotFoundByUniqueKeyDelegate x)
 			{
 				x.HandleEntityNotFound(entityName, propertyName, key);
 				return;
@@ -27,9 +27,11 @@ namespace NHibernate.Proxy
 	}
 
 	/// <summary> 
-	/// Delegate to handle the scenario of an entity not found by a specified id and property. 
+	/// Delegate to handle the scenario of an entity not found by a specified id and property.
+	/// This is a temporary interface until it can be merged into IEntityNotFoundDelegate 
 	/// </summary>
-	public interface IEntityNotFoundPropertyDelegate
+	//6.0 TODO Remove and add to method to IEntityNotFoundDelegate interface
+	public interface IEntityNotFoundByUniqueKeyDelegate
 	{
 		void HandleEntityNotFound(string entityName, string propertyName, object key);
 	}


### PR DESCRIPTION
NHibernate 5.3 changed the behavior of entity not found.  In the code there is this comment that _//6.0 TODO Add to IEntityNotFoundDelegate interface_ that made me assume it will be correctly fixed in 6.0.  My guess was that in the point version it was desired to not add additional methods to public interfaces so `void HandleEntityNotFound(string entityName, string propertyName, object key);` was not added to IEntityNotFoundDelegate but because DefaultEntityNotFoundDelegate is internal it appeared to make it so there was no way to changed the handling of EntityNotFound in the case of when there was a property associated with it.  So I added a new interface that an IEntityNotFoundDelegate could also implement so the behavior could be modified.  I think it would be better if IEntityNotFoundDelegate just had the additional method but by making a new interface it does not break current compile but make it easy for projects that need the override to change the behavior.