### PR TITLE
Fix DB2/400 schema generation on 5.3.x

### DIFF
--- a/.github/workflows/GenerateAsyncCode.yml
+++ b/.github/workflows/GenerateAsyncCode.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 2.2.x
+        dotnet-version: 2.1.x
 
     - name: Generate Async code
       run: |

--- a/src/NHibernate/Dialect/DB2400Dialect.cs
+++ b/src/NHibernate/Dialect/DB2400Dialect.cs
@@ -1,4 +1,6 @@
-using NHibernate.Cfg;
+using System;
+using System.Data.Common;
+using NHibernate.Dialect.Schema;
 using NHibernate.SqlCommand;
 
 namespace NHibernate.Dialect
@@ -23,7 +25,13 @@ namespace NHibernate.Dialect
 	{
 		public DB2400Dialect()
 		{
-			DefaultProperties[Environment.ConnectionDriver] = "NHibernate.Driver.DB2400Driver";
+			DefaultProperties[Cfg.Environment.ConnectionDriver] = "NHibernate.Driver.DB2400Driver";
+		}
+
+		public override IDataBaseSchema GetDataBaseSchema(DbConnection connection)
+		{
+			// The DB2 implementation is not valid for DB2400.
+			throw new NotSupportedException();
 		}
 
 		public override bool SupportsSequences


### PR DESCRIPTION
Fix #3438

Replace #3439.

That the commits from there, cherry-picked on 5.3.x with another one from #3450 allowing building 5.3.x.