### PR TITLE
Some string.Intern's for minimizing duplicate strings count

### DIFF
--- a/src/NHibernate/Criterion/EntityProjection.cs
+++ b/src/NHibernate/Criterion/EntityProjection.cs
@@ -1,11 +1,12 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using NHibernate.Engine;
-using NHibernate.Loader;
 using NHibernate.Loader.Criteria;
 using NHibernate.Persister.Entity;
 using NHibernate.SqlCommand;
 using NHibernate.Type;
+using NHibernate.Util;
+
 using IQueryable = NHibernate.Persister.Entity.IQueryable;
 
 namespace NHibernate.Criterion
@@ -204,7 +205,7 @@ namespace NHibernate.Criterion
 				subcriteria,
 				Persister.IdentifierPropertyName ?? string.Empty);
 
-			ColumnAliasSuffix = BasicLoader.GenerateSuffix(criteriaQuery.GetIndexForAlias());
+			ColumnAliasSuffix = StringHelper.GenerateSuffix(criteriaQuery.GetIndexForAlias());
 
 			_identifierColumnAliases = Persister.GetIdentifierAliases(ColumnAliasSuffix);
 

--- a/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/HqlSqlWalker.cs
@@ -485,7 +485,7 @@ namespace NHibernate.Hql.Ast.ANTLR
 				return suffix;
 			}
 
-			suffix = _suffixes.Count == 0 ? string.Empty : _suffixes.Count.ToString() + '_';
+			suffix = _suffixes.Count == 0 ? string.Empty : StringHelper.GenerateSuffix(_suffixes.Count);
 			_suffixes.Add(fromElement, suffix);
 
 			return suffix;

--- a/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementType.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/Tree/FromElementType.cs
@@ -532,7 +532,7 @@ namespace NHibernate.Hql.Ast.ANTLR.Tree
 
 		private static string GenerateSuffix(int size, int k)
 		{
-			String suffix = size == 1 ? "" : k.ToString() + '_';
+			String suffix = size == 1 ? "" : StringHelper.GenerateSuffix(k);
 			return suffix;
 		}
 

--- a/src/NHibernate/Loader/BasicLoader.cs
+++ b/src/NHibernate/Loader/BasicLoader.cs
@@ -99,15 +99,10 @@ namespace NHibernate.Loader
 
 			for (int i = 0; i < length; i++)
 			{
-				suffixes[i] = GenerateSuffix(i + seed);
+				suffixes[i] = StringHelper.GenerateSuffix(i + seed);
 			}
 
 			return suffixes;
-		}
-
-		public static string GenerateSuffix(int index)
-		{
-			return index.ToString() + StringHelper.Underscore;
 		}
 	}
 }

--- a/src/NHibernate/Mapping/Property.cs
+++ b/src/NHibernate/Mapping/Property.cs
@@ -66,7 +66,7 @@ namespace NHibernate.Mapping
 		public string Name
 		{
 			get { return name; }
-			set { name = value; }
+			set { name = value == null ? null : string.Intern(value); }
 		}
 
 		public bool IsComposite
@@ -122,7 +122,7 @@ namespace NHibernate.Mapping
 		public string Cascade
 		{
 			get { return cascade; }
-			set { cascade = value; }
+			set { cascade = value == null ? null : string.Intern(value); }
 		}
 
 		public bool IsUpdateable
@@ -168,7 +168,7 @@ namespace NHibernate.Mapping
 		public string PropertyAccessorName
 		{
 			get { return propertyAccessorName; }
-			set { propertyAccessorName = value; }
+			set { propertyAccessorName = value == null ? null : string.Intern(value); }
 		}
 
 		public IGetter GetGetter(System.Type clazz)

--- a/src/NHibernate/Mapping/SimpleValue.cs
+++ b/src/NHibernate/Mapping/SimpleValue.cs
@@ -60,7 +60,7 @@ namespace NHibernate.Mapping
 		public string IdentifierGeneratorStrategy
 		{
 			get { return identifierGeneratorStrategy; }
-			set { identifierGeneratorStrategy = value; }
+			set { identifierGeneratorStrategy = value == null ? null : string.Intern(value); }
 		}
 
 		public virtual bool IsComposite
@@ -127,7 +127,7 @@ namespace NHibernate.Mapping
 				if ((typeName == null && value != null) || (typeName != null && !typeName.Equals(value)))
 				{
 					// the property change
-					typeName = value;
+					typeName = value == null ? null : string.Intern(value);
 					type = null; // invalidate type
 				}
 			}
@@ -353,7 +353,8 @@ namespace NHibernate.Mapping
 				}
 				try
 				{
-					typeName = ReflectHelper.ReflectedPropertyClass(className, propertyName, accesorName).AssemblyQualifiedName;
+					var aqn = ReflectHelper.ReflectedPropertyClass(className, propertyName, accesorName).AssemblyQualifiedName;
+					typeName = aqn == null ? null : string.Intern(aqn);
 				}
 				catch (HibernateException he)
 				{
@@ -372,7 +373,8 @@ namespace NHibernate.Mapping
 				}
 				try
 				{
-					typeName = ReflectHelper.ReflectedPropertyClass(propertyOwnerType, propertyName, accessorName).AssemblyQualifiedName;
+					var aqn = ReflectHelper.ReflectedPropertyClass(propertyOwnerType, propertyName, accessorName).AssemblyQualifiedName;
+					typeName = aqn == null ? null : string.Intern(aqn);
 				}
 				catch (HibernateException he)
 				{

--- a/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
+++ b/src/NHibernate/Persister/Entity/AbstractEntityPersister.cs
@@ -2376,14 +2376,14 @@ namespace NHibernate.Persister.Entity
 				{
 					if (entityMetamodel.HasNonIdentifierPropertyNamedId)
 					{
-						subclassPropertyAliases[EntityPersister.EntityID + "." + idPropertyNames[i]] = new string[] { idAliases[i] };
-						subclassPropertyColumnNames[EntityPersister.EntityID + "." + IdentifierPropertyName + "." + idPropertyNames[i]] = new string[] { idColumnNames[i] };
+						subclassPropertyAliases[string.Intern(EntityPersister.EntityID + "." + idPropertyNames[i])] = new string[] { idAliases[i] };
+						subclassPropertyColumnNames[string.Intern(EntityPersister.EntityID + "." + IdentifierPropertyName + "." + idPropertyNames[i])] = new string[] { idColumnNames[i] };
 					}
 					//				if (hasIdentifierProperty() && !ENTITY_ID.equals( getIdentifierPropertyName() ) ) {
 					if (HasIdentifierProperty)
 					{
-						subclassPropertyAliases[IdentifierPropertyName + "." + idPropertyNames[i]] = new string[] { idAliases[i] };
-						subclassPropertyColumnNames[IdentifierPropertyName + "." + idPropertyNames[i]] = new string[] { idColumnNames[i] };
+						subclassPropertyAliases[string.Intern(IdentifierPropertyName + "." + idPropertyNames[i])] = new string[] { idAliases[i] };
+						subclassPropertyColumnNames[string.Intern(IdentifierPropertyName + "." + idPropertyNames[i])] = new string[] { idColumnNames[i] };
 					}
 					else
 					{

--- a/src/NHibernate/Persister/Entity/AbstractPropertyMapping.cs
+++ b/src/NHibernate/Persister/Entity/AbstractPropertyMapping.cs
@@ -211,7 +211,7 @@ namespace NHibernate.Persister.Entity
 			if (string.IsNullOrEmpty(path))
 				return property;
 			
-			return StringHelper.Qualify(path, property);
+			return string.Intern(StringHelper.Qualify(path, property));
 		}
 
 		public string[] GetColumnNames(string propertyName)

--- a/src/NHibernate/Tuple/Entity/EntityMetamodel.cs
+++ b/src/NHibernate/Tuple/Entity/EntityMetamodel.cs
@@ -449,7 +449,7 @@ namespace NHibernate.Tuple.Entity
 				for (var i = 0; i < componentType.PropertyNames.Length; i++)
 				{
 					MapIdentifierPropertyTypes(
-						!string.IsNullOrEmpty(path) ? $"{path}.{componentType.PropertyNames[i]}" : componentType.PropertyNames[i],
+						!string.IsNullOrEmpty(path) ? string.Intern($"{path}.{componentType.PropertyNames[i]}") : componentType.PropertyNames[i],
 						componentType.Subtypes[i]);
 				}
 			}

--- a/src/NHibernate/Type/PersistentEnumType.cs
+++ b/src/NHibernate/Type/PersistentEnumType.cs
@@ -294,7 +294,7 @@ namespace NHibernate.Type
 		public EnumType() : base(typeof (T))
 		{
 			System.Type type = GetType();
-			typeName = type.FullName + ", " + type.Assembly.GetName().Name;
+			typeName = string.Intern(type.FullName + ", " + type.Assembly.GetName().Name);
 		}
 
 		public override string Name

--- a/src/NHibernate/Util/StringHelper.cs
+++ b/src/NHibernate/Util/StringHelper.cs
@@ -871,5 +871,15 @@ namespace NHibernate.Util
 			newLineLength = 0;
 			return false;
 		}
+
+		public static string GenerateSuffix(int index)
+		{
+			return index switch
+			{
+				0 => "0_",
+				1 => "1_",
+				_ => string.Intern(index.ToString() + Underscore)
+			};
+		}
 	}
 }


### PR DESCRIPTION
After startup application that I develop now has ~9% of duplicate strings from all allocated objects.
1st consumer is ASP.NET MVC routing,  NHib related strings seems on 2d place
![image](https://github.com/user-attachments/assets/ecdae493-15e3-4f03-95c6-c763be9f67b0)
and many others

1.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e | 491,36 KB | 2420 | 2 |
| System.Boolean, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e | 281,78 KB | 1375 | 2 |
| NHibernate.Envers.Entities.RevisionTypeType, NHibernate.Envers, Version=5.5.2.0, Culture=neutral, PublicKeyToken=e2c5b946037fb7f8 | 212,9 KB | 846 |
| Int64 | 8,41 KB	 | 862 | 8 |
| Int32 | 6,97 KB	 | 715 | 6 |

![image](https://github.com/user-attachments/assets/0fe27d2f-4b0f-46a0-b0b6-6ff5ffefcd51)
Minimized by interning **SimpleValue.typeName**

2.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| NN.Core.BL.NhibTune.IdGenerators.LongIdGenerator, Core.BL, Version=9.0.0.1, Culture=neutral, PublicKeyToken=null | 61,25 KB | 281 | - |

![image](https://github.com/user-attachments/assets/852967e5-4274-4ab7-b346-cc0adb4ef8d5)
Minimized by interning **SimpleValue.identifierGeneratorStrategy**

3.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| originalId.REV | 55,21 KB | 2020 | - |
| originalId.REV.id | 16,77 KB | 506 | 2 |
| originalId.REV.Id | 16,73 KB | 505 | - |

![image](https://github.com/user-attachments/assets/5a3e160e-c4e8-4d91-b122-a8bb17a073dd)
![image](https://github.com/user-attachments/assets/f6400220-5d87-40d1-945f-e1811fa5e436)
![image](https://github.com/user-attachments/assets/35294ec6-0dd8-4e5c-a33f-4ea2399a8c2e)
Minimized by interning in 
**AbstractPropertyMapping .ExtendPath
EntityMetamodel.MapIdentifierPropertyTypes
AbstractEntityPersister. InitSubclassPropertyAliasesMap**

4.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| 0_ | 31,14 KB | 7973 | - |
| 1_ | 2,75 KB | 704 | 6 |

![image](https://github.com/user-attachments/assets/064c52b5-e377-4323-81a3-44c8289e704a)
![image](https://github.com/user-attachments/assets/741b5711-6a3d-4f50-a9ae-ea0df5e262d6)
![image](https://github.com/user-attachments/assets/b3158fb6-cd7d-4db5-b49c-a9f6c0b0388f)
Minimized by generating suffix with interning
**StringHelper.GenerateSuffix**

5.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| Id | 8,57 KB | 2195 | 1867 | 
| REV | 5,68 KB | 970 | 506 | 

![image](https://github.com/user-attachments/assets/f997df65-496a-4cf6-a23f-49249c1f8e73)
![image](https://github.com/user-attachments/assets/fc2f6455-bf12-4d8e-b86b-baa18a1a71f9)
Some minimization by interning **Property.name**

6.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| property | 79,38 KB | 5081 | 507 |

![image](https://github.com/user-attachments/assets/845d976a-2ea1-4edd-b0e1-8ebfbcf040c3)
Some minimization by interning **Property.propertyAccessorName**

7.
| Value | Wasted | Count | CountAfter |
|---|---|---|---|
| all,delete-orphan | 6,14 KB | 186 | -  |

![image](https://github.com/user-attachments/assets/7cac462a-6e22-4f73-8f68-4713eb2f89e0)
Minimized by interning **Property.cascade**

8.
| Value | Wasted | Count |
|---|---|---|
| NHibernate.Type.EnumType`1[[..RateType, .., Culture=neutral, PublicKeyToken=null]], NHibernate | 27,42 KB | 102 |
| NHibernate.Type.EnumType`1[[..DayCountBasis, .., Culture=neutral, PublicKeyToken=null]], NHibernate | 19,97 KB | 72 |
| NHibernate.Type.EnumType`1[[..DefaultViewType, .., Culture=neutral, PublicKeyToken=null]], NHibernate | 17,61 KB | 55 |

And many other similar
![image](https://github.com/user-attachments/assets/bf1f9972-e516-41e2-9c53-16bdb8eda269)
Some minimization by interning **EnumType<T>.typeName**

Current result ~ 50K duplicates removed
![image](https://github.com/user-attachments/assets/7afe4b4c-76af-478c-8a24-1a5146b93728)

