### PR TITLE
Partial fix fetching lazy property after Select in Linq

### DIFF
--- a/src/NHibernate.Test/Async/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/Async/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -186,6 +186,18 @@ namespace NHibernate.Test.FetchLazyProperties
 			AssertFetchProperty(person);
 		}
 
+		[Test]
+		public async Task TestLinqFetchPropertyAfterSelectAsync()
+		{
+			using var s = OpenSession();
+			var owner = await (s.Query<Animal>()
+			             .Select(a => a.Owner)
+			             .Fetch(o => o.Image)
+			             .FirstOrDefaultAsync(o => o.Id == 1));
+
+			AssertFetchProperty(owner);
+		}
+
 		private static void AssertFetchProperty(Person person)
 		{
 			Assert.That(person, Is.Not.Null);

--- a/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -175,6 +175,18 @@ namespace NHibernate.Test.FetchLazyProperties
 			AssertFetchProperty(person);
 		}
 
+		[Test]
+		public void TestLinqFetchPropertyAfterSelect()
+		{
+			using var s = OpenSession();
+			var owner = s.Query<Animal>()
+			             .Select(a => a.Owner)
+			             .Fetch(o => o.Image)
+			             .FirstOrDefault(o => o.Id == 1);
+
+			AssertFetchProperty(owner);
+		}
+
 		private static void AssertFetchProperty(Person person)
 		{
 			Assert.That(person, Is.Not.Null);

--- a/src/NHibernate/Linq/IntermediateHqlTree.cs
+++ b/src/NHibernate/Linq/IntermediateHqlTree.cs
@@ -127,6 +127,17 @@ namespace NHibernate.Linq
 			_root.NodesPreOrder.OfType<HqlFrom>().First().AddChild(from);
 		}
 
+		internal HqlTreeNode GetFromNodeByAlias(string alias) =>
+			_root.NodesPreOrder
+			     .First(x => x.AstNode.Type == HqlSqlWalker.FROM).Children
+			     .First(x => GetNodeAlias(x) == alias);
+
+		private static string GetNodeAlias(HqlTreeNode fromNode) =>
+			fromNode.Children
+			        .Select(x => x.AstNode)
+			        .First(x => x.Type == HqlSqlWalker.ALIAS)
+			        .Text;
+
 		internal HqlRange GetFromRangeClause()
 		{
 			return _root.NodesPreOrder.OfType<HqlFrom>().First().Children.OfType<HqlRange>().FirstOrDefault();

--- a/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFetch.cs
+++ b/src/NHibernate/Linq/Visitors/ResultOperatorProcessors/ProcessFetch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NHibernate.Hql.Ast;
+using NHibernate.Hql.Ast.ANTLR;
 using NHibernate.Persister.Entity;
 using NHibernate.Type;
 using Remotion.Linq.EagerFetching;
@@ -21,7 +22,7 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 
 		public void Process(FetchRequestBase resultOperator, QueryModelVisitor queryModelVisitor, IntermediateHqlTree tree, string sourceAlias)
 		{
-			Process(resultOperator, queryModelVisitor, tree, null, sourceAlias);
+			Process(resultOperator, queryModelVisitor, tree, tree.GetFromNodeByAlias(sourceAlias), sourceAlias);
 		}
 
 		private void Process(
@@ -68,13 +69,12 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 						propType = metadata.GetPropertyType(resultOperator.RelationMember.Name);
 					}
 				}
-				
+
 				if (propType != null && !propType.IsAssociationType)
 				{
 					if (currentNode == null)
 					{
-						currentNode = tree.GetFromRangeClause()
-									?? throw new InvalidOperationException($"Property {resultOperator.RelationMember.Name} cannot be fetched for this type of query.");
+						throw new InvalidOperationException($"Property {resultOperator.RelationMember.Name} cannot be fetched for this type of query.");
 					}
 
 					currentNode.AddChild(tree.TreeBuilder.Fetch());
@@ -85,12 +85,13 @@ namespace NHibernate.Linq.Visitors.ResultOperatorProcessors
 					{
 						if (componentType == null)
 						{
-							componentType = propType as ComponentType;
-							if (componentType == null)
+							if (!propType.IsComponentType)
 							{
 								throw new InvalidOperationException(
 									$"Property {innerFetch.RelationMember.Name} cannot be fetched from a non component type property {resultOperator.RelationMember.Name}.");
 							}
+
+							componentType = (ComponentType) propType;
 						}
 
 						var subTypeIndex = componentType.GetPropertyIndex(innerFetch.RelationMember.Name);


### PR DESCRIPTION
Partial fix of #3356

Added proper from node detection required for lazy property fetching.

To fully fix #3356 we need to find a way to reliable detect query source (see https://github.com/nhibernate/nhibernate-core/pull/3392#discussion_r1281514034)
