### PR TITLE
Get rid of select queries for each ManyToMany not found ignored element in hql

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using NHibernate.Cfg;
 using NHibernate.Criterion;
 using NHibernate.Transform;
 using NUnit.Framework;
@@ -17,11 +16,20 @@ using NUnit.Framework;
 namespace NHibernate.Test.NHSpecificTest.NH750
 {
 	using System.Threading.Tasks;
-	[TestFixture]
+	[TestFixture(0)]
+	[TestFixture(1)]
+	[TestFixture(2)]
 	public class ManyToManyNotFoundIgnoreFixtureAsync : BugTestCase
 	{
 		private int id1;
 		private int id2;
+		private readonly int _drivesCount;
+		private int DrivesCountWithOneIgnored => _drivesCount == 0? 0 : _drivesCount - 1;
+
+		public ManyToManyNotFoundIgnoreFixtureAsync(int drivesCount)
+		{
+			_drivesCount = drivesCount;
+		}
 
 		protected override void OnSetUp()
 		{
@@ -36,10 +44,10 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				s.Save(dr1);
 				s.Save(dr2);
 				s.Save(dr3);
-				dv1.Drives.Add(dr1);
-				dv1.Drives.Add(dr2);
-				dv2.Drives.Add(dr1);
-				dv2.Drives.Add(dr3);
+				AddDrive(dv1, dr2);
+				AddDrive(dv1, dr1);
+				AddDrive(dv2, dr3);
+				AddDrive(dv2, dr1);
 
 				id1 = (int) s.Save(dv1);
 				id2 = (int) s.Save(dv2);
@@ -51,11 +59,19 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			}
 		}
 
+		private void AddDrive(Device dv, Drive drive)
+		{
+			if(dv.Drives.Count >= _drivesCount)
+				return;
+			dv.Drives.Add(drive);
+		}
+
 		protected override void OnTearDown()
 		{
 			using (ISession s = Sfi.OpenSession())
 			using (var t = s.BeginTransaction())
 			{
+				s.CreateSQLQuery("delete from DriveOfDevice").ExecuteUpdate();
 				s.Delete("from Device");
 				s.Delete("from Drive");
 				t.Commit();
@@ -73,9 +89,9 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				dv2 = (Device) await (s.LoadAsync(typeof(Device), id2));
 			}
 
-			Assert.That(dv1.Drives, Has.Count.EqualTo(2).And.None.Null);
+			Assert.That(dv1.Drives, Has.Count.EqualTo(_drivesCount).And.None.Null);
 			// Verify one is missing
-			Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
+			Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
 
 			//Make sure that flush didn't touch not-found="ignore" records for not modified collection
 			using (var s = Sfi.OpenSession())
@@ -86,18 +102,22 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				await (t.CommitAsync());
 			}
 
-			await (VerifyResultAsync(expectedInCollection: 1, expectedInDb: 2, msg: "not modified collection"));
+			await (VerifyResultAsync(expectedInCollection: DrivesCountWithOneIgnored, expectedInDb: _drivesCount, msg: "not modified collection"));
 
 			//Many-to-many clears collection and recreates it so not-found ignore records are lost
 			using (var s = Sfi.OpenSession())
 			using (var t = s.BeginTransaction())
 			{
 				dv2 = await (s.GetAsync<Device>(dv2.Id));
-				dv2.Drives.Add(dv1.Drives[1]);
+				if(_drivesCount > 0)
+					dv2.Drives.Add(dv1.Drives[0]);
 				await (t.CommitAsync());
 			}
 
-			await (VerifyResultAsync(2, 2, msg: "modified collection"));
+			if(_drivesCount == 1)
+				Assert.Ignore("Test case fails for unrelated reasons");
+
+			await (VerifyResultAsync(_drivesCount, _drivesCount, msg: "modified collection"));
 
 			async Task VerifyResultAsync(int expectedInCollection, int expectedInDb, string msg)
 			{
@@ -127,23 +147,23 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 							.SingleOrDefaultAsync());
 
 				Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
-				Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
+				Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
 			}
 		}
 
 		[Test]
 		public async Task HqlFetchAsync()
 		{
-			using (var s = OpenSession())
-			{
-				var dv2 = await (s.CreateQuery("from Device d left join fetch d.Drives where d.id = :id")
-							.SetResultTransformer(Transformers.DistinctRootEntity)
-							.SetParameter("id", id2)
-							.UniqueResultAsync<Device>());
+			using var log = new SqlLogSpy();
+			using var s = OpenSession();
+			var dv2 = await (s.CreateQuery("from Device d left join fetch d.Drives where d.id = :id")
+			           .SetResultTransformer(Transformers.DistinctRootEntity)
+			           .SetParameter("id", id2)
+			           .UniqueResultAsync<Device>());
 
-				Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
-				Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
-			}
+			Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
+			Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
+			Assert.That(log.Appender.GetEvents().Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -155,7 +175,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				await (NHibernateUtil.InitializeAsync(dv2.Drives));
 
 				Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
-				Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
+				Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -110,7 +110,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			{
 				dv2 = await (s.GetAsync<Device>(dv2.Id));
 				if(_drivesCount > 0)
-					dv2.Drives.Add(dv1.Drives[0]);
+					dv2.Drives.Add(await (s.GetAsync<Drive>(dv1.Drives[0].Id)));
 				await (t.CommitAsync());
 			}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -23,6 +23,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 	{
 		private int id1;
 		private int id2;
+		private int _drive2Id;
 		private readonly int _drivesCount;
 		private int DrivesCountWithOneIgnored => _drivesCount == 0? 0 : _drivesCount - 1;
 
@@ -42,7 +43,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			using (var t = s.BeginTransaction())
 			{
 				s.Save(dr1);
-				s.Save(dr2);
+				_drive2Id = (int)s.Save(dr2);
 				s.Save(dr3);
 				AddDrive(dv1, dr2);
 				AddDrive(dv1, dr1);
@@ -110,7 +111,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			{
 				dv2 = await (s.GetAsync<Device>(dv2.Id));
 				if(_drivesCount > 0)
-					dv2.Drives.Add(await (s.GetAsync<Drive>(dv1.Drives[0].Id)));
+					dv2.Drives.Add(await (s.LoadAsync<Drive>(_drive2Id)));
 				await (t.CommitAsync());
 			}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -12,6 +12,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 	{
 		private int id1;
 		private int id2;
+		private int _drive2Id;
 		private readonly int _drivesCount;
 		private int DrivesCountWithOneIgnored => _drivesCount == 0? 0 : _drivesCount - 1;
 
@@ -31,7 +32,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			using (var t = s.BeginTransaction())
 			{
 				s.Save(dr1);
-				s.Save(dr2);
+				_drive2Id = (int)s.Save(dr2);
 				s.Save(dr3);
 				AddDrive(dv1, dr2);
 				AddDrive(dv1, dr1);
@@ -99,7 +100,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			{
 				dv2 = s.Get<Device>(dv2.Id);
 				if(_drivesCount > 0)
-					dv2.Drives.Add(s.Get<Drive>(dv1.Drives[0].Id));
+					dv2.Drives.Add(s.Load<Drive>(_drive2Id));
 				t.Commit();
 			}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -1,16 +1,24 @@
 using System;
-using NHibernate.Cfg;
 using NHibernate.Criterion;
 using NHibernate.Transform;
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH750
 {
-	[TestFixture]
+	[TestFixture(0)]
+	[TestFixture(1)]
+	[TestFixture(2)]
 	public class ManyToManyNotFoundIgnoreFixture : BugTestCase
 	{
 		private int id1;
 		private int id2;
+		private readonly int _drivesCount;
+		private int DrivesCountWithOneIgnored => _drivesCount == 0? 0 : _drivesCount - 1;
+
+		public ManyToManyNotFoundIgnoreFixture(int drivesCount)
+		{
+			_drivesCount = drivesCount;
+		}
 
 		protected override void OnSetUp()
 		{
@@ -25,10 +33,10 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				s.Save(dr1);
 				s.Save(dr2);
 				s.Save(dr3);
-				dv1.Drives.Add(dr1);
-				dv1.Drives.Add(dr2);
-				dv2.Drives.Add(dr1);
-				dv2.Drives.Add(dr3);
+				AddDrive(dv1, dr2);
+				AddDrive(dv1, dr1);
+				AddDrive(dv2, dr3);
+				AddDrive(dv2, dr1);
 
 				id1 = (int) s.Save(dv1);
 				id2 = (int) s.Save(dv2);
@@ -40,11 +48,19 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			}
 		}
 
+		private void AddDrive(Device dv, Drive drive)
+		{
+			if(dv.Drives.Count >= _drivesCount)
+				return;
+			dv.Drives.Add(drive);
+		}
+
 		protected override void OnTearDown()
 		{
 			using (ISession s = Sfi.OpenSession())
 			using (var t = s.BeginTransaction())
 			{
+				s.CreateSQLQuery("delete from DriveOfDevice").ExecuteUpdate();
 				s.Delete("from Device");
 				s.Delete("from Drive");
 				t.Commit();
@@ -62,9 +78,9 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				dv2 = (Device) s.Load(typeof(Device), id2);
 			}
 
-			Assert.That(dv1.Drives, Has.Count.EqualTo(2).And.None.Null);
+			Assert.That(dv1.Drives, Has.Count.EqualTo(_drivesCount).And.None.Null);
 			// Verify one is missing
-			Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
+			Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
 
 			//Make sure that flush didn't touch not-found="ignore" records for not modified collection
 			using (var s = Sfi.OpenSession())
@@ -75,18 +91,22 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				t.Commit();
 			}
 
-			VerifyResult(expectedInCollection: 1, expectedInDb: 2, msg: "not modified collection");
+			VerifyResult(expectedInCollection: DrivesCountWithOneIgnored, expectedInDb: _drivesCount, msg: "not modified collection");
 
 			//Many-to-many clears collection and recreates it so not-found ignore records are lost
 			using (var s = Sfi.OpenSession())
 			using (var t = s.BeginTransaction())
 			{
 				dv2 = s.Get<Device>(dv2.Id);
-				dv2.Drives.Add(dv1.Drives[1]);
+				if(_drivesCount > 0)
+					dv2.Drives.Add(dv1.Drives[0]);
 				t.Commit();
 			}
 
-			VerifyResult(2, 2, msg: "modified collection");
+			if(_drivesCount == 1)
+				Assert.Ignore("Test case fails for unrelated reasons");
+
+			VerifyResult(_drivesCount, _drivesCount, msg: "modified collection");
 
 			void VerifyResult(int expectedInCollection, int expectedInDb, string msg)
 			{
@@ -116,23 +136,23 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 							.SingleOrDefault();
 
 				Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
-				Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
+				Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
 			}
 		}
 
 		[Test]
 		public void HqlFetch()
 		{
-			using (var s = OpenSession())
-			{
-				var dv2 = s.CreateQuery("from Device d left join fetch d.Drives where d.id = :id")
-							.SetResultTransformer(Transformers.DistinctRootEntity)
-							.SetParameter("id", id2)
-							.UniqueResult<Device>();
+			using var log = new SqlLogSpy();
+			using var s = OpenSession();
+			var dv2 = s.CreateQuery("from Device d left join fetch d.Drives where d.id = :id")
+			           .SetResultTransformer(Transformers.DistinctRootEntity)
+			           .SetParameter("id", id2)
+			           .UniqueResult<Device>();
 
-				Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
-				Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
-			}
+			Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
+			Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
+			Assert.That(log.Appender.GetEvents().Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -144,7 +164,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 				NHibernateUtil.Initialize(dv2.Drives);
 
 				Assert.That(NHibernateUtil.IsInitialized(dv2.Drives), Is.True);
-				Assert.That(dv2.Drives, Has.Count.EqualTo(1).And.None.Null);
+				Assert.That(dv2.Drives, Has.Count.EqualTo(DrivesCountWithOneIgnored).And.None.Null);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -58,14 +58,13 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 
 		protected override void OnTearDown()
 		{
-			using (ISession s = Sfi.OpenSession())
-			using (var t = s.BeginTransaction())
-			{
-				s.CreateSQLQuery("delete from DriveOfDevice").ExecuteUpdate();
-				s.Delete("from Device");
-				s.Delete("from Drive");
-				t.Commit();
-			}
+			using var s = Sfi.OpenSession();
+			using var t = s.BeginTransaction();
+
+			s.CreateSQLQuery("delete from DriveOfDevice").ExecuteUpdate();
+			s.Delete("from Device");
+			s.Delete("from Drive");
+			t.Commit();
 		}
 
 		[Test]

--- a/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -99,7 +99,7 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 			{
 				dv2 = s.Get<Device>(dv2.Id);
 				if(_drivesCount > 0)
-					dv2.Drives.Add(dv1.Drives[0]);
+					dv2.Drives.Add(s.Get<Drive>(dv1.Drives[0].Id));
 				t.Commit();
 			}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH750/ManyToManyNotFoundIgnoreFixture.cs
@@ -94,18 +94,19 @@ namespace NHibernate.Test.NHSpecificTest.NH750
 
 			VerifyResult(expectedInCollection: DrivesCountWithOneIgnored, expectedInDb: _drivesCount, msg: "not modified collection");
 
-			//Many-to-many clears collection and recreates it so not-found ignore records are lost
+			// Many-to-many clears collection and recreates it so not-found ignore records are lost
+			// Note: It's not the case when no valid records are present, so loaded Drives collection is empty
+			// Just skip this check in this case:
+			if (_drivesCount < 2)
+				return;
+
 			using (var s = Sfi.OpenSession())
 			using (var t = s.BeginTransaction())
 			{
 				dv2 = s.Get<Device>(dv2.Id);
-				if(_drivesCount > 0)
-					dv2.Drives.Add(s.Load<Drive>(_drive2Id));
+				dv2.Drives.Add(s.Load<Drive>(_drive2Id));
 				t.Commit();
 			}
-
-			if(_drivesCount == 1)
-				Assert.Ignore("Test case fails for unrelated reasons");
 
 			VerifyResult(_drivesCount, _drivesCount, msg: "modified collection");
 

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementFactory.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementFactory.cs
@@ -424,7 +424,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 
 				// Add the second join, the one that ends in the destination table.
 				JoinSequence joinSequence = CreateJoinSequence(roleAlias, joinType, implicitJoin);
-				joinSequence.AddJoin(sfh.GetElementAssociationType(_collectionType), tableAlias,type.IsNullable ? JoinType.InnerJoin : joinType, secondJoinColumns);
+				// It's safe to always use inner join for many-to-many not-found ignore mapping as it's processed by table group join
+				var secondJoinType = type.IsNullable ? JoinType.InnerJoin : joinType;
+				joinSequence.AddJoin(sfh.GetElementAssociationType(_collectionType), tableAlias, secondJoinType, secondJoinColumns);
 				elem = CreateJoin(associatedEntityName, tableAlias, joinSequence, type, false);
 				elem.UseFromFragment = true;
 			}

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementFactory.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementFactory.cs
@@ -424,7 +424,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 
 				// Add the second join, the one that ends in the destination table.
 				JoinSequence joinSequence = CreateJoinSequence(roleAlias, joinType, implicitJoin);
-				joinSequence.AddJoin(sfh.GetElementAssociationType(_collectionType), tableAlias, joinType, secondJoinColumns);
+				joinSequence.AddJoin(sfh.GetElementAssociationType(_collectionType), tableAlias,type.IsNullable ? JoinType.InnerJoin : joinType, secondJoinColumns);
 				elem = CreateJoin(associatedEntityName, tableAlias, joinSequence, type, false);
 				elem.UseFromFragment = true;
 			}


### PR DESCRIPTION
Use table group join with inner joined entity table for many-to-many not-found="ignore" mapping:
```sql
FROM Device device0_
LEFT OUTER JOIN (
	DriveOfDevice drives1_ 
	INNER JOIN Drive drive2_ ON drives1_.DriveId = drive2_.id
	) ON device0_.id = drives1_.DeviceId
```