### PR TITLE
Simplify aggregateDistinctAll rule in Hql.g

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/Hql.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/Hql.g
@@ -632,7 +632,7 @@ aggregateDistinctAll
 	;
 
 distinctAll
-	: {input.LA(1) == DISTINCT || input.LA(2) == ALL}? ( DISTINCT | ALL ) 
+	: {input.LA(1) == DISTINCT || input.LA(1) == ALL}? ( DISTINCT | ALL ) 
 	;
 
 //## collection: ( OPEN query CLOSE ) | ( 'elements'|'indices' OPEN path CLOSE );

--- a/src/NHibernate/Hql/Ast/ANTLR/Hql.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/Hql.g
@@ -628,12 +628,11 @@ aggregateArgument
 	;
 
 aggregateDistinctAll
-	: ( distinctAll aggregateArgument ) => (distinctAll aggregateArgument)
-	| aggregateArgument
+	: ( distinctAll? aggregateArgument )
 	;
 
 distinctAll
-	: ( DISTINCT | ALL ) 
+	: {input.LA(1) == DISTINCT || input.LA(2) == ALL}? ( DISTINCT | ALL ) 
 	;
 
 //## collection: ( OPEN query CLOSE ) | ( 'elements'|'indices' OPEN path CLOSE );


### PR DESCRIPTION
Syntatic predicate is replaced with [Semantic predicate](https://www.javacodegeeks.com/2012/12/antlr-semantic-predicates.html) to help antlr with [parsing](https://github.com/nhibernate/nhibernate-core/pull/2502#discussion_r479744552) (which avoids double parsing for this rule)