### PR TITLE
Migrate appveyor build to MySql 8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,10 +39,10 @@ before_test:
         Pop-Location
       }
       'MySQL' {
-        Start-Service 'MySQL57'
+        Start-Service 'MySQL80'
         # Create nhibernate database (not handled by NHibernate.TestDatabaseSetup.dll)
         $env:MYSQL_PWD = 'Password12!'
-        & 'C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql' -e 'CREATE DATABASE nhibernate CHARACTER SET utf8 COLLATE utf8_general_ci;' --user=root
+        & 'C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql' -e 'CREATE DATABASE nhibernate CHARACTER SET utf8 COLLATE utf8_general_ci;' --user=root
       }
       'Odbc' { Start-Service 'MSSQL$SQL2017' }
       'PostgreSQL' {

--- a/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
@@ -59,6 +59,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesIntoObjectArrayAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Name, u.InvalidLoginAttempts})
 				.FirstAsync());
 
@@ -71,6 +72,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectComponentsIntoObjectArrayAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Component, u.Component.OtherComponent})
 				.FirstAsync());
 
@@ -106,6 +108,7 @@ namespace NHibernate.Test.Linq
 			const string name = "Julian";
 
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, pi, name, DateTime.MinValue})
 				.FirstAsync());
 
@@ -119,6 +122,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesFromAssociationsIntoObjectArrayAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Role.Name, u.Role.Entity.Output})
 				.FirstAsync());
 
@@ -131,6 +135,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesIntoObjectArrayInPropertyAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new object[] { u.Id, u.Name, new object[u.Id] } })
 				.FirstAsync());
 
@@ -144,6 +149,7 @@ namespace NHibernate.Test.Linq
 		public async Task CanSelectPropertiesIntoPropertyListInPropertyAsync()
 		{
 			var result = await (db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new List<object> { u.Id, u.Name, new object[u.Id] } })
 				.FirstAsync());
 
@@ -156,7 +162,7 @@ namespace NHibernate.Test.Linq
 		[Test, Description("NH-2744")]
 		public async Task CanSelectPropertiesIntoNestedObjectArraysAsync()
 		{
-			var query = db.Users.Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
+			var query = db.Users.OrderBy(u => u.Id).Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
 			var result = await (query.FirstAsync());
 
 			Assert.That(result.Length, Is.EqualTo(2));

--- a/src/NHibernate.Test/Extralazy/UserGroup.hbm.xml
+++ b/src/NHibernate.Test/Extralazy/UserGroup.hbm.xml
@@ -4,7 +4,7 @@
 				   assembly="NHibernate.Test"
 				   namespace="NHibernate.Test.Extralazy">
 
-	<class name="Group" table="groups">
+	<class name="Group" table="`groups`">
 		<id name="Name"/>
 		<map name="Users" cascade="persist" table="group_user" lazy="extra">
 			<key column="groupName"/>

--- a/src/NHibernate.Test/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Linq/MethodCallTests.cs
@@ -47,6 +47,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesIntoObjectArray()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Name, u.InvalidLoginAttempts})
 				.First();
 
@@ -59,6 +60,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectComponentsIntoObjectArray()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Component, u.Component.OtherComponent})
 				.First();
 
@@ -94,6 +96,7 @@ namespace NHibernate.Test.Linq
 			const string name = "Julian";
 
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, pi, name, DateTime.MinValue})
 				.First();
 
@@ -107,6 +110,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesFromAssociationsIntoObjectArray()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new object[] {u.Id, u.Role.Name, u.Role.Entity.Output})
 				.First();
 
@@ -119,6 +123,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesIntoObjectArrayInProperty()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new object[] { u.Id, u.Name, new object[u.Id] } })
 				.First();
 
@@ -132,6 +137,7 @@ namespace NHibernate.Test.Linq
 		public void CanSelectPropertiesIntoPropertyListInProperty()
 		{
 			var result = db.Users
+				.OrderBy(u => u.Id)
 				.Select(u => new { Cells = new List<object> { u.Id, u.Name, new object[u.Id] } })
 				.First();
 
@@ -144,7 +150,7 @@ namespace NHibernate.Test.Linq
 		[Test, Description("NH-2744")]
 		public void CanSelectPropertiesIntoNestedObjectArrays()
 		{
-			var query = db.Users.Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
+			var query = db.Users.OrderBy(u => u.Id).Select(u => new object[] {"Root", new object[] {"Sub1", u.Name, new object[] {"Sub2", u.Name}}});
 			var result = query.First();
 
 			Assert.That(result.Length, Is.EqualTo(2));

--- a/src/NHibernate.Test/NHSpecificTest/NH2113/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2113/Mappings.hbm.xml
@@ -15,7 +15,7 @@
     <property name="Name" />
 	</class>
 
-  <class name="Group" table="Groups">
+  <class name="Group" table="`Groups`">
     <id name="Id" column="GroupID">
       <generator class="increment"/>
     </id>

--- a/src/NHibernate.Test/NHSpecificTest/NH2907/Mappings.hbm.xml
+++ b/src/NHibernate.Test/NHSpecificTest/NH2907/Mappings.hbm.xml
@@ -12,7 +12,7 @@
 		<property name="Name" type="string"/>
 	</class>
 
-	<class name="Group" table="groups">
+	<class name="Group" table="`groups`">
 		<id name="Id">
 			<column name="GroupId"/>
 			<generator class="native"/>

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="8.5.2" />
     <PackageReference Include="Npgsql" Version="6.0.6" />
-    <PackageReference Include="MySql.Data" Version="8.0.27" />
+    <PackageReference Include="MySql.Data" Version="8.0.30" />
   </ItemGroup>
   <ItemGroup Condition="$(NhNetFx)">
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
Replace #3447.

5.3.x is targeting an old AppVeyor image still having MySql 5.7, as seen by @bahusoid.