### PR TITLE
Bump AsyncGenerator to 0.18.3 for 5.3 branch with fix for .net 6

### DIFF
--- a/Tools/packages.csproj
+++ b/Tools/packages.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="CSharpAsyncGenerator.CommandLine" Version="0.18.2" />
+    <PackageReference Include="CSharpAsyncGenerator.CommandLine" Version="0.18.3" />
     <PackageReference Include="vswhere" Version="2.1.4" />
     <PackageReference Include="NUnit.Console" Version="3.10.0" />
     <PackageReference Include="GitReleaseManager" Version="0.11.0" />


### PR DESCRIPTION
5.3 specific fix (not to be merged to master) See discussion starting from https://github.com/maca88/AsyncGenerator/issues/157#issuecomment-992362078

Requires 2.1.x - 3.1.200 SDK (one of it)

global.json  trick is no longer required on my machine (with 6.0.101 and 2.1.602 sdks installed)