### PR TITLE
Remove Microsoft.SourceLink.GitHub

### DIFF
--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -38,7 +38,6 @@
     </PackageReference>
     <PackageReference Include="Antlr3.Runtime" Version="[3.5.1, 4.0)" />
     <PackageReference Include="Iesi.Collections" Version="4.1.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Remotion.Linq" Version="[2.2.0, 3.0)" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="[2.2.0, 3.0)" />
   </ItemGroup>


### PR DESCRIPTION
This is part of .NET 8 SDK now and not required to be explicitly referenced anymore