### PR TITLE
Eliminate memory allocations in GuidCombGenerator under .NET 8+

### DIFF
--- a/src/NHibernate.Test/IdGen/GuidComb/GuidCombFixture.cs
+++ b/src/NHibernate.Test/IdGen/GuidComb/GuidCombFixture.cs
@@ -1,0 +1,32 @@
+using System;
+using NHibernate.Id;
+using NUnit.Framework;
+
+namespace NHibernate.Test.IdGen.GuidComb;
+
+[TestFixture]
+public class GuidCombFixture
+{
+	class GuidCombGeneratorEx : GuidCombGenerator
+	{
+		public static Guid Generate(string guid, DateTime utcNow) => GenerateComb(Guid.Parse(guid), utcNow);
+	}
+
+	[Test]
+	public void CanGenerateSequentialGuid()
+	{
+		Assert.AreEqual(Guid.Parse("076a04fa-ef4e-4093-8479-b0e10103cdc5"),
+			GuidCombGeneratorEx.Generate(
+				"076a04fa-ef4e-4093-8479-8599e96f14cf",
+				new DateTime(2023, 12, 23, 15, 45, 55, DateTimeKind.Utc)),
+			"seed: 076a04fa");
+
+		Assert.AreEqual(Guid.Parse("81162ee2-a4cb-4611-9327-d61f0137e5b6"),
+		    GuidCombGeneratorEx.Generate(
+			    "81162ee2-a4cb-4611-9327-23bbda36176c",
+			    new DateTime(2050, 01, 29, 18, 55, 35, DateTimeKind.Utc)),
+			"seed: 81162ee2");
+
+	}
+	
+}

--- a/src/NHibernate/Async/Id/GuidCombGenerator.cs
+++ b/src/NHibernate/Async/Id/GuidCombGenerator.cs
@@ -9,6 +9,7 @@
 
 
 using System;
+using System.Diagnostics;
 using NHibernate.Engine;
 
 namespace NHibernate.Id


### PR DESCRIPTION
Replace memory allocations with stack allocations in `GuidComboGenerator` under .NET 8+

`ToByteArray()` and `GetBytes()` are replaced with non-allocating equivalents.