### PR TITLE
* Basic support for T-SQL query hints.

### DIFF
--- a/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
+++ b/src/NHibernate/Async/Engine/Query/HQLQueryPlan.cs
@@ -50,6 +50,7 @@ namespace NHibernate.Engine.Query
 				RowSelection selection = new RowSelection();
 				selection.FetchSize = queryParameters.RowSelection.FetchSize;
 				selection.Timeout = queryParameters.RowSelection.Timeout;
+				selection.Hint = queryParameters.RowSelection.Hint;
 				queryParametersToUse = queryParameters.CreateCopyUsing(selection);
 			}
 			else

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -2408,6 +2408,11 @@ namespace NHibernate.Dialect
 		/// </summary>
 		public virtual bool SupportsDateTimeScale => false;
 
+		/// <summary>
+        /// Does this dialect support T-SQL query hints
+        /// </summary>
+		public virtual bool SupportsQueryHints => false;
+
 		#endregion
 
 		/// <summary>
@@ -2674,6 +2679,21 @@ namespace NHibernate.Dialect
 			// since SQLErrorCode is extremely vendor-specific.  Specific Dialects
 			// may override to return whatever is most appropriate for that vendor.
 			return new SQLStateConverter(ViolatedConstraintNameExtracter);
+		}
+
+		/// <summary>
+        /// If the dialect supports T-SQL query hints, this method returns the corresponding SQL. 
+        /// </summary>
+        /// <param name="queryString">The input query string to transform</param>
+        /// <param name="hint">The query hint string</param>
+        /// <returns>Modified query string with the given T-SQL query hint.</returns>
+        /// <exception cref="NotSupportedException">
+        /// This exception is thrown if the dialect does state it supports query hints, but the current dialect
+        /// has no implementation for it.
+        /// </exception>
+		public virtual SqlString GetQueryHintString(SqlString queryString, string hint)
+		{
+			throw new NotSupportedException("Dialect does not have support for query hints.");
 		}
 	}
 }

--- a/src/NHibernate/Dialect/MsSql2008Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2008Dialect.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using NHibernate.Dialect.Function;
 using NHibernate.Driver;
+using NHibernate.SqlCommand;
 using NHibernate.SqlTypes;
 using NHibernate.Util;
 using Environment = NHibernate.Cfg.Environment;
@@ -107,5 +109,17 @@ namespace NHibernate.Dialect
 
 		/// <inheritdoc />
 		public override bool SupportsDateTimeScale => !KeepDateTime;
+		
+		/// <inheritdoc />
+		public override bool SupportsQueryHints => true;
+
+		/// <inheritdoc />
+		public override SqlString GetQueryHintString(SqlString queryString, string hint)
+		{
+			if (String.IsNullOrEmpty(hint))
+				return queryString;
+
+			return queryString.Append($" OPTION({hint})");
+		}
 	}
 }

--- a/src/NHibernate/Engine/RowSelection.cs
+++ b/src/NHibernate/Engine/RowSelection.cs
@@ -18,6 +18,7 @@ namespace NHibernate.Engine
 		private int maxRows = NoValue;
 		private int timeout = NoValue;
 		private int fetchSize = NoValue;
+		private string hint = null;
 
 		/// <summary>
 		/// Gets or Sets the Index of the First Row to Select
@@ -61,6 +62,12 @@ namespace NHibernate.Engine
 		public bool DefinesLimits
 		{
 			get { return maxRows != NoValue || firstRow > 0; }
+		}
+
+		public string Hint
+		{
+			get { return hint; }
+			set { hint = value; }
 		}
 	}
 }

--- a/src/NHibernate/IQuery.cs
+++ b/src/NHibernate/IQuery.cs
@@ -647,6 +647,11 @@ namespace NHibernate
 		IQuery SetResultTransformer(IResultTransformer resultTransformer);
 
 		/// <summary>
+		/// Provide a query hint. Needs support of the underlying dialect.
+		/// </summary>
+		IQuery SetHint(string hint);
+
+		/// <summary>
 		/// Get a enumerable that when enumerated will execute
 		/// a batch of queries in a single database roundtrip
 		/// </summary>

--- a/src/NHibernate/Impl/AbstractDetachedQuery.cs
+++ b/src/NHibernate/Impl/AbstractDetachedQuery.cs
@@ -443,7 +443,8 @@ namespace NHibernate.Impl
 				.SetReadOnly(readOnly)
 				.SetTimeout(selection.Timeout)
 				.SetFlushMode(flushMode)
-				.SetFetchSize(selection.FetchSize);
+				.SetFetchSize(selection.FetchSize)
+				.SetHint(selection.Hint);
 			if (!string.IsNullOrEmpty(comment))
 				q.SetComment(comment);
 			if (!string.IsNullOrEmpty(cacheRegion))

--- a/src/NHibernate/Impl/AbstractQueryImpl.cs
+++ b/src/NHibernate/Impl/AbstractQueryImpl.cs
@@ -903,6 +903,12 @@ namespace NHibernate.Impl
 			return this;
 		}
 
+		public IQuery SetHint(string hint)
+		{
+			selection.Hint = hint;
+			return this;
+		}
+
 		public IQuery SetCollectionKey(object collectionKey)
 		{
 			this.collectionKey = collectionKey;

--- a/src/NHibernate/Linq/IQueryableOptions.cs
+++ b/src/NHibernate/Linq/IQueryableOptions.cs
@@ -38,5 +38,12 @@ namespace NHibernate.Linq
 		/// <param name="timeout">The timeout in seconds.</param>
 		/// <returns><see langword="this" /> (for method chaining).</returns>
 		IQueryableOptions SetTimeout(int timeout);
+
+		/// <summary>
+		/// Set a T-SQL Query hint as an Option to the query
+		/// </summary>
+		/// <param name="hint">The t-sql query hint</param>
+		/// <returns><see langword="this" /> (for method chaining).</returns>
+		IQueryableOptions SetHint(string hint);
 	}
 }

--- a/src/NHibernate/Linq/NhQueryableOptions.cs
+++ b/src/NHibernate/Linq/NhQueryableOptions.cs
@@ -15,6 +15,7 @@ namespace NHibernate.Linq
 		protected bool? ReadOnly { get; private set; }
 		protected string Comment { get; private set; }
 		protected FlushMode? FlushMode { get; private set; }
+		protected string Hint { get; private set; }
 
 #pragma warning disable 618
 		/// <inheritdoc />
@@ -28,6 +29,9 @@ namespace NHibernate.Linq
 
 		/// <inheritdoc />
 		IQueryableOptions IQueryableOptions.SetTimeout(int timeout) => SetTimeout(timeout);
+
+		/// <inheritdoc />
+		IQueryableOptions IQueryableOptions.SetHint(string hint) => SetHint(hint);
 #pragma warning restore 618
 
 		/// <summary>
@@ -125,6 +129,20 @@ namespace NHibernate.Linq
 			return this;
 		}
 
+		/// <summary>
+		/// Set a T-SQL query hint which is appended to the query.
+		/// </summary>
+		/// <remarks>
+		/// The underlying dialect needs support for query hints.
+		/// </remarks>
+		/// <param name="hint">The query hint which should be appended to the query.</param>
+		/// <returns><see langword="this"/> (for method chaining).</returns>
+		public NhQueryableOptions SetHint(string hint)
+		{
+			Hint = hint;
+			return this;
+		}
+
 		protected internal NhQueryableOptions Clone()
 		{
 			return new NhQueryableOptions
@@ -135,7 +153,8 @@ namespace NHibernate.Linq
 				Timeout = Timeout,
 				ReadOnly = ReadOnly,
 				Comment = Comment,
-				FlushMode = FlushMode
+				FlushMode = FlushMode,
+				Hint = Hint
 			};
 		}
 
@@ -161,6 +180,9 @@ namespace NHibernate.Linq
 
 			if (FlushMode.HasValue)
 				query.SetFlushMode(FlushMode.Value);
+
+			if (!string.IsNullOrEmpty(Hint))
+				query.SetHint(Hint);
 		}
 	}
 }

--- a/src/NHibernate/Loader/Hql/QueryLoader.cs
+++ b/src/NHibernate/Loader/Hql/QueryLoader.cs
@@ -104,6 +104,14 @@ namespace NHibernate.Loader.Hql
 			return dialect.ApplyLocksToSql(sql, aliasedLockModes, keyColumnNames);
 		}
 
+		protected override SqlString ApplyHint(SqlString sql, string hint, Dialect.Dialect dialect)
+		{
+			if (dialect.SupportsQueryHints)
+				return dialect.GetQueryHintString(sql, hint);
+
+			return base.ApplyHint(sql, hint, dialect);
+		}
+
 		protected override string[] Aliases
 		{
 			get { return _sqlAliases; }
@@ -343,9 +351,9 @@ namespace NHibernate.Loader.Hql
 			Object[] resultRow = GetResultRow(row, rs, session);
 			bool hasTransform = HasSelectNew || resultTransformer != null;
 			return (!hasTransform && resultRow.Length == 1
-				        ? resultRow[0]
-				        : resultRow
-			       );
+						? resultRow[0]
+						: resultRow
+				   );
 		}
 
 		protected override object[] GetResultRow(object[] row, DbDataReader rs, ISessionImplementor session)
@@ -441,7 +449,7 @@ namespace NHibernate.Loader.Hql
 			var rs = GetResultSet(cmd, queryParameters, session, null);
 
 			var resultTransformer = _selectNewTransformer ?? queryParameters.ResultTransformer;
-			IEnumerable result = 
+			IEnumerable result =
 				new EnumerableImpl(rs, cmd, session, queryParameters.IsReadOnly(session), _queryTranslator.ReturnTypes, _queryTranslator.GetColumnNames(), queryParameters.RowSelection, resultTransformer, _queryReturnAliases);
 
 			if (stopWatch != null)

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -228,6 +228,16 @@ namespace NHibernate.Loader
 		}
 
 		/// <summary>
+		/// Append <c> OPTION(...hints...)</c> clause, if necessary. This
+		/// empty superclass implementation merely returns its first
+		/// argument.
+		/// </summary>
+		protected virtual SqlString ApplyHint(SqlString sql, string hints, Dialect.Dialect dialect)
+		{
+			return sql;
+		}
+
+		/// <summary>
 		/// Does this query return objects that might be already cached by 
 		/// the session, whose lock mode may need upgrading.
 		/// </summary>


### PR DESCRIPTION
With this patch a basic support for T-SQL query hints is provided. It is possible to use:

`.WithOptions(u => u.SetHint("RECOMPILE"))`