### PR TITLE
Upgrade Npgsql to a non vulnerable version

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="8.5.2" />
-    <PackageReference Include="Npgsql" Version="6.0.6" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="MySql.Data" Version="8.0.30" />
   </ItemGroup>
   <ItemGroup Condition="$(NhNetFx)">


### PR DESCRIPTION
That is mostly for not having a warning in the solution, since the dependency is only there in tests, and the tests run in a very controlled context.