### PR TITLE
MappingByCode: Support backfield property access

### DIFF
--- a/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/AllPropertiesRegistrationTests.cs
+++ b/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/AllPropertiesRegistrationTests.cs
@@ -189,6 +189,20 @@ namespace NHibernate.Test.MappingByCode.ExpliticMappingTests
 		}
 
 		[Test]
+		public void BackfieldAccessPropertyMapping()
+		{
+			var mapper = new ModelMapper();
+			mapper.Class<MyClass>(mc =>
+								  {
+									mc.Id(x => x.Id, m => m.Access(Accessor.Backfield));
+								  });
+
+			HbmMapping mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
+			HbmClass hbmClass = mappings.RootClasses[0];
+			Assert.That(hbmClass.Id.access, Is.EqualTo("backfield"));
+		}
+
+		[Test]
 		public void WhenMapBagWithWrongElementTypeThenThrows()
 		{
 			var mapper = new ModelMapper();

--- a/src/NHibernate/Mapping/ByCode/IAccessorPropertyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IAccessorPropertyMapper.cs
@@ -6,7 +6,8 @@ namespace NHibernate.Mapping.ByCode
 		Field,
 		NoSetter,
 		ReadOnly,
-		None
+		None,
+		Backfield,
 	}
 
 	public interface IAccessorPropertyMapper

--- a/src/NHibernate/Mapping/ByCode/Impl/AccessorPropertyMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/Impl/AccessorPropertyMapper.cs
@@ -92,6 +92,9 @@ namespace NHibernate.Mapping.ByCode.Impl
 				case Accessor.None:
 					setAccessor("none");
 					break;
+				case Accessor.Backfield:
+					setAccessor("backfield");
+					break;
 				default:
 					throw new ArgumentOutOfRangeException("accessor");
 			}


### PR DESCRIPTION
Fixes #3251

Let's add to 5.4 as a trivial fix