### PR TITLE
Fix schema validator for Npgsql 5

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.6.0" />
-    <PackageReference Include="Npgsql" Version="4.0.3" />
+    <PackageReference Include="Npgsql" Version="5.0.11" />
   </ItemGroup>
   <ItemGroup Condition="$(NhNetFx)">
     <Reference Include="System.Configuration" />

--- a/src/NHibernate/Dialect/Schema/PostgreSQLMetadata.cs
+++ b/src/NHibernate/Dialect/Schema/PostgreSQLMetadata.cs
@@ -138,7 +138,43 @@ namespace NHibernate.Dialect.Schema
 			this.SetNumericalPrecision(rs["NUMERIC_PRECISION"]);
 
 			Nullable = Convert.ToString(rs["IS_NULLABLE"]);
-			TypeName = Convert.ToString(rs["DATA_TYPE"]);
+			TypeName = NormalizeTypeNames(Convert.ToString(rs["DATA_TYPE"]));
+		}
+
+		private static string NormalizeTypeNames(string typeName)
+		{
+			switch (typeName)
+			{
+				case "double precision":
+					return "float8";
+				case "real":
+					return "float4";
+				case "smallint":
+					return "int2";
+				case "integer":
+					return "int4";
+				case "bigint":
+					return "int8";
+			}
+
+			if (typeName.StartsWith("character", StringComparison.Ordinal))
+			{
+				return typeName.Replace("character varying", "varchar").Replace("character", "char");
+			}
+
+			if (typeName.EndsWith(" with time zone", StringComparison.Ordinal))
+			{
+				return typeName.StartsWith("timestamp", StringComparison.Ordinal)
+					? typeName.Replace(" with time zone", string.Empty).Replace("timestamp", "timestamptz")
+					: typeName.Replace(" with time zone", string.Empty).Replace("time", "timetz");
+			}
+
+			if (typeName.EndsWith(" without time zone", StringComparison.Ordinal))
+			{
+				return typeName.Replace(" without time zone", string.Empty);
+			}
+
+			return typeName;
 		}
 	}
 


### PR DESCRIPTION
Npgsql 5 returns different type names for some of the types. Normalize them back to what dialect expects.  

Fixes #2876