### PR TITLE
Do not throw for unknown type in hql case node

### DIFF
--- a/src/NHibernate.Test/Async/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/HqlFixture.cs
@@ -142,6 +142,17 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
+		public async Task ParametersInCaseThenClauseAsync()
+		{
+			using ISession s = OpenSession();
+			var result = await (s.CreateQuery("select a from Animal a where (case when 2=2 then ? else ? end) = 1")
+			              .SetParameter(0, 1)
+			              .SetParameter(1, 0)
+			              .UniqueResultAsync());
+			Assert.AreEqual(null, result);
+		}
+
+		[Test]
 		public async Task ParameterInCaseThenClauseAsync()
 		{
 			using (ISession s = OpenSession())

--- a/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/HqlFixture.cs
@@ -148,6 +148,17 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
+		public void ParametersInCaseThenClause()
+		{
+			using ISession s = OpenSession();
+			var result = s.CreateQuery("select a from Animal a where (case when 2=2 then ? else ? end) = 1")
+			              .SetParameter(0, 1)
+			              .SetParameter(1, 0)
+			              .UniqueResult();
+			Assert.AreEqual(null, result);
+		}
+
+		[Test]
 		public void ParameterInCaseThenClause()
 		{
 			using (ISession s = OpenSession())

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/CaseNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/CaseNode.cs
@@ -35,7 +35,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 						return select.DataType;
 				}
 
-				throw new HibernateException("Unable to determine data type of CASE statement.");
+				return base.DataType;
 			}
 			set { base.DataType = value; }
 		}


### PR DESCRIPTION
Type can be obtained later from usage context or simply be not important