### PR TITLE
[5.2] Lazy property with nosetter.pascalcase-underscore accessor

### DIFF
--- a/src/NHibernate.Test/LazyProperty/Book.cs
+++ b/src/NHibernate.Test/LazyProperty/Book.cs
@@ -14,5 +14,14 @@
 		}
 
 		public virtual string FieldInterceptor { get; set; }
+
+		private byte[] _NoSetterImage;
+
+		public virtual byte[] NoSetterImage
+		{
+			get { return _NoSetterImage; }
+			set { _NoSetterImage = value; }
+		}
+
 	}
 }

--- a/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
+++ b/src/NHibernate.Test/LazyProperty/LazyPropertyFixture.cs
@@ -46,6 +46,7 @@ namespace NHibernate.Test.LazyProperty
 					Name = "some name",
 					Id = 1,
 					ALotOfText = "a lot of text ...",
+					NoSetterImage = new byte[10],
 					FieldInterceptor = "Why not that name?"
 				});
 				tx.Commit();
@@ -208,6 +209,31 @@ namespace NHibernate.Test.LazyProperty
 				Assert.That(book, Is.Not.Null);
 				Assert.That(book.Name, Is.EqualTo("some name two"));
 				Assert.That(book.ALotOfText, Is.EqualTo("a lot of text two..."));
+			}
+		}
+
+		[Test]
+		public void GetLazyPropertyWithNoSetterAccessor_PropertyShouldBeInitialized()
+		{
+			using (ISession s = OpenSession())
+			{
+				var book = s.Get<Book>(1);
+				var image = book.NoSetterImage;
+				// Fails. Property remains uninitialized after it has been accessed.
+				Assert.That(NHibernateUtil.IsPropertyInitialized(book, "NoSetterImage"), Is.True);
+			}
+		}
+
+		[Test]
+		public void GetLazyPropertyWithNoSetterAccessorTwice_ResultsAreSameObject()
+		{
+			using (ISession s = OpenSession())
+			{
+				var book = s.Get<Book>(1);
+				var image = book.NoSetterImage;
+				var sameImage = book.NoSetterImage;
+				// Fails. Each call to a property getter returns a new object.
+				Assert.That(ReferenceEquals(image, sameImage), Is.True);
 			}
 		}
 	}

--- a/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
+++ b/src/NHibernate.Test/LazyProperty/Mappings.hbm.xml
@@ -10,6 +10,7 @@
 		<property name="Name" />
 		<property name="ALotOfText" lazy="true" />
 		<property name="FieldInterceptor" />
+		<property name="NoSetterImage" access="nosetter.pascalcase-underscore" lazy="true" />
 	</class>
 
 </hibernate-mapping>


### PR DESCRIPTION
In my project after upgrading from version 5.2 to 5.3 there is a problem with lazy properties that have nosetter.pascal-underscore accessor in their mapping.

- After accessing the property it remains uninitialized
- Each call to a property getter returns a new object

There is no such problem in version 5.2
Tests fails here #3331
