### PR TITLE
Add workaround for Rider to see the Antlr3 generated files at design time

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,6 +44,7 @@ indent_size = 2
 [*.csproj]
 indent_style = space
 indent_size = 2
+ij_xml_space_inside_empty_tag = true
 
 [*.vbproj]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -37,18 +37,10 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.xml]
-indent_style = space
-indent_size = 2
-
-[*.csproj]
+[{*.xml,*.csproj,*.vbproj}]
 indent_style = space
 indent_size = 2
 ij_xml_space_inside_empty_tag = true
-
-[*.vbproj]
-indent_style = space
-indent_size = 2
 
 [*.g]
 indent_style = tab

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../build-common/NHibernate.props" />
 
   <PropertyGroup>
@@ -13,8 +13,6 @@
     <PackageDescription>NHibernate is a mature, open source object-relational mapper for the .NET framework. It is actively developed, fully featured and used in thousands of successful projects.</PackageDescription>
     <PackageTags>ORM; O/RM; DataBase; DAL; ObjectRelationalMapping; NHibernate; ADO.Net; Core</PackageTags>
     <PackageReadmeFile>NHibernate.readme.md</PackageReadmeFile>
-    <!-- Workaround to enable Rider to see the Antlr3 generated files at design time -->
-    <CoreCompileDependsOn>DesignTimeGrammarCompilation;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
   
   <ItemGroup>
@@ -94,4 +92,11 @@
     </Content>
     <None Include="../../logo/NHibernate-NuGet.png" Pack="true" PackagePath="/" />
   </ItemGroup>
+
+  <!-- Workaround to enable Rider to see the Antlr3 generated files at design time -->
+  <Target Name="_AntrlDesignTimeGrammarCompilationWorkaround" BeforeTargets="CoreCompile" Condition="'$(BuildingByReSharper)' == 'true'">
+    <CallTarget
+      Targets="AntlrCompile"
+      Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'" />
+  </Target>
 </Project>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -13,6 +13,8 @@
     <PackageDescription>NHibernate is a mature, open source object-relational mapper for the .NET framework. It is actively developed, fully featured and used in thousands of successful projects.</PackageDescription>
     <PackageTags>ORM; O/RM; DataBase; DAL; ObjectRelationalMapping; NHibernate; ADO.Net; Core</PackageTags>
     <PackageReadmeFile>NHibernate.readme.md</PackageReadmeFile>
+    <!-- Workaround to enable Rider to see the Antlr3 generated files at design time -->
+    <CoreCompileDependsOn>DesignTimeGrammarCompilation;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -14,7 +14,7 @@
     <PackageTags>ORM; O/RM; DataBase; DAL; ObjectRelationalMapping; NHibernate; ADO.Net; Core</PackageTags>
     <PackageReadmeFile>NHibernate.readme.md</PackageReadmeFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Remove="**\*.g" />
     <None Remove="**\*.xsd" />
@@ -97,6 +97,8 @@
   <Target Name="_AntrlDesignTimeGrammarCompilationWorkaround" BeforeTargets="CoreCompile" Condition="'$(BuildingByReSharper)' == 'true'">
     <CallTarget
       Targets="AntlrCompile"
-      Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'" />
+      ContinueOnError="true"
+      Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'"
+    />
   </Target>
 </Project>


### PR DESCRIPTION
Re-implemented Antlr's `DesignTimeGrammarCompilationWorkaround` task to be explicitly run by Rider in design time

I've submitted [patch](https://github.com/antlr/antlrcs/pull/130) to Antlr, but doubt that it'll be accepted.