### PR TITLE
Bugfix for Issue 3622: ISession.Refresh does not update lazy properties

### DIFF
--- a/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
+++ b/src/NHibernate.Test/FetchLazyProperties/FetchLazyPropertiesFixture.cs
@@ -1076,6 +1076,41 @@ namespace NHibernate.Test.FetchLazyProperties
 			}
 		}
 
+		[Test]
+		public void TestRefreshRemovesLazyLoadedProperties()
+		{
+			using (var outerSession = OpenSession())
+			{
+				const string query = "from Person fetch Image where Id = 1";
+				const string namePostFix = "_MODIFIED";
+				const int imageLength = 4711;
+				
+				Person outerPerson = outerSession.CreateQuery(query).UniqueResult<Person>();
+				
+				Assert.That(outerPerson.Name.EndsWith(namePostFix), Is.False); // Normal property 
+				Assert.That(outerPerson.Image.Length, Is.EqualTo(1)); // Lazy Property
+				
+				// Changing the properties of the person in a different sessions
+				using (var innerSession = OpenSession())
+				{
+					var transaction = innerSession.BeginTransaction();
+				
+					Person innerPerson = innerSession.CreateQuery(query).UniqueResult<Person>();
+					innerPerson.Image = new byte[imageLength];
+					innerPerson.Name += namePostFix;
+					innerSession.Update(innerPerson);
+					
+					transaction.Commit();
+				}
+				
+				// Refreshing the person in the outer session
+				outerSession.Refresh(outerPerson);
+				
+				Assert.That(outerPerson.Name.EndsWith(namePostFix), Is.True); // Value has changed
+				Assert.That(outerPerson.Image.Length, Is.EqualTo(imageLength)); // This is still the old value
+			}
+		}
+		
 		private static Person GeneratePerson(int i, Person bestFriend)
 		{
 			return new Person

--- a/src/NHibernate/Engine/EntityEntry.cs
+++ b/src/NHibernate/Engine/EntityEntry.cs
@@ -200,9 +200,7 @@ namespace NHibernate.Engine
 		{
 			get { return rowId; }
 		}
-
-		// Since 5.3
-		[Obsolete("This property is not used and will be removed in a future version.")]
+		
 		public bool LoadedWithLazyPropertiesUnfetched
 		{
 			get { return loadedWithLazyPropertiesUnfetched; }

--- a/src/NHibernate/Engine/IPersistenceContext.cs
+++ b/src/NHibernate/Engine/IPersistenceContext.cs
@@ -173,8 +173,6 @@ namespace NHibernate.Engine
 		/// Generates an appropriate EntityEntry instance and adds it
 		/// to the event source's internal caches.
 		/// </summary>
-		// Since 5.3
-		[Obsolete("Use the AddEntry extension method instead")]
 		EntityEntry AddEntry(object entity, Status status, object[] loadedState, object rowId, object id, object version,
 		                     LockMode lockMode, bool existsInDatabase, IEntityPersister persister, bool disableVersionIncrement,
 		                     bool lazyPropertiesAreUnfetched);

--- a/src/NHibernate/Engine/TwoPhaseLoad.cs
+++ b/src/NHibernate/Engine/TwoPhaseLoad.cs
@@ -30,8 +30,6 @@ namespace NHibernate.Engine
 		/// to resolve any associations yet, because there might be other entities waiting to be
 		/// read from the JDBC result set we are currently processing
 		/// </summary>
-		// Since 5.3
-		[Obsolete("Use the overload without lazyPropertiesAreUnfetched parameter instead")]
 		public static void PostHydrate(IEntityPersister persister, object id, object[] values, object rowId, object obj, LockMode lockMode, bool lazyPropertiesAreUnfetched, ISessionImplementor session)
 		{
 			object version = Versioning.GetVersion(values, persister);

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1147,7 +1147,8 @@ namespace NHibernate.Loader
 
 			ILoadable concretePersister = GetConcretePersister(dr, i, persister, key.Identifier, session);
 
-			if (optionalObjectKey != null && key.Equals(optionalObjectKey))
+			bool useOptionalObject = optionalObjectKey != null && key.Equals(optionalObjectKey);
+			if (useOptionalObject)
 			{
 				// its the given optional object
 				obj = optionalObject;
@@ -1163,8 +1164,8 @@ namespace NHibernate.Loader
 			// (but don't yet initialize the object itself)
 			// note that we acquired LockMode.READ even if it was not requested
 			LockMode acquiredLockMode = lockMode == LockMode.None ? LockMode.Read : lockMode;
-			LoadFromResultSet(dr, i, obj, concretePersister, key, acquiredLockMode, persister, session);
-
+			LoadFromResultSet(dr, i, obj, concretePersister, key, acquiredLockMode, persister, session, useOptionalObject);
+			
 			// materialize associations (and initialize the object) later
 			hydratedObjects.Add(obj);
 
@@ -1291,7 +1292,7 @@ namespace NHibernate.Loader
 		/// </summary>
 		private void LoadFromResultSet(DbDataReader rs, int i, object obj, ILoadable persister, EntityKey key,
 									   LockMode lockMode, ILoadable rootPersister,
-									   ISessionImplementor session)
+									   ISessionImplementor session, bool lazyPropertiesAreUnfetched)
 		{
 			object id = key.Identifier;
 
@@ -1316,7 +1317,7 @@ namespace NHibernate.Loader
 
 			object rowId = persister.HasRowId ? rs[EntityAliases[i].RowIdAlias] : null;
 
-			TwoPhaseLoad.PostHydrate(persister, id, values, rowId, obj, lockMode, session);
+			TwoPhaseLoad.PostHydrate(persister, id, values, rowId, obj, lockMode, lazyPropertiesAreUnfetched, session);
 		}
 
 		private string[][] GetSubclassEntityAliases(int i, ILoadable persister)

--- a/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
+++ b/src/NHibernate/Tuple/Entity/PocoEntityTuplizer.cs
@@ -226,7 +226,7 @@ namespace NHibernate.Tuple.Entity
 			if (IsInstrumented)
 			{
 				var interceptor = _enhancementMetadata.ExtractInterceptor(entity);
-				if (interceptor == null)
+				if (interceptor == null || HasAnyInitializedLazyProperty(entity, session))
 				{
 					interceptor = _enhancementMetadata.InjectInterceptor(entity, session);
 				}
@@ -237,6 +237,13 @@ namespace NHibernate.Tuple.Entity
 
 				interceptor?.ClearDirty();
 			}
+		}
+
+		private static bool HasAnyInitializedLazyProperty(object entity, ISessionImplementor session)
+		{
+			IPersistenceContext persistenceContext = session.PersistenceContext;
+			EntityEntry entityEntry = persistenceContext.GetEntry(entity);
+			return entityEntry.LoadedWithLazyPropertiesUnfetched;
 		}
 
 		public override object GetPropertyValue(object entity, int i)


### PR DESCRIPTION
Fixes issue #3622

Some obsolete attributes had to be removed.