### PR TITLE
SqlStringHelper.RemoveAsAliasesFromSql remove *all* aliases

### DIFF
--- a/src/NHibernate/Criterion/GroupedProjection.cs
+++ b/src/NHibernate/Criterion/GroupedProjection.cs
@@ -25,6 +25,9 @@ namespace NHibernate.Criterion
 		{
 			if (projection is IPropertyProjection propertyProjection)
 				return new SqlString(string.Join(", ", criteriaQuery.GetColumns(criteria, propertyProjection.PropertyName)));
+			// This is because if grouped by an entity, multiple columns are in an projection which all have as aliases, which are not allowed.
+			if (projection is EntityProjection)
+				return SqlStringHelper.RemoveAllAsAliasesFromSql(renderedProjection);
 
 			//This is kind of a hack. The hack is based on the fact that ToGroupSqlString always called after ToSqlString.
 			return SqlStringHelper.RemoveAsAliasesFromSql(renderedProjection);

--- a/src/NHibernate/SqlCommand/SqlString.cs
+++ b/src/NHibernate/SqlCommand/SqlString.cs
@@ -408,6 +408,7 @@ namespace NHibernate.SqlCommand
 		/// </summary>
 		/// <param name="text">Text to look for in the <see cref="SqlString" />. Must be in lower
 		/// case.</param>
+		/// <param name="startIndex">The zero-based index of the search starting position.</param>
 		/// <remarks>
 		/// The text must be located entirely in a string part of the <see cref="SqlString" />.
 		/// Searching for <c>"a ? b"</c> in an <see cref="SqlString" /> consisting of
@@ -415,9 +416,9 @@ namespace NHibernate.SqlCommand
 		/// </remarks>
 		/// <returns>The index of the first occurrence of <paramref name="text" />, or -1
 		/// if not found.</returns>
-		public int IndexOfCaseInsensitive(string text)
+		public int IndexOfCaseInsensitive(string text, int startIndex = 0)
 		{
-			return IndexOf(text, 0, _length, StringComparison.InvariantCultureIgnoreCase);
+			return IndexOf(text, startIndex, _length, StringComparison.InvariantCultureIgnoreCase);
 		}
 
 		internal int IndexOfOrdinal(string text)

--- a/src/NHibernate/SqlCommand/SqlStringHelper.cs
+++ b/src/NHibernate/SqlCommand/SqlStringHelper.cs
@@ -88,9 +88,17 @@ namespace NHibernate.SqlCommand
 		/// <returns><paramref name="sql" /> if it was not aliased, otherwise an un-aliased <c>SqlString</c> representing the column.</returns>
 		public static SqlString RemoveAsAliasesFromSql(SqlString sql)
 		{
-			int index = sql.LastIndexOfCaseInsensitive(" as ");
+			int index = sql.IndexOfCaseInsensitive(" as ");
 			if (index < 0) return sql;
-			return sql.Substring(0, index);
+			var sb = new SqlStringBuilder();
+			int start = 0;
+			while (index > 0)
+			{
+				sb.Add(sql.Substring(start, index-start));
+				start = sql.IndexOfCaseInsensitive(",", index);
+				index = start < 0 ? start : sql.IndexOfCaseInsensitive(" as ", start);
+			}
+			return sb.ToSqlString();
 		}
 
 		public static bool IsNotEmpty(SqlString str)

--- a/src/NHibernate/SqlCommand/SqlStringHelper.cs
+++ b/src/NHibernate/SqlCommand/SqlStringHelper.cs
@@ -77,16 +77,30 @@ namespace NHibernate.SqlCommand
 			{
 				result[i] = new SqlString(x[i], sep, y[i]);
 			}
+
 			return result;
 		}
 
 		/// <summary>
-		/// Removes the <c>as someColumnAlias</c> clause from a <c>SqlString</c> representing a column expression.
+		/// Removes the last <c>as someColumnAlias</c> clause from a <c>SqlString</c> representing a column expression.
 		/// Consider using <c>CriterionUtil.GetColumn...</c> methods instead.
 		/// </summary>
 		/// <param name="sql">The <c>SqlString</c> representing a column expression which might be aliased.</param>
 		/// <returns><paramref name="sql" /> if it was not aliased, otherwise an un-aliased <c>SqlString</c> representing the column.</returns>
 		public static SqlString RemoveAsAliasesFromSql(SqlString sql)
+		{
+			int index = sql.LastIndexOfCaseInsensitive(" as ");
+			if (index < 0) return sql;
+			return sql.Substring(0, index);
+		}
+
+		/// <summary>
+		/// Removes all the <c>as someColumnAlias</c> clause from a <c>SqlString</c> representing a column expression.
+		/// Consider using <c>CriterionUtil.GetColumn...</c> methods instead.
+		/// </summary>
+		/// <param name="sql">The <c>SqlString</c> representing a column expression which might be aliased.</param>
+		/// <returns><paramref name="sql" /> if it was not aliased, otherwise an un-aliased <c>SqlString</c> representing the column.</returns>
+		public static SqlString RemoveAllAsAliasesFromSql(SqlString sql)
 		{
 			int index = sql.IndexOfCaseInsensitive(" as ");
 			if (index < 0) return sql;
@@ -94,10 +108,11 @@ namespace NHibernate.SqlCommand
 			int start = 0;
 			while (index > 0)
 			{
-				sb.Add(sql.Substring(start, index-start));
+				sb.Add(sql.Substring(start, index - start));
 				start = sql.IndexOfCaseInsensitive(",", index);
 				index = start < 0 ? start : sql.IndexOfCaseInsensitive(" as ", start);
 			}
+
 			return sb.ToSqlString();
 		}
 


### PR DESCRIPTION
This removes multiple occurrences of aliases from the sql string not just the last one.

I had the problem while using the following projection, which results in invalid sql (sqlserver)
```csharp
Projections.Distinct(Projections.ProjectionList()
.Add(Projections.Max(() => ability.Role))
.Add(Projections.GroupProperty(Projections.RootEntity())))
```