### PR TITLE
Add new DB2NetDriver and obsolete DB2CoreDriver

### DIFF
--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -124,9 +124,14 @@ namespace NHibernate.Test
 		public virtual bool SupportsModuloOnDecimal => true;
 
 		/// <summary>
+		/// Supports sub-selects in order by clause
+		/// </summary>
+		public virtual bool SupportsSubSelectsInOrderBy => _dialect.SupportsScalarSubSelects;
+
+		/// <summary>
 		/// Supports aggregating sub-selects in order by clause
 		/// </summary>
-		public virtual bool SupportsAggregatingScalarSubSelectsInOrderBy => _dialect.SupportsScalarSubSelects;
+		public virtual bool SupportsAggregatingScalarSubSelectsInOrderBy => SupportsSubSelectsInOrderBy;
 
 		/// <summary>
 		/// Supports order by and limits/top in correlated sub-queries

--- a/src/NHibernate.Test/TestDialects/DB2TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/DB2TestDialect.cs
@@ -1,0 +1,16 @@
+namespace NHibernate.Test.TestDialects
+{
+	public class DB2TestDialect: TestDialect
+	{
+		public DB2TestDialect(Dialect.Dialect dialect) : base(dialect)
+		{
+		}
+
+		public override bool HasBrokenTypeInferenceOnSelectedParameters => true;
+		public override bool SupportsCancelQuery => false;
+		public override bool SupportsComplexExpressionInGroupBy => false;
+		public override bool SupportsNonDataBoundCondition => false;
+		public override bool SupportsSelectForUpdateWithPaging => false;
+		public override bool SupportsSubSelectsInOrderBy => false;
+	}
+}

--- a/src/NHibernate.TestDatabaseSetup/TestDatabaseSetup.cs
+++ b/src/NHibernate.TestDatabaseSetup/TestDatabaseSetup.cs
@@ -32,6 +32,9 @@ namespace NHibernate.TestDatabaseSetup
 				{"NHibernate.Driver.OracleManagedDataClientDriver", SetupOracle},
 				{"NHibernate.Driver.OdbcDriver", SetupSqlServerOdbc},
 				{"NHibernate.Driver.SQLite20Driver", SetupSQLite},
+				{"NHibernate.Driver.DB2Driver", SetupDB2},
+				{"NHibernate.Driver.DB2CoreDriver", SetupDB2},
+				{"NHibernate.Driver.DB2NetDriver", SetupDB2},
 #if NETFX
 				{"NHibernate.Driver.SqlServerCeDriver", SetupSqlServerCe},
 				{"NHibernate.Driver.SapSQLAnywhere17Driver", SetupSqlAnywhere}
@@ -205,6 +208,10 @@ namespace NHibernate.TestDatabaseSetup
 			{
 				Console.WriteLine(e);
 			}
+		}
+
+		private static void SetupDB2(Cfg.Configuration cfg)
+		{
 		}
 
 		private static void SetupOracle(Cfg.Configuration cfg)

--- a/src/NHibernate/Dialect/DB2Dialect.cs
+++ b/src/NHibernate/Dialect/DB2Dialect.cs
@@ -214,6 +214,8 @@ namespace NHibernate.Dialect
 			get { return true; }
 		}
 
+		public override string QuerySequencesString => "select seqname from syscat.sequences";
+
 		/// <summary></summary>
 		public override bool SupportsLimit
 		{
@@ -310,6 +312,9 @@ namespace NHibernate.Dialect
 		public override bool SupportsLobValueChangePropogation => false;
 
 		public override bool SupportsExistsInSelect => false;
+
+		/// <inheritdoc/>
+		public override bool SupportsHavingOnGroupedByComputation => false;
 
 		public override bool DoesReadCommittedCauseWritersToBlockReaders => true;
 

--- a/src/NHibernate/Driver/DB2CoreDriver.cs
+++ b/src/NHibernate/Driver/DB2CoreDriver.cs
@@ -1,27 +1,16 @@
-using System.Data.Common;
-using NHibernate.SqlTypes;
+using System;
 
 namespace NHibernate.Driver
 {
 	/// <summary>
 	/// A NHibernate Driver for using the IBM.Data.DB2.Core DataProvider.
 	/// </summary>
-	public class DB2CoreDriver : DB2DriverBase
-	{		
+	// Since v5.6
+	[Obsolete("Please use DB2NetDriver")]
+	public class DB2CoreDriver : DB2NetDriver
+	{
 		public DB2CoreDriver() : base("IBM.Data.DB2.Core")
 		{
-		}
-		
-		public override bool UseNamedPrefixInSql => true;
-
-		public override bool UseNamedPrefixInParameter => true;
-
-		public override string NamedPrefix => "@";
-
-		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
-		{
-			dbParam.ParameterName = FormatNameForParameter(name);
-			base.InitializeParameter(dbParam, name, sqlType);
 		}
 	}
 }

--- a/src/NHibernate/Driver/DB2CoreDriver.cs
+++ b/src/NHibernate/Driver/DB2CoreDriver.cs
@@ -9,8 +9,11 @@ namespace NHibernate.Driver
 	[Obsolete("Please use DB2NetDriver")]
 	public class DB2CoreDriver : DB2NetDriver
 	{
+		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(DB2CoreDriver));
+		
 		public DB2CoreDriver() : base("IBM.Data.DB2.Core")
 		{
+		    Log.Warn("DB2CoreDriver is obsolete, please use DB2NetDriver instead.");
 		}
 	}
 }

--- a/src/NHibernate/Driver/DB2NetDriver.cs
+++ b/src/NHibernate/Driver/DB2NetDriver.cs
@@ -1,0 +1,29 @@
+using System.Data.Common;
+using NHibernate.SqlTypes;
+
+namespace NHibernate.Driver
+{
+	/// <summary>
+	/// A NHibernate Driver for using the Net5.IBM.Data.Db2/Net.IBM.Data.Db2 DataProvider.
+	/// </summary>
+	public class DB2NetDriver : DB2DriverBase
+	{
+		private protected DB2NetDriver(string assemblyName) : base(assemblyName)
+		{
+		}
+
+		public DB2NetDriver() : base("IBM.Data.Db2")
+		{
+		}
+
+		public override bool UseNamedPrefixInSql => true;
+		public override bool UseNamedPrefixInParameter => true;
+		public override string NamedPrefix => "@";
+
+		protected override void InitializeParameter(DbParameter dbParam, string name, SqlType sqlType)
+		{
+			dbParam.ParameterName = FormatNameForParameter(name);
+			base.InitializeParameter(dbParam, name, sqlType);
+		}
+	}
+}


### PR DESCRIPTION
* Added new driver for IBM DB2 to be used with [Net5.IBM.Data.Db2](https://www.nuget.org/packages/Net5.IBM.Data.Db2) (.NET 5) and [Net.IBM.Data.Db2](https://www.nuget.org/packages/Net.IBM.Data.Db2) (.NET 6-8).
* Obsolete driver for .NET Core 2-3.1
---
_**NB:**_ on Windows set `DB2LANG=en_US` environment variable.