### PR TITLE
Remove ConstantConverter

### DIFF
--- a/src/NHibernate/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
@@ -547,62 +547,11 @@ namespace NHibernate.Hql.Ast.ANTLR
 			try
 			{
 				var ast = (IASTNode) parser.statement().Tree;
-
-				var walker = new NodeTraverser(new ConstantConverter(_sfi));
-				walker.TraverseDepthFirst(ast);
-
 				return ast;
 			}
 			finally
 			{
 				parser.ParseErrorHandler.ThrowQueryException();
-			}
-		}
-
-		class ConstantConverter : IVisitationStrategy
-		{
-			private IASTNode _dotRoot;
-			private readonly ISessionFactoryImplementor _sfi;
-
-			public ConstantConverter(ISessionFactoryImplementor sfi)
-			{
-				_sfi = sfi;
-			}
-
-			public void Visit(IASTNode node)
-			{
-				if (_dotRoot != null)
-				{
-					// we are already processing a dot-structure
-					if (ASTUtil.IsSubtreeChild(_dotRoot, node))
-					{
-						// ignore it...
-						return;
-					}
-
-					// we are now at a new tree level
-					_dotRoot = null;
-				}
-
-				if (_dotRoot == null && node.Type == HqlSqlWalker.DOT)
-				{
-					_dotRoot = node;
-					HandleDotStructure(_dotRoot);
-				}
-			}
-
-			private void HandleDotStructure(IASTNode dotStructureRoot)
-			{
-				var expression = ASTUtil.GetPathText(dotStructureRoot);
-
-				var constant = ReflectHelper.GetConstantValue(expression, _sfi);
-
-				if (constant != null)
-				{
-					dotStructureRoot.ClearChildren();
-					dotStructureRoot.Type = HqlSqlWalker.JAVA_CONSTANT;
-					dotStructureRoot.Text = expression;
-				}
 			}
 		}
 	}

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -289,12 +289,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			return DataType;
 		}
 
-		public void SetResolvedConstant(string text)
-		{
-			_path = text;
-			_dereferenceType = DerefJavaConstant;
-			IsResolved = true; // Don't resolve the node again.
-		}
+		public void SetResolvedConstant(string text) => SetResolvedConstant(text, null);
 
 		public void SetResolvedConstant(string text, object value)
 		{
@@ -797,10 +792,9 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 
 		public override SqlString RenderText(ISessionFactoryImplementor sessionFactory)
 		{
-			if(Type != HqlSqlWalker.JAVA_CONSTANT)
-				return base.RenderText(sessionFactory);
-			return new SqlString(
-				JavaConstantNode.ResolveToLiteralString(DataType, _constantValue, sessionFactory.Dialect));
+			return Type == HqlSqlWalker.JAVA_CONSTANT
+				? JavaConstantNode.ResolveToLiteralString(DataType, _constantValue, sessionFactory.Dialect)
+				: base.RenderText(sessionFactory);
 		}
 	}
 }

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/DotNode.cs
@@ -18,7 +18,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 	/// Ported by: Steve Strong
 	/// </summary>
 	[CLSCompliant(false)]
-	public class DotNode : FromReferenceNode 
+	public class DotNode : FromReferenceNode, IExpectedTypeAwareNode
 	{
 		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(DotNode));
 
@@ -71,6 +71,8 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 		/// The type of join to create.   Default is an inner join.
 		/// </summary>
 		private JoinType _joinType = JoinType.InnerJoin;
+
+		private object _constantValue;
 
 		public DotNode(IToken token) : base(token)
 		{
@@ -292,6 +294,14 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			_path = text;
 			_dereferenceType = DerefJavaConstant;
 			IsResolved = true; // Don't resolve the node again.
+		}
+
+		public void SetResolvedConstant(string text, object value)
+		{
+			_path = text;
+			_dereferenceType = DerefJavaConstant;
+			IsResolved = true; // Don't resolve the node again.
+			_constantValue = value;
 		}
 
 		private static QueryException BuildIllegalCollectionDereferenceException(string propertyName, IASTNode lhs)
@@ -771,6 +781,26 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 				CheckSubclassOrSuperclassPropertyReference(lhs, lhs.NextSibling.Text);
 				lhs = (FromReferenceNode)lhs.GetChild(0);
 			}
+		}
+
+		public IType ExpectedType
+		{
+			get => DataType;
+			set
+			{
+				if (Type != HqlSqlWalker.JAVA_CONSTANT)
+					return;
+
+				DataType = value;
+			}
+		}
+
+		public override SqlString RenderText(ISessionFactoryImplementor sessionFactory)
+		{
+			if(Type != HqlSqlWalker.JAVA_CONSTANT)
+				return base.RenderText(sessionFactory);
+			return new SqlString(
+				JavaConstantNode.ResolveToLiteralString(DataType, _constantValue, sessionFactory.Dialect));
 		}
 	}
 }

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/JavaConstantNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/JavaConstantNode.cs
@@ -38,30 +38,30 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 			set { _factory = value; }
 		}
 
-        public override SqlString RenderText(ISessionFactoryImplementor sessionFactory)
-        {
-            ProcessText();
+		public override SqlString RenderText(ISessionFactoryImplementor sessionFactory)
+		{
+			ProcessText();
 
 			IType type = _expectedType ?? _heuristicType;
-			return new SqlString(ResolveToLiteralString( type ));
+			return ResolveToLiteralString(type);
 		}
 
-        private string ResolveToLiteralString(IType type)
-        {
-	        return ResolveToLiteralString(type, _constantValue, _factory.Dialect);
-        }
+		private SqlString ResolveToLiteralString(IType type)
+		{
+			return ResolveToLiteralString(type, _constantValue, _factory.Dialect);
+		}
 
-        internal static string ResolveToLiteralString(IType type, object constantValue, Dialect.Dialect dialect)
-        {
-	        try
-	        {
-		        return ((ILiteralType)type).ObjectToSQLString(constantValue, dialect);
-	        }
-	        catch (Exception t)
-	        {
-		        throw new QueryException(LiteralProcessor.ErrorCannotFormatLiteral + constantValue, t);
-	        }
-        }
+		internal static SqlString ResolveToLiteralString(IType type, object constantValue, Dialect.Dialect dialect)
+		{
+			try
+			{
+				return new SqlString(((ILiteralType) type).ObjectToSQLString(constantValue, dialect));
+			}
+			catch (Exception t)
+			{
+				throw new QueryException(LiteralProcessor.ErrorCannotFormatLiteral + constantValue, t);
+			}
+		}
 
         private void ProcessText()
         {

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/JavaConstantNode.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/JavaConstantNode.cs
@@ -48,16 +48,19 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 
         private string ResolveToLiteralString(IType type)
         {
-            try
-            {
-                ILiteralType literalType = (ILiteralType)type;
-                Dialect.Dialect dialect = _factory.Dialect;
-                return literalType.ObjectToSQLString(_constantValue, dialect);
-            }
-            catch (Exception t)
-            {
-                throw new QueryException(LiteralProcessor.ErrorCannotFormatLiteral + Text, t);
-            }
+	        return ResolveToLiteralString(type, _constantValue, _factory.Dialect);
+        }
+
+        internal static string ResolveToLiteralString(IType type, object constantValue, Dialect.Dialect dialect)
+        {
+	        try
+	        {
+		        return ((ILiteralType)type).ObjectToSQLString(constantValue, dialect);
+	        }
+	        catch (Exception t)
+	        {
+		        throw new QueryException(LiteralProcessor.ErrorCannotFormatLiteral + constantValue, t);
+	        }
         }
 
         private void ProcessText()

--- a/src/NHibernate/Hql/Ast/ANTLR/Util/LiteralProcessor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Util/LiteralProcessor.cs
@@ -70,7 +70,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 			}
 			else
 			{
-				Object value = ReflectHelper.GetConstantValue(text);
+				var value = ReflectHelper.GetConstantValue(text, _walker.SessionFactoryHelper.Factory);
 				if (value == null)
 				{
 					throw new InvalidPathException("Invalid path: '" + text + "'");
@@ -149,6 +149,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 				if (isIdent && queryable != null)
 				{
 					constant.Text = queryable.DiscriminatorSQLValue;
+					constant.DataType = queryable.DiscriminatorType;
 				}
 				// Otherwise, it's a literal.
 				else
@@ -273,76 +274,11 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 				log.Debug("setConstantValue() {0} -> {1} {2}", text, value, value.GetType().Name);
 			}
 
-			node.ClearChildren();	// Chop off the rest of the tree.
+			node.ClearChildren();
 
-			if (value is string)
-			{
-				node.Type = HqlSqlWalker.QUOTED_String;
-			}
-			else if (value is char)
-			{
-				node.Type = HqlSqlWalker.QUOTED_String;
-			}
-			else if (value is byte)
-			{
-				node.Type = HqlSqlWalker.NUM_INT;
-			}
-			else if (value is short)
-			{
-				node.Type = HqlSqlWalker.NUM_INT;
-			}
-			else if (value is int)
-			{
-				node.Type = HqlSqlWalker.NUM_INT;
-			}
-			else if (value is long)
-			{
-				node.Type = HqlSqlWalker.NUM_LONG;
-			}
-			else if (value is double)
-			{
-				node.Type = HqlSqlWalker.NUM_DOUBLE;
-			}
-			else if (value is decimal)
-			{
-				node.Type = HqlSqlWalker.NUM_DECIMAL;
-			}
-			else if (value is float)
-			{
-				node.Type = HqlSqlWalker.NUM_FLOAT;
-			}
-			else
-			{
-				node.Type = HqlSqlWalker.CONSTANT;
-			}
-
-			IType type;
-			try
-			{
-				type = TypeFactory.HeuristicType(value.GetType().Name);
-			}
-			catch (MappingException me)
-			{
-				throw new QueryException(me);
-			}
-
-			if (type == null)
-			{
-				throw new QueryException(LiteralProcessor.ErrorCannotDetermineType + node.Text);
-			}
-			try
-			{
-				ILiteralType literalType = (ILiteralType)type;
-				NHibernate.Dialect.Dialect dialect = _walker.SessionFactoryHelper.Factory.Dialect;
-				node.Text = literalType.ObjectToSQLString(value, dialect);
-			}
-			catch (Exception e)
-			{
-				throw new QueryException(LiteralProcessor.ErrorCannotFormatLiteral + node.Text, e);
-			}
-
-			node.DataType = type;
-			node.SetResolvedConstant(text);
+			node.Type = HqlSqlWalker.JAVA_CONSTANT;
+			node.DataType = TypeFactory.HeuristicType(value.GetType().Name);
+			node.SetResolvedConstant(text, value);
 		}
 
 		interface IDecimalFormatter

--- a/src/NHibernate/Hql/Ast/ANTLR/Util/LiteralProcessor.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Util/LiteralProcessor.cs
@@ -274,7 +274,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Util
 				log.Debug("setConstantValue() {0} -> {1} {2}", text, value, value.GetType().Name);
 			}
 
-			node.ClearChildren();
+			node.ClearChildren();	// Chop off the rest of the tree.
 
 			node.Type = HqlSqlWalker.JAVA_CONSTANT;
 			node.DataType = TypeFactory.HeuristicType(value.GetType().Name);

--- a/src/NHibernate/Util/ReflectHelper.cs
+++ b/src/NHibernate/Util/ReflectHelper.cs
@@ -820,31 +820,18 @@ namespace NHibernate.Util
 			return foundMethod;
 		}
 
-		internal static object GetConstantValue(string qualifiedName)
-		{
-			return GetConstantValue(qualifiedName, null);
-		}
-
 		internal static object GetConstantValue(string qualifiedName, ISessionFactoryImplementor sfi)
 		{
 			string className = StringHelper.Qualifier(qualifiedName);
 
-			if (!string.IsNullOrEmpty(className))
-			{
-				System.Type t = System.Type.GetType(className);
+			if (string.IsNullOrEmpty(className))
+				return null;
 
-				if (t == null && sfi != null)
-				{
-					t = System.Type.GetType(sfi.GetImportedClassName(className));
-				}
+			var t = System.Type.GetType(sfi?.GetImportedClassName(className) ?? className);
 
-				if (t != null)
-				{
-					return GetConstantValue(t, StringHelper.Unqualify(qualifiedName));
-				}
-			}
-
-			return null;
+			return t == null
+				? null
+				: GetConstantValue(t, StringHelper.Unqualify(qualifiedName));
 		}
 
 		// Since v5


### PR DESCRIPTION
That's quite dumb and not effective class that processes all DotNode nodes in query and tries to parse them as constants (load them via reflection)

Example of query where it's needed:
https://github.com/nhibernate/nhibernate-core/blob/8f05f67e808dc2fc503d4fd0d94b6c9cb66429a1/src/NHibernate.Test/Legacy/FooBarTest.cs#L4292

Where `FooStatus.OFF` string is transformed to actual enum value. `ContstantConverter` tries to convert both `f.Status` and `FooStatus.OFF` to constant value

Instead fix existing logic present in DotNode that makes reflection calls and checks only when necessary.