### PR TITLE
Remove redundant collection BeforeAssemble call from query cache

### DIFF
--- a/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
@@ -1593,6 +1593,7 @@ namespace NHibernate.Test.CacheTest
 		{
 			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
 			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
+			itemCache.ClearStatistics();
 			int id;
 			using (var s = OpenSession())
 			{

--- a/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/BatchableCacheFixture.cs
@@ -1588,6 +1588,53 @@ namespace NHibernate.Test.CacheTest
 			Assert.That(itemCache.GetMultipleCalls.Count, Is.EqualTo(2));
 		}
 
+		[Test]
+		public async Task CollectionLazyInitializationFromCacheIsBatched_FillCacheByQueryCacheAsync()
+		{
+			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
+			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
+			int id;
+			using (var s = OpenSession())
+			{
+				id = await (s.Query<ReadOnly>().Select(x => x.Id).FirstAsync());
+				var readOnly = (await (s.Query<ReadOnly>().Fetch(x => x.Items)
+				                .Where(x => x.Id == id)
+				                .WithOptions(x => x.SetCacheable(true))
+				                .ToListAsync()))
+				                .First();
+				Assert.That(itemCache.PutMultipleCalls.Count, Is.EqualTo(1));
+				Assert.That(itemCache.GetMultipleCalls.Count, Is.EqualTo(0));
+				Assert.That(NHibernateUtil.IsInitialized(readOnly.Items));
+				Assert.That(readOnly.Items.Count, Is.EqualTo(6));
+			}
+
+			itemCache.ClearStatistics();
+			using (var s = OpenSession())
+			{
+				var readOnly = (await (s.Query<ReadOnly>().Fetch(x => x.Items)
+				                .Where(x => x.Id == id)
+				                .WithOptions(x => x.SetCacheable(true))
+				                .ToListAsync()))
+				                .First();
+				Assert.That(itemCache.PutMultipleCalls.Count, Is.EqualTo(0));
+				Assert.That(itemCache.GetMultipleCalls.Count, Is.EqualTo(1));
+				Assert.That(NHibernateUtil.IsInitialized(readOnly.Items));
+				Assert.That(readOnly.Items.Count, Is.EqualTo(6));
+			}
+
+			itemCache.ClearStatistics();
+
+
+			using (var s = OpenSession())
+			{
+				var readOnly = await (s.GetAsync<ReadOnly>(id));
+				Assert.That(readOnly.Items.Count, Is.EqualTo(6));
+			}
+
+			// 6 items with batch-size = 4 so 2 GetMany calls are expected 1st call: 4 items + 2nd call: 2 items
+			Assert.That(itemCache.GetMultipleCalls.Count, Is.EqualTo(2));
+		}
+
 		private async Task AssertMultipleCacheCallsAsync<TEntity>(IEnumerable<int> loadIds,  IReadOnlyList<int> getIds, int idIndex, 
 		                                               int[][] fetchedIdIndexes, int[] putIdIndexes, Func<int, bool> cacheBeforeLoadFn = null, CancellationToken cancellationToken = default(CancellationToken))
 			where TEntity : CacheEntity

--- a/src/NHibernate.Test/CacheTest/BatchableCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/BatchableCacheFixture.cs
@@ -1581,6 +1581,7 @@ namespace NHibernate.Test.CacheTest
 		{
 			var itemPersister = Sfi.GetEntityPersister(typeof(ReadOnlyItem).FullName);
 			var itemCache = (BatchableCache) itemPersister.Cache.Cache;
+			itemCache.ClearStatistics();
 			int id;
 			using (var s = OpenSession())
 			{

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericBag.cs
@@ -111,10 +111,7 @@ namespace NHibernate.Collection.Generic
 			BeforeInitialize(persister, size);
 
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i++)
-			{
-				await (elementType.BeforeAssembleAsync(array[i], Session, cancellationToken)).ConfigureAwait(false);
-			}
+			await (BeforeAssembleAsync(elementType, array, cancellationToken)).ConfigureAwait(false);
 
 			for (var i = 0; i < size; i++)
 			{
@@ -123,6 +120,18 @@ namespace NHibernate.Collection.Generic
 				{
 					_gbag.Add((T) element);
 				}
+			}
+		}
+
+		private async Task BeforeAssembleAsync(IType elementType, object[] array, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				await (elementType.BeforeAssembleAsync(array[i], Session, cancellationToken)).ConfigureAwait(false);
 			}
 		}
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericList.cs
@@ -100,15 +100,24 @@ namespace NHibernate.Collection.Generic
 			BeforeInitialize(persister, size);
 			
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i++)
-			{
-				await (elementType.BeforeAssembleAsync(array[i], Session, cancellationToken)).ConfigureAwait(false);
-			}
+			await (BeforeAssembleAsync(elementType, array, cancellationToken)).ConfigureAwait(false);
 
 			for (int i = 0; i < size; i++)
 			{
 				var element = await (elementType.AssembleAsync(array[i], Session, owner, cancellationToken)).ConfigureAwait(false);
 				WrappedList.Add((T) (element ?? DefaultForType));
+			}
+		}
+
+		private async Task BeforeAssembleAsync(IType elementType, object[] array, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				await (elementType.BeforeAssembleAsync(array[i], Session, cancellationToken)).ConfigureAwait(false);
 			}
 		}
 

--- a/src/NHibernate/Async/Collection/Generic/PersistentGenericSet.cs
+++ b/src/NHibernate/Async/Collection/Generic/PersistentGenericSet.cs
@@ -86,10 +86,7 @@ namespace NHibernate.Collection.Generic
 			BeforeInitialize(persister, size);
 
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i++)
-			{
-				await (elementType.BeforeAssembleAsync(array[i], Session, cancellationToken)).ConfigureAwait(false);
-			}
+			await (BeforeAssembleAsync(elementType, array, cancellationToken)).ConfigureAwait(false);
 
 			for (int i = 0; i < size; i++)
 			{
@@ -100,6 +97,18 @@ namespace NHibernate.Collection.Generic
 				}
 			}
 			SetInitialized();
+		}
+
+		private async Task BeforeAssembleAsync(IType elementType, object[] array, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				await (elementType.BeforeAssembleAsync(array[i], Session, cancellationToken)).ConfigureAwait(false);
+			}
 		}
 
 		public override async Task<object> ReadFromAsync(DbDataReader rs, ICollectionPersister role, ICollectionAliases descriptor, object owner, CancellationToken cancellationToken)

--- a/src/NHibernate/Async/Collection/PersistentArrayHolder.cs
+++ b/src/NHibernate/Async/Collection/PersistentArrayHolder.cs
@@ -95,14 +95,23 @@ namespace NHibernate.Collection
 			array = System.Array.CreateInstance(persister.ElementClass, cached.Length);
 
 			var elementType = persister.ElementType;
-			for (int i = 0; i < cached.Length; i++)
-			{
-				await (elementType.BeforeAssembleAsync(cached[i], Session, cancellationToken)).ConfigureAwait(false);
-			}
+			await (BeforeAssembleAsync(elementType, cached, cancellationToken)).ConfigureAwait(false);
 
 			for (int i = 0; i < cached.Length; i++)
 			{
 				array.SetValue(await (elementType.AssembleAsync(cached[i], Session, owner, cancellationToken)).ConfigureAwait(false), i);
+			}
+		}
+
+		private async Task BeforeAssembleAsync(IType elementType, object[] cached, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < cached.Length; i++)
+			{
+				await (elementType.BeforeAssembleAsync(cached[i], Session, cancellationToken)).ConfigureAwait(false);
 			}
 		}
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericBag.cs
@@ -402,10 +402,7 @@ namespace NHibernate.Collection.Generic
 			BeforeInitialize(persister, size);
 
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i++)
-			{
-				elementType.BeforeAssemble(array[i], Session);
-			}
+			BeforeAssemble(elementType, array);
 
 			for (var i = 0; i < size; i++)
 			{
@@ -414,6 +411,17 @@ namespace NHibernate.Collection.Generic
 				{
 					_gbag.Add((T) element);
 				}
+			}
+		}
+
+		private void BeforeAssemble(IType elementType, object[] array)
+		{
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				elementType.BeforeAssemble(array[i], Session);
 			}
 		}
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericIdentifierBag.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericIdentifierBag.cs
@@ -78,16 +78,24 @@ namespace NHibernate.Collection.Generic
 
 			var identifierType = persister.IdentifierType;
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i += 2)
-			{
-				identifierType.BeforeAssemble(array[i], Session);
-				elementType.BeforeAssemble(array[i + 1], Session);
-			}
+			BeforeAssemble(identifierType, elementType, array);
 
 			for (int i = 0; i < size; i += 2)
 			{
 				_identifiers[i / 2] = identifierType.Assemble(array[i], Session, owner);
 				_values.Add((T) elementType.Assemble(array[i + 1], Session, owner));
+			}
+		}
+
+		private void BeforeAssemble(IType identifierType, IType elementType, object[] array)
+		{
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i += 2)
+			{
+				identifierType.BeforeAssemble(array[i], Session);
+				elementType.BeforeAssemble(array[i + 1], Session);
 			}
 		}
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericList.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericList.cs
@@ -162,15 +162,23 @@ namespace NHibernate.Collection.Generic
 			BeforeInitialize(persister, size);
 			
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i++)
-			{
-				elementType.BeforeAssemble(array[i], Session);
-			}
+			BeforeAssemble(elementType, array);
 
 			for (int i = 0; i < size; i++)
 			{
 				var element = elementType.Assemble(array[i], Session, owner);
 				WrappedList.Add((T) (element ?? DefaultForType));
+			}
+		}
+
+		private void BeforeAssemble(IType elementType, object[] array)
+		{
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				elementType.BeforeAssemble(array[i], Session);
 			}
 		}
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericMap.cs
@@ -166,16 +166,24 @@ namespace NHibernate.Collection.Generic
 
 			var indexType = persister.IndexType;
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i += 2)
-			{
-				indexType.BeforeAssemble(array[i], Session);
-				elementType.BeforeAssemble(array[i + 1], Session);
-			}
+			BeforeAssemble(indexType, elementType, array);
 
 			for (int i = 0; i < size; i += 2)
 			{
 				WrappedMap[(TKey)indexType.Assemble(array[i], Session, owner)] =
 					(TValue)elementType.Assemble(array[i + 1], Session, owner);
+			}
+		}
+
+		private void BeforeAssemble(IType indexType, IType elementType, object[] array)
+		{
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i += 2)
+			{
+				indexType.BeforeAssemble(array[i], Session);
+				elementType.BeforeAssemble(array[i + 1], Session);
 			}
 		}
 

--- a/src/NHibernate/Collection/Generic/PersistentGenericSet.cs
+++ b/src/NHibernate/Collection/Generic/PersistentGenericSet.cs
@@ -156,10 +156,7 @@ namespace NHibernate.Collection.Generic
 			BeforeInitialize(persister, size);
 
 			var elementType = persister.ElementType;
-			for (int i = 0; i < size; i++)
-			{
-				elementType.BeforeAssemble(array[i], Session);
-			}
+			BeforeAssemble(elementType, array);
 
 			for (int i = 0; i < size; i++)
 			{
@@ -170,6 +167,17 @@ namespace NHibernate.Collection.Generic
 				}
 			}
 			SetInitialized();
+		}
+
+		private void BeforeAssemble(IType elementType, object[] array)
+		{
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				elementType.BeforeAssemble(array[i], Session);
+			}
 		}
 
 		public override bool Empty

--- a/src/NHibernate/Collection/PersistentArrayHolder.cs
+++ b/src/NHibernate/Collection/PersistentArrayHolder.cs
@@ -197,14 +197,22 @@ namespace NHibernate.Collection
 			array = System.Array.CreateInstance(persister.ElementClass, cached.Length);
 
 			var elementType = persister.ElementType;
-			for (int i = 0; i < cached.Length; i++)
-			{
-				elementType.BeforeAssemble(cached[i], Session);
-			}
+			BeforeAssemble(elementType, cached);
 
 			for (int i = 0; i < cached.Length; i++)
 			{
 				array.SetValue(elementType.Assemble(cached[i], Session, owner), i);
+			}
+		}
+
+		private void BeforeAssemble(IType elementType, object[] cached)
+		{
+			if (Session.PersistenceContext.BatchFetchQueue.QueryCacheQueue != null)
+				return;
+
+			for (int i = 0; i < cached.Length; i++)
+			{
+				elementType.BeforeAssemble(cached[i], Session);
 			}
 		}
 


### PR DESCRIPTION
Investigated my [concern](https://github.com/nhibernate/nhibernate-core/pull/3365#issuecomment-1638431519). Turns out it's a bit different issue:
Query cache prepares collection elements separately (so collection fetch from query cache worked properly without #3365). So collection BeforeAssemble call can be skipped for query cache processing. There are no ill effects apart from double processing.