### PR TITLE
fixing a truncated table name

### DIFF
--- a/src/NHibernate.Test/DialectTest/Oracle8iDialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/Oracle8iDialectFixture.cs
@@ -1,4 +1,4 @@
-﻿using NHibernate.Cfg;
+using NHibernate.Cfg;
 using NHibernate.Dialect;
 using NHibernate.SqlCommand;
 using NHibernate.Util;
@@ -148,5 +148,18 @@ namespace NHibernate.Test.DialectTest
 		}
 
 		#endregion
+		[Test]
+		public void TemporaryTableNameTruncation()
+		{
+			string temporaryTableName = new Oracle8iDialect().GenerateTemporaryTableName(
+				"TABLE_NAME_THAT_EXCEEDS_30_CHARACTERS");
+			Assert.AreEqual(
+				30,
+				temporaryTableName.Length);
+			Assert.AreEqual(
+				"HT_TABLE_NAME_THAT_EXCEEDS_30_",
+				temporaryTableName
+			);
+		}
 	}
 }

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -529,7 +529,7 @@ namespace NHibernate.Dialect
 		public override string GenerateTemporaryTableName(String baseTableName)
 		{
 			string name = base.GenerateTemporaryTableName(baseTableName);
-			return name.Length > 30 ? name.Substring(1, (30) - (1)) : name;
+			return name.Length > 30 ? name.Substring(0, (30) - (1)) : name;
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
When the Oracle8iDialect creates a temporary table name for tables with names longer than 27 characters, the "H" from the usual temporary table name prefix ("HT_") is truncated.

fix #3456