### PR TITLE
Encourage use of .NET 9.0's System.Threading.Lock

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -6,7 +6,7 @@
     <VersionPatch  Condition="'$(VersionPatch)'  == ''">0</VersionPatch>
     <!-- Clear VersionSuffix for making release and set it to dev for making development builds -->
     <VersionSuffix Condition="'$(VersionSuffix)' == ''">dev</VersionSuffix>
-    <LangVersion Condition="'$(MSBuildProjectExtension)' != '.vbproj'">12.0</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' != '.vbproj'">preview</LangVersion>
 
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(NhVersion).$(VersionPatch)</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix).$(BuildNumber)</VersionSuffix>

--- a/src/NHibernate.Test/NHSpecificTest/NH2030/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2030/Fixture.cs
@@ -15,7 +15,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2030
 		[Test]
 		public void GetTypeWithLenShouldBeThreadSafe()
 		{
-			Lock sync = new Lock();
+			object sync = new object();
 			List<Exception> exceptions = new List<Exception>();
 
 			ManualResetEvent startEvent = new ManualResetEvent(false);

--- a/src/NHibernate.Test/NHSpecificTest/NH2030/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2030/Fixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -15,7 +15,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2030
 		[Test]
 		public void GetTypeWithLenShouldBeThreadSafe()
 		{
-			object sync = new object();
+			Lock sync = new Lock();
 			List<Exception> exceptions = new List<Exception>();
 
 			ManualResetEvent startEvent = new ManualResetEvent(false);

--- a/src/NHibernate.Test/NHSpecificTest/NH2192/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2192/Fixture.cs
@@ -45,7 +45,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2192
 		[Test]
 		public void HqlIsThreadsafe_UsingThreads()
 		{
-			object sync = new object();
+			Lock sync = new Lock();
 			List<int> results = new List<int>();
 			List<Exception> exceptions = new List<Exception>();
 

--- a/src/NHibernate.Test/NHSpecificTest/NH2192/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH2192/Fixture.cs
@@ -45,7 +45,7 @@ namespace NHibernate.Test.NHSpecificTest.NH2192
 		[Test]
 		public void HqlIsThreadsafe_UsingThreads()
 		{
-			Lock sync = new Lock();
+			object sync = new object();
 			List<int> results = new List<int>();
 			List<Exception> exceptions = new List<Exception>();
 

--- a/src/NHibernate/Cache/SyncCacheLock.cs
+++ b/src/NHibernate/Cache/SyncCacheLock.cs
@@ -6,9 +6,9 @@ namespace NHibernate.Cache
 {
 	class SyncCacheLock : ICacheLock
 	{
-		private readonly MonitorLock _monitorLock;
+		private readonly InternalLock _internalLock;
 
-		class MonitorLock : IDisposable
+		class InternalLock : IDisposable
 		{
 			private readonly Lock _lockObj = new Lock();
 
@@ -26,7 +26,7 @@ namespace NHibernate.Cache
 
 		public SyncCacheLock()
 		{
-			_monitorLock = new();
+			_internalLock = new();
 		}
 
 		public void Dispose()
@@ -35,12 +35,12 @@ namespace NHibernate.Cache
 
 		public IDisposable ReadLock()
 		{
-			return _monitorLock.Lock();
+			return _internalLock.Lock();
 		}
 
 		public IDisposable WriteLock()
 		{
-			return _monitorLock.Lock();
+			return _internalLock.Lock();
 		}
 
 		public Task<IDisposable> ReadLockAsync()

--- a/src/NHibernate/Cache/SyncCacheLock.cs
+++ b/src/NHibernate/Cache/SyncCacheLock.cs
@@ -10,28 +10,23 @@ namespace NHibernate.Cache
 
 		class MonitorLock : IDisposable
 		{
-			private readonly object _lockObj;
-
-			public MonitorLock(object lockObj)
-			{
-				_lockObj = lockObj;
-			}
+			private readonly Lock _lockObj = new Lock();
 
 			public IDisposable Lock()
 			{
-				Monitor.Enter(_lockObj);
+				_lockObj.Enter();
 				return this;
 			}
 
 			public void Dispose()
 			{
-				Monitor.Exit(_lockObj);
+				_lockObj.Exit();
 			}
 		}
 
 		public SyncCacheLock()
 		{
-			_monitorLock = new MonitorLock(this);
+			_monitorLock = new();
 		}
 
 		public void Dispose()

--- a/src/NHibernate/Cache/Timestamper.cs
+++ b/src/NHibernate/Cache/Timestamper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace NHibernate.Cache
 {
@@ -11,7 +12,7 @@ namespace NHibernate.Cache
 	///	</remarks>
 	public static class Timestamper
 	{
-		private static object lockObject = new object();
+		private static Lock lockObject = new Lock();
 
 		// hibernate is using System.currentMilliSeconds which is calculated
 		// from jan 1, 1970

--- a/src/NHibernate/Context/MapBasedSessionContext.cs
+++ b/src/NHibernate/Context/MapBasedSessionContext.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Threading;
 using NHibernate.Engine;
 
 namespace NHibernate.Context
@@ -9,7 +10,7 @@ namespace NHibernate.Context
 		private readonly ISessionFactoryImplementor _factory;
 
 		// Must be static, different instances of MapBasedSessionContext may have to yield the same map.
-		private static readonly object _locker = new object();
+		private static readonly Lock _locker = new Lock();
 
 		protected MapBasedSessionContext(ISessionFactoryImplementor factory)
 		{

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -73,6 +73,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <PackageReference Include="Backport.System.Threading.Lock" Version="1.1.6" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="*.xsd">
       <PackagePath>./</PackagePath>

--- a/src/NHibernate/Stat/StatisticsImpl.cs
+++ b/src/NHibernate/Stat/StatisticsImpl.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Text;
 using NHibernate.Engine;
 using System.Linq;
+using System.Threading;
 
 namespace NHibernate.Stat
 {
 	public class StatisticsImpl : IStatistics, IStatisticsImplementor
 	{
-		private readonly object _syncRoot = new object();
+		private readonly Lock _syncRoot = new Lock();
 
 		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(StatisticsImpl));
 		private readonly ISessionFactoryImplementor sessionFactory;

--- a/src/NHibernate/Util/SimpleMRUCache.cs
+++ b/src/NHibernate/Util/SimpleMRUCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace NHibernate.Util
 {
@@ -17,7 +18,7 @@ namespace NHibernate.Util
 	{
 		private const int DefaultStrongRefCount = 128;
 
-		private readonly object _syncRoot = new object();
+		private readonly Lock _syncRoot = new Lock();
 
 		private readonly int strongReferenceCount;
 

--- a/src/NHibernate/Util/SoftLimitMRUCache.cs
+++ b/src/NHibernate/Util/SoftLimitMRUCache.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace NHibernate.Util
 {
@@ -23,7 +24,7 @@ namespace NHibernate.Util
 	public class SoftLimitMRUCache : IDeserializationCallback
 	{
 		private const int DefaultStrongRefCount = 128;
-		private readonly object _syncRoot = new object();
+		private readonly Lock _syncRoot = new Lock();
 
 		private readonly int strongReferenceCount;
 


### PR DESCRIPTION
Will improve performance once the library starts targeting .NET 9.0 as locking on System.Threading.Lock is ~25% more performant over locking on an object. Newly-added micro dependency allows backported use without affecting performance.