### PR TITLE
Fix table group join issue with subclasses

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/JoinTests.cs
@@ -299,6 +299,19 @@ namespace NHibernate.Test.Linq.ByMethod
 						select new {o, o2}).Take(1).ToListAsync());
 		}
 
+		[Test]
+		public async Task CanInnerJoinOnEntityWithSubclassesAsync()
+		{
+			//inner joined animal is not used in output (no need to join subclasses)
+			var resultsFromOuter1 = await (db.Animals.Join(db.Animals, o => o.Id, i => i.Id, (o, i) => o).Take(1).ToListAsync());
+
+			//inner joined mammal is not used in output (but subclass join is needed for mammal)
+			var resultsFromOuter2 = await (db.Animals.Join(db.Mammals, o => o.Id, i => i.Id, (o, i) => o).Take(1).ToListAsync());
+
+			//inner joined animal is used in output (all subclass joins are required)
+			var resultsFromInner1 = await (db.Animals.Join(db.Animals, o => o.Id, i => i.Id, (o, i) => i).Take(1).ToListAsync());
+		}
+
 		[Test(Description = "GH-2580")]
 		public async Task CanInnerJoinOnSubclassWithBaseTableReferenceInOnClauseAsync()
 		{

--- a/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/JoinTests.cs
@@ -287,6 +287,19 @@ namespace NHibernate.Test.Linq.ByMethod
 						select new {o, o2}).Take(1).ToList();
 		}
 
+		[Test]
+		public void CanInnerJoinOnEntityWithSubclasses()
+		{
+			//inner joined animal is not used in output (no need to join subclasses)
+			var resultsFromOuter1 = db.Animals.Join(db.Animals, o => o.Id, i => i.Id, (o, i) => o).Take(1).ToList();
+
+			//inner joined mammal is not used in output (but subclass join is needed for mammal)
+			var resultsFromOuter2 = db.Animals.Join(db.Mammals, o => o.Id, i => i.Id, (o, i) => o).Take(1).ToList();
+
+			//inner joined animal is used in output (all subclass joins are required)
+			var resultsFromInner1 = db.Animals.Join(db.Animals, o => o.Id, i => i.Id, (o, i) => i).Take(1).ToList();
+		}
+
 		[Test(Description = "GH-2580")]
 		public void CanInnerJoinOnSubclassWithBaseTableReferenceInOnClause()
 		{

--- a/src/NHibernate/Engine/TableGroupJoinHelper.cs
+++ b/src/NHibernate/Engine/TableGroupJoinHelper.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Engine
 	{
 		internal static bool ProcessAsTableGroupJoin(IReadOnlyList<IJoin> tableGroupJoinables, SqlString[] withClauseFragments, bool includeAllSubclassJoins, JoinFragment joinFragment, Func<string, bool> isSubclassIncluded, ISessionFactoryImplementor sessionFactoryImplementor)
 		{
-			if (!NeedsTableGroupJoin(tableGroupJoinables, withClauseFragments, includeAllSubclassJoins))
+			if (!NeedsTableGroupJoin(tableGroupJoinables, withClauseFragments, includeAllSubclassJoins, isSubclassIncluded))
 				return false;
 
 			var first = tableGroupJoinables[0];
@@ -58,7 +58,7 @@ namespace NHibernate.Engine
 		}
 
 		// detect cases when withClause is used on multiple tables or when join keys depend on subclass columns
-		private static bool NeedsTableGroupJoin(IReadOnlyList<IJoin> joins, SqlString[] withClauseFragments, bool includeSubclasses)
+		private static bool NeedsTableGroupJoin(IReadOnlyList<IJoin> joins, SqlString[] withClauseFragments, bool includeSubclasses, Func<string, bool> isSubclassIncluded)
 		{
 			bool hasWithClause = withClauseFragments.Any(x => SqlStringHelper.IsNotEmpty(x));
 
@@ -69,7 +69,7 @@ namespace NHibernate.Engine
 			foreach (var join in joins)
 			{
 				var entityPersister = GetEntityPersister(join.Joinable);
-				if (entityPersister?.HasSubclassJoins(includeSubclasses) != true)
+				if (entityPersister?.HasSubclassJoins(includeSubclasses && isSubclassIncluded(join.Alias)) != true)
 					continue;
 
 				if (hasWithClause)


### PR DESCRIPTION
Problematic scenario: invalid SQL is generated when joined entity with subclasses doesn't need subclass joins 
```C#
//inner joined animal is not used in output (no need to join subclasses)
var resultsFromOuter1 = db.Animals.Join(db.Animals, o => o.Id, i => i.Id, (o, i) => o).Take(1).ToList();
```