### PR TITLE
Improve path rule handling with reserved words in Hql.g

### DIFF
--- a/src/NHibernate.Test/Hql/Parser/HqlParserFixture.cs
+++ b/src/NHibernate.Test/Hql/Parser/HqlParserFixture.cs
@@ -1,0 +1,30 @@
+﻿using Antlr.Runtime;
+using NHibernate.Hql.Ast.ANTLR;
+using NHibernate.Hql.Ast.ANTLR.Tree;
+using NUnit.Framework;
+
+namespace NHibernate.Test.Hql.Parser
+{
+	[TestFixture]
+	public class HqlParserFixture
+	{
+		[Test]
+		public void HandlesPathWithReservedWords()
+		{
+			Assert.DoesNotThrow(() => Parse("delete from System.Object"));
+			Assert.DoesNotThrow(() => Parse("delete from Object.Object.Object.Object"));
+		}
+
+		private static void Parse(string hql)
+		{
+			var lex = new HqlLexer(new CaseInsensitiveStringStream(hql));
+			var tokens = new CommonTokenStream(lex);
+
+			var parser = new HqlParser(tokens)
+			{
+				TreeAdaptor = new ASTTreeAdaptor(),
+				ParseErrorHandler = new WarningAsErrorReporter()
+			}.statement();
+		}
+	}
+}

--- a/src/NHibernate.Test/Hql/Parser/WarningAsErrorReporter.cs
+++ b/src/NHibernate.Test/Hql/Parser/WarningAsErrorReporter.cs
@@ -1,0 +1,29 @@
+using Antlr.Runtime;
+using NHibernate.Hql.Ast.ANTLR;
+
+namespace NHibernate.Test.Hql.Parser
+{
+	public class WarningAsErrorReporter : IParseErrorHandler
+	{
+		public void ReportError(RecognitionException e)
+		{
+			throw e;
+		}
+
+		public void ReportError(string s)
+		{
+			throw new QueryException(s);
+		}
+
+		public void ReportWarning(string s)
+		{
+			throw new QueryException(s);
+		}
+
+		public int GetErrorCount() => 0;
+
+		public void ThrowQueryException()
+		{
+		}
+	}
+}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -46,6 +46,9 @@
     <Compile Remove="**\NHSpecificTest\NH3121\**" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\NHibernate\Hql\Ast\ANTLR\CaseInsensitiveStringStream.cs">
+      <Link>Hql\Parser\CaseInsensitiveStringStream.cs</Link>
+    </Compile>
     <Compile Include="..\NHibernate\Util\AsyncReaderWriterLock.cs">
       <Link>UtilityTest\AsyncReaderWriterLock.cs</Link>
     </Compile>

--- a/src/NHibernate/Hql/Ast/ANTLR/Hql.g
+++ b/src/NHibernate/Hql/Ast/ANTLR/Hql.g
@@ -695,10 +695,9 @@ constant
 
 path
 @init {
-// TODO - need to clean up DotIdent - suspect that DotIdent2 supersedes the other one, but need to do the analysis
-//HandleDotIdent2();
+HandleDotIdents();
 }
-	: identifier ( DOT^ { WeakKeywords(); } identifier )*
+	: identifier ( DOT^ identifier )*
 	;
 
 // Wraps the IDENT token from the lexer, in order to provide

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlParser.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlParser.cs
@@ -112,6 +112,27 @@ namespace NHibernate.Hql.Ast.ANTLR
             throw new MismatchedTokenException(ttype, input);
         }
 
+		public void HandleDotIdents()
+		{
+			int i = 2;
+
+			while (input.LA(i) == DOT)
+			{
+				var next = input.LT(i + 1);
+				if (next != null)
+					next.Type = IDENT;
+				i += 2;
+			}
+
+			if (input.LA(1) == IDENT || input.LA(2) != DOT)
+				return;
+
+			if (IsPossibleId(input.LT(1)))
+			{
+				input.LT(1).Type = IDENT;
+			}
+		}
+
 		public void WeakKeywords()
 		{
 			int t = input.LA(1);


### PR DESCRIPTION
Avoids exception ([handled](https://github.com/nhibernate/nhibernate-core/blob/f38a6fd86c5bd15927a1d487c9911842f08ce152/src/NHibernate/Hql/Ast/ANTLR/Hql.g#L709C1-L712C3)) when parsing queries with reserved words in path. Example of query that no longer triggers exception "from System.Object"

