### PR TITLE
No way of detecting if AutoFlush performed in added AutoFlushEventListener

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/NH3583/AutoFlushFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3583/AutoFlushFixture.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Transactions;
 using NHibernate.Cfg.MappingSchema;
-using NHibernate.Linq;
+using NHibernate.Impl;
 using NHibernate.Mapping.ByCode;
 using NUnit.Framework;
 
@@ -50,6 +52,24 @@ namespace NHibernate.Test.NHSpecificTest.NH3583
 				Assert.That(result.Count, Is.EqualTo(1));
 			}
 		}
+		
+		[Test]
+		public void AutoFlushIfRequiredShouldReturnTrue()
+		{
+			using (var session = OpenSession())
+			using (session.BeginTransaction())
+			{
+				var e1 = new Entity { Name = "Bob" };
+				session.Save(e1);
+
+				var implementor = session as AbstractSessionImpl;
+				var spaces = new HashSet<string> { "Entity" };
+				Debug.Assert(implementor != null, nameof(implementor) + " != null");
+				Assert.That(session.FlushMode, Is.EqualTo(FlushMode.Auto), "Issue is only presented in FlushMode.Auto");
+				Assert.That(implementor.AutoFlushIfRequired(spaces), Is.True, "AutoFlushIfRequired should have reported, that the flush has been done.");
+			}
+		}
+		
 
 		[Test]
 		public void ShouldAutoFlushWhenInDistributedTransaction()

--- a/src/NHibernate/Async/Event/Default/DefaultAutoFlushEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/DefaultAutoFlushEventListener.cs
@@ -39,7 +39,8 @@ namespace NHibernate.Event.Default
 
 					await (FlushEverythingToExecutionsAsync(@event, cancellationToken)).ConfigureAwait(false);
 
-					if (FlushIsReallyNeeded(@event, source))
+					var flushIsReallyNeeded = FlushIsReallyNeeded(@event, source);
+					if (flushIsReallyNeeded)
 					{
 						if (log.IsDebugEnabled())
 							log.Debug("Need to execute flush");
@@ -61,7 +62,7 @@ namespace NHibernate.Event.Default
 						source.ActionQueue.ClearFromFlushNeededCheck(oldSize);
 					}
 
-					@event.FlushRequired = FlushIsReallyNeeded(@event, source);
+					@event.FlushRequired = flushIsReallyNeeded;
 				}
 			}
 		}

--- a/src/NHibernate/Event/Default/DefaultAutoFlushEventListener.cs
+++ b/src/NHibernate/Event/Default/DefaultAutoFlushEventListener.cs
@@ -31,7 +31,8 @@ namespace NHibernate.Event.Default
 
 					FlushEverythingToExecutions(@event);
 
-					if (FlushIsReallyNeeded(@event, source))
+					var flushIsReallyNeeded = FlushIsReallyNeeded(@event, source);
+					if (flushIsReallyNeeded)
 					{
 						if (log.IsDebugEnabled())
 							log.Debug("Need to execute flush");
@@ -53,7 +54,7 @@ namespace NHibernate.Event.Default
 						source.ActionQueue.ClearFromFlushNeededCheck(oldSize);
 					}
 
-					@event.FlushRequired = FlushIsReallyNeeded(@event, source);
+					@event.FlushRequired = flushIsReallyNeeded;
 				}
 			}
 		}


### PR DESCRIPTION
No way of detecting if AutoFlush performed when extending DefaultAutoFlushEventListener

Result of AutoFlushIfRequired is always false for FlushMode.Auto. This is caused by repeated call of FlushIsReallyNeeded(). But if the Flush is needed in Auto-Mode, then it is done and successive call of FlushIsReallyNeeded() returns false.