### PR TITLE
Fix ArgumentException : Column 'SQL_TYPE_NAME' does not belong to table DataTypes (#3438)

### DIFF
--- a/src/NHibernate/Dialect/Schema/DB2MetaData.cs
+++ b/src/NHibernate/Dialect/Schema/DB2MetaData.cs
@@ -37,15 +37,19 @@ namespace NHibernate.Dialect.Schema
 
 			var dtTypes = Connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
 
-			var typeNameColumn = dtTypes.Columns.Cast<DataColumn>()
-							.FirstOrDefault(column => column.ColumnName == "SQL_TYPE_NAME");
+			var typeNameColumnIndex = dtTypes.Columns.IndexOf("SQL_TYPE_NAME");
 
-			if (typeNameColumn == null) //todo We can try to fallback to "TypeName" columnName
-				return result;
+			if (typeNameColumnIndex == -1)
+			{
+				typeNameColumnIndex = dtTypes.Columns.IndexOf("TypeName");
+
+				if (typeNameColumnIndex == -1)
+					return result;
+			}
 
 			foreach (DataRow row in dtTypes.Rows)
 			{
-				result.Add(row[typeNameColumn].ToString());
+				result.Add(row[typeNameColumnIndex].ToString());
 			}
 
 			return result;

--- a/src/NHibernate/Dialect/Schema/DB2MetaData.cs
+++ b/src/NHibernate/Dialect/Schema/DB2MetaData.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Dialect.Schema
 			var dtTypes = Connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
 
 			var typeNameColumn = dtTypes.Columns.Cast<DataColumn>()
-										.FirstOrDefault(column => column.ColumnName == "SQL_TYPE_NAME");
+							.FirstOrDefault(column => column.ColumnName == "SQL_TYPE_NAME");
 
 			if (typeNameColumn == null) //todo We can try to fallback to "TypeName" columnName
 				return result;


### PR DESCRIPTION
Fix for #3438

Data types will be included in the DB2 reserved words, only if a a column existes with the name "SQL_TYPE_NAME". If not il will not throw an ArgumentException : Column 'SQL_TYPE_NAME' does not belong to table DataTypes.

This PR includes only the uncaught exception. But if you are ok I can add a fallback to the TypeName column if the first does not exist.