### PR TITLE
Migrate .NET Core SQLite Windows tests from AppVeyor to GitHub Actions

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -12,7 +12,7 @@ jobs:
         include:
           - DB: SqlServer2008
             CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"
-            OS: windows-latest
+            OS: ubuntu-latest
             DB_INIT: |
               docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P@ssw0rd" -e "MSSQL_PID=Express" -p 1433:1433 -d --name sqlexpress mcr.microsoft.com/mssql/server:2019-latest;
           - DB: SqlServer2008-MicrosoftDataSqlClientDriver

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -1,4 +1,4 @@
-name: .NET Core ${{matrix.OS}}
+name: .NET Core
 
 on: [push, pull_request]
 
@@ -50,7 +50,7 @@ jobs:
     continue-on-error: ${{matrix.ALLOW_FAILURE == true}}
     env:
       LANG: en-US.UTF-8 #default POSIX locale doesn't support ignore case comparisons
-    name: ${{matrix.DB}}
+    name: ${{matrix.DB}} - ${{matrix.OS}}
 
     steps:
     - name: Set up ${{matrix.DB}}

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -7,42 +7,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        DB: [SQLite]
+        OS: [ubuntu-latest, windows-latest, macos-13]
         include:
           - DB: SqlServer2008
             CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"
+            OS: windows-latest
             DB_INIT: |
               docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P@ssw0rd" -e "MSSQL_PID=Express" -p 1433:1433 -d --name sqlexpress mcr.microsoft.com/mssql/server:2019-latest;
           - DB: SqlServer2008-MicrosoftDataSqlClientDriver
             CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"
+            OS: ubuntu-latest
             DB_INIT: |
               docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P@ssw0rd" -e "MSSQL_PID=Express" -p 1433:1433 -d --name sqlexpress mcr.microsoft.com/mssql/server:2019-latest;
           - DB: PostgreSQL
             CONNECTION_STRING: "Host=localhost;Username=nhibernate;Password=nhibernate;Database=nhibernate;Enlist=true;"
+            OS: ubuntu-latest
             DB_INIT: |
              docker run -d -e POSTGRES_USER=nhibernate  -e POSTGRES_PASSWORD=nhibernate -e POSTGRES_DB=nhibernate -p 5432:5432 postgres:13
           - DB: Firebird
             CONNECTION_STRING: "DataSource=localhost;Database=nhibernate;User=SYSDBA;Password=nhibernate;charset=utf8;"
+            OS: ubuntu-latest
             DB_INIT: |
               docker run --name firebird -e EnableWireCrypt=true -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e ISC_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d jacobalberty/firebird:v3.0
           - DB: Firebird4
             CONNECTION_STRING: "DataSource=localhost;Database=nhibernate;User=SYSDBA;Password=nhibernate;charset=utf8;"
+            OS: ubuntu-latest
             DB_INIT: |
               docker run --name firebird -e EnableWireCrypt=true -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e ISC_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d jacobalberty/firebird:v4.0
           - DB: MySQL
             CONNECTION_STRING: "Server=localhost;Uid=root;Password=nhibernate;Database=nhibernate;Old Guids=True;SslMode=none;"
+            OS: ubuntu-latest
             DB_INIT: |
               sudo service mysql stop
               docker run --name mysql -e MYSQL_ROOT_PASSWORD=nhibernate -e MYSQL_USER=nhibernate -e MYSQL_PASSWORD=nhibernate -e MYSQL_DATABASE=nhibernate -p 3306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -d mysql:5.7 mysqld --lower_case_table_names=1 --character-set-server=utf8 --collation-server=utf8_general_ci
           - DB: Oracle
             CONNECTION_STRING: "User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XEPDB1)))"
+            OS: ubuntu-latest
             DB_INIT: |
               docker run -d -p 1521:1521 -e APP_USER=nhibernate -e APP_USER_PASSWORD=nhibernate -e ORACLE_PASSWORD=nhibernate gvenzl/oracle-xe:21-slim
-          - DB: SQLite
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.OS}}
     continue-on-error: ${{matrix.ALLOW_FAILURE == true}}
     env:
       LANG: en-US.UTF-8 #default POSIX locale doesn't support ignore case comparisons
-    name: ${{matrix.DB}}
+    name: ${{matrix.DB}} - ${{matrix.OS}}
 
     steps:
     - name: Set up ${{matrix.DB}}

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET Core ${{matrix.OS}}
 
 on: [push, pull_request]
 
@@ -50,7 +50,7 @@ jobs:
     continue-on-error: ${{matrix.ALLOW_FAILURE == true}}
     env:
       LANG: en-US.UTF-8 #default POSIX locale doesn't support ignore case comparisons
-    name: ${{matrix.DB}} - ${{matrix.OS}}
+    name: ${{matrix.DB}}
 
     steps:
     - name: Set up ${{matrix.DB}}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
   - DB: Firebird4
   - DB: MySQL
     CONNECTION_STRING: Server=127.0.0.1;Uid=root;Pwd=Password12!;Database=nhibernate;Old Guids=True;SslMode=none;CharSet=utf8;
-  - DB: SQLite
 init:
     # Required for having windows endlines in sources zip
     - git config --global core.autocrlf true


### PR DESCRIPTION
 - Migrated .NET Core SQLite Windows tests from AppVeyor to GitHub Actions
 - Add tests for SQLite on MacOS 13
 - Added ability to run .NET Core tests on multiple platforms