### PR TITLE
Improve exception for query on delayed id

### DIFF
--- a/src/NHibernate.Test/Async/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
+++ b/src/NHibernate.Test/Async/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
@@ -262,7 +262,7 @@ namespace NHibernate.Test.Generatedkeys.Identity
 						Assert.That(query.ToList, Throws.Nothing);
 						break;
 					case FlushMode.Commit:
-						Assert.That(query.ToList, Throws.Exception.TypeOf(typeof(HibernateException)).And.Not.TypeOf(typeof(GenericADOException)));
+						Assert.That(query.ToList, Throws.Exception.TypeOf(typeof(UnresolvableObjectException)));
 						break;
 				}
 				await (t.CommitAsync());

--- a/src/NHibernate.Test/Async/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
+++ b/src/NHibernate.Test/Async/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
@@ -8,7 +8,9 @@
 //------------------------------------------------------------------------------
 
 
+using System.Linq;
 using NHibernate.Cfg;
+using NHibernate.Exceptions;
 using NUnit.Framework;
 
 namespace NHibernate.Test.Generatedkeys.Identity
@@ -38,6 +40,19 @@ namespace NHibernate.Test.Generatedkeys.Identity
 			configuration.SetProperty(Environment.GenerateStatistics, "true");
 		}
 
+		protected override void OnTearDown()
+		{
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.CreateQuery("delete from MyChild").ExecuteUpdate();
+				s.CreateQuery("delete from MySibling").ExecuteUpdate();
+				s.CreateQuery("delete from System.Object").ExecuteUpdate();
+				t.Commit();
+				s.Close();
+			}
+		}
+
 		[Test]
 		public async Task IdentityColumnGeneratedIdsAsync()
 		{
@@ -49,6 +64,207 @@ namespace NHibernate.Test.Generatedkeys.Identity
 				Assert.IsNotNull(id, "identity column did not force immediate insert");
 				Assert.AreEqual(id, myEntity.Id);
 				await (s.DeleteAsync(myEntity));
+				await (t.CommitAsync());
+				s.Close();
+			}
+		}
+
+		[Test]
+		public async Task PersistOutsideTransactionAsync()
+		{
+			var myEntity1 = new MyEntity("test-save");
+			var myEntity2 = new MyEntity("test-persist");
+			using (var s = OpenSession())
+			{
+				// first test save() which should force an immediate insert...
+				long id = (long) await (s.SaveAsync(myEntity1));
+				Assert.IsNotNull(id, "identity column did not force immediate insert");
+				Assert.AreEqual(id, myEntity1.Id);
+
+				// next test persist() which should cause a delayed insert...
+				long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+				await (s.PersistAsync(myEntity2));
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity2.Id);
+
+				// an explicit flush should cause execution of the delayed insertion
+				await (s.FlushAsync());
+				Assert.AreEqual(
+					initialInsertCount + 1,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				await (s.DeleteAsync(myEntity1));
+				await (s.DeleteAsync(myEntity2));
+				await (t.CommitAsync());
+				s.Close();
+			}
+		}
+
+		[Test]
+		public async Task PersistOutsideTransactionCascadedToNonInverseCollectionAsync()
+		{
+			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity = new MyEntity("test-persist");
+				myEntity.NonInverseChildren.Add(new MyChild("test-child-persist-non-inverse"));
+				await (s.PersistAsync(myEntity));
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity.Id);
+				await (s.FlushAsync());
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				await (s.DeleteAsync("from MyChild"));
+				await (s.DeleteAsync("from MyEntity"));
+				await (t.CommitAsync());
+				s.Close();
+			}
+		}
+
+		[Test]
+		public async Task PersistOutsideTransactionCascadedToInverseCollectionAsync()
+		{
+			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity2 = new MyEntity("test-persist-2");
+				MyChild child = new MyChild("test-child-persist-inverse");
+				myEntity2.InverseChildren.Add(child);
+				child.InverseParent = myEntity2;
+				await (s.PersistAsync(myEntity2));
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity2.Id);
+				await (s.FlushAsync());
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				await (s.DeleteAsync("from MyChild"));
+				await (s.DeleteAsync("from MyEntity"));
+				await (t.CommitAsync());
+				s.Close();
+			}
+		}
+
+		[Test]
+		public async Task PersistOutsideTransactionCascadedToManyToOneAsync()
+		{
+			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity = new MyEntity("test-persist");
+				myEntity.Sibling = new MySibling("test-persist-sibling-out");
+				await (s.PersistAsync(myEntity));
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity.Id);
+				await (s.FlushAsync());
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				await (s.DeleteAsync("from MyEntity"));
+				await (s.DeleteAsync("from MySibling"));
+				await (t.CommitAsync());
+				s.Close();
+			}
+		}
+
+		[Test]
+		public async Task PersistOutsideTransactionCascadedFromManyToOneAsync()
+		{
+			long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+			using (var s = OpenSession())
+			{
+				MyEntity myEntity2 = new MyEntity("test-persist-2");
+				MySibling sibling = new MySibling("test-persist-sibling-in");
+				sibling.Entity = myEntity2;
+				await (s.PersistAsync(sibling));
+				Assert.AreEqual(
+					initialInsertCount,
+					Sfi.Statistics.EntityInsertCount,
+					"persist on identity column not delayed");
+				Assert.AreEqual(0, myEntity2.Id);
+				await (s.FlushAsync());
+				Assert.AreEqual(
+					initialInsertCount + 2,
+					Sfi.Statistics.EntityInsertCount,
+					"delayed persist insert not executed on flush");
+				s.Close();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				await (s.DeleteAsync("from MySibling"));
+				await (s.DeleteAsync("from MyEntity"));
+				await (t.CommitAsync());
+				s.Close();
+			}
+		}
+
+		[Test]
+		public async Task QueryOnPersistedEntityAsync([Values(FlushMode.Auto, FlushMode.Commit)] FlushMode flushMode)
+		{
+			var myEntity = new MyEntity("test-persist");
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				s.FlushMode = flushMode;
+
+				var initialInsertCount = Sfi.Statistics.EntityInsertCount;
+				await (s.PersistAsync(myEntity));
+				Assert.That(Sfi.Statistics.EntityInsertCount, Is.EqualTo(initialInsertCount),
+					"persist on identity column not delayed");
+				Assert.That(myEntity.Id, Is.Zero);
+
+				var query = s.Query<MyChild>().Where(c => c.InverseParent == myEntity);
+				switch (flushMode)
+				{
+					case FlushMode.Auto:
+						Assert.That(query.ToList, Throws.Nothing);
+						break;
+					case FlushMode.Commit:
+						Assert.That(query.ToList, Throws.Exception.TypeOf(typeof(HibernateException)).And.Not.TypeOf(typeof(GenericADOException)));
+						break;
+				}
 				await (t.CommitAsync());
 				s.Close();
 			}

--- a/src/NHibernate.Test/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
+++ b/src/NHibernate.Test/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
@@ -251,7 +251,7 @@ namespace NHibernate.Test.Generatedkeys.Identity
 						Assert.That(query.ToList, Throws.Nothing);
 						break;
 					case FlushMode.Commit:
-						Assert.That(query.ToList, Throws.Exception.TypeOf(typeof(HibernateException)).And.Not.TypeOf(typeof(GenericADOException)));
+						Assert.That(query.ToList, Throws.Exception.TypeOf(typeof(UnresolvableObjectException)));
 						break;
 				}
 				t.Commit();

--- a/src/NHibernate.Test/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
+++ b/src/NHibernate.Test/Generatedkeys/Identity/IdentityGeneratedKeysTest.cs
@@ -48,11 +48,14 @@ namespace NHibernate.Test.Generatedkeys.Identity
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
 			{
-				MyEntity myEntity = new MyEntity("test");
-				long id = (long) s.Save(myEntity);
-				Assert.IsNotNull(id, "identity column did not force immediate insert");
-				Assert.AreEqual(id, myEntity.Id);
-				s.Delete(myEntity);
+				var entity1 = new MyEntity("test");
+				var id1 = (long) s.Save(entity1);
+				var entity2 = new MyEntity("test2");
+				var id2 = (long) s.Save(entity2);
+				// As 0 may be a valid identity value, we check for returned ids being not the same when saving two entities.
+				Assert.That(id1, Is.Not.EqualTo(id2), "identity column did not force immediate insert");
+				Assert.That(id1, Is.EqualTo(entity1.Id));
+				Assert.That(id2, Is.EqualTo(entity2.Id));
 				t.Commit();
 				s.Close();
 			}
@@ -66,12 +69,16 @@ namespace NHibernate.Test.Generatedkeys.Identity
 			using (var s = OpenSession())
 			{
 				// first test save() which should force an immediate insert...
-				long id = (long) s.Save(myEntity1);
-				Assert.IsNotNull(id, "identity column did not force immediate insert");
-				Assert.AreEqual(id, myEntity1.Id);
+				var initialInsertCount = Sfi.Statistics.EntityInsertCount;
+				var id = (long) s.Save(myEntity1);
+				Assert.That(
+					Sfi.Statistics.EntityInsertCount,
+					Is.GreaterThan(initialInsertCount),
+					"identity column did not force immediate insert");
+				Assert.That(id, Is.EqualTo(myEntity1.Id));
 
 				// next test persist() which should cause a delayed insert...
-				long initialInsertCount = Sfi.Statistics.EntityInsertCount;
+				initialInsertCount = Sfi.Statistics.EntityInsertCount;
 				s.Persist(myEntity2);
 				Assert.AreEqual(
 					initialInsertCount,

--- a/src/NHibernate.Test/Generatedkeys/Identity/MyEntity.hbm.xml
+++ b/src/NHibernate.Test/Generatedkeys/Identity/MyEntity.hbm.xml
@@ -1,45 +1,45 @@
 <?xml version="1.0"?>
 <hibernate-mapping xmlns="urn:nhibernate-mapping-2.2"
-				   assembly="NHibernate.Test"
-				   namespace="NHibernate.Test.Generatedkeys.Identity" default-access="field">
-    <class name="MyEntity" table="my_entity">
-    	<id name="id">
-    		<generator class="identity"/>
-    	</id>
-        <property name="name"/>
+    assembly="NHibernate.Test"
+    namespace="NHibernate.Test.Generatedkeys.Identity">
+  <class name="MyEntity" table="my_entity">
+    <id name="Id">
+      <generator class="identity"/>
+    </id>
+    <property name="Name"/>
 
-        <!-- used to test cascades "out" to a many-to-one association -->
-        <many-to-one name="sibling" class="MySibling" cascade="persist, merge"/>
+    <!-- used to test cascades "out" to a many-to-one association -->
+    <many-to-one name="Sibling" class="MySibling" cascade="persist, merge"/>
 
-        <!-- used to test cascades "out" to non-inverse collections -->
-        <set name="nonInverseChildren" inverse="false" cascade="persist, merge">
-            <key column="non_inv_parent_id"/>
-            <one-to-many class="MyChild"/>
-        </set>
+    <!-- used to test cascades "out" to non-inverse collections -->
+    <set name="NonInverseChildren" inverse="false" cascade="persist, merge">
+      <key column="non_inv_parent_id"/>
+      <one-to-many class="MyChild"/>
+    </set>
 
-        <!-- used to test cascades "out" to inverse collections -->
-        <set name="inverseChildren" inverse="true" cascade="persist, merge">
-            <key column="inv_parent_id"/>
-            <one-to-many class="MyChild"/>
-        </set>
-    </class>
-
-
-    <class name="MySibling" table="my_sibling">
-        <id name="id">
-            <generator class="increment"/>
-        </id>
-        <property name="name"/>
-        <many-to-one name="entity" class="MyEntity" cascade="persist, merge"/>
-    </class>
+    <!-- used to test cascades "out" to inverse collections -->
+    <set name="InverseChildren" inverse="true" cascade="persist, merge">
+      <key column="inv_parent_id"/>
+      <one-to-many class="MyChild"/>
+    </set>
+  </class>
 
 
-    <class name="MyChild" table="my_child">
-        <id name="id">
-            <generator class="increment"/>
-        </id>
-        <property name="name"/>
-        <many-to-one name="inverseParent" column="inv_parent_id" class="MyEntity"/>
-    </class>
+  <class name="MySibling" table="my_sibling">
+    <id name="Id">
+      <generator class="increment"/>
+    </id>
+    <property name="Name"/>
+    <many-to-one name="Entity" class="MyEntity" cascade="persist, merge"/>
+  </class>
+
+
+  <class name="MyChild" table="my_child">
+    <id name="Id">
+      <generator class="increment"/>
+    </id>
+    <property name="Name"/>
+    <many-to-one name="InverseParent" column="inv_parent_id" class="MyEntity"/>
+  </class>
 
 </hibernate-mapping>

--- a/src/NHibernate/Async/Type/EntityType.cs
+++ b/src/NHibernate/Async/Type/EntityType.cs
@@ -86,9 +86,11 @@ namespace NHibernate.Type
 			cancellationToken.ThrowIfCancellationRequested();
 			var referenceValue = await (GetReferenceValueAsync(value, session, cancellationToken)).ConfigureAwait(false);
 			if (forbidDelayed && referenceValue is DelayedPostInsertIdentifier)
+			{
 				throw new UnresolvableObjectException(
 					$"Cannot resolve the identifier from a {nameof(DelayedPostInsertIdentifier)}. Consider flushing the session first.",
 					referenceValue, returnedClass);
+			}
 
 			return referenceValue;
 		}

--- a/src/NHibernate/Async/Type/EntityType.cs
+++ b/src/NHibernate/Async/Type/EntityType.cs
@@ -18,6 +18,7 @@ using NHibernate.Persister.Entity;
 using NHibernate.Proxy;
 using NHibernate.Util;
 using System.Collections.Generic;
+using NHibernate.Action;
 
 namespace NHibernate.Type
 {
@@ -78,6 +79,18 @@ namespace NHibernate.Type
 
 				return propertyValue;
 			}
+		}
+
+		protected internal async Task<object> GetReferenceValueAsync(object value, ISessionImplementor session, bool forbidDelayed, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var referenceValue = await (GetReferenceValueAsync(value, session, cancellationToken)).ConfigureAwait(false);
+			if (forbidDelayed && referenceValue is DelayedPostInsertIdentifier)
+				throw new UnresolvableObjectException(
+					$"Cannot resolve the identifier from a {nameof(DelayedPostInsertIdentifier)}. Consider flushing the session first.",
+					referenceValue, returnedClass);
+
+			return referenceValue;
 		}
 
 		public override async Task<object> ReplaceAsync(object original, object target, ISessionImplementor session, object owner, IDictionary copyCache, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Type/ManyToOneType.cs
+++ b/src/NHibernate/Async/Type/ManyToOneType.cs
@@ -26,14 +26,14 @@ namespace NHibernate.Type
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			await (GetIdentifierOrUniqueKeyType(session.Factory)
-				.NullSafeSetAsync(st, await (GetReferenceValueAsync(value, session, cancellationToken)).ConfigureAwait(false), index, settable, session, cancellationToken)).ConfigureAwait(false);
+				.NullSafeSetAsync(st, await (GetReferenceValueAsync(value, session, true, cancellationToken)).ConfigureAwait(false), index, settable, session, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task NullSafeSetAsync(DbCommand cmd, object value, int index, ISessionImplementor session, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			await (GetIdentifierOrUniqueKeyType(session.Factory)
-				.NullSafeSetAsync(cmd, await (GetReferenceValueAsync(value, session, cancellationToken)).ConfigureAwait(false), index, session, cancellationToken)).ConfigureAwait(false);
+				.NullSafeSetAsync(cmd, await (GetReferenceValueAsync(value, session, true, cancellationToken)).ConfigureAwait(false), index, session, cancellationToken)).ConfigureAwait(false);
 		}
 
 		/// <summary>

--- a/src/NHibernate/Async/Type/OneToOneType.cs
+++ b/src/NHibernate/Async/Type/OneToOneType.cs
@@ -43,7 +43,7 @@ namespace NHibernate.Type
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			await (GetIdentifierOrUniqueKeyType(session.Factory)
-				.NullSafeSetAsync(cmd, await (GetReferenceValueAsync(value, session, cancellationToken)).ConfigureAwait(false), index, session, cancellationToken)).ConfigureAwait(false);
+				.NullSafeSetAsync(cmd, await (GetReferenceValueAsync(value, session, true, cancellationToken)).ConfigureAwait(false), index, session, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override Task<bool> IsDirtyAsync(object old, object current, ISessionImplementor session, CancellationToken cancellationToken)

--- a/src/NHibernate/Type/EntityType.cs
+++ b/src/NHibernate/Type/EntityType.cs
@@ -8,6 +8,7 @@ using NHibernate.Persister.Entity;
 using NHibernate.Proxy;
 using NHibernate.Util;
 using System.Collections.Generic;
+using NHibernate.Action;
 
 namespace NHibernate.Type
 {
@@ -183,6 +184,17 @@ namespace NHibernate.Type
 
 				return propertyValue;
 			}
+		}
+
+		protected internal object GetReferenceValue(object value, ISessionImplementor session, bool forbidDelayed)
+		{
+			var referenceValue = GetReferenceValue(value, session);
+			if (forbidDelayed && referenceValue is DelayedPostInsertIdentifier)
+				throw new UnresolvableObjectException(
+					$"Cannot resolve the identifier from a {nameof(DelayedPostInsertIdentifier)}. Consider flushing the session first.",
+					referenceValue, returnedClass);
+
+			return referenceValue;
 		}
 
 		public override string ToLoggableString(object value, ISessionFactoryImplementor factory)

--- a/src/NHibernate/Type/EntityType.cs
+++ b/src/NHibernate/Type/EntityType.cs
@@ -190,9 +190,11 @@ namespace NHibernate.Type
 		{
 			var referenceValue = GetReferenceValue(value, session);
 			if (forbidDelayed && referenceValue is DelayedPostInsertIdentifier)
+			{
 				throw new UnresolvableObjectException(
 					$"Cannot resolve the identifier from a {nameof(DelayedPostInsertIdentifier)}. Consider flushing the session first.",
 					referenceValue, returnedClass);
+			}
 
 			return referenceValue;
 		}

--- a/src/NHibernate/Type/ManyToOneType.cs
+++ b/src/NHibernate/Type/ManyToOneType.cs
@@ -58,13 +58,13 @@ namespace NHibernate.Type
 		public override void NullSafeSet(DbCommand st, object value, int index, bool[] settable, ISessionImplementor session)
 		{
 			GetIdentifierOrUniqueKeyType(session.Factory)
-				.NullSafeSet(st, GetReferenceValue(value, session), index, settable, session);
+				.NullSafeSet(st, GetReferenceValue(value, session, true), index, settable, session);
 		}
 
 		public override void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
 		{
 			GetIdentifierOrUniqueKeyType(session.Factory)
-				.NullSafeSet(cmd, GetReferenceValue(value, session), index, session);
+				.NullSafeSet(cmd, GetReferenceValue(value, session, true), index, session);
 		}
 
 		public override bool IsOneToOne

--- a/src/NHibernate/Type/OneToOneType.cs
+++ b/src/NHibernate/Type/OneToOneType.cs
@@ -49,7 +49,7 @@ namespace NHibernate.Type
 		public override void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
 		{
 			GetIdentifierOrUniqueKeyType(session.Factory)
-				.NullSafeSet(cmd, GetReferenceValue(value, session), index, session);
+				.NullSafeSet(cmd, GetReferenceValue(value, session, true), index, session);
 		}
 
 		public override bool IsOneToOne


### PR DESCRIPTION
Test #3041

The question is, should we improve the exception, offer an option to still flush the entity in such case, do something else, or nothing?

Full exception of the failing case:
```
NHibernate.Exceptions.GenericADOException: could not execute query
[ select mychild0_.Id as id1_2_, mychild0_.Name as name2_2_, mychild0_.inv_parent_id as inv3_2_ from my_child mychild0_ where mychild0_.inv_parent_id=? ]
  Name:p1 - Value:NHibernate.Test.Generatedkeys.Identity.MyEntity
[SQL: select mychild0_.Id as id1_2_, mychild0_.Name as name2_2_, mychild0_.inv_parent_id as inv3_2_ from my_child mychild0_ where mychild0_.inv_parent_id=?] ---> System.InvalidCastException: Impossible d'effectuer un cast d'un objet de type 'NHibernate.Action.DelayedPostInsertIdentifier' en type 'System.IConvertible'.
   à System.Convert.ToInt64(Object value)
   à NHibernate.Type.Int64Type.Set(DbCommand rs, Object value, Int32 index, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Type\Int64Type.cs:ligne 61
   à NHibernate.Type.NullableType.NullSafeSet(DbCommand st, Object value, Int32 index, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Type\NullableType.cs:ligne 162
   à NHibernate.Type.ManyToOneType.NullSafeSet(DbCommand cmd, Object value, Int32 index, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Type\ManyToOneType.cs:ligne 66
   à NHibernate.Param.NamedParameterSpecification.Bind(DbCommand command, IList`1 multiSqlQueryParametersList, Int32 singleSqlParametersOffset, IList`1 sqlQueryParametersList, QueryParameters queryParameters, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Param\NamedParameterSpecification.cs:ligne 64
   à NHibernate.Param.NamedParameterSpecification.Bind(DbCommand command, IList`1 sqlQueryParametersList, QueryParameters queryParameters, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Param\NamedParameterSpecification.cs:ligne 55
   à NHibernate.SqlCommand.SqlCommandImpl.Bind(DbCommand command, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\SqlCommand\SqlCommandImpl.cs:ligne 156
   à NHibernate.Loader.Loader.PrepareQueryCommand(QueryParameters queryParameters, Boolean scroll, ISessionImplementor session) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 1466
   à NHibernate.Loader.Loader.DoQuery(ISessionImplementor session, QueryParameters queryParameters, Boolean returnProxies, IResultTransformer forcedResultTransformer, QueryCacheResultBuilder queryCacheResultBuilder) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 503
   à NHibernate.Loader.Loader.DoQueryAndInitializeNonLazyCollections(ISessionImplementor session, QueryParameters queryParameters, Boolean returnProxies, IResultTransformer forcedResultTransformer, QueryCacheResultBuilder queryCacheResultBuilder) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 303
   à NHibernate.Loader.Loader.DoList(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer, QueryCacheResultBuilder queryCacheResultBuilder) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 1972
   --- Fin de la trace de la pile d'exception interne ---
   à NHibernate.Loader.Loader.DoList(ISessionImplementor session, QueryParameters queryParameters, IResultTransformer forcedResultTransformer, QueryCacheResultBuilder queryCacheResultBuilder) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 1981
   à NHibernate.Loader.Loader.DoList(ISessionImplementor session, QueryParameters queryParameters) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 1950
   à NHibernate.Loader.Loader.ListIgnoreQueryCache(ISessionImplementor session, QueryParameters queryParameters) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 1837
   à NHibernate.Loader.Loader.List(ISessionImplementor session, QueryParameters queryParameters, ISet`1 querySpaces) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Loader.cs:ligne 1827
   à NHibernate.Loader.Hql.QueryLoader.List(ISessionImplementor session, QueryParameters queryParameters) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Loader\Hql\QueryLoader.cs:ligne 325
   à NHibernate.Hql.Ast.ANTLR.QueryTranslatorImpl.List(ISessionImplementor session, QueryParameters queryParameters) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Hql\Ast\ANTLR\QueryTranslatorImpl.cs:ligne 131
   à NHibernate.Engine.Query.HQLQueryPlan.PerformList(QueryParameters queryParameters, ISessionImplementor session, IList results) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Engine\Query\HQLQueryPlan.cs:ligne 115
   à NHibernate.Impl.SessionImpl.List(IQueryExpression queryExpression, QueryParameters queryParameters, IList results, Object filterConnection) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Impl\SessionImpl.cs:ligne 559
   à NHibernate.Impl.SessionImpl.List(IQueryExpression queryExpression, QueryParameters queryParameters, IList results) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Impl\SessionImpl.cs:ligne 523
   à NHibernate.Impl.AbstractSessionImpl.List[T](IQueryExpression query, QueryParameters parameters) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Impl\AbstractSessionImpl.cs:ligne 182
   à NHibernate.Impl.AbstractQueryImpl2.List[T]() dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Impl\AbstractQueryImpl2.cs:ligne 111
   à NHibernate.Linq.DefaultQueryProvider.ExecuteList[TResult](Expression expression) dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Linq\DefaultQueryProvider.cs:ligne 111
   à NHibernate.Linq.NhQueryable`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator() dans E:\Projets\nhibernate\nhibernate-core\src\NHibernate\Linq\NhQueryable.cs:ligne 65
   à System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   à System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
--- Fin de la trace de la pile à partir de l'emplacement précédent au niveau duquel l'exception a été levée ---
   à System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   à NUnit.Framework.Internal.ExceptionHelper.Rethrow(Exception exception)
   à NUnit.Framework.Internal.Reflect.DynamicInvokeWithTransparentExceptions(Delegate delegate)
   à NUnit.Framework.Internal.ExceptionHelper.RecordException(Delegate parameterlessDelegate, String parameterName)
```