### PR TITLE
Improve LINQ Contains subquery parameter detection

### DIFF
--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -662,7 +662,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task ContainsSubqueryWithCoalesceStringEnumSelectAsync()
 		{
-			if (Dialect is MsSqlCeDialect)
+			if (Dialect is MsSqlCeDialect || Dialect is SQLiteDialect)
 				Assert.Ignore("Dialect is not supported");
 
 			var results =

--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -15,6 +15,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using log4net.Core;
+using NHibernate.Dialect;
 using NHibernate.Engine.Query;
 using NHibernate.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
@@ -647,12 +648,33 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public async Task TimesheetsWithEnumerableContainsOnSelectAsync()
 		{
+			if (Dialect is MsSqlCeDialect)
+				Assert.Ignore("Dialect is not supported");
+
 			var value = (EnumStoredAsInt32) 1000;
 			var query = await ((from sheet in db.Timesheets
 			             where sheet.Users.Select(x => x.NullableEnum2 ?? value).Contains(value)
 			             select sheet).ToListAsync());
 
 			Assert.That(query.Count, Is.EqualTo(1));
+		}
+
+		[Test]
+		public async Task ContainsSubqueryWithCoalesceStringEnumSelectAsync()
+		{
+			if (Dialect is MsSqlCeDialect)
+				Assert.Ignore("Dialect is not supported");
+
+			var results =
+				await (db.Timesheets.Where(
+					  o =>
+						  o.Users
+						   .Where(u => u.Id != 0.MappedAs(NHibernateUtil.Int32))
+						   .Select(u => u.Name == u.Name ? u.Enum1 : u.NullableEnum1.Value)
+						   .Contains(EnumStoredAsString.Small))
+				  .ToListAsync());
+
+			Assert.That(results.Count, Is.EqualTo(1));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -663,7 +663,7 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void ContainsSubqueryWithCoalesceStringEnumSelect()
 		{
-			if (Dialect is MsSqlCeDialect)
+			if (Dialect is MsSqlCeDialect || Dialect is SQLiteDialect)
 				Assert.Ignore("Dialect is not supported");
 
 			var results =

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using log4net.Core;
+using NHibernate.Dialect;
 using NHibernate.Engine.Query;
 using NHibernate.Linq;
 using NHibernate.DomainModel.Northwind.Entities;
@@ -648,12 +649,33 @@ namespace NHibernate.Test.Linq
 		[Test]
 		public void TimesheetsWithEnumerableContainsOnSelect()
 		{
+			if (Dialect is MsSqlCeDialect)
+				Assert.Ignore("Dialect is not supported");
+
 			var value = (EnumStoredAsInt32) 1000;
 			var query = (from sheet in db.Timesheets
 			             where sheet.Users.Select(x => x.NullableEnum2 ?? value).Contains(value)
 			             select sheet).ToList();
 
 			Assert.That(query.Count, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void ContainsSubqueryWithCoalesceStringEnumSelect()
+		{
+			if (Dialect is MsSqlCeDialect)
+				Assert.Ignore("Dialect is not supported");
+
+			var results =
+				db.Timesheets.Where(
+					  o =>
+						  o.Users
+						   .Where(u => u.Id != 0.MappedAs(NHibernateUtil.Int32))
+						   .Select(u => u.Name == u.Name ? u.Enum1 : u.NullableEnum1.Value)
+						   .Contains(EnumStoredAsString.Small))
+				  .ToList();
+
+			Assert.That(results.Count, Is.EqualTo(1));
 		}
 
 		[Test]

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -305,7 +305,12 @@ namespace NHibernate.Linq.Visitors
 					return;
 				}
 
-				var left = UnwrapUnary(Visit(queryModel.SelectClause.Selector));
+				Expression selector =
+					queryModel.SelectClause.Selector is QuerySourceReferenceExpression { ReferencedQuerySource: MainFromClause mainFromClause }
+						? mainFromClause.FromExpression
+						: queryModel.SelectClause.Selector;
+
+				var left = UnwrapUnary(Visit(selector));
 				var right = UnwrapUnary(Visit(containsOperator.Item));
 
 				// Copy all found MemberExpressions to the constant expression


### PR DESCRIPTION
Replaces #3212 
We should always try to detect parameters. And parameter detection shouldn't skip query transformation.

Also fixes SqlServerCe test for #3271