### PR TITLE
Update readme with actual dev build information for 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Nightly Development Builds
 --------------------------
 
 The quickest way to get the latest development build of NHibernate is to add it to your project using 
-NuGet from MyGet feed (<https://www.myget.org/gallery/nhibernate>).
+NuGet from Cloudsmith feed (<https://cloudsmith.io/~nhibernate/repos/nhibernate-core/packages/>).
 
 In order to make life a little bit easier you can register the package source in the NuGet.Config
 file in the top folder of your project, similar to the following.
@@ -35,10 +35,17 @@ file in the top folder of your project, similar to the following.
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NHibernateDevBuilds" value="https://www.myget.org/F/nhibernate/api/v3/index.json" />
+    <add key="NHibernateDevBuilds" value="https://nuget.cloudsmith.io/nhibernate/nhibernate-core/v3/index.json" />
   </packageSources>
 </configuration>
 ```
+
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.
+
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.com)
 
 Community Forums
 ----------------


### PR DESCRIPTION
Just noticed that for 5.4 we started to publish readme on nuget:  https://www.nuget.org/packages/NHibernate#readme-body-tab

So let's actualize this info.