### PR TITLE
Add NUnit analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,8 @@ dotnet_diagnostic.NUnit2031.severity = suggestion
 dotnet_diagnostic.NUnit2049.severity = suggestion
 # NUnit 4 no longer supports string.Format specification for Assert
 dotnet_diagnostic.NUnit2050.severity = suggestion
+# The SameAs constraint always fails on value types as the actual and the expected value cannot be the same reference
+dotnet_diagnostic.NUnit2040.severity = suggestion
 
 [*.xsd]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,18 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
+dotnet_diagnostic.NUnit1032.severity = suggestion
+dotnet_diagnostic.NUnit1028.severity = none
+dotnet_diagnostic.NUnit2045.severity = none
+# Consider using the constraint model, Assert.That
+dotnet_diagnostic.NUnit2005.severity = suggestion
+dotnet_diagnostic.NUnit2006.severity = suggestion
+dotnet_diagnostic.NUnit2015.severity = suggestion
+dotnet_diagnostic.NUnit2031.severity = suggestion
+dotnet_diagnostic.NUnit2049.severity = suggestion
+# NUnit 4 no longer supports string.Format specification for Assert
+dotnet_diagnostic.NUnit2050.severity = suggestion
+
 [*.xsd]
 indent_style = tab
 
@@ -33,10 +45,6 @@ indent_size = 2
 [*.vbproj]
 indent_style = space
 indent_size = 2
-
-[*.cshtml]
-indent_style = space
-indent_size = 4
 
 [*.g]
 indent_style = tab

--- a/src/NHibernate.Test/Async/CompositeId/CompositeIdFixture.cs
+++ b/src/NHibernate.Test/Async/CompositeId/CompositeIdFixture.cs
@@ -199,8 +199,8 @@ namespace NHibernate.Test.CompositeId
 			Assert.AreEqual(2, c.Orders.Count);
 			Assert.IsTrue(NHibernateUtil.IsInitialized(((Order) c.Orders[0]).LineItems));
 			Assert.IsTrue(NHibernateUtil.IsInitialized(((Order) c.Orders[1]).LineItems));
-			Assert.AreEqual(((Order) c.Orders[0]).LineItems.Count, 2);
-			Assert.AreEqual(((Order) c.Orders[1]).LineItems.Count, 2);
+			Assert.AreEqual(2, ((Order) c.Orders[0]).LineItems.Count);
+			Assert.AreEqual(2, ((Order) c.Orders[1]).LineItems.Count);
 			await (t.CommitAsync());
 			s.Close();
 

--- a/src/NHibernate.Test/Async/Criteria/CriteriaQueryTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/CriteriaQueryTest.cs
@@ -3093,7 +3093,7 @@ namespace NHibernate.Test.Criteria
 				var countExec = CriteriaTransformer.TransformToRowCount(ec);
 				var countRes = await (countExec.UniqueResultAsync());
 
-				Assert.AreEqual(countRes, 1);
+				Assert.AreEqual(1, countRes);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/Criteria/SelectModeTest/SelectModeTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/SelectModeTest/SelectModeTest.cs
@@ -347,7 +347,7 @@ namespace NHibernate.Test.Criteria.SelectModeTest
 
 				Assert.That(NHibernateUtil.IsInitialized(rootChild), Is.True);
 				Assert.That(NHibernateUtil.IsInitialized(parentJoin), Is.True);
-				Assert.That(NHibernateUtil.IsPropertyInitialized(parentJoin, nameof(parentJoin.LazyProp)), Is.Not.Null.Or.Empty);
+				Assert.That(NHibernateUtil.IsPropertyInitialized(parentJoin, nameof(parentJoin.LazyProp)), Is.True);
 				Assert.That(parentJoin.LazyProp, Is.Not.Null.Or.Empty);
 
 				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");

--- a/src/NHibernate.Test/Async/ExpressionTest/Projection/ProjectionSqlFixture.cs
+++ b/src/NHibernate.Test/Async/ExpressionTest/Projection/ProjectionSqlFixture.cs
@@ -74,9 +74,9 @@ namespace NHibernate.Test.ExpressionTest.Projection
 		                			.Add(Projections.Min("Pay")));
 				c.SetResultTransformer(trans);
 				ProjectionReport report = await (c.UniqueResultAsync<ProjectionReport>());
-				Assert.AreEqual(report.AvgPay, 2.5);
-				Assert.AreEqual(report.MaxPay, 4);
-				Assert.AreEqual(report.MinPay, 1);
+				Assert.AreEqual(2.5, report.AvgPay);
+				Assert.AreEqual(4, report.MaxPay);
+				Assert.AreEqual(1, report.MinPay);
 			}
 		}
 
@@ -97,10 +97,10 @@ namespace NHibernate.Test.ExpressionTest.Projection
                 Assert.IsTrue(result[0] is object[], 
                     "expected object[] as result, but found " + result[0].GetType().Name);
                 object[] results = (object[])result[0];
-                Assert.AreEqual(results.Length, 3);
-                Assert.AreEqual(results[0], 2.5);
-                Assert.AreEqual(results[1], 4);
-                Assert.AreEqual(results[2], 1);
+                Assert.AreEqual(3, results.Length);
+                Assert.AreEqual(2.5, results[0]);
+                Assert.AreEqual(4, results[1]);
+                Assert.AreEqual(1, results[2]);
             }
         }
 
@@ -119,7 +119,7 @@ namespace NHibernate.Test.ExpressionTest.Projection
                 IList result = await (c.ListAsync()); // c.UniqueResult();
                 Assert.IsTrue(result.Count == 1);
                 object results = result[0];
-                Assert.AreEqual(results, 2.5);
+                Assert.AreEqual(2.5, results);
             }
         }
     }

--- a/src/NHibernate.Test/Async/FilterTest/DynamicFilterTest.cs
+++ b/src/NHibernate.Test/Async/FilterTest/DynamicFilterTest.cs
@@ -108,7 +108,7 @@ namespace NHibernate.Test.FilterTest
 				salespersons = await (session.CreateQuery("select s from Salesperson as s left join fetch s.Orders").ListAsync());
 				Assert.AreEqual(1, salespersons.Count, "Incorrect salesperson count");
 				sp = (Salesperson) salespersons[0];
-				Assert.AreEqual(sp.Orders.Count, 1, "Incorrect order count");
+				Assert.AreEqual(1, sp.Orders.Count, "Incorrect order count");
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Async/Legacy/FooBarTest.cs
@@ -1078,8 +1078,8 @@ namespace NHibernate.Test.Legacy
 			using (ISession s = OpenSession())
 			{
 				Holder h = (Holder) await (s.LoadAsync(typeof(Holder), hid));
-				Assert.AreEqual(h.Name, "foo");
-				Assert.AreEqual(h.OtherHolder.Name, "bar");
+				Assert.AreEqual("foo", h.Name);
+				Assert.AreEqual("bar", h.OtherHolder.Name);
 				object[] res =
 					(object[]) (await (s.CreateQuery("from Holder h join h.OtherHolder oh where h.OtherHolder.Name = 'bar'").ListAsync()))[0];
 				Assert.AreSame(h, res[0]);
@@ -1430,7 +1430,7 @@ namespace NHibernate.Test.Legacy
 			// DictionaryEntry key - not the index.
 			foreach (Sortable sortable in b.Sortablez)
 			{
-				Assert.AreEqual(sortable.name, "bar");
+				Assert.AreEqual("bar", sortable.name);
 				break;
 			}
 
@@ -1446,7 +1446,7 @@ namespace NHibernate.Test.Legacy
 			Assert.IsTrue(b.Sortablez.Count == 3);
 			foreach (Sortable sortable in b.Sortablez)
 			{
-				Assert.AreEqual(sortable.name, "bar");
+				Assert.AreEqual("bar", sortable.name);
 				break;
 			}
 			await (s.FlushAsync());
@@ -1461,7 +1461,7 @@ namespace NHibernate.Test.Legacy
 			Assert.IsTrue(b.Sortablez.Count == 3);
 			foreach (Sortable sortable in b.Sortablez)
 			{
-				Assert.AreEqual(sortable.name, "bar");
+				Assert.AreEqual("bar", sortable.name);
 				break;
 			}
 			await (s.DeleteAsync(b));

--- a/src/NHibernate.Test/Async/Legacy/MasterDetailTest.cs
+++ b/src/NHibernate.Test/Async/Legacy/MasterDetailTest.cs
@@ -184,7 +184,7 @@ namespace NHibernate.Test.Legacy
 			// Save parent and cascade update detached child
 			Category persistentParent = await (s.MergeAsync(parent));
 			Assert.IsTrue(persistentParent.Subcategories.Count == 1);
-			Assert.AreEqual(((Category) persistentParent.Subcategories[0]).Name, "child2");
+			Assert.AreEqual("child2", ((Category) persistentParent.Subcategories[0]).Name);
 			await (s.FlushAsync());
 			s.Close();
 

--- a/src/NHibernate.Test/Async/Legacy/SQLLoaderTest.cs
+++ b/src/NHibernate.Test/Async/Legacy/SQLLoaderTest.cs
@@ -481,7 +481,7 @@ namespace NHibernate.Test.Legacy
 			IQuery q = session.CreateSQLQuery(sql).AddEntity("comp", typeof(Componentizable));
 			IList list = await (q.ListAsync(cancellationToken));
 
-			Assert.AreEqual(list.Count, 1);
+			Assert.AreEqual(1, list.Count);
 
 			Componentizable co = (Componentizable) list[0];
 

--- a/src/NHibernate.Test/Async/Linq/ByMethod/AverageTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/AverageTests.cs
@@ -25,7 +25,7 @@ namespace NHibernate.Test.Linq.ByMethod
 			//NH-2429
 			var average = await (db.Products.AverageAsync(x => x.UnitsOnOrder));
 
-			Assert.AreEqual(average, 10.129870d, 0.000001d);
+			Assert.AreEqual(10.129870d, average, 0.000001d);
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Linq/PagingTests.cs
+++ b/src/NHibernate.Test/Async/Linq/PagingTests.cs
@@ -136,7 +136,7 @@ namespace NHibernate.Test.Linq
 			var query = await ((from c in db.Customers
 						 orderby c.CustomerId
 						 select c.CustomerId).Skip(10).Take(10).ToListAsync());
-			Assert.AreEqual(query[0], "BSBEV");
+			Assert.AreEqual("BSBEV", query[0]);
 			Assert.AreEqual(10, query.Count);
 		}
 
@@ -146,19 +146,19 @@ namespace NHibernate.Test.Linq
 			var query = await ((from c in db.Customers
 							orderby c.CustomerId
 							select c.CustomerId).Skip(10).Take(10).ToListAsync());
-			Assert.AreEqual(query[0], "BSBEV");
+			Assert.AreEqual("BSBEV", query[0]);
 			Assert.AreEqual(10, query.Count);
 
 			query = await ((from c in db.Customers
 						orderby c.CustomerId
 						select c.CustomerId).Skip(20).Take(10).ToListAsync());
-			Assert.AreNotEqual(query[0], "BSBEV");
+			Assert.AreNotEqual("BSBEV", query[0]);
 			Assert.AreEqual(10, query.Count);
 
 			query = await ((from c in db.Customers
 						orderby c.CustomerId
 						select c.CustomerId).Skip(10).Take(20).ToListAsync());
-			Assert.AreEqual(query[0], "BSBEV");
+			Assert.AreEqual("BSBEV", query[0]);
 			Assert.AreEqual(20, query.Count);
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/GH1754/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/GH1754/Fixture.cs
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -86,7 +87,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				Assert.That(parent.Children, Does.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -104,7 +105,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				Assert.That(parent.Children, Does.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -132,7 +133,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				// Merge should duplicate child and leave original instance un-associated with the session.
 				Assert.That(parent.Children, Does.Not.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -153,7 +154,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				// Merge should duplicate child and leave original instance un-associated with the session.
 				Assert.That(parent.Children, Does.Not.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -179,7 +180,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -192,7 +193,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -215,7 +216,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -228,7 +229,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -254,7 +255,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -267,7 +268,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -290,7 +291,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -303,7 +304,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -329,7 +330,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -342,7 +343,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -365,7 +366,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -378,7 +379,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -404,7 +405,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -417,7 +418,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -440,7 +441,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -453,7 +454,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1098/FilterParameterOrderFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1098/FilterParameterOrderFixture.cs
@@ -204,7 +204,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1098
 
 				var a = await (query.UniqueResultAsync<A>());
 
-				Assert.AreEqual(a.C[1], "Text1");
+				Assert.AreEqual("Text1", a.C[1]);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1394/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1394/Fixture.cs
@@ -105,9 +105,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1394
 						// Oracle order NULL Last (ASC)
 						nullRelationOffSet = 0;
 					}
-					Assert.AreEqual(list[nullRelationOffSet].Name, "Tim");
-					Assert.AreEqual(list[nullRelationOffSet + 1].Name, "Joe");
-					Assert.AreEqual(list[nullRelationOffSet + 2].Name, "Sally");
+					Assert.AreEqual("Tim", list[nullRelationOffSet].Name);
+					Assert.AreEqual("Joe", list[nullRelationOffSet + 1].Name);
+					Assert.AreEqual("Sally", list[nullRelationOffSet + 2].Name);
 				}
 			}
 		}
@@ -133,9 +133,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1394
 					// Oracle order NULL First (DESC)
 					nullRelationOffSet = 2;
 				}
-				Assert.AreEqual(list[nullRelationOffSet+2].Name, "Tim");
-				Assert.AreEqual(list[nullRelationOffSet+1].Name, "Joe");
-				Assert.AreEqual(list[nullRelationOffSet].Name, "Sally");
+				Assert.AreEqual("Tim", list[nullRelationOffSet+2].Name);
+				Assert.AreEqual("Joe", list[nullRelationOffSet+1].Name);
+				Assert.AreEqual("Sally", list[nullRelationOffSet].Name);
 			}
 		}
 

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1413/PagingTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1413/PagingTest.cs
@@ -39,7 +39,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1413
 				ICriteria icriteria = criteria.GetExecutableCriteria(session);
 				icriteria.SetFirstResult(0);
 				icriteria.SetMaxResults(2);
-				Assert.That(2, Is.EqualTo((await (icriteria.ListAsync<Foo>())).Count));
+				Assert.That((await (icriteria.ListAsync<Foo>())).Count, Is.EqualTo(2));
 			}
 
 			using (ISession session = OpenSession())

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1679/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1679/Fixture.cs
@@ -64,7 +64,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1679
 				action.Invoke(criteria);
 				
 				IList  l = await (criteria.GetExecutableCriteria(session).ListAsync(cancellationToken));
-				Assert.AreNotEqual(l, null);
+				Assert.AreNotEqual(null, l);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1688/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1688/Fixture.cs
@@ -73,7 +73,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1688
 				action.Invoke(criteria);
 
 				IList l = await (criteria.GetExecutableCriteria(session).ListAsync(cancellationToken));
-				Assert.AreNotEqual(l, null);
+				Assert.AreNotEqual(null, l);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1821/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1821/Fixture.cs
@@ -42,13 +42,13 @@ where 1=1";
 				Regex whitespaces = new Regex(@"\s+", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
 
 				Assert.AreEqual(
+					0
+,
 					string.Compare(
 						whitespaces.Replace(sql, " ").Trim(),
 						whitespaces.Replace(renderedSql, " ").Trim(),
 						true
-						),
-					0
-				);
+						)				);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1821/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1821/Fixture.cs
@@ -41,14 +41,10 @@ where 1=1";
 
 				Regex whitespaces = new Regex(@"\s+", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
 
-				Assert.AreEqual(
-					0
-,
-					string.Compare(
-						whitespaces.Replace(sql, " ").Trim(),
-						whitespaces.Replace(renderedSql, " ").Trim(),
-						true
-						)				);
+				Assert.That(
+					whitespaces.Replace(renderedSql, " ").Trim(),
+					Is.EqualTo(whitespaces.Replace(sql, " ").Trim()).IgnoreCase
+				);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH1859/SampleTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH1859/SampleTest.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1859
 				IQuery qry = session.CreateSQLQuery("select /* first comment */ o.* /* second comment*/ from domainclass o")
 					.AddEntity("o", typeof (DomainClass));
 				var res = await (qry.ListAsync<DomainClass>());
-				Assert.AreEqual(res[0].Id, 1);
+				Assert.AreEqual(1, res[0].Id);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2092/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2092/Fixture.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2092
 
 					Assert.That(NHibernateUtil.IsInitialized(employee.Person), Is.False);
 
-					Assert.That("Person1", Is.EqualTo(employee.Person.Name));
+					Assert.That(employee.Person.Name, Is.EqualTo("Person1"));
 
 					Assert.That(NHibernateUtil.IsInitialized(employee.Person), Is.True);
 				}

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2093/Fixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2093/Fixture.cs
@@ -87,7 +87,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2093
             .SetEntity("p", person)
             .ListAsync<Employee>());
 
-          Assert.AreEqual(list.Count, 1);
+          Assert.AreEqual(1, list.Count);
         }
       }
       finally

--- a/src/NHibernate.Test/Async/NHSpecificTest/Properties/CompositePropertyRefTest.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/Properties/CompositePropertyRefTest.cs
@@ -72,7 +72,7 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 					Assert.IsNull(p2.Address);
 					Assert.IsNotNull(p.Address);
 					var l = await (s.CreateQuery("from Person").ListAsync()); //pull address references for cache
-					Assert.AreEqual(l.Count, 2);
+					Assert.AreEqual(2, l.Count);
 					Assert.IsTrue(l.Contains(p) && l.Contains(p2));
 				}
 			}
@@ -86,7 +86,7 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 				using (s.BeginTransaction())
 				{
 					var l = await (s.CreateQuery("from Person p order by p.Name").ListAsync<Person>()); 
-					Assert.AreEqual(l.Count, 2);
+					Assert.AreEqual(2, l.Count);
 					Assert.IsNull(l[0].Address);
 					Assert.IsNotNull(l[1].Address);
 				}
@@ -101,7 +101,7 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 				using (s.BeginTransaction())
 				{
 					var l = await (s.CreateQuery("from Person p left join fetch p.Address a order by a.Country").ListAsync<Person>());
-					Assert.AreEqual(l.Count, 2);
+					Assert.AreEqual(2, l.Count);
 					if (l[0].Name.Equals("Max"))
 					{
 						Assert.IsNull(l[0].Address);
@@ -146,11 +146,11 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 					var l = await (s.CreateQuery("from Person p left join fetch p.Accounts a order by p.Name").ListAsync<Person>());
 					var p0 = l[0];
 					Assert.IsTrue(NHibernateUtil.IsInitialized(p0.Accounts));
-					Assert.AreEqual(p0.Accounts.Count, 1);
+					Assert.AreEqual(1, p0.Accounts.Count);
 					Assert.AreSame(p0.Accounts.First().User, p0);
 					var p1 = l[1];
 					Assert.IsTrue(NHibernateUtil.IsInitialized(p1.Accounts));
-					Assert.AreEqual(p1.Accounts.Count, 0);
+					Assert.AreEqual(0, p1.Accounts.Count);
 				}
 			}
 		}

--- a/src/NHibernate.Test/Async/SqlTest/Custom/CustomSQLSupportTest.cs
+++ b/src/NHibernate.Test/Async/SqlTest/Custom/CustomSQLSupportTest.cs
@@ -59,10 +59,10 @@ namespace NHibernate.Test.SqlTest.Custom
 			s = OpenSession();
 			t = s.BeginTransaction();
 			jboss = (Organization)await (s.GetAsync(typeof(Organization), orgId));
-			Assert.AreEqual(jboss.Employments.Count, 2);
+			Assert.AreEqual(2, jboss.Employments.Count);
 			emp = (Employment)GetFirstItem(jboss.Employments);
 			gavin = emp.Employee;
-			Assert.AreEqual(gavin.Name, "GAVIN");
+			Assert.AreEqual("GAVIN", gavin.Name);
 			Assert.AreEqual(s.GetCurrentLockMode(gavin), LockMode.Upgrade);
 			emp.EndDate = DateTime.Today;
 			Employment emp3 = new Employment(gavin, jboss, "US");
@@ -75,7 +75,7 @@ namespace NHibernate.Test.SqlTest.Custom
 			IEnumerator iter = (await (s.GetNamedQuery("allOrganizationsWithEmployees").ListAsync())).GetEnumerator();
 			Assert.IsTrue(iter.MoveNext());
 			Organization o = (Organization)iter.Current;
-			Assert.AreEqual(o.Employments.Count, 3);
+			Assert.AreEqual(3, o.Employments.Count);
 
 			foreach (Employment e in o.Employments)
 			{

--- a/src/NHibernate.Test/Async/SqlTest/Custom/CustomStoredProcSupportTest.cs
+++ b/src/NHibernate.Test/Async/SqlTest/Custom/CustomStoredProcSupportTest.cs
@@ -26,8 +26,8 @@ namespace NHibernate.Test.SqlTest.Custom
 			namedQuery.SetInt64("number", 43L);
 			IList list = await (namedQuery.ListAsync());
 			object[] o = (object[])list[0];
-			Assert.AreEqual(o[0], "getAll");
-			Assert.AreEqual(o[1], 43L);
+			Assert.AreEqual("getAll", o[0]);
+			Assert.AreEqual(43L, o[1]);
 			s.Close();
 		}
 
@@ -41,16 +41,16 @@ namespace NHibernate.Test.SqlTest.Custom
 			namedQuery.SetInt64(1, 20L);
 			IList list = await (namedQuery.ListAsync());
 			object[] o = (Object[])list[0];
-			Assert.AreEqual(o[0], 10L);
-			Assert.AreEqual(o[1], 20L);
+			Assert.AreEqual(10L, o[0]);
+			Assert.AreEqual(20L, o[1]);
 
 			namedQuery = s.GetNamedQuery("paramhandling_mixed");
 			namedQuery.SetInt64(0, 10L);
 			namedQuery.SetInt64("second", 20L);
 			list = await (namedQuery.ListAsync());
 			o = (object[])list[0];
-			Assert.AreEqual(o[0], 10L);
-			Assert.AreEqual(o[1], 20L);
+			Assert.AreEqual(10L, o[0]);
+			Assert.AreEqual(20L, o[1]);
 			s.Close();
 		}
 

--- a/src/NHibernate.Test/Async/SqlTest/Query/NativeSQLQueriesFixture.cs
+++ b/src/NHibernate.Test/Async/SqlTest/Query/NativeSQLQueriesFixture.cs
@@ -130,7 +130,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.AddJoin("emp", "org.employments")
 					.AddJoin("pers", "emp.employee")
 					.ListAsync());
-				Assert.AreEqual(l.Count, 1);
+				Assert.AreEqual(1, l.Count);
 
 				await (t.CommitAsync());
 			}
@@ -146,7 +146,7 @@ namespace NHibernate.Test.SqlTest.Query
 						.AddJoin("emp", "org.employments")
 						.SetResultTransformer(new DistinctRootEntityResultTransformer())
 						.ListAsync());
-				Assert.AreEqual(l.Count, 2);
+				Assert.AreEqual(2, l.Count);
 
 				await (t.CommitAsync());
 				s.Close();
@@ -183,7 +183,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.AddJoin("pers", "emp.employee")
 					.SetCacheable(true)
 					.ListAsync());
-				Assert.AreEqual(l.Count, 1);
+				Assert.AreEqual(1, l.Count);
 
 				await (t.CommitAsync());
 			}
@@ -200,7 +200,7 @@ namespace NHibernate.Test.SqlTest.Query
 						.SetCacheable(true)
 						.SetResultTransformer(new DistinctRootEntityResultTransformer())
 						.ListAsync());
-				Assert.AreEqual(l.Count, 2);
+				Assert.AreEqual(2, l.Count);
 
 				await (t.CommitAsync());
 				s.Close();
@@ -478,12 +478,12 @@ namespace NHibernate.Test.SqlTest.Query
 			IList l = await (s.CreateSQLQuery(OrgEmpRegionSQL)
 			           .SetResultSetMapping("org-emp-regionCode")
 			           .ListAsync());
-			Assert.AreEqual(l.Count, 2);
+			Assert.AreEqual(2, l.Count);
 
 			l = await (s.CreateSQLQuery(OrgEmpPersonSQL)
 			     .SetResultSetMapping("org-emp-person")
 			     .ListAsync());
-			Assert.AreEqual(l.Count, 1);
+			Assert.AreEqual(1, l.Count);
 
 			await (t.CommitAsync());
 			s.Close();
@@ -522,12 +522,12 @@ namespace NHibernate.Test.SqlTest.Query
 			IEnumerator iter = (await (s.GetNamedQuery("orgNamesAndOrgs").ListAsync())).GetEnumerator();
 			iter.MoveNext();
 			object[] o = (object[]) iter.Current;
-			Assert.AreEqual(o[0], "IFA");
-			Assert.AreEqual(((Organization) o[1]).Name, "IFA");
+			Assert.AreEqual("IFA", o[0]);
+			Assert.AreEqual("IFA", ((Organization) o[1]).Name);
 			iter.MoveNext();
 			o = (object[]) iter.Current;
-			Assert.AreEqual(o[0], "JBoss");
-			Assert.AreEqual(((Organization) o[1]).Name, "JBoss");
+			Assert.AreEqual("JBoss", o[0]);
+			Assert.AreEqual("JBoss", ((Organization) o[1]).Name);
 
 			await (t.CommitAsync());
 			s.Close();
@@ -542,13 +542,13 @@ namespace NHibernate.Test.SqlTest.Query
 			Assert.AreEqual(typeof(Organization), row[0].GetType(), "expecting non-scalar result first");
 			Assert.AreEqual(typeof(string), row[1].GetType(), "expecting scalar result second");
 			Assert.AreEqual("IFA", ((Organization) row[0]).Name);
-			Assert.AreEqual(row[1], "IFA");
+			Assert.AreEqual("IFA", row[1]);
 			iter.MoveNext();
 			row = (object[]) iter.Current;
 			Assert.AreEqual(typeof(Organization), row[0].GetType(), "expecting non-scalar result first");
 			Assert.AreEqual(typeof(string), row[1].GetType(), "expecting scalar result second");
-			Assert.AreEqual(((Organization) row[0]).Name, "JBoss");
-			Assert.AreEqual(row[1], "JBoss");
+			Assert.AreEqual("JBoss", ((Organization) row[0]).Name);
+			Assert.AreEqual("JBoss", row[1]);
 			Assert.IsFalse(iter.MoveNext());
 
 			await (t.CommitAsync());
@@ -560,11 +560,11 @@ namespace NHibernate.Test.SqlTest.Query
 			iter = (await (s.GetNamedQuery("orgIdsAndOrgNames").ListAsync())).GetEnumerator();
 			iter.MoveNext();
 			o = (object[]) iter.Current;
-			Assert.AreEqual(o[1], "IFA");
+			Assert.AreEqual("IFA", o[1]);
 			Assert.AreEqual(o[0], idIfa);
 			iter.MoveNext();
 			o = (object[]) iter.Current;
-			Assert.AreEqual(o[1], "JBoss");
+			Assert.AreEqual("JBoss", o[1]);
 			Assert.AreEqual(o[0], idJBoss);
 
 			await (t.CommitAsync());
@@ -713,7 +713,7 @@ namespace NHibernate.Test.SqlTest.Query
 			IQuery queryWithCollection = s.GetNamedQuery("organizationEmploymentsExplicitAliases");
 			queryWithCollection.SetInt64("id", jboss.Id);
 			list = await (queryWithCollection.ListAsync());
-			Assert.AreEqual(list.Count, 1);
+			Assert.AreEqual(1, list.Count);
 
 			s.Clear();
 
@@ -804,7 +804,7 @@ namespace NHibernate.Test.SqlTest.Query
 			IList l = await (s.CreateSQLQuery("select name, id, flength, name as scalarName from Speech")
 			           .SetResultSetMapping("speech")
 			           .ListAsync());
-			Assert.AreEqual(l.Count, 1);
+			Assert.AreEqual(1, l.Count);
 
 			await (t.RollbackAsync());
 			s.Close();
@@ -883,7 +883,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.SetResultTransformer(transformer)
 					.Future<object[]>();
 
-				Assert.AreEqual((await (l.GetEnumerableAsync())).Count(), 1);
+				Assert.AreEqual(1, (await (l.GetEnumerableAsync())).Count());
 				Assert.AreEqual("Ricardo", (await (l.GetEnumerableAsync())).ElementAt(0)[0]);
 				Assert.IsTrue(transformer.TransformListCalled);
 				Assert.IsTrue(transformer.TransformTupleCalled);
@@ -928,7 +928,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.CreateSQLQuery("select Name from Person")
 					.Future<string>();
 
-				Assert.AreEqual((await (l.GetEnumerableAsync())).Count(), 1);
+				Assert.AreEqual(1, (await (l.GetEnumerableAsync())).Count());
 				Assert.AreEqual("Ricardo", (await (l.GetEnumerableAsync())).ElementAt(0));
 			}
 		}

--- a/src/NHibernate.Test/Async/SubselectFetchTest/SubselectFetchFixture.cs
+++ b/src/NHibernate.Test/Async/SubselectFetchTest/SubselectFetchFixture.cs
@@ -55,24 +55,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
@@ -120,24 +120,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
@@ -185,24 +185,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
@@ -251,8 +251,8 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
-			Assert.AreEqual(p.MoreChildren.Count, 0);
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(0, p.MoreChildren.Count);
+			Assert.AreEqual(2, p.Children.Count);
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
@@ -261,8 +261,8 @@ namespace NHibernate.Test.SubselectFetchTest
 			r = (Parent) await (s.GetAsync(typeof(Parent), r.Name));
 			Assert.IsTrue(NHibernateUtil.IsInitialized(r.Children)); // The test for True is the test of H3.2
 			Assert.IsFalse(NHibernateUtil.IsInitialized(r.MoreChildren));
-			Assert.AreEqual(r.Children.Count, 1);
-			Assert.AreEqual(r.MoreChildren.Count, 0);
+			Assert.AreEqual(1, r.Children.Count);
+			Assert.AreEqual(0, r.MoreChildren.Count);
 
 			await (s.DeleteAsync(p));
 			await (s.DeleteAsync(q));
@@ -344,24 +344,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 

--- a/src/NHibernate.Test/Async/TypeParameters/TypeParameterTest.cs
+++ b/src/NHibernate.Test/Async/TypeParameters/TypeParameterTest.cs
@@ -83,7 +83,7 @@ namespace NHibernate.Test.TypeParameters
 			              "Default value should have been mapped to null");
 			Assert.IsTrue(reader.GetValue(reader.GetOrdinal("VALUE_TWO")) == DBNull.Value,
 			              "Default value should have been mapped to null");
-			Assert.AreEqual(Convert.ToInt32(reader.GetValue(reader.GetOrdinal("VALUE_THREE"))), 5,
+			Assert.AreEqual(5, Convert.ToInt32(reader.GetValue(reader.GetOrdinal("VALUE_THREE"))),
 			                "Non-Default value should not be changed");
 			Assert.IsTrue(reader.GetValue(reader.GetOrdinal("VALUE_FOUR")) == DBNull.Value,
 			              "Default value should have been mapped to null");
@@ -105,17 +105,17 @@ namespace NHibernate.Test.TypeParameters
 
 			Widget obj = (Widget) await (s.CreateQuery("from Widget o where o.Str = :string")
 			                      	.SetString("string", "all-normal").UniqueResultAsync());
-			Assert.AreEqual(obj.ValueOne, 7, "Non-Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueTwo, 8, "Non-Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueThree, 9, "Non-Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueFour, 10, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(7, obj.ValueOne, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(8, obj.ValueTwo, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(9, obj.ValueThree, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(10, obj.ValueFour, "Non-Default value incorrectly loaded");
 
 			obj = (Widget) await (s.CreateQuery("from Widget o where o.Str = :string")
 			               	.SetString("string", "all-default").UniqueResultAsync());
-			Assert.AreEqual(obj.ValueOne, 1, "Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueTwo, 2, "Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueThree, -1, "Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueFour, -5, "Default value incorrectly loaded");
+			Assert.AreEqual(1, obj.ValueOne, "Default value incorrectly loaded");
+			Assert.AreEqual(2, obj.ValueTwo, "Default value incorrectly loaded");
+			Assert.AreEqual(-1, obj.ValueThree, "Default value incorrectly loaded");
+			Assert.AreEqual(-5, obj.ValueFour, "Default value incorrectly loaded");
 
 			await (t.CommitAsync());
 			s.Close();

--- a/src/NHibernate.Test/Async/Unionsubclass/UnionSubclassFixture.cs
+++ b/src/NHibernate.Test/Async/Unionsubclass/UnionSubclassFixture.cs
@@ -66,7 +66,7 @@ namespace NHibernate.Test.Unionsubclass
 				using (ITransaction t = s.BeginTransaction())
 				{
 					Human gavin = (Human)await (s.CreateCriteria(typeof(Human)).UniqueResultAsync());
-					Assert.AreEqual(gavin.Info.Count, 2);
+					Assert.AreEqual(2, gavin.Info.Count);
 					await (s.DeleteAsync(gavin));
 					await (s.DeleteAsync(gavin.Location));
 					await (t.CommitAsync());

--- a/src/NHibernate.Test/Async/VersionTest/VersionFixture.cs
+++ b/src/NHibernate.Test/Async/VersionTest/VersionFixture.cs
@@ -48,7 +48,7 @@ namespace NHibernate.Test.VersionTest
 			await (t.CommitAsync());
 			s.Close();
 
-			Assert.AreEqual(passp.Version, 2);
+			Assert.AreEqual(2, passp.Version);
 
 			s = OpenSession();
 			t = s.BeginTransaction();

--- a/src/NHibernate.Test/CompositeId/CompositeIdFixture.cs
+++ b/src/NHibernate.Test/CompositeId/CompositeIdFixture.cs
@@ -187,8 +187,8 @@ namespace NHibernate.Test.CompositeId
 			Assert.AreEqual(2, c.Orders.Count);
 			Assert.IsTrue(NHibernateUtil.IsInitialized(((Order) c.Orders[0]).LineItems));
 			Assert.IsTrue(NHibernateUtil.IsInitialized(((Order) c.Orders[1]).LineItems));
-			Assert.AreEqual(((Order) c.Orders[0]).LineItems.Count, 2);
-			Assert.AreEqual(((Order) c.Orders[1]).LineItems.Count, 2);
+			Assert.AreEqual(2, ((Order) c.Orders[0]).LineItems.Count);
+			Assert.AreEqual(2, ((Order) c.Orders[1]).LineItems.Count);
 			t.Commit();
 			s.Close();
 

--- a/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
+++ b/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
@@ -3216,7 +3216,7 @@ namespace NHibernate.Test.Criteria
 				var countExec = CriteriaTransformer.TransformToRowCount(ec);
 				var countRes = countExec.UniqueResult();
 
-				Assert.AreEqual(countRes, 1);
+				Assert.AreEqual(1, countRes);
 			}
 		}
 	}

--- a/src/NHibernate.Test/Criteria/Lambda/LambdaFixtureBase.cs
+++ b/src/NHibernate.Test/Criteria/Lambda/LambdaFixtureBase.cs
@@ -81,7 +81,7 @@ namespace NHibernate.Test.Criteria.Lambda
 			foreach (object key in expected.Keys)
 			{
 				if (!actual.Contains(key))
-					Assert.AreEqual(key, null, _fieldPath.Peek() + "[" + key.ToString() + "]");
+					Assert.AreEqual(null, key, _fieldPath.Peek() + "[" + key.ToString() + "]");
 
 				AssertObjectsAreEqual(expected[key], actual[key], "[" + key.ToString() + "]");
 			}

--- a/src/NHibernate.Test/Criteria/SelectModeTest/SelectModeTest.cs
+++ b/src/NHibernate.Test/Criteria/SelectModeTest/SelectModeTest.cs
@@ -336,7 +336,7 @@ namespace NHibernate.Test.Criteria.SelectModeTest
 
 				Assert.That(NHibernateUtil.IsInitialized(rootChild), Is.True);
 				Assert.That(NHibernateUtil.IsInitialized(parentJoin), Is.True);
-				Assert.That(NHibernateUtil.IsPropertyInitialized(parentJoin, nameof(parentJoin.LazyProp)), Is.Not.Null.Or.Empty);
+				Assert.That(NHibernateUtil.IsPropertyInitialized(parentJoin, nameof(parentJoin.LazyProp)), Is.True);
 				Assert.That(parentJoin.LazyProp, Is.Not.Null.Or.Empty);
 
 				Assert.That(sqlLog.Appender.GetEvents().Length, Is.EqualTo(1), "Only one SQL select is expected");

--- a/src/NHibernate.Test/ExpressionTest/Projection/ProjectionSqlFixture.cs
+++ b/src/NHibernate.Test/ExpressionTest/Projection/ProjectionSqlFixture.cs
@@ -63,9 +63,9 @@ namespace NHibernate.Test.ExpressionTest.Projection
 		                			.Add(Projections.Min("Pay")));
 				c.SetResultTransformer(trans);
 				ProjectionReport report = c.UniqueResult<ProjectionReport>();
-				Assert.AreEqual(report.AvgPay, 2.5);
-				Assert.AreEqual(report.MaxPay, 4);
-				Assert.AreEqual(report.MinPay, 1);
+				Assert.AreEqual(2.5, report.AvgPay);
+				Assert.AreEqual(4, report.MaxPay);
+				Assert.AreEqual(1, report.MinPay);
 			}
 		}
 
@@ -86,10 +86,10 @@ namespace NHibernate.Test.ExpressionTest.Projection
                 Assert.IsTrue(result[0] is object[], 
                     "expected object[] as result, but found " + result[0].GetType().Name);
                 object[] results = (object[])result[0];
-                Assert.AreEqual(results.Length, 3);
-                Assert.AreEqual(results[0], 2.5);
-                Assert.AreEqual(results[1], 4);
-                Assert.AreEqual(results[2], 1);
+                Assert.AreEqual(3, results.Length);
+                Assert.AreEqual(2.5, results[0]);
+                Assert.AreEqual(4, results[1]);
+                Assert.AreEqual(1, results[2]);
             }
         }
 
@@ -108,7 +108,7 @@ namespace NHibernate.Test.ExpressionTest.Projection
                 IList result = c.List(); // c.UniqueResult();
                 Assert.IsTrue(result.Count == 1);
                 object results = result[0];
-                Assert.AreEqual(results, 2.5);
+                Assert.AreEqual(2.5, results);
             }
         }
     }

--- a/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
+++ b/src/NHibernate.Test/FilterTest/DynamicFilterTest.cs
@@ -96,7 +96,7 @@ namespace NHibernate.Test.FilterTest
 				salespersons = session.CreateQuery("select s from Salesperson as s left join fetch s.Orders").List();
 				Assert.AreEqual(1, salespersons.Count, "Incorrect salesperson count");
 				sp = (Salesperson) salespersons[0];
-				Assert.AreEqual(sp.Orders.Count, 1, "Incorrect order count");
+				Assert.AreEqual(1, sp.Orders.Count, "Incorrect order count");
 			}
 		}
 

--- a/src/NHibernate.Test/FilterTest/FilterConfig.cs
+++ b/src/NHibernate.Test/FilterTest/FilterConfig.cs
@@ -15,13 +15,13 @@ namespace NHibernate.Test.FilterTest
 		{
 			Configuration cfg = new Configuration();
 			cfg.AddResource(mappingCfg, this.GetType().Assembly);
-			Assert.AreEqual(cfg.FilterDefinitions.Count, 2);
+			Assert.AreEqual(2, cfg.FilterDefinitions.Count);
 
 			Assert.IsTrue(cfg.FilterDefinitions.ContainsKey("LiveFilter"));
 
 			FilterDefinition f = cfg.FilterDefinitions["LiveFilter"];
 
-			Assert.AreEqual(f.ParameterTypes.Count, 1);
+			Assert.AreEqual(1, f.ParameterTypes.Count);
 
 			BooleanType t = f.ParameterTypes["LiveParam"] as BooleanType;
 
@@ -40,7 +40,7 @@ namespace NHibernate.Test.FilterTest
 
 			IFilter filter = session.EnableFilter("LiveFilter");
 
-			Assert.AreEqual(filter.FilterDefinition.FilterName, "LiveFilter");
+			Assert.AreEqual("LiveFilter", filter.FilterDefinition.FilterName);
 
 			filter.SetParameter("LiveParam", true);
 

--- a/src/NHibernate.Test/Legacy/FooBarTest.cs
+++ b/src/NHibernate.Test/Legacy/FooBarTest.cs
@@ -1066,8 +1066,8 @@ namespace NHibernate.Test.Legacy
 			using (ISession s = OpenSession())
 			{
 				Holder h = (Holder) s.Load(typeof(Holder), hid);
-				Assert.AreEqual(h.Name, "foo");
-				Assert.AreEqual(h.OtherHolder.Name, "bar");
+				Assert.AreEqual("foo", h.Name);
+				Assert.AreEqual("bar", h.OtherHolder.Name);
 				object[] res =
 					(object[]) s.CreateQuery("from Holder h join h.OtherHolder oh where h.OtherHolder.Name = 'bar'").List()[0];
 				Assert.AreSame(h, res[0]);
@@ -1418,7 +1418,7 @@ namespace NHibernate.Test.Legacy
 			// DictionaryEntry key - not the index.
 			foreach (Sortable sortable in b.Sortablez)
 			{
-				Assert.AreEqual(sortable.name, "bar");
+				Assert.AreEqual("bar", sortable.name);
 				break;
 			}
 
@@ -1434,7 +1434,7 @@ namespace NHibernate.Test.Legacy
 			Assert.IsTrue(b.Sortablez.Count == 3);
 			foreach (Sortable sortable in b.Sortablez)
 			{
-				Assert.AreEqual(sortable.name, "bar");
+				Assert.AreEqual("bar", sortable.name);
 				break;
 			}
 			s.Flush();
@@ -1449,7 +1449,7 @@ namespace NHibernate.Test.Legacy
 			Assert.IsTrue(b.Sortablez.Count == 3);
 			foreach (Sortable sortable in b.Sortablez)
 			{
-				Assert.AreEqual(sortable.name, "bar");
+				Assert.AreEqual("bar", sortable.name);
 				break;
 			}
 			s.Delete(b);

--- a/src/NHibernate.Test/Legacy/MasterDetailTest.cs
+++ b/src/NHibernate.Test/Legacy/MasterDetailTest.cs
@@ -183,7 +183,7 @@ namespace NHibernate.Test.Legacy
 			// Save parent and cascade update detached child
 			Category persistentParent = s.Merge(parent);
 			Assert.IsTrue(persistentParent.Subcategories.Count == 1);
-			Assert.AreEqual(((Category) persistentParent.Subcategories[0]).Name, "child2");
+			Assert.AreEqual("child2", ((Category) persistentParent.Subcategories[0]).Name);
 			s.Flush();
 			s.Close();
 

--- a/src/NHibernate.Test/Legacy/SQLLoaderTest.cs
+++ b/src/NHibernate.Test/Legacy/SQLLoaderTest.cs
@@ -520,7 +520,7 @@ namespace NHibernate.Test.Legacy
 			IQuery q = session.CreateSQLQuery(sql).AddEntity("comp", typeof(Componentizable));
 			IList list = q.List();
 
-			Assert.AreEqual(list.Count, 1);
+			Assert.AreEqual(1, list.Count);
 
 			Componentizable co = (Componentizable) list[0];
 

--- a/src/NHibernate.Test/Linq/ByMethod/AverageTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/AverageTests.cs
@@ -13,7 +13,7 @@ namespace NHibernate.Test.Linq.ByMethod
 			//NH-2429
 			var average = db.Products.Average(x => x.UnitsOnOrder);
 
-			Assert.AreEqual(average, 10.129870d, 0.000001d);
+			Assert.AreEqual(10.129870d, average, 0.000001d);
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/PagingTests.cs
+++ b/src/NHibernate.Test/Linq/PagingTests.cs
@@ -229,7 +229,7 @@ namespace NHibernate.Test.Linq
 			var query = (from c in db.Customers
 						 orderby c.CustomerId
 						 select c.CustomerId).Skip(10).Take(10).ToList();
-			Assert.AreEqual(query[0], "BSBEV");
+			Assert.AreEqual("BSBEV", query[0]);
 			Assert.AreEqual(10, query.Count);
 		}
 
@@ -239,19 +239,19 @@ namespace NHibernate.Test.Linq
 			var query = (from c in db.Customers
 							orderby c.CustomerId
 							select c.CustomerId).Skip(10).Take(10).ToList();
-			Assert.AreEqual(query[0], "BSBEV");
+			Assert.AreEqual("BSBEV", query[0]);
 			Assert.AreEqual(10, query.Count);
 
 			query = (from c in db.Customers
 						orderby c.CustomerId
 						select c.CustomerId).Skip(20).Take(10).ToList();
-			Assert.AreNotEqual(query[0], "BSBEV");
+			Assert.AreNotEqual("BSBEV", query[0]);
 			Assert.AreEqual(10, query.Count);
 
 			query = (from c in db.Customers
 						orderby c.CustomerId
 						select c.CustomerId).Skip(10).Take(20).ToList();
-			Assert.AreEqual(query[0], "BSBEV");
+			Assert.AreEqual("BSBEV", query[0]);
 			Assert.AreEqual(20, query.Count);
 		}
 
@@ -276,7 +276,7 @@ namespace NHibernate.Test.Linq
 		{
 			var q = (from c in db.Customers select c.CustomerId).Skip(10).Skip(5);
 			var query = q.ToList();
-			Assert.AreEqual(query[0], "CONSH");
+			Assert.AreEqual("CONSH", query[0]);
 			Assert.AreEqual(76, query.Count);
 		}
 

--- a/src/NHibernate.Test/Linq/PreEvaluationTests.cs
+++ b/src/NHibernate.Test/Linq/PreEvaluationTests.cs
@@ -323,7 +323,7 @@ namespace NHibernate.Test.Linq
 
 					Assert.That(x, Has.Count.GreaterThan(0));
 					var randomValues = x.Select(o => o.r).Distinct().ToArray();
-					Assert.That(randomValues, Has.All.GreaterThanOrEqualTo(0).And.LessThan(1));
+					Assert.That(randomValues, Has.All.GreaterThanOrEqualTo(0).And.All.LessThan(1));
 
 					if (!LegacyPreEvaluation && IsFunctionSupported("random"))
 					{
@@ -380,7 +380,7 @@ namespace NHibernate.Test.Linq
 					var randomValues = x.Select(o => o.r).Distinct().ToArray();
 					Assert.That(
 						randomValues,
-						Has.All.GreaterThanOrEqualTo(0).And.LessThan(int.MaxValue).And.TypeOf<int>());
+						Has.All.GreaterThanOrEqualTo(0).And.All.LessThan(int.MaxValue).And.All.TypeOf<int>());
 
 					if (!LegacyPreEvaluation && IsFunctionSupported("random") && IsFunctionSupported("floor"))
 					{
@@ -436,7 +436,7 @@ namespace NHibernate.Test.Linq
 
 					Assert.That(x, Has.Count.GreaterThan(0));
 					var randomValues = x.Select(o => o.r).Distinct().ToArray();
-					Assert.That(randomValues, Has.All.GreaterThanOrEqualTo(0).And.LessThan(10).And.TypeOf<int>());
+					Assert.That(randomValues, Has.All.GreaterThanOrEqualTo(0).And.All.LessThan(10).And.All.TypeOf<int>());
 
 					if (!LegacyPreEvaluation && IsFunctionSupported("random") && IsFunctionSupported("floor"))
 					{
@@ -492,7 +492,7 @@ namespace NHibernate.Test.Linq
 
 					Assert.That(x, Has.Count.GreaterThan(0));
 					var randomValues = x.Select(o => o.r).Distinct().ToArray();
-					Assert.That(randomValues, Has.All.GreaterThanOrEqualTo(1).And.LessThan(11).And.TypeOf<int>());
+					Assert.That(randomValues, Has.All.GreaterThanOrEqualTo(1).And.All.LessThan(11).And.All.TypeOf<int>());
 
 					if (!LegacyPreEvaluation && IsFunctionSupported("random") && IsFunctionSupported("floor"))
 					{

--- a/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/BasicMappingOfSimpleClass.cs
+++ b/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/BasicMappingOfSimpleClass.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Test.MappingByCode.ExplicitMappingTests
 				ca.Property(x => x.Something, map => map.Length(150));
 			});
 			var hbmMapping = mapper.CompileMappingFor(new[] { typeof(MyClass) });
-			Assert.AreEqual(hbmMapping.RootClasses[0].@abstract, true);
+			Assert.AreEqual(true, hbmMapping.RootClasses[0].@abstract);
 		}
 
 		[Test]

--- a/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/ComponentAsIdTests.cs
+++ b/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/ComponentAsIdTests.cs
@@ -41,7 +41,7 @@ namespace NHibernate.Test.MappingByCode.ExpliticMappingTests
 
 			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
 
-			Assert.AreEqual(mapping.RootClasses[0].CompositeId.unsavedvalue, HbmUnsavedValueType.Any);
+			Assert.AreEqual(HbmUnsavedValueType.Any, mapping.RootClasses[0].CompositeId.unsavedvalue);
 		}
 
 		[Test]

--- a/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/OptimisticLockModeTests.cs
+++ b/src/NHibernate.Test/MappingByCode/ExplicitMappingTests/OptimisticLockModeTests.cs
@@ -26,7 +26,7 @@ namespace NHibernate.Test.MappingByCode.ExplicitMappingTests
 				});
 
 			var mappings = mapper.CompileMappingForAllExplicitlyAddedEntities();
-			Assert.AreEqual(mappings.RootClasses[0].optimisticlock, HbmOptimisticLockMode.Dirty);
+			Assert.AreEqual(HbmOptimisticLockMode.Dirty, mappings.RootClasses[0].optimisticlock);
 		}
 	}
 }

--- a/src/NHibernate.Test/MappingByCode/IntegrationTests/NH3110/Fixture.cs
+++ b/src/NHibernate.Test/MappingByCode/IntegrationTests/NH3110/Fixture.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test.MappingByCode.IntegrationTests.NH3110
 			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
 
 			var entity = mapping.RootClasses[0];
-			Assert.AreEqual(entity.polymorphism, HbmPolymorphismType.Explicit);
+			Assert.AreEqual(HbmPolymorphismType.Explicit, entity.polymorphism);
 		}
 	}
 }

--- a/src/NHibernate.Test/MappingByCode/ModelExplicitDeclarationsHolderMergeTest.cs
+++ b/src/NHibernate.Test/MappingByCode/ModelExplicitDeclarationsHolderMergeTest.cs
@@ -343,7 +343,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsPropertySplit(new SplitDefinition(typeof (MyClass), "foo", property));
 
 			destination.Merge(source);
-			Assert.That(destination.SplitDefinitions, Has.Count.EqualTo(1));
+			Assert.That(destination.SplitDefinitions.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -354,7 +354,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsPersistentMember(property);
 
 			destination.Merge(source);
-			Assert.That(destination.PersistentMembers, Has.Count.EqualTo(1));
+			Assert.That(destination.PersistentMembers.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -365,7 +365,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsProperty(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Properties, Has.Count.EqualTo(1));
+			Assert.That(destination.Properties.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -376,7 +376,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsMap(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Dictionaries, Has.Count.EqualTo(1));
+			Assert.That(destination.Dictionaries.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -387,7 +387,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsArray(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Arrays, Has.Count.EqualTo(1));
+			Assert.That(destination.Arrays.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -398,7 +398,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsList(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Lists, Has.Count.EqualTo(1));
+			Assert.That(destination.Lists.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -409,7 +409,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsIdBag(property);
 
 			destination.Merge(source);
-			Assert.That(destination.IdBags, Has.Count.EqualTo(1));
+			Assert.That(destination.IdBags.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -420,7 +420,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsBag(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Bags, Has.Count.EqualTo(1));
+			Assert.That(destination.Bags.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -431,7 +431,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsSet(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Sets, Has.Count.EqualTo(1));
+			Assert.That(destination.Sets.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -442,7 +442,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsNaturalId(property);
 
 			destination.Merge(source);
-			Assert.That(destination.NaturalIds, Has.Count.EqualTo(1));
+			Assert.That(destination.NaturalIds.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -453,7 +453,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsVersionProperty(property);
 
 			destination.Merge(source);
-			Assert.That(destination.VersionProperties, Has.Count.EqualTo(1));
+			Assert.That(destination.VersionProperties.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -464,7 +464,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsPoid(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Poids, Has.Count.EqualTo(1));
+			Assert.That(destination.Poids.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -475,7 +475,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsAny(property);
 
 			destination.Merge(source);
-			Assert.That(destination.Any, Has.Count.EqualTo(1));
+			Assert.That(destination.Any.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -486,7 +486,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsOneToManyRelation(property);
 
 			destination.Merge(source);
-			Assert.That(destination.OneToManyRelations, Has.Count.EqualTo(1));
+			Assert.That(destination.OneToManyRelations.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -497,7 +497,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsManyToAnyRelation(property);
 
 			destination.Merge(source);
-			Assert.That(destination.ManyToAnyRelations, Has.Count.EqualTo(1));
+			Assert.That(destination.ManyToAnyRelations.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -508,7 +508,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsManyToManyItemRelation(property);
 
 			destination.Merge(source);
-			Assert.That(destination.ItemManyToManyRelations, Has.Count.EqualTo(1));
+			Assert.That(destination.ItemManyToManyRelations.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -519,7 +519,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsManyToOneRelation(property);
 
 			destination.Merge(source);
-			Assert.That(destination.ManyToOneRelations, Has.Count.EqualTo(1));
+			Assert.That(destination.ManyToOneRelations.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -530,7 +530,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsOneToOneRelation(property);
 
 			destination.Merge(source);
-			Assert.That(destination.OneToOneRelations, Has.Count.EqualTo(1));
+			Assert.That(destination.OneToOneRelations.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -541,7 +541,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsTablePerConcreteClassEntity(typeof (MyClass));
 
 			destination.Merge(source);
-			Assert.That(destination.TablePerConcreteClassEntities, Has.Count.EqualTo(1));
+			Assert.That(destination.TablePerConcreteClassEntities.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -552,7 +552,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsTablePerClassHierarchyEntity(typeof (MyClass));
 
 			destination.Merge(source);
-			Assert.That(destination.TablePerClassHierarchyEntities, Has.Count.EqualTo(1));
+			Assert.That(destination.TablePerClassHierarchyEntities.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -563,7 +563,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsTablePerClassEntity(typeof (MyClass));
 
 			destination.Merge(source);
-			Assert.That(destination.TablePerClassEntities, Has.Count.EqualTo(1));
+			Assert.That(destination.TablePerClassEntities.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -574,7 +574,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsComponent(typeof (MyClass));
 
 			destination.Merge(source);
-			Assert.That(destination.Components, Has.Count.EqualTo(1));
+			Assert.That(destination.Components.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -585,7 +585,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsRootEntity(typeof (MyClass));
 
 			destination.Merge(source);
-			Assert.That(destination.RootEntities, Has.Count.EqualTo(1));
+			Assert.That(destination.RootEntities.Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -596,7 +596,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsDynamicComponent(property, typeof(MyClass));
 
 			destination.Merge(source);
-			Assert.That(destination.DynamicComponents, Has.Count.EqualTo(1));
+			Assert.That(destination.DynamicComponents.Count(), Is.EqualTo(1));
 			Assert.That(destination.GetDynamicComponentTemplate(property), Is.EqualTo(typeof(MyClass)));
 		}
 
@@ -608,7 +608,7 @@ namespace NHibernate.Test.MappingByCode
 			source.AddAsPartOfComposedId(property);
 
 			destination.Merge(source);
-			Assert.That(destination.ComposedIds, Has.Count.EqualTo(1));
+			Assert.That(destination.ComposedIds.Count(), Is.EqualTo(1));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/NHSpecificTest/GH1754/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH1754/Fixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
@@ -74,7 +75,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				Assert.That(parent.Children, Does.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -92,7 +93,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				Assert.That(parent.Children, Does.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -120,7 +121,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				// Merge should duplicate child and leave original instance un-associated with the session.
 				Assert.That(parent.Children, Does.Not.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -141,7 +142,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(1));
 				// Merge should duplicate child and leave original instance un-associated with the session.
 				Assert.That(parent.Children, Does.Not.Contain(child));
-				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(parent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 		}
 
@@ -167,7 +168,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -180,7 +181,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -203,7 +204,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -216,7 +217,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -242,7 +243,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -255,7 +256,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -278,7 +279,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -291,7 +292,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -317,7 +318,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -330,7 +331,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -353,7 +354,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -366,7 +367,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -392,7 +393,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -405,7 +406,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 
@@ -428,7 +429,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0));
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1));
 				Assert.That(nextParent.Children, Does.Contain(child));
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0));
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty));
 			}
 
 			using (var session = OpenSession())
@@ -441,7 +442,7 @@ namespace NHibernate.Test.NHSpecificTest.GH1754
 				Assert.That(parent.Children, Has.Count.EqualTo(0), "Reloaded data");
 				Assert.That(nextParent.Children, Has.Count.EqualTo(1), "Reloaded data");
 				Assert.That(nextParent.Children, Does.Contain(child), "Reloaded data");
-				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(0), "Reloaded data");
+				Assert.That(nextParent.Children.Single().Id, Is.Not.EqualTo(Guid.Empty), "Reloaded data");
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1098/FilterParameterOrderFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1098/FilterParameterOrderFixture.cs
@@ -226,7 +226,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1098
 
 				var a = query.UniqueResult<A>();
 
-				Assert.AreEqual(a.C[1], "Text1");
+				Assert.AreEqual("Text1", a.C[1]);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1394/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1394/Fixture.cs
@@ -94,9 +94,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1394
 						// Oracle order NULL Last (ASC)
 						nullRelationOffSet = 0;
 					}
-					Assert.AreEqual(list[nullRelationOffSet].Name, "Tim");
-					Assert.AreEqual(list[nullRelationOffSet + 1].Name, "Joe");
-					Assert.AreEqual(list[nullRelationOffSet + 2].Name, "Sally");
+					Assert.AreEqual("Tim", list[nullRelationOffSet].Name);
+					Assert.AreEqual("Joe", list[nullRelationOffSet + 1].Name);
+					Assert.AreEqual("Sally", list[nullRelationOffSet + 2].Name);
 				}
 			}
 		}
@@ -122,9 +122,9 @@ namespace NHibernate.Test.NHSpecificTest.NH1394
 					// Oracle order NULL First (DESC)
 					nullRelationOffSet = 2;
 				}
-				Assert.AreEqual(list[nullRelationOffSet+2].Name, "Tim");
-				Assert.AreEqual(list[nullRelationOffSet+1].Name, "Joe");
-				Assert.AreEqual(list[nullRelationOffSet].Name, "Sally");
+				Assert.AreEqual("Tim", list[nullRelationOffSet+2].Name);
+				Assert.AreEqual("Joe", list[nullRelationOffSet+1].Name);
+				Assert.AreEqual("Sally", list[nullRelationOffSet].Name);
 			}
 		}
 

--- a/src/NHibernate.Test/NHSpecificTest/NH1413/PagingTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1413/PagingTest.cs
@@ -28,7 +28,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1413
 				ICriteria icriteria = criteria.GetExecutableCriteria(session);
 				icriteria.SetFirstResult(0);
 				icriteria.SetMaxResults(2);
-				Assert.That(2, Is.EqualTo(icriteria.List<Foo>().Count));
+				Assert.That(icriteria.List<Foo>().Count, Is.EqualTo(2));
 			}
 
 			using (ISession session = OpenSession())

--- a/src/NHibernate.Test/NHSpecificTest/NH1679/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1679/Fixture.cs
@@ -52,7 +52,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1679
 				action.Invoke(criteria);
 				
 				IList  l = criteria.GetExecutableCriteria(session).List();
-				Assert.AreNotEqual(l, null);
+				Assert.AreNotEqual(null, l);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1688/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1688/Fixture.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1688
 				action.Invoke(criteria);
 
 				IList l = criteria.GetExecutableCriteria(session).List();
-				Assert.AreNotEqual(l, null);
+				Assert.AreNotEqual(null, l);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1821/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1821/Fixture.cs
@@ -30,14 +30,10 @@ where 1=1";
 
 				Regex whitespaces = new Regex(@"\s+", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
 
-				Assert.AreEqual(
-					0
-,
-					string.Compare(
-						whitespaces.Replace(sql, " ").Trim(),
-						whitespaces.Replace(renderedSql, " ").Trim(),
-						true
-						)				);
+				Assert.That(
+					whitespaces.Replace(renderedSql, " ").Trim(),
+					Is.EqualTo(whitespaces.Replace(sql, " ").Trim()).IgnoreCase
+				);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1821/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1821/Fixture.cs
@@ -31,13 +31,13 @@ where 1=1";
 				Regex whitespaces = new Regex(@"\s+", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
 
 				Assert.AreEqual(
+					0
+,
 					string.Compare(
 						whitespaces.Replace(sql, " ").Trim(),
 						whitespaces.Replace(renderedSql, " ").Trim(),
 						true
-						),
-					0
-				);
+						)				);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH1859/SampleTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH1859/SampleTest.cs
@@ -33,7 +33,7 @@ namespace NHibernate.Test.NHSpecificTest.NH1859
 				IQuery qry = session.CreateSQLQuery("select /* first comment */ o.* /* second comment*/ from domainclass o")
 					.AddEntity("o", typeof (DomainClass));
 				var res = qry.List<DomainClass>();
-				Assert.AreEqual(res[0].Id, 1);
+				Assert.AreEqual(1, res[0].Id);
 			}
 		}
 	}

--- a/src/NHibernate.Test/NHSpecificTest/NH2092/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2092/Fixture.cs
@@ -27,7 +27,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2092
 
 					Assert.That(NHibernateUtil.IsInitialized(employee.Person), Is.False);
 
-					Assert.That("Person1", Is.EqualTo(employee.Person.Name));
+					Assert.That(employee.Person.Name, Is.EqualTo("Person1"));
 
 					Assert.That(NHibernateUtil.IsInitialized(employee.Person), Is.True);
 				}

--- a/src/NHibernate.Test/NHSpecificTest/NH2093/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2093/Fixture.cs
@@ -76,7 +76,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2093
             .SetEntity("p", person)
             .List<Employee>();
 
-          Assert.AreEqual(list.Count, 1);
+          Assert.AreEqual(1, list.Count);
         }
       }
       finally

--- a/src/NHibernate.Test/NHSpecificTest/NH3004/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3004/Fixture.cs
@@ -41,7 +41,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3004
 			unusedParam.ParameterName = driver.FormatNameForParameter("unused");
 			command.Parameters.Add(unusedParam);
 
-			Assert.AreEqual(command.Parameters.Count, 2);
+			Assert.AreEqual(2, command.Parameters.Count);
 
 			SqlString sqlString = new SqlStringBuilder()
 				.AddParameter()
@@ -49,7 +49,7 @@ namespace NHibernate.Test.NHSpecificTest.NH3004
 
 			driver.RemoveUnusedCommandParameters(command, sqlString);
 
-			Assert.AreEqual(command.Parameters.Count, 1);
+			Assert.AreEqual(1, command.Parameters.Count);
 			
 			Assert.AreEqual(command.Parameters[0], usedParam);
 		}

--- a/src/NHibernate.Test/NHSpecificTest/Properties/CompositePropertyRefTest.cs
+++ b/src/NHibernate.Test/NHSpecificTest/Properties/CompositePropertyRefTest.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 					Assert.IsNull(p2.Address);
 					Assert.IsNotNull(p.Address);
 					var l = s.CreateQuery("from Person").List(); //pull address references for cache
-					Assert.AreEqual(l.Count, 2);
+					Assert.AreEqual(2, l.Count);
 					Assert.IsTrue(l.Contains(p) && l.Contains(p2));
 				}
 			}
@@ -75,7 +75,7 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 				using (s.BeginTransaction())
 				{
 					var l = s.CreateQuery("from Person p order by p.Name").List<Person>(); 
-					Assert.AreEqual(l.Count, 2);
+					Assert.AreEqual(2, l.Count);
 					Assert.IsNull(l[0].Address);
 					Assert.IsNotNull(l[1].Address);
 				}
@@ -90,7 +90,7 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 				using (s.BeginTransaction())
 				{
 					var l = s.CreateQuery("from Person p left join fetch p.Address a order by a.Country").List<Person>();
-					Assert.AreEqual(l.Count, 2);
+					Assert.AreEqual(2, l.Count);
 					if (l[0].Name.Equals("Max"))
 					{
 						Assert.IsNull(l[0].Address);
@@ -135,11 +135,11 @@ namespace NHibernate.Test.NHSpecificTest.Properties
 					var l = s.CreateQuery("from Person p left join fetch p.Accounts a order by p.Name").List<Person>();
 					var p0 = l[0];
 					Assert.IsTrue(NHibernateUtil.IsInitialized(p0.Accounts));
-					Assert.AreEqual(p0.Accounts.Count, 1);
+					Assert.AreEqual(1, p0.Accounts.Count);
 					Assert.AreSame(p0.Accounts.First().User, p0);
 					var p1 = l[1];
 					Assert.IsTrue(NHibernateUtil.IsInitialized(p1.Accounts));
-					Assert.AreEqual(p1.Accounts.Count, 0);
+					Assert.AreEqual(0, p1.Accounts.Count);
 				}
 			}
 		}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -70,6 +70,7 @@
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.3" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="9.1.1" />

--- a/src/NHibernate.Test/SqlCommandTest/SqlStringFixture.cs
+++ b/src/NHibernate.Test/SqlCommandTest/SqlStringFixture.cs
@@ -434,7 +434,8 @@ namespace NHibernate.Test.SqlCommandTest
 			Assert.IsNull(parameters2[0].ParameterPosition);
 
 			// more simple version of the test
-			Assert.That(Parameter.Placeholder, Is.Not.SameAs(Parameter.Placeholder));
+			var placeholder = Parameter.Placeholder;
+			Assert.That(placeholder, Is.Not.SameAs(Parameter.Placeholder));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/SqlTest/Custom/CustomSQLSupportTest.cs
+++ b/src/NHibernate.Test/SqlTest/Custom/CustomSQLSupportTest.cs
@@ -48,10 +48,10 @@ namespace NHibernate.Test.SqlTest.Custom
 			s = OpenSession();
 			t = s.BeginTransaction();
 			jboss = (Organization)s.Get(typeof(Organization), orgId);
-			Assert.AreEqual(jboss.Employments.Count, 2);
+			Assert.AreEqual(2, jboss.Employments.Count);
 			emp = (Employment)GetFirstItem(jboss.Employments);
 			gavin = emp.Employee;
-			Assert.AreEqual(gavin.Name, "GAVIN");
+			Assert.AreEqual("GAVIN", gavin.Name);
 			Assert.AreEqual(s.GetCurrentLockMode(gavin), LockMode.Upgrade);
 			emp.EndDate = DateTime.Today;
 			Employment emp3 = new Employment(gavin, jboss, "US");
@@ -64,7 +64,7 @@ namespace NHibernate.Test.SqlTest.Custom
 			IEnumerator iter = s.GetNamedQuery("allOrganizationsWithEmployees").List().GetEnumerator();
 			Assert.IsTrue(iter.MoveNext());
 			Organization o = (Organization)iter.Current;
-			Assert.AreEqual(o.Employments.Count, 3);
+			Assert.AreEqual(3, o.Employments.Count);
 
 			foreach (Employment e in o.Employments)
 			{

--- a/src/NHibernate.Test/SqlTest/Custom/CustomStoredProcSupportTest.cs
+++ b/src/NHibernate.Test/SqlTest/Custom/CustomStoredProcSupportTest.cs
@@ -15,8 +15,8 @@ namespace NHibernate.Test.SqlTest.Custom
 			namedQuery.SetInt64("number", 43L);
 			IList list = namedQuery.List();
 			object[] o = (object[])list[0];
-			Assert.AreEqual(o[0], "getAll");
-			Assert.AreEqual(o[1], 43L);
+			Assert.AreEqual("getAll", o[0]);
+			Assert.AreEqual(43L, o[1]);
 			s.Close();
 		}
 
@@ -30,16 +30,16 @@ namespace NHibernate.Test.SqlTest.Custom
 			namedQuery.SetInt64(1, 20L);
 			IList list = namedQuery.List();
 			object[] o = (Object[])list[0];
-			Assert.AreEqual(o[0], 10L);
-			Assert.AreEqual(o[1], 20L);
+			Assert.AreEqual(10L, o[0]);
+			Assert.AreEqual(20L, o[1]);
 
 			namedQuery = s.GetNamedQuery("paramhandling_mixed");
 			namedQuery.SetInt64(0, 10L);
 			namedQuery.SetInt64("second", 20L);
 			list = namedQuery.List();
 			o = (object[])list[0];
-			Assert.AreEqual(o[0], 10L);
-			Assert.AreEqual(o[1], 20L);
+			Assert.AreEqual(10L, o[0]);
+			Assert.AreEqual(20L, o[1]);
 			s.Close();
 		}
 

--- a/src/NHibernate.Test/SqlTest/Query/NativeSQLQueriesFixture.cs
+++ b/src/NHibernate.Test/SqlTest/Query/NativeSQLQueriesFixture.cs
@@ -119,7 +119,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.AddJoin("emp", "org.employments")
 					.AddJoin("pers", "emp.employee")
 					.List();
-				Assert.AreEqual(l.Count, 1);
+				Assert.AreEqual(1, l.Count);
 
 				t.Commit();
 			}
@@ -135,7 +135,7 @@ namespace NHibernate.Test.SqlTest.Query
 						.AddJoin("emp", "org.employments")
 						.SetResultTransformer(new DistinctRootEntityResultTransformer())
 						.List();
-				Assert.AreEqual(l.Count, 2);
+				Assert.AreEqual(2, l.Count);
 
 				t.Commit();
 				s.Close();
@@ -172,7 +172,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.AddJoin("pers", "emp.employee")
 					.SetCacheable(true)
 					.List();
-				Assert.AreEqual(l.Count, 1);
+				Assert.AreEqual(1, l.Count);
 
 				t.Commit();
 			}
@@ -189,7 +189,7 @@ namespace NHibernate.Test.SqlTest.Query
 						.SetCacheable(true)
 						.SetResultTransformer(new DistinctRootEntityResultTransformer())
 						.List();
-				Assert.AreEqual(l.Count, 2);
+				Assert.AreEqual(2, l.Count);
 
 				t.Commit();
 				s.Close();
@@ -460,12 +460,12 @@ namespace NHibernate.Test.SqlTest.Query
 			IList l = s.CreateSQLQuery(OrgEmpRegionSQL)
 			           .SetResultSetMapping("org-emp-regionCode")
 			           .List();
-			Assert.AreEqual(l.Count, 2);
+			Assert.AreEqual(2, l.Count);
 
 			l = s.CreateSQLQuery(OrgEmpPersonSQL)
 			     .SetResultSetMapping("org-emp-person")
 			     .List();
-			Assert.AreEqual(l.Count, 1);
+			Assert.AreEqual(1, l.Count);
 
 			t.Commit();
 			s.Close();
@@ -504,12 +504,12 @@ namespace NHibernate.Test.SqlTest.Query
 			IEnumerator iter = s.GetNamedQuery("orgNamesAndOrgs").List().GetEnumerator();
 			iter.MoveNext();
 			object[] o = (object[]) iter.Current;
-			Assert.AreEqual(o[0], "IFA");
-			Assert.AreEqual(((Organization) o[1]).Name, "IFA");
+			Assert.AreEqual("IFA", o[0]);
+			Assert.AreEqual("IFA", ((Organization) o[1]).Name);
 			iter.MoveNext();
 			o = (object[]) iter.Current;
-			Assert.AreEqual(o[0], "JBoss");
-			Assert.AreEqual(((Organization) o[1]).Name, "JBoss");
+			Assert.AreEqual("JBoss", o[0]);
+			Assert.AreEqual("JBoss", ((Organization) o[1]).Name);
 
 			t.Commit();
 			s.Close();
@@ -524,13 +524,13 @@ namespace NHibernate.Test.SqlTest.Query
 			Assert.AreEqual(typeof(Organization), row[0].GetType(), "expecting non-scalar result first");
 			Assert.AreEqual(typeof(string), row[1].GetType(), "expecting scalar result second");
 			Assert.AreEqual("IFA", ((Organization) row[0]).Name);
-			Assert.AreEqual(row[1], "IFA");
+			Assert.AreEqual("IFA", row[1]);
 			iter.MoveNext();
 			row = (object[]) iter.Current;
 			Assert.AreEqual(typeof(Organization), row[0].GetType(), "expecting non-scalar result first");
 			Assert.AreEqual(typeof(string), row[1].GetType(), "expecting scalar result second");
-			Assert.AreEqual(((Organization) row[0]).Name, "JBoss");
-			Assert.AreEqual(row[1], "JBoss");
+			Assert.AreEqual("JBoss", ((Organization) row[0]).Name);
+			Assert.AreEqual("JBoss", row[1]);
 			Assert.IsFalse(iter.MoveNext());
 
 			t.Commit();
@@ -542,11 +542,11 @@ namespace NHibernate.Test.SqlTest.Query
 			iter = s.GetNamedQuery("orgIdsAndOrgNames").List().GetEnumerator();
 			iter.MoveNext();
 			o = (object[]) iter.Current;
-			Assert.AreEqual(o[1], "IFA");
+			Assert.AreEqual("IFA", o[1]);
 			Assert.AreEqual(o[0], idIfa);
 			iter.MoveNext();
 			o = (object[]) iter.Current;
-			Assert.AreEqual(o[1], "JBoss");
+			Assert.AreEqual("JBoss", o[1]);
 			Assert.AreEqual(o[0], idJBoss);
 
 			t.Commit();
@@ -769,7 +769,7 @@ namespace NHibernate.Test.SqlTest.Query
 			IQuery queryWithCollection = s.GetNamedQuery("organizationEmploymentsExplicitAliases");
 			queryWithCollection.SetInt64("id", jboss.Id);
 			list = queryWithCollection.List();
-			Assert.AreEqual(list.Count, 1);
+			Assert.AreEqual(1, list.Count);
 
 			s.Clear();
 
@@ -860,7 +860,7 @@ namespace NHibernate.Test.SqlTest.Query
 			IList l = s.CreateSQLQuery("select name, id, flength, name as scalarName from Speech")
 			           .SetResultSetMapping("speech")
 			           .List();
-			Assert.AreEqual(l.Count, 1);
+			Assert.AreEqual(1, l.Count);
 
 			t.Rollback();
 			s.Close();
@@ -939,7 +939,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.SetResultTransformer(transformer)
 					.Future<object[]>();
 
-				Assert.AreEqual(l.GetEnumerable().Count(), 1);
+				Assert.AreEqual(1, l.GetEnumerable().Count());
 				Assert.AreEqual("Ricardo", l.GetEnumerable().ElementAt(0)[0]);
 				Assert.IsTrue(transformer.TransformListCalled);
 				Assert.IsTrue(transformer.TransformTupleCalled);
@@ -984,7 +984,7 @@ namespace NHibernate.Test.SqlTest.Query
 					.CreateSQLQuery("select Name from Person")
 					.Future<string>();
 
-				Assert.AreEqual(l.GetEnumerable().Count(), 1);
+				Assert.AreEqual(1, l.GetEnumerable().Count());
 				Assert.AreEqual("Ricardo", l.GetEnumerable().ElementAt(0));
 			}
 		}

--- a/src/NHibernate.Test/SubselectFetchTest/SubselectFetchFixture.cs
+++ b/src/NHibernate.Test/SubselectFetchTest/SubselectFetchFixture.cs
@@ -44,24 +44,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
@@ -109,24 +109,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
@@ -174,24 +174,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 
@@ -240,8 +240,8 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
-			Assert.AreEqual(p.MoreChildren.Count, 0);
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(0, p.MoreChildren.Count);
+			Assert.AreEqual(2, p.Children.Count);
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
@@ -250,8 +250,8 @@ namespace NHibernate.Test.SubselectFetchTest
 			r = (Parent) s.Get(typeof(Parent), r.Name);
 			Assert.IsTrue(NHibernateUtil.IsInitialized(r.Children)); // The test for True is the test of H3.2
 			Assert.IsFalse(NHibernateUtil.IsInitialized(r.MoreChildren));
-			Assert.AreEqual(r.Children.Count, 1);
-			Assert.AreEqual(r.MoreChildren.Count, 0);
+			Assert.AreEqual(1, r.Children.Count);
+			Assert.AreEqual(0, r.MoreChildren.Count);
 
 			s.Delete(p);
 			s.Delete(q);
@@ -333,24 +333,24 @@ namespace NHibernate.Test.SubselectFetchTest
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.Children));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(p.Children.Count, 2);
+			Assert.AreEqual(2, p.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(p.Children[0]));
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children));
 
-			Assert.AreEqual(q.Children.Count, 2);
+			Assert.AreEqual(2, q.Children.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.Children[0]));
 
 			Assert.IsFalse(NHibernateUtil.IsInitialized(p.MoreChildren));
 			Assert.IsFalse(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(p.MoreChildren.Count, 0);
+			Assert.AreEqual(0, p.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren));
 
-			Assert.AreEqual(q.MoreChildren.Count, 2);
+			Assert.AreEqual(2, q.MoreChildren.Count);
 
 			Assert.IsTrue(NHibernateUtil.IsInitialized(q.MoreChildren[0]));
 

--- a/src/NHibernate.Test/TypeParameters/TypeParameterTest.cs
+++ b/src/NHibernate.Test/TypeParameters/TypeParameterTest.cs
@@ -71,7 +71,7 @@ namespace NHibernate.Test.TypeParameters
 			              "Default value should have been mapped to null");
 			Assert.IsTrue(reader.GetValue(reader.GetOrdinal("VALUE_TWO")) == DBNull.Value,
 			              "Default value should have been mapped to null");
-			Assert.AreEqual(Convert.ToInt32(reader.GetValue(reader.GetOrdinal("VALUE_THREE"))), 5,
+			Assert.AreEqual(5, Convert.ToInt32(reader.GetValue(reader.GetOrdinal("VALUE_THREE"))),
 			                "Non-Default value should not be changed");
 			Assert.IsTrue(reader.GetValue(reader.GetOrdinal("VALUE_FOUR")) == DBNull.Value,
 			              "Default value should have been mapped to null");
@@ -93,17 +93,17 @@ namespace NHibernate.Test.TypeParameters
 
 			Widget obj = (Widget) s.CreateQuery("from Widget o where o.Str = :string")
 			                      	.SetString("string", "all-normal").UniqueResult();
-			Assert.AreEqual(obj.ValueOne, 7, "Non-Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueTwo, 8, "Non-Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueThree, 9, "Non-Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueFour, 10, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(7, obj.ValueOne, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(8, obj.ValueTwo, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(9, obj.ValueThree, "Non-Default value incorrectly loaded");
+			Assert.AreEqual(10, obj.ValueFour, "Non-Default value incorrectly loaded");
 
 			obj = (Widget) s.CreateQuery("from Widget o where o.Str = :string")
 			               	.SetString("string", "all-default").UniqueResult();
-			Assert.AreEqual(obj.ValueOne, 1, "Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueTwo, 2, "Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueThree, -1, "Default value incorrectly loaded");
-			Assert.AreEqual(obj.ValueFour, -5, "Default value incorrectly loaded");
+			Assert.AreEqual(1, obj.ValueOne, "Default value incorrectly loaded");
+			Assert.AreEqual(2, obj.ValueTwo, "Default value incorrectly loaded");
+			Assert.AreEqual(-1, obj.ValueThree, "Default value incorrectly loaded");
+			Assert.AreEqual(-5, obj.ValueFour, "Default value incorrectly loaded");
 
 			t.Commit();
 			s.Close();

--- a/src/NHibernate.Test/Unionsubclass/UnionSubclassFixture.cs
+++ b/src/NHibernate.Test/Unionsubclass/UnionSubclassFixture.cs
@@ -55,7 +55,7 @@ namespace NHibernate.Test.Unionsubclass
 				using (ITransaction t = s.BeginTransaction())
 				{
 					Human gavin = (Human)s.CreateCriteria(typeof(Human)).UniqueResult();
-					Assert.AreEqual(gavin.Info.Count, 2);
+					Assert.AreEqual(2, gavin.Info.Count);
 					s.Delete(gavin);
 					s.Delete(gavin.Location);
 					t.Commit();

--- a/src/NHibernate.Test/VersionTest/VersionFixture.cs
+++ b/src/NHibernate.Test/VersionTest/VersionFixture.cs
@@ -38,7 +38,7 @@ namespace NHibernate.Test.VersionTest
 			t.Commit();
 			s.Close();
 
-			Assert.AreEqual(passp.Version, 2);
+			Assert.AreEqual(2, passp.Version);
 
 			s = OpenSession();
 			t = s.BeginTransaction();


### PR DESCRIPTION
*  Add NUnit.Analyzers 
* Fix NUnit2007: The actual value should not be a constant 
* Fix NUnit2041: The comparison constraint always fails as the actual and the expected value are not comparable
* Fix NUnit2022: The type of the actual argument - 'IEnumerable<>' - has no property 'Count'
* Fix NUnit2023: The type of the actual argument - 'bool' - can never be null
* Fix other issues