### PR TITLE
Obsolete literal AddColumn

### DIFF
--- a/src/NHibernate.Test/SqlCommandTest/SqlInsertBuilderFixture.cs
+++ b/src/NHibernate.Test/SqlCommandTest/SqlInsertBuilderFixture.cs
@@ -26,7 +26,9 @@ namespace NHibernate.Test.SqlCommandTest
 
 			insert.AddColumn("intColumn", NHibernateUtil.Int32);
 			insert.AddColumn("longColumn", NHibernateUtil.Int64);
+#pragma warning disable CS0618 // Type or member is obsolete
 			insert.AddColumn("literalColumn", false, (ILiteralType) NHibernateUtil.Boolean);
+#pragma warning restore CS0618 // Type or member is obsolete
 			insert.AddColumn("stringColumn", 5.ToString());
 
 			SqlCommandInfo sqlCommand = insert.ToSqlCommandInfo();
@@ -53,7 +55,9 @@ namespace NHibernate.Test.SqlCommandTest
 
 			insert.SetTableName("test_insert_builder");
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			insert.AddColumn("stringColumn", "aSQLValue", (ILiteralType)NHibernateUtil.String);
+#pragma warning restore CS0618 // Type or member is obsolete
 			insert.SetComment("Test insert");
 			string expectedSql =
 	"/* Test insert */ INSERT INTO test_insert_builder (stringColumn) VALUES ('aSQLValue')";
@@ -71,7 +75,9 @@ namespace NHibernate.Test.SqlCommandTest
 
 			insert.SetTableName("test_insert_builder");
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			insert.AddColumn("literalColumn", false, (ILiteralType)NHibernateUtil.Boolean);
+#pragma warning restore CS0618 // Type or member is obsolete
 			insert.AddColumn("intColumn", NHibernateUtil.Int32);
 			insert.AddColumn("stringColumn", 5.ToString());
 			insert.AddColumn("longColumn", NHibernateUtil.Int64);

--- a/src/NHibernate.Test/SqlCommandTest/SqlUpdateBuilderFixture.cs
+++ b/src/NHibernate.Test/SqlCommandTest/SqlUpdateBuilderFixture.cs
@@ -28,7 +28,9 @@ namespace NHibernate.Test.SqlCommandTest
 
 			update.AddColumns(new string[] {"intColumn"}, NHibernateUtil.Int32);
 			update.AddColumns(new string[] {"longColumn"}, NHibernateUtil.Int64);
+#pragma warning disable CS0618 // Type or member is obsolete
 			update.AddColumn("literalColumn", false, (ILiteralType) NHibernateUtil.Boolean);
+#pragma warning restore CS0618 // Type or member is obsolete
 			update.AddColumn("stringColumn", 5.ToString());
 
 			update.SetIdentityColumn(new string[] {"decimalColumn"}, NHibernateUtil.Decimal);

--- a/src/NHibernate/SqlCommand/SqlInsertBuilder.cs
+++ b/src/NHibernate/SqlCommand/SqlInsertBuilder.cs
@@ -66,6 +66,8 @@ namespace NHibernate.SqlCommand
 		/// <param name="val">The value to set for the column.</param>
 		/// <param name="literalType">The NHibernateType to use to convert the value to a sql string.</param>
 		/// <returns>The SqlInsertBuilder.</returns>
+		// Since v5.6
+		[Obsolete("This method is unsafe and has no more usages. Use the overload with a property type and use a parameterized query.")]
 		public SqlInsertBuilder AddColumn(string columnName, object val, ILiteralType literalType)
 		{
 			return AddColumn(columnName, literalType.ObjectToSQLString(val, Dialect));

--- a/src/NHibernate/SqlCommand/SqlUpdateBuilder.cs
+++ b/src/NHibernate/SqlCommand/SqlUpdateBuilder.cs
@@ -47,6 +47,8 @@ namespace NHibernate.SqlCommand
 		/// <param name="val">The value to set for the column.</param>
 		/// <param name="literalType">The NHibernateType to use to convert the value to a sql string.</param>
 		/// <returns>The SqlUpdateBuilder.</returns>
+		// Since v5.6
+		[Obsolete("This method is unsafe and has no more usages. Use the overload with a property type and use a parameterized query.")]
 		public SqlUpdateBuilder AddColumn(string columnName, object val, ILiteralType literalType)
 		{
 			return AddColumn(columnName, literalType.ObjectToSQLString(val, Dialect));


### PR DESCRIPTION
SqlInsert/UpdateBuilder AddColumn overloads taking a value have a SQL injection vulnerability, and have no usage.