### PR TITLE
Reenable use of SelectClauseVisitor for subqueries

### DIFF
--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -660,6 +660,19 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task TimesheetsWithProjectionInSubqueryAsync()
+		{
+			if (Dialect is MsSqlCeDialect)
+				Assert.Ignore("Dialect is not supported");
+
+			var query = await ((from sheet in db.Timesheets
+						 where sheet.Users.Select(x => new { Id = x.Id, Name = x.Name }).Any(x => x.Id == 1)
+						 select sheet).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
+		[Test]
 		public async Task ContainsSubqueryWithCoalesceStringEnumSelectAsync()
 		{
 			if (Dialect is MsSqlCeDialect || Dialect is SQLiteDialect)

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -661,6 +661,19 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void TimesheetsWithProjectionInSubquery()
+		{
+			if (Dialect is MsSqlCeDialect)
+				Assert.Ignore("Dialect is not supported");
+
+			var query = (from sheet in db.Timesheets
+						 where sheet.Users.Select(x => new { Id = x.Id, Name = x.Name }).Any(x => x.Id == 1)
+						 select sheet).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
+		[Test]
 		public void ContainsSubqueryWithCoalesceStringEnumSelect()
 		{
 			if (Dialect is MsSqlCeDialect || Dialect is SQLiteDialect)

--- a/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
@@ -476,13 +476,9 @@ namespace NHibernate.Linq.Visitors
 
 		private HqlSelect GetSelectClause(Expression selectClause)
 		{
-			if (!_root)
-				return _hqlTree.TreeBuilder.Select(
-					HqlGeneratorExpressionVisitor.Visit(selectClause, VisitorParameters).AsExpression());
-
 			var visitor = new SelectClauseVisitor(typeof(object[]), VisitorParameters);
 
-			visitor.VisitSelector(selectClause);
+			visitor.VisitSelector(selectClause, !_root);
 
 			if (visitor.ProjectionExpression != null)
 			{

--- a/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseNominator.cs
@@ -43,13 +43,13 @@ namespace NHibernate.Linq.Visitors
 			_parameters = parameters;
 		}
 
-		internal Expression Nominate(Expression expression)
+		internal Expression Nominate(Expression expression, bool isSubQuery = false)
 		{
 			HqlCandidates = new HashSet<Expression>();
 			ContainsUntranslatedMethodCalls = false;
 			_canBeCandidate = true;
 			_stateStack = new Stack<bool>();
-			_stateStack.Push(false);
+			_stateStack.Push(isSubQuery);
 
 			return Visit(expression);
 		}

--- a/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
@@ -33,8 +33,8 @@ namespace NHibernate.Linq.Visitors
 		{
 			return _hqlTreeNodes;
 		}
-
-		public void VisitSelector(Expression expression, bool isSubQuery = false)
+		public void VisitSelector(Expression expression) => VisitSelector(expression, false);
+		public void VisitSelector(Expression expression, bool isSubQuery)
 		{
 			var distinct = expression as NhDistinctExpression;
 			if (distinct != null)

--- a/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Linq.Visitors
 			return _hqlTreeNodes;
 		}
 
-		public void VisitSelector(Expression expression)
+		public void VisitSelector(Expression expression, bool isSubQuery = false)
 		{
 			var distinct = expression as NhDistinctExpression;
 			if (distinct != null)
@@ -44,7 +44,7 @@ namespace NHibernate.Linq.Visitors
 
 			// Find the sub trees that can be expressed purely in HQL
 			var nominator = new SelectClauseHqlNominator(_parameters);
-			expression = nominator.Nominate(expression);
+			expression = nominator.Nominate(expression, isSubQuery);
 			_hqlNodes = nominator.HqlCandidates;
 
 			// Linq2SQL ignores calls to local methods. Linq2EF seems to not support

--- a/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
@@ -33,6 +33,7 @@ namespace NHibernate.Linq.Visitors
 		{
 			return _hqlTreeNodes;
 		}
+
 		public void VisitSelector(Expression expression) => VisitSelector(expression, false);
 
 		public void VisitSelector(Expression expression, bool isSubQuery)

--- a/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/SelectClauseVisitor.cs
@@ -34,6 +34,7 @@ namespace NHibernate.Linq.Visitors
 			return _hqlTreeNodes;
 		}
 		public void VisitSelector(Expression expression) => VisitSelector(expression, false);
+
 		public void VisitSelector(Expression expression, bool isSubQuery)
 		{
 			var distinct = expression as NhDistinctExpression;


### PR DESCRIPTION
Regression caused by #3271. 

Select clause rewriting is needed for subqueries, since they may (quite often) use projections with "new". 

Relaxing the SelectClauseNominator for subqueries is a potential solution. There shouldn't be a resulting ProjectionExpression, but it works. 
