### PR TITLE
BuildCache method returns now a CacheBase type as per TODO

### DIFF
--- a/src/NHibernate/Cache/ICacheProvider.cs
+++ b/src/NHibernate/Cache/ICacheProvider.cs
@@ -14,10 +14,7 @@ namespace NHibernate.Cache
 		/// <param name="regionName">The name of the cache region.</param>
 		/// <param name="properties">Configuration settings.</param>
 		/// <returns>A cache.</returns>
-		// 6.0 TODO: return a CacheBase instead
-#pragma warning disable 618
-		ICache BuildCache(string regionName, IDictionary<string, string> properties);
-#pragma warning restore 618
+		CacheBase BuildCache(string regionName, IDictionary<string, string> properties);
 
 		/// <summary>
 		/// generate a timestamp


### PR DESCRIPTION
Hi, 

I believe that the returned type of the BuildCache method in ICacheProvider should be CacheBase.
It was written as summary long time ago as a TODO but perhaps it was forgotten.

Hope this helps.