### PR TITLE
Fix SetSnapShot CopyTo variance failure

### DIFF
--- a/src/NHibernate.Test/UtilityTest/SetSnapShotFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/SetSnapShotFixture.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using NHibernate.Collection.Generic.SetHelpers;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace NHibernate.Test.UtilityTest
@@ -83,7 +85,7 @@ namespace NHibernate.Test.UtilityTest
 		}
 
 		[Test]
-		public void WhenCopyToIsCalledWithIncompatibleArrayTypeThenThrowArgumentException()
+		public void WhenCopyToIsCalledWithIncompatibleArrayTypeThenThrowArgumentOrInvalidCastException()
 		{
 			var list = new List<string> { "test1", null, "test2" };
 			ICollection sn = new SetSnapShot<string>(list);
@@ -91,7 +93,7 @@ namespace NHibernate.Test.UtilityTest
 			var array = new int[3];
 			Assert.That(
 				() => sn.CopyTo(array, 0),
-				Throws.ArgumentException);
+				Throws.ArgumentException.Or.TypeOf<InvalidCastException>());
 		}
 
 		[Test]

--- a/src/NHibernate.Test/UtilityTest/SetSnapShotFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/SetSnapShotFixture.cs
@@ -83,6 +83,18 @@ namespace NHibernate.Test.UtilityTest
 		}
 
 		[Test]
+		public void WhenCopyToIsCalledWithIncompatibleArrayTypeThenThrowArgumentException()
+		{
+			var list = new List<string> { "test1", null, "test2" };
+			ICollection sn = new SetSnapShot<string>(list);
+
+			var array = new int[3];
+			Assert.That(
+				() => sn.CopyTo(array, 0),
+				Throws.ArgumentException);
+		}
+
+		[Test]
 		public void TestSerialization()
 		{
 			var list = new List<string> {"test1", null, "test2"};

--- a/src/NHibernate.Test/UtilityTest/SetSnapShotFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/SetSnapShotFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using NHibernate.Collection.Generic.SetHelpers;
@@ -66,6 +67,17 @@ namespace NHibernate.Test.UtilityTest
 			var sn = new SetSnapShot<string>(list);
 
 			var array = new string[3];
+			sn.CopyTo(array, 0);
+			Assert.That(list, Is.EquivalentTo(array));
+		}
+
+		[Test]
+		public void TestCopyToObjectArray()
+		{
+			var list = new List<string> { "test1", null, "test2" };
+			ICollection sn = new SetSnapShot<string>(list);
+
+			var array = new object[3];
 			sn.CopyTo(array, 0);
 			Assert.That(list, Is.EquivalentTo(array));
 		}

--- a/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
+++ b/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
@@ -120,16 +120,10 @@ namespace NHibernate.Collection.Generic.SetHelpers
 				return;
 			}
 
-			if (array.GetType().GetElementType().IsAssignableFrom(typeof(T)))
-			{
-				if (_hasNull)
-					array.SetValue(default(T), index);
-				ICollection keysCollection = _values.Keys;
-				keysCollection.CopyTo(array, index + (_hasNull ? 1 : 0));
-				return;
-			}
-
-			throw new ArgumentException($"Array must be of type {typeof(T[])}.", nameof(array));
+			if (_hasNull)
+				array.SetValue(default(T), index);
+			ICollection keysCollection = _values.Keys;
+			keysCollection.CopyTo(array, index + (_hasNull ? 1 : 0));
 		}
 
 		public int Count => _values.Count + (_hasNull ? 1 : 0);

--- a/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
+++ b/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
@@ -114,12 +114,22 @@ namespace NHibernate.Collection.Generic.SetHelpers
 
 		void ICollection.CopyTo(Array array, int index)
 		{
-			if (!(array is T[] typedArray))
+			if (array is T[] typedArray)
 			{
-				throw new ArgumentException($"Array must be of type {typeof(T[])}.", nameof(array));
+				CopyTo(typedArray, index);
+				return;
 			}
 
-			CopyTo(typedArray, index);
+			if (array.GetType().GetElementType().IsAssignableFrom(typeof(T)))
+			{
+				if (_hasNull)
+					array.SetValue(default(T), index);
+				ICollection keysCollection = _values.Keys;
+				keysCollection.CopyTo(array, index + (_hasNull ? 1 : 0));
+				return;
+			}
+
+			throw new ArgumentException($"Array must be of type {typeof(T[])}.", nameof(array));
 		}
 
 		public int Count => _values.Count + (_hasNull ? 1 : 0);

--- a/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
+++ b/src/NHibernate/Collection/Generic/SetHelpers/SetSnapShot.cs
@@ -157,12 +157,26 @@ namespace NHibernate.Collection.Generic.SetHelpers
 
 		void ICollection.CopyTo(Array array, int index)
 		{
-			if (!(array is T[] typedArray))
+			if (array is T[] typedArray)
 			{
-				throw new ArgumentException($"Array must be of type {typeof(T[])}.", nameof(array));
+				CopyTo(typedArray, index);
+				return;
 			}
 
-			CopyTo(typedArray, index);
+			if (array == null)
+				throw new ArgumentNullException(nameof(array));
+
+			if (index < 0)
+				throw new ArgumentOutOfRangeException(nameof(index), index, "Array index cannot be negative");
+
+			if (index > array.Length || Count > array.Length - index)
+				throw new ArgumentException("Provided array is too small", nameof(array));
+
+			foreach (var value in this)
+			{
+				array.SetValue(value, index);
+				index++;
+			}
 		}
 
 		bool ICollection.IsSynchronized => false;


### PR DESCRIPTION
This failure causes tests to fail when upgrading the NUnit engine.