### PR TITLE
Inserting multiple associations of the same entity fails

### DIFF
--- a/src/NHibernate.Test/Async/BulkManipulation/HQLBulkOperations.cs
+++ b/src/NHibernate.Test/Async/BulkManipulation/HQLBulkOperations.cs
@@ -47,6 +47,9 @@ namespace NHibernate.Test.BulkManipulation
 		[Test]
 		public async Task InsertFromSelectWithMultipleAssociationsAsync()
 		{
+			Assume.That(TestDialect.NativeGeneratorSupportsBulkInsertion,
+				"The dialect does not support a native generator compatible with bulk insertion.");
+
 			using var s = OpenSession();
 			using var tx = s.BeginTransaction();
 

--- a/src/NHibernate.Test/Async/BulkManipulation/HQLBulkOperations.cs
+++ b/src/NHibernate.Test/Async/BulkManipulation/HQLBulkOperations.cs
@@ -43,5 +43,18 @@ namespace NHibernate.Test.BulkManipulation
 				await (tx.CommitAsync());
 			}
 		}
+
+		[Test, KnownBug("#3489")]
+		public async Task InsertFromSelectWithMultipleAssociationsAsync()
+		{
+			using var s = OpenSession();
+			using var tx = s.BeginTransaction();
+
+			await (s.CreateQuery("insert into Enrolment (Course, Student)" +
+				" select e.Course, e.Student from Enrolment e")
+				.ExecuteUpdateAsync());
+
+			await (tx.CommitAsync());
+		}
 	}
 }

--- a/src/NHibernate.Test/Async/BulkManipulation/HQLBulkOperations.cs
+++ b/src/NHibernate.Test/Async/BulkManipulation/HQLBulkOperations.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Test.BulkManipulation
 			}
 		}
 
-		[Test, KnownBug("#3489")]
+		[Test]
 		public async Task InsertFromSelectWithMultipleAssociationsAsync()
 		{
 			using var s = OpenSession();

--- a/src/NHibernate.Test/BulkManipulation/Course.cs
+++ b/src/NHibernate.Test/BulkManipulation/Course.cs
@@ -1,0 +1,8 @@
+namespace NHibernate.Test.BulkManipulation
+{
+	public class Course
+	{
+		public virtual long CourseId { get; set; }
+		public virtual string Description { get; set; }
+	}
+}

--- a/src/NHibernate.Test/BulkManipulation/Enrolment.cs
+++ b/src/NHibernate.Test/BulkManipulation/Enrolment.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NHibernate.Test.BulkManipulation
+{
+	[Serializable]
+	public class Enrolment
+	{
+		public virtual long EnrolmentId { get; set; }
+		public virtual Student Student { get; set; }
+		public virtual Course Course { get; set; }
+	}
+}

--- a/src/NHibernate.Test/BulkManipulation/Enrolment.hbm.xml
+++ b/src/NHibernate.Test/BulkManipulation/Enrolment.hbm.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0"?>
+<hibernate-mapping
+	xmlns="urn:nhibernate-mapping-2.2"
+	assembly="NHibernate.Test"
+	namespace="NHibernate.Test.BulkManipulation">
+
+  <class name="Course">
+    <id name="CourseId">
+      <generator class="native" />
+    </id>
+    <property name="Description" />
+  </class>
+
+  <class name="Student">
+    <id name="StudentId">
+      <generator class="native" />
+    </id>
+    <property name="Name" />
+  </class>
+
+  <class name="Enrolment">
+    <id name="EnrolmentId">
+      <generator class="native" />
+    </id>
+    <many-to-one name="Student" column="StudentId" class="Student" />
+    <many-to-one name="Course" column="CourseId" class="Course" />
+  </class>
+
+</hibernate-mapping>

--- a/src/NHibernate.Test/BulkManipulation/HQLBulkOperations.cs
+++ b/src/NHibernate.Test/BulkManipulation/HQLBulkOperations.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Test.BulkManipulation
 			}
 		}
 
-		[Test, KnownBug("#3489")]
+		[Test]
 		public void InsertFromSelectWithMultipleAssociations()
 		{
 			using var s = OpenSession();

--- a/src/NHibernate.Test/BulkManipulation/HQLBulkOperations.cs
+++ b/src/NHibernate.Test/BulkManipulation/HQLBulkOperations.cs
@@ -36,6 +36,9 @@ namespace NHibernate.Test.BulkManipulation
 		[Test]
 		public void InsertFromSelectWithMultipleAssociations()
 		{
+			Assume.That(TestDialect.NativeGeneratorSupportsBulkInsertion,
+				"The dialect does not support a native generator compatible with bulk insertion.");
+
 			using var s = OpenSession();
 			using var tx = s.BeginTransaction();
 

--- a/src/NHibernate.Test/BulkManipulation/HQLBulkOperations.cs
+++ b/src/NHibernate.Test/BulkManipulation/HQLBulkOperations.cs
@@ -32,5 +32,18 @@ namespace NHibernate.Test.BulkManipulation
 				tx.Commit();
 			}
 		}
+
+		[Test, KnownBug("#3489")]
+		public void InsertFromSelectWithMultipleAssociations()
+		{
+			using var s = OpenSession();
+			using var tx = s.BeginTransaction();
+
+			s.CreateQuery("insert into Enrolment (Course, Student)" +
+				" select e.Course, e.Student from Enrolment e")
+				.ExecuteUpdate();
+
+			tx.Commit();
+		}
 	}
 }

--- a/src/NHibernate.Test/BulkManipulation/Student.cs
+++ b/src/NHibernate.Test/BulkManipulation/Student.cs
@@ -1,0 +1,8 @@
+namespace NHibernate.Test.BulkManipulation
+{
+	public class Student
+	{
+		public virtual long StudentId { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/SelectClause.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/SelectClause.cs
@@ -493,10 +493,14 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 					continue;
 				}
 
-				var node = (IASTNode) e;
-				if (processedElements.Add(fromElement))
+				var isNewFrom = processedElements.Add(fromElement);
+				if (isNewFrom)
 				{
 					combinedFromElements.Add(fromElement);
+				}
+				var node = (IASTNode) e;
+				if (isNewFrom || node.Type == SqlGenerator.DOT)
+				{
 					RenderNonScalarIdentifiers(fromElement, inheritedExpressions.ContainsKey(e) ? null : e, appender);
 				}
 				else if (!inheritedExpressions.ContainsKey(e) && node.Parent != null)


### PR DESCRIPTION
This works in 5.3.3, for example, but not in 5.5.0.
Thoughts as to why / how to fix?

Here's the failing test message:
```
NHibernate.Hql.Ast.ANTLR.QuerySyntaxException : A recognition error occurred. [insert into Enrolment (Course, Student) select e.Course, e.Student from Enrolment e]
  ----> Antlr.Runtime.MismatchedTreeNodeException : A recognition error occurred.
```
And the stack trace:
```
ErrorCounter.ThrowQueryException() line 71
BasicExecutor.ctor(IStatement statement, IQueryable persister) line 36
QueryTranslatorImpl.BuildAppropriateStatementExecutor(IStatement statement) line 478
QueryTranslatorImpl.DoCompile(IDictionary`2 replacements, Boolean shallow, String collectionRole) line 430
QueryTranslatorImpl.Compile(IDictionary`2 replacements, Boolean shallow) line 116
ASTQueryTranslatorFactory.CreateQueryTranslators(IQueryExpression queryExpression, IASTNode ast, String queryIdentifier, String collectionRole, Boolean shallow, IDictionary`2 filters, ISessionFactoryImplementor factory) line 53
ASTQueryTranslatorFactory.CreateQueryTranslators(IQueryExpression queryExpression, String collectionRole, Boolean shallow, IDictionary`2 filters, ISessionFactoryImplementor factory) line 21
QueryExpressionPlan.CreateTranslators(IQueryExpression queryExpression, String collectionRole, Boolean shallow, IDictionary`2 enabledFilters, ISessionFactoryImplementor factory) line 37
QueryExpressionPlan.ctor(IQueryExpression queryExpression, Boolean shallow, IDictionary`2 enabledFilters, ISessionFactoryImplementor factory) line 19
QueryPlanCache.GetHQLQueryPlan(IQueryExpression queryExpression, Boolean shallow, IDictionary`2 enabledFilters) line 76
AbstractSessionImpl.GetHQLQueryPlan(IQueryExpression queryExpression, Boolean shallow) line 584
AbstractSessionImpl.CreateQuery(String queryString) line 563
HqlBulkOperations.InsertFromSelectWithMultipleAssociations() line 46
--MismatchedTreeNodeException
TreeParser.RecoverFromMismatchedToken(IIntStream input, Int32 ttype, BitSet follow)
BaseRecognizer.Match(IIntStream input, Int32 ttype, BitSet follow)
SqlGenerator.selectClause() line 2099
```
And the standard output:
```
13:24:05,570 ERROR Parser:199 - MismatchedTreeNodeException(151!=3)
13:24:05,680 ERROR Parser:199 - MismatchedTreeNodeException(3!=49)
13:24:05,683 ERROR Parser:199 - MismatchedTreeNodeException(49!=3)
```