### PR TITLE
Disable auto rebasing for renovate bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   "pruneStaleBranches": false,
   "automerge": true,
   "platformAutomerge": true,
+  "rebaseWhen": "never",
   "labels": [
     "dependencies",
     "p: Lowest",


### PR DESCRIPTION
To avoid long builds queue on TC. I hope it will work properly with renovate..

https://docs.renovatebot.com/configuration-options/#rebasewhen
`never: Renovate will never rebase the branch or update it unless manually requested`
