### PR TITLE
Migrate AppVeyor & TC builds to PostgreSQL 13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,8 +47,8 @@ before_test:
       'Odbc' { Start-Service 'MSSQL$SQL2017' }
       'PostgreSQL' {
         # Enable prepared transactions
-        Add-Content -Path 'C:\Program Files\PostgreSQL\10\data\postgresql.conf' -Value "`r`nmax_prepared_transactions = 100"
-        Start-Service 'postgresql-x64-10'
+        Add-Content -Path 'C:\Program Files\PostgreSQL\13\data\postgresql.conf' -Value "`r`nmax_prepared_transactions = 100"
+        Start-Service 'postgresql-x64-13'
       }
       'SqlServer2008' { Start-Service 'MSSQL$SQL2017' }
       'SqlServer2012' { Start-Service 'MSSQL$SQL2017' }

--- a/lib/teamcity/postgresql/postgresql_installation.txt
+++ b/lib/teamcity/postgresql/postgresql_installation.txt
@@ -1,7 +1,7 @@
 
 Installation steps for PostgreSQL for NH TeamCity:
 
-1.  Download PostgreSQL (postgresql-9.0.3-1-windows_x64.exe):  http://www.enterprisedb.com/products-services-training/pgdownload#windows;
+1.  Download PostgreSQL: https://www.enterprisedb.com/downloads/postgres-postgresql-downloads;
 2.  Run the installer ... when prompted to make a password for the service account, make it 'password';
 3.  Leave the port number at the default (5432), and leave the default locale;
 4.  The setup should install PostgreSQL on the machine;
@@ -12,8 +12,8 @@ Installation steps for PostgreSQL for NH TeamCity:
 
 Creating the NH user:
 
-a.  Open pgAdmin III (start -> programs -> PostgreSQL 9.0 -> pgAdmin III);
-b.  right-click the PostgreSQL 9.0 database, select connect, and enter the password from step 2 above;
-c.  right-clilck the Login Roles, and select "New Login Role ...";
-d.  create a login with "Role name=nhibernate", "Password=nhibernate", and select Superuser on the Role privileges tab.
+a.  Open pgAdmin 4;
+b.  Right-click the PostgreSQL database, select connect, and enter the password from step 2 above;
+c.  Right-clilck the Login Roles, and select "New Login Role ...";
+d.  Create a login with "Role name=nhibernate", "Password=nhibernate", and select Superuser on the Role privileges tab.
 

--- a/teamcity.build
+++ b/teamcity.build
@@ -124,7 +124,7 @@
 	</target>
 
 	<target name="setup-teamcity-postgresql">
-		<property name="db-service" value="postgresql-x64-10" />
+		<property name="db-service" value="postgresql-x64-13" />
 		<property name="nhibernate.connection.driver_class"			value="NHibernate.Driver.NpgsqlDriver" />
 		<property name="nhibernate.dialect"							value="NHibernate.Dialect.PostgreSQL83Dialect" />
 		<property name="nhibernate.connection.connection_string"	value="Host=localhost;Port=5432;Database=nhibernate;Username=nhibernate;Password=nhibernate;Enlist=true" />


### PR DESCRIPTION
It seems that PostgreSQL 10 is now gone from AppVeyor and build fails.

Use this as an opportunity to update TC build to PostgreSQL 13 as well.