### PR TITLE
Add `datetimex` keyword to SapSQLAnywhere17Dialect

### DIFF
--- a/src/NHibernate/Dialect/SapSQLAnywhere17Dialect.cs
+++ b/src/NHibernate/Dialect/SapSQLAnywhere17Dialect.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Dialect
 
 		private static readonly string[] DialectKeywords =
 		{
-			"datetimex"
+			"datetimex",
 			"executing",
 			"executing_user",
 			"extract",

--- a/src/NHibernate/Dialect/SapSQLAnywhere17Dialect.cs
+++ b/src/NHibernate/Dialect/SapSQLAnywhere17Dialect.cs
@@ -39,6 +39,7 @@ namespace NHibernate.Dialect
 
 		private static readonly string[] DialectKeywords =
 		{
+			"datetimex"
 			"executing",
 			"executing_user",
 			"extract",


### PR DESCRIPTION
After upgrade to SQL Anywhere to 17.0.**11** the test started failing.