### PR TITLE
Migrate appveyor build to MySql 8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,10 +42,10 @@ before_test:
         Pop-Location
       }
       'MySQL' {
-        Start-Service 'MySQL57'
+        Start-Service 'MySQL80'
         # Create nhibernate database (not handled by NHibernate.TestDatabaseSetup.dll)
         $env:MYSQL_PWD = 'Password12!'
-        & 'C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql' -e 'CREATE DATABASE nhibernate;' --user=root
+        & 'C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql' -e 'CREATE DATABASE nhibernate CHARACTER SET utf8 COLLATE utf8_general_ci;' --user=root
       }
       'Odbc' { Start-Service 'MSSQL$SQL2017' }
       'PostgreSQL' {

--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -21,6 +21,7 @@
     <NhNetCoreApp>false</NhNetCoreApp>
     <NhNetCoreApp Condition="$(TargetFramework.StartsWith('netcoreapp'))">true</NhNetCoreApp>
     <DefineConstants Condition="$(NhNetCoreApp) AND $(NhVbNet) == ''" >NETCOREAPP2_0_OR_GREATER;$(DefineConstants)</DefineConstants>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
 
     <Product>NHibernate</Product>
     <Company>NHibernate.info</Company>

--- a/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
@@ -59,6 +59,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesIntoObjectArrayAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Name, u.InvalidLoginAttempts})
 				.FirstAsync());
 
@@ -71,6 +72,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectComponentsIntoObjectArrayAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Component, u.Component.OtherComponent})
 				.FirstAsync());
 
@@ -106,6 +108,7 @@ namespace NHibernate.Test.Linq
 			const string name = "Julian";
 
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, pi, name, DateTime.MinValue})
 				.FirstAsync());
 
@@ -119,6 +122,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesFromAssociationsIntoObjectArrayAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Role.Name, u.Role.Entity.Output})
 				.FirstAsync());
 
@@ -131,6 +135,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesIntoObjectArrayInPropertyAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new object[] { u.Id, u.Name, new object[u.Id] } })
 				.FirstAsync());
 
@@ -144,6 +149,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesIntoPropertyListInPropertyAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new List<object> { u.Id, u.Name, new object[u.Id] } })
 				.FirstAsync());
 
@@ -156,7 +162,7 @@ namespace NHibernate.Test.Linq
 		[Test, Description("NH-2744")]
 		public async Task CanSelectPropertiesIntoNestedObjectArraysAsync()
 		{
-			var query = db.Users.Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
+			var query = db.Users.OrderBy(u => u.Id).Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
 			var result = await (query.FirstAsync());
 
 			Assert.That(result.Length, Is.EqualTo(2));

--- a/src/NHibernate.Test/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Linq/MethodCallTests.cs
@@ -47,6 +47,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesIntoObjectArray()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Name, u.InvalidLoginAttempts})
 				.First();
 
@@ -59,6 +60,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectComponentsIntoObjectArray()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Component, u.Component.OtherComponent})
 				.First();
 
@@ -94,6 +96,7 @@ namespace NHibernate.Test.Linq
 			const string name = "Julian";
 
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, pi, name, DateTime.MinValue})
 				.First();
 
@@ -107,6 +110,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesFromAssociationsIntoObjectArray()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Role.Name, u.Role.Entity.Output})
 				.First();
 
@@ -119,6 +123,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesIntoObjectArrayInProperty()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new object[] { u.Id, u.Name, new object[u.Id] } })
 				.First();
 
@@ -132,6 +137,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesIntoPropertyListInProperty()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new List<object> { u.Id, u.Name, new object[u.Id] } })
 				.First();
 
@@ -144,7 +150,7 @@ namespace NHibernate.Test.Linq
 		[Test, Description("NH-2744")]
 		public void CanSelectPropertiesIntoNestedObjectArrays()
 		{
-			var query = db.Users.Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
+			var query = db.Users.OrderBy(u => u.Id).Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
 			var result = query.First();
 
 			Assert.That(result.Length, Is.EqualTo(2));

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />
-    <PackageReference Include="MySql.Data" Version="6.9.11" />
+    <PackageReference Include="MySql.Data" Version="8.0.30" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
@@ -82,7 +82,7 @@
     <PackageReference Include="System.Data.OracleClient" Version="1.0.8" />
     <PackageReference Include="System.Data.Odbc" Version="4.5.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="MySql.Data" Version="8.0.30" />
     <PackageReference Include="NUnitLite" Version="3.13.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
@@ -91,7 +91,7 @@
     <PackageReference Include="System.Data.OracleClient" Version="1.0.8" />
     <PackageReference Include="System.Data.Odbc" Version="4.5.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="MySql.Data" Version="8.0.30" />
     <PackageReference Include="NUnitLite" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Replace #3447 .

Or maybe not: on that branch, MySql appveyor failures are allowed. But without doing that, the build would entirely fail instead of failing just for a few tests.
