### PR TITLE
Lazy property with nosetter.pascalcase-underscore accessor remains uninitialized

### DIFF
--- a/src/NHibernate.Test/Async/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/Async/LazyProperty/LazyPropertyFixture.cs
@@ -67,6 +67,7 @@ namespace NHibernate.Test.LazyProperty
 					Id = 1,
 					ALotOfText = "a lot of text ...",
 					Image = new byte[10],
+					NoSetterImage = new byte[10],
 					FieldInterceptor = "Why not that name?"
 				});
 				tx.Commit();
@@ -389,6 +390,31 @@ namespace NHibernate.Test.LazyProperty
 				book = await (s.GetAsync<Book>(3));
 				Assert.That(book.Words.Any(), Is.True);
 				Assert.That(book.Words.First().Content, Is.EqualTo(new byte[1] { 0 }));
+			}
+		}
+
+		[Test]
+		public async Task GetLazyPropertyWithNoSetterAccessor_PropertyShouldBeInitializedAsync()
+		{
+			using (ISession s = OpenSession())
+			{
+				var book = await (s.GetAsync<Book>(1));
+				var image = book.NoSetterImage;
+				// Fails. Property remains uninitialized after it has been accessed.
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "NoSetterImage"), Is.True);
+			}
+		}
+
+		[Test]
+		public async Task GetLazyPropertyWithNoSetterAccessorTwice_ResultsAreSameObjectAsync()
+		{
+			using (ISession s = OpenSession())
+			{
+				var book = await (s.GetAsync<Book>(1));
+				var image = book.NoSetterImage;
+				var sameImage = book.NoSetterImage;
+				// Fails. Each call to a property getter returns a new object.
+				Assert.That(ReferenceEquals(image, sameImage), Is.True);
 			}
 		}
 	}

--- a/src/NHibernate.Test/LazyProperty/Book.cs
+++ b/src/NHibernate.Test/LazyProperty/Book.cs
@@ -17,6 +17,14 @@ namespace NHibernate.Test.LazyProperty
 
 		public virtual byte[] Image { get; set; }
 
+		private byte[] _NoSetterImage;
+
+		public virtual byte[] NoSetterImage
+		{
+			get { return _NoSetterImage; }
+			set { _NoSetterImage = value; }
+		}
+
 		public virtual string FieldInterceptor { get; set; }
 
 		public virtual IList<Word> Words { get; set; }

--- a/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
@@ -55,6 +55,7 @@ namespace NHibernate.Test.LazyProperty
 					Id = 1,
 					ALotOfText = "a lot of text ...",
 					Image = new byte[10],
+					NoSetterImage = new byte[10],
 					FieldInterceptor = "Why not that name?"
 				});
 				tx.Commit();
@@ -383,6 +384,31 @@ namespace NHibernate.Test.LazyProperty
 				book = s.Get<Book>(3);
 				Assert.That(book.Words.Any(), Is.True);
 				Assert.That(book.Words.First().Content, Is.EqualTo(new byte[1] { 0 }));
+			}
+		}
+
+		[Test]
+		public void GetLazyPropertyWithNoSetterAccessor_PropertyShouldBeInitialized()
+		{
+			using (ISession s = OpenSession())
+			{
+				var book = s.Get<Book>(1);
+				var image = book.NoSetterImage;
+				// Fails. Property remains uninitialized after it has been accessed.
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "NoSetterImage"), Is.True);
+			}
+		}
+
+		[Test]
+		public void GetLazyPropertyWithNoSetterAccessorTwice_ResultsAreSameObject()
+		{
+			using (ISession s = OpenSession())
+			{
+				var book = s.Get<Book>(1);
+				var image = book.NoSetterImage;
+				var sameImage = book.NoSetterImage;
+				// Fails. Each call to a property getter returns a new object.
+				Assert.That(ReferenceEquals(image, sameImage), Is.True);
 			}
 		}
 	}

--- a/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
+++ b/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
@@ -11,6 +11,7 @@
 		<property name="Name" />
 		<property name="ALotOfText" lazy="true" />
 		<property name="Image" lazy="true" />
+		<property name="NoSetterImage" access="nosetter.pascalcase-underscore" lazy="true" />
 		<property name="FieldInterceptor" />
     <bag name="Words" inverse="true" generic="true" cascade="all-delete-orphan" lazy="true" >
       <key column="ParentId" />


### PR DESCRIPTION
In my project after upgrading from version 5.2 to 5.3 there is a problem with lazy properties that have nosetter.pascal-underscore accessor in their mapping.
- After accessing the property it remains uninitialized
- Each call to a property getter returns a new object

I have added tests which demonstrate the problem.

There is no such problem in version 5.2 #3332