### PR TITLE
Treat transparentcast as guessed type in hql

### DIFF
--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -174,13 +174,12 @@ namespace NHibernate.Test.Linq
 			}
 		}
 
-		[Test]
-		public async Task CanQueryComplexExpressionOnTestEnumAsync()
+		[TestCase(null)]
+		[TestCase(TestEnum.Unspecified)]
+		public async Task CanQueryComplexExpressionOnTestEnumAsync(TestEnum? value)
 		{
-			//TODO: Fix issue on SQLite with type set to  TestEnum.Unspecified
-			TestEnum? type = null;
+			TestEnum? type = value;
 			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
 			{
 				var entities = session.Query<EnumEntity>();
 
@@ -197,7 +196,7 @@ namespace NHibernate.Test.Linq
 								 coalesce = user.NullableEnum1 ?? TestEnum.Medium
 							 }).ToListAsync());
 
-				Assert.That(query.Count, Is.EqualTo(0));
+				Assert.That(query.Count, Is.EqualTo(type == TestEnum.Unspecified ? 1 : 0));
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Async/Linq/EnumTests.cs
@@ -176,9 +176,8 @@ namespace NHibernate.Test.Linq
 
 		[TestCase(null)]
 		[TestCase(TestEnum.Unspecified)]
-		public async Task CanQueryComplexExpressionOnTestEnumAsync(TestEnum? value)
+		public async Task CanQueryComplexExpressionOnTestEnumAsync(TestEnum? type)
 		{
-			TestEnum? type = value;
 			using (var session = OpenSession())
 			{
 				var entities = session.Query<EnumEntity>();

--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -67,6 +67,32 @@ namespace NHibernate.Test.Linq
 			Assert.That(query.Count, Is.EqualTo(1));
 		}
 
+		[Test(Description = "GH-3256")]
+		public async Task CanUseStringEnumInConditionalAsync()
+		{
+			var query = db.Users
+			              .Where(
+				              user => (user.Enum1 == EnumStoredAsString.Small
+					              ? EnumStoredAsString.Small
+					              : EnumStoredAsString.Large) == user.Enum1)
+			              .Select(x => x.Enum1);
+
+			Assert.That(await (query.CountAsync()), Is.GreaterThan(0));
+		}
+
+		[Test(Description = "GH-3256")]
+		public async Task CanUseStringEnumInConditional2Async()
+		{
+			var query = db.Users
+			              .Where(
+				              user => (user.Enum1 == EnumStoredAsString.Small
+					              ? user.Enum1
+					              : EnumStoredAsString.Large) == user.Enum1)
+			              .Select(x => x.Enum1);
+
+			Assert.That(await (query.CountAsync()), Is.GreaterThan(0));
+		}
+
 		[Test]
 		public async Task FirstElementWithWhereAsync()
 		{

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -161,13 +161,12 @@ namespace NHibernate.Test.Linq
 			}
 		}
 
-		[Test]
-		public void CanQueryComplexExpressionOnTestEnum()
+		[TestCase(null)]
+		[TestCase(TestEnum.Unspecified)]
+		public void CanQueryComplexExpressionOnTestEnum(TestEnum? value)
 		{
-			//TODO: Fix issue on SQLite with type set to  TestEnum.Unspecified
-			TestEnum? type = null;
+			TestEnum? type = value;
 			using (var session = OpenSession())
-			using (var trans = session.BeginTransaction())
 			{
 				var entities = session.Query<EnumEntity>();
 
@@ -184,7 +183,7 @@ namespace NHibernate.Test.Linq
 								 coalesce = user.NullableEnum1 ?? TestEnum.Medium
 							 }).ToList();
 
-				Assert.That(query.Count, Is.EqualTo(0));
+				Assert.That(query.Count, Is.EqualTo(type == TestEnum.Unspecified ? 1 : 0));
 			}
 		}
 

--- a/src/NHibernate.Test/Linq/EnumTests.cs
+++ b/src/NHibernate.Test/Linq/EnumTests.cs
@@ -163,9 +163,8 @@ namespace NHibernate.Test.Linq
 
 		[TestCase(null)]
 		[TestCase(TestEnum.Unspecified)]
-		public void CanQueryComplexExpressionOnTestEnum(TestEnum? value)
+		public void CanQueryComplexExpressionOnTestEnum(TestEnum? type)
 		{
-			TestEnum? type = value;
 			using (var session = OpenSession())
 			{
 				var entities = session.Query<EnumEntity>();

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -55,6 +55,32 @@ namespace NHibernate.Test.Linq
 			Assert.That(query.Count, Is.EqualTo(1));
 		}
 
+		[Test(Description = "GH-3256")]
+		public void CanUseStringEnumInConditional()
+		{
+			var query = db.Users
+			              .Where(
+				              user => (user.Enum1 == EnumStoredAsString.Small
+					              ? EnumStoredAsString.Small
+					              : EnumStoredAsString.Large) == user.Enum1)
+			              .Select(x => x.Enum1);
+
+			Assert.That(query.Count(), Is.GreaterThan(0));
+		}
+
+		[Test(Description = "GH-3256")]
+		public void CanUseStringEnumInConditional2()
+		{
+			var query = db.Users
+			              .Where(
+				              user => (user.Enum1 == EnumStoredAsString.Small
+					              ? user.Enum1
+					              : EnumStoredAsString.Large) == user.Enum1)
+			              .Select(x => x.Enum1);
+
+			Assert.That(query.Count(), Is.GreaterThan(0));
+		}
+
 		[Test]
 		public void FirstElementWithWhere()
 		{

--- a/src/NHibernate/Hql/Ast/ANTLR/SqlGenerator.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/SqlGenerator.cs
@@ -285,7 +285,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 				// this function has a template -> restore output, apply the template and write the result out
 				var functionArguments = (FunctionArguments)writer; // TODO: Downcast to avoid using an interface?  Yuck.
 				writer = outputStack.Pop();
-				Out(template.Render(functionArguments.Args, sessionFactory));
+				Out(methodNode.Render(functionArguments.Args));
 			}
 		}
 

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/BinaryLogicOperatorNode.cs
@@ -56,14 +56,11 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			IType lhsType = ExtractDataType( lhs );
 			IType rhsType = ExtractDataType( rhs );
 
-			if ( lhsType == null ) 
-			{
+			if (lhsType == null || (IsGuessedType(lhs) && rhsType != null))
 				lhsType = rhsType;
-			}
-			if ( rhsType == null ) 
-			{
+
+			if (rhsType == null || (IsGuessedType(rhs) && lhsType != null))
 				rhsType = lhsType;
-			}
 
 			if (lhs is IExpectedTypeAwareNode lshTypeAwareNode && lshTypeAwareNode.ExpectedType == null)
 			{
@@ -247,6 +244,8 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			}
 			throw new HibernateException( "dont know how to extract row value elements from node : " + operand );
 		}
+
+		private static bool IsGuessedType(IASTNode operand) => TransparentCastNode.IsTransparentCast(operand);
 
 		protected static IType ExtractDataType(IASTNode operand) 
 		{

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/HqlSqlWalkerTreeAdapter.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/HqlSqlWalkerTreeAdapter.cs
@@ -69,7 +69,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 					ret = new SqlFragment(payload);
 					break;
 				case HqlSqlWalker.METHOD_CALL:
-					ret = new MethodNode(payload);
+					ret = payload.Text == TransparentCastNode.Name
+						? new TransparentCastNode(payload)
+						: new MethodNode(payload);
 					break;
 				case HqlSqlWalker.ELEMENTS:
 				case HqlSqlWalker.INDICES:

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/MethodNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/MethodNode.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Antlr.Runtime;
 
 using NHibernate.Dialect.Function;
 using NHibernate.Hql.Ast.ANTLR.Util;
 using NHibernate.Persister.Collection;
+using NHibernate.SqlCommand;
 using NHibernate.Type;
 
 namespace NHibernate.Hql.Ast.ANTLR.Tree
@@ -211,6 +213,11 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			/*else {
 				methodName = (String) getWalker().getTokenReplacements().get( methodName );
 			}*/
+		}
+
+		public virtual SqlString Render(IList args)
+		{
+			return _function.Render(args, SessionFactoryHelper.Factory);
 		}
 	}
 }

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/TransparentCastNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/TransparentCastNode.cs
@@ -28,8 +28,8 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			{
 				_expectedType = value;
 				var node = GetChild(0).NextSibling.GetChild(0);
-				//transparentcast on parameters is a special use case - skip it.
-				if (node.Type != HqlSqlWalker.NAMED_PARAM && node is IExpectedTypeAwareNode  typeNode && typeNode.ExpectedType == null)
+				// A transparent cast on parameters is a special use case - skip it.
+				if (node.Type != HqlSqlWalker.NAMED_PARAM && node is IExpectedTypeAwareNode typeNode && typeNode.ExpectedType == null)
 					typeNode.ExpectedType = value;
 			}
 		}
@@ -37,7 +37,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		public override SqlString Render(IList args)
 		{
 			return ExpectedType != null
-				// Provide expected type in case transparent cast is transformed to real
+				// Provide the expected type in case the transparent cast is transformed to an actual cast.
 				? ((CastFunction) SQLFunction).Render(args, ExpectedType, SessionFactoryHelper.Factory)
 				: base.Render(args);
 		}

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/TransparentCastNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/TransparentCastNode.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using Antlr.Runtime;
+using NHibernate.Dialect.Function;
+using NHibernate.SqlCommand;
+using NHibernate.Type;
+
+namespace NHibernate.Hql.Ast.ANTLR.Tree
+{
+	class TransparentCastNode : MethodNode, IExpectedTypeAwareNode
+	{
+		private IType _expectedType;
+
+		public const string Name = "transparentcast";
+
+		public static bool IsTransparentCast(IASTNode node)
+		{
+			return node.Type == HqlSqlWalker.METHOD_CALL && node.Text == Name;
+		}
+
+		public TransparentCastNode(IToken token) : base(token)
+		{
+		}
+
+		public IType ExpectedType
+		{
+			get => _expectedType;
+			set
+			{
+				_expectedType = value;
+				var node = GetChild(0).NextSibling.GetChild(0);
+				//transparentcast on parameters is a special use case - skip it.
+				if (node.Type != HqlSqlWalker.NAMED_PARAM && node is IExpectedTypeAwareNode  typeNode && typeNode.ExpectedType == null)
+					typeNode.ExpectedType = value;
+			}
+		}
+
+		public override SqlString Render(IList args)
+		{
+			return ExpectedType != null
+				// Provide expected type in case transparent cast is transformed to real
+				? ((CastFunction) SQLFunction).Render(args, ExpectedType, SessionFactoryHelper.Factory)
+				: base.Render(args);
+		}
+	}
+}

--- a/src/NHibernate/Hql/Ast/HqlTreeNode.cs
+++ b/src/NHibernate/Hql/Ast/HqlTreeNode.cs
@@ -724,9 +724,9 @@ namespace NHibernate.Hql.Ast
 	public class HqlTransparentCast : HqlExpression
 	{
 		public HqlTransparentCast(IASTFactory factory, HqlExpression expression, System.Type type)
-			: base(HqlSqlWalker.METHOD_CALL, "method", factory)
+			: base(HqlSqlWalker.METHOD_CALL, TransparentCastNode.Name, factory)
 		{
-			AddChild(new HqlIdent(factory, "transparentcast"));
+			AddChild(new HqlIdent(factory, TransparentCastNode.Name));
 			AddChild(new HqlExpressionList(factory, expression, new HqlIdent(factory, type)));
 		}
 	}


### PR DESCRIPTION
Fixes #3256

Related to #707
The whole `transparentcast` concept is a bit hacky and breaks hql parameter detection logic in case some custom type is used (enum string is one example). So let's extend this hack a bit more to let hql know that `transparentcast` is just a guessed type hint.