### PR TITLE
Int32Type: avoid unnecessary boxing for common cases

### DIFF
--- a/src/NHibernate/Type/Int32Type.cs
+++ b/src/NHibernate/Type/Int32Type.cs
@@ -31,8 +31,10 @@ namespace NHibernate.Type
 		{
 			try
 			{
-				return rs[index] switch
+				var value = rs[index];
+				return value switch
 				{
+					int _ => value,
 					BigInteger bi => (int) bi,
 					var c => Convert.ToInt32(c)
 				};


### PR DESCRIPTION
Indexed properties of `DbDataReader` returns a boxed value, which we convert to `Int32` (and then box again, but it is a different story).
This is a performance hit and produces memory traffic. Why? Because, for example, `SqlDataReader` in Microsoft.Data.SqlClient stores `int` (and all other reference types) as a reference value, and reading of value as `object` forces `SqlDataReader` to box it.