### PR TITLE
Npgsql 6: set parameter DbType to DateTime2 when value is not Utc DateTime

### DIFF
--- a/src/NHibernate/Driver/NpgsqlDriver.cs
+++ b/src/NHibernate/Driver/NpgsqlDriver.cs
@@ -88,10 +88,19 @@ namespace NHibernate.Driver
 				for (var i = 0; i < command.Parameters.Count; i++)
 				{
 					var parameter = command.Parameters[i];
-					if (parameter.Value is DateTime)
+					if (parameter.DbType == DbType.DateTime &&
+					    parameter.Value is DateTime dateTime &&
+					    dateTime.Kind != DateTimeKind.Utc)
 					{
-						// Let Npgsql 6 driver to decide parameter type
-						parameter.ResetDbType();
+						// There are breaking changes in Npgsql 6 as following:
+						// UTC DateTime is now strictly mapped to timestamptz,
+						// while Local/Unspecified DateTime is now strictly mapped to timestamp.
+						//
+						// DbType.DateTime now maps to timestamptz, not timestamp.
+						// DbType.DateTime2 continues to map to timestamp
+						//
+						// See more details here: https://www.npgsql.org/doc/release-notes/6.0.html#detailed-notes
+						parameter.DbType = DbType.DateTime2;
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #3291 