### PR TITLE
Guards against use of a disposed session factory

### DIFF
--- a/src/NHibernate.Test/Async/SessionBuilder/Fixture.cs
+++ b/src/NHibernate.Test/Async/SessionBuilder/Fixture.cs
@@ -227,5 +227,22 @@ namespace NHibernate.Test.SessionBuilder
 				Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with {value}");
 			}
 		}
+
+		[Test]
+		public void ThrowWhenUsingSessionFromDisposedFactoryAsync()
+		{
+			using (var session = Sfi.OpenSession())
+			{
+				try
+				{
+					Sfi.Dispose();
+					Assert.That(() => session.GetAsync<Entity>(Guid.Empty), Throws.InstanceOf(typeof(ObjectDisposedException)));
+				}
+				finally
+				{
+					RebuildSessionFactory();
+				}
+			}
+		}
 	}
 }

--- a/src/NHibernate.Test/SessionBuilder/Fixture.cs
+++ b/src/NHibernate.Test/SessionBuilder/Fixture.cs
@@ -298,5 +298,36 @@ namespace NHibernate.Test.SessionBuilder
 				Assert.AreEqual(sb, fsb, $"{sbType}: Unexpected fluent return after call with {value}");
 			}
 		}
+
+		[Test]
+		public void ThrowWhenOpeningFromDisposedFactory()
+		{
+			try
+			{
+				Sfi.Dispose();
+				Assert.That(Sfi.OpenSession, Throws.InstanceOf(typeof(ObjectDisposedException)));
+			}
+			finally
+			{
+				RebuildSessionFactory();
+			}
+		}
+
+		[Test]
+		public void ThrowWhenUsingSessionFromDisposedFactory()
+		{
+			using (var session = Sfi.OpenSession())
+			{
+				try
+				{
+					Sfi.Dispose();
+					Assert.That(() => session.Get<Entity>(Guid.Empty), Throws.InstanceOf(typeof(ObjectDisposedException)));
+				}
+				finally
+				{
+					RebuildSessionFactory();
+				}
+			}
+		}
 	}
 }

--- a/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
@@ -353,6 +353,7 @@ namespace NHibernate.Impl
 			// NH Different implementation
 			if (queryCache != null)
 			{
+				CheckNotClosed();
 				await (queryCache.ClearAsync(cancellationToken)).ConfigureAwait(false);
 				if (queryCaches.Count == 0)
 				{
@@ -377,6 +378,7 @@ namespace NHibernate.Impl
 				{
 					if (settings.IsQueryCacheEnabled)
 					{
+						CheckNotClosed();
 						if (queryCaches.TryGetValue(cacheRegion, out var currentQueryCache))
 						{
 							return currentQueryCache.Value.ClearAsync(cancellationToken);


### PR DESCRIPTION
Help diagnose #3026 reports.

I suspect those reports are due to user code errors, using a disposed session factory. It appears a disposed session factory does not throw when used. It lets things fail quite later with harder to understand exceptions. This leads to bug reports for what is likely user bugs.

This PR currently targets 5.3.x. But this may be considered as too much of a possible breaking change for this branch, even if using a disposed session factory is a bug on user side.
In my opinion it is ok to have it in 5.3.x.