### PR TITLE
Improve some sparse arrays

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH2898/BinaryFormatterCache.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH2898/BinaryFormatterCache.cs
@@ -23,6 +23,31 @@ namespace NHibernate.Test.NHSpecificTest.NH2898
 	public partial class BinaryFormatterCache : CacheBase
 	{
 
+		public override Task<object> GetAsync(object key, CancellationToken cancellationToken)
+		{
+			try
+			{
+				var entry = _hashtable[key] as byte[];
+				if (entry == null)
+					return Task.FromResult<object>(null);
+
+				var fmt = new BinaryFormatter
+				{
+#if !NETFX
+					SurrogateSelector = new SerializationHelper.SurrogateSelector()	
+#endif
+				};
+				using (var stream = new MemoryStream(entry))
+				{
+					return Task.FromResult<object>(fmt.Deserialize(stream));
+				}
+			}
+			catch (System.Exception ex)
+			{
+				return Task.FromException<object>(ex);
+			}
+		}
+
 		public override Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			try

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -82,7 +82,7 @@ namespace NHibernate.Loader
 		/// <summary>
 		/// Caches subclass entity aliases for given persister index in <see cref="EntityPersisters"/>  and subclass entity name
 		/// </summary>
-		private readonly ConcurrentDictionary<Tuple<int, string>, string[][]> _subclassEntityAliasesMap = new ConcurrentDictionary<Tuple<int, string>, string[][]>();
+		private readonly Lazy<ConcurrentDictionary<Tuple<int, string>, string[][]>> _subclassEntityAliasesMap = new(()=>new ConcurrentDictionary<Tuple<int, string>, string[][]>());
 
 		protected Loader(ISessionFactoryImplementor factory)
 		{
@@ -1322,7 +1322,7 @@ namespace NHibernate.Loader
 		private string[][] GetSubclassEntityAliases(int i, ILoadable persister)
 		{
 			var cacheKey = System.Tuple.Create(i, persister.EntityName);
-			return _subclassEntityAliasesMap.GetOrAdd(
+			return _subclassEntityAliasesMap.Value.GetOrAdd(
 				cacheKey,
 				k => EntityAliases[i].GetSuffixedPropertyAliases(persister));
 		}

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -82,7 +82,8 @@ namespace NHibernate.Loader
 		/// <summary>
 		/// Caches subclass entity aliases for given persister index in <see cref="EntityPersisters"/>  and subclass entity name
 		/// </summary>
-		private readonly Lazy<ConcurrentDictionary<Tuple<int, string>, string[][]>> _subclassEntityAliasesMap = new(()=>new ConcurrentDictionary<Tuple<int, string>, string[][]>());
+		private readonly Lazy<ConcurrentDictionary<Tuple<int, string>, string[][]>> _subclassEntityAliasesMap =
+			new(() => new ConcurrentDictionary<Tuple<int, string>, string[][]>());
 
 		protected Loader(ISessionFactoryImplementor factory)
 		{

--- a/src/NHibernate/Mapping/Constraint.cs
+++ b/src/NHibernate/Mapping/Constraint.cs
@@ -15,7 +15,7 @@ namespace NHibernate.Mapping
 	public abstract class Constraint : IRelationalModel
 	{
 		private string name;
-		private readonly List<Column> columns = new List<Column>();
+		private readonly List<Column> columns = new List<Column>(1);
 		private Table table;
 
 		/// <summary>

--- a/src/NHibernate/Mapping/ForeignKey.cs
+++ b/src/NHibernate/Mapping/ForeignKey.cs
@@ -180,14 +180,7 @@ namespace NHibernate.Mapping
 
 		internal void AddReferencedTable(PersistentClass referencedClass)
 		{
-			if (referencedColumns != null && referencedColumns.Count > 0)
-			{
-				referencedTable = referencedColumns[0].Value.Table;
-			}
-			else
-			{
-				referencedTable = referencedClass.Table;
-			}
+			referencedTable = IsReferenceToPrimaryKey ? referencedClass.Table : referencedColumns[0].Value.Table;
 		}
 
 		public override string ToString()

--- a/src/NHibernate/Mapping/ForeignKey.cs
+++ b/src/NHibernate/Mapping/ForeignKey.cs
@@ -27,29 +27,26 @@ namespace NHibernate.Mapping
 		/// <returns>
 		/// A string that contains the SQL to create the named Foreign Key Constraint.
 		/// </returns>
-		public override string SqlConstraintString(Dialect.Dialect d, string constraintName, string defaultCatalog, string defaultSchema)
+		public override string SqlConstraintString(
+			Dialect.Dialect d,
+			string constraintName,
+			string defaultCatalog,
+			string defaultSchema)
 		{
-			string[] cols = new string[ColumnSpan];
-			string[] refcols = new string[ColumnSpan];
-			int i = 0;
-			IEnumerable<Column> refiter;
-			if (IsReferenceToPrimaryKey)
-				refiter = referencedTable.PrimaryKey.ColumnIterator;
-			else
-				refiter = referencedColumns ?? Enumerable.Empty<Column>();
-			foreach (Column column in ColumnIterator)
-			{
-				cols[i] = column.GetQuotedName(d);
-				i++;
-			}
+			var refiter = IsReferenceToPrimaryKey
+				? referencedTable.PrimaryKey.Columns
+				: referencedColumns;
 
-			i = 0;
-			foreach (Column column in refiter)
-			{
-				refcols[i] = column.GetQuotedName(d);
-				i++;
-			}
-			string result = d.GetAddForeignKeyConstraintString(constraintName, cols, referencedTable.GetQualifiedName(d, defaultCatalog, defaultSchema), refcols, IsReferenceToPrimaryKey);
+			var cols = Columns.ToArray(column => column.GetQuotedName(d));
+			var refcols = refiter.ToArray(column => column.GetQuotedName(d));
+
+			string result = d.GetAddForeignKeyConstraintString(
+				constraintName,
+				cols,
+				referencedTable.GetQualifiedName(d, defaultCatalog, defaultSchema),
+				refcols,
+				IsReferenceToPrimaryKey);
+
 			return cascadeDeleteEnabled && d.SupportsCascadeDelete ? result + " on delete cascade" : result;
 		}
 
@@ -217,10 +214,7 @@ namespace NHibernate.Mapping
 		}
 
 		/// <summary>Does this foreignkey reference the primary key of the reference table </summary>
-		public bool IsReferenceToPrimaryKey
-		{
-			get { return referencedColumns == null || referencedColumns.Count == 0; }
-		}
+		public bool IsReferenceToPrimaryKey => referencedColumns == null || referencedColumns.Count == 0;
 
 		public string GeneratedConstraintNamePrefix => "FK_";
 
@@ -231,12 +225,7 @@ namespace NHibernate.Mapping
 			if (dialect.SupportsNullInUnique || IsReferenceToPrimaryKey)
 				return true;
 
-			foreach (var column in referencedColumns)
-			{
-				if (column.IsNullable)
-					return false;
-			}
-			return true;
+			return referencedColumns.All(column => !column.IsNullable);
 		}
 	}
 }

--- a/src/NHibernate/Mapping/ForeignKey.cs
+++ b/src/NHibernate/Mapping/ForeignKey.cs
@@ -192,22 +192,12 @@ namespace NHibernate.Mapping
 
 		public override string ToString()
 		{
-			if (!IsReferenceToPrimaryKey)
-			{
-				var result = new StringBuilder();
-				result.Append(GetType().FullName)
-					.Append('(')
-					.Append(Table.Name)
-					.Append(string.Join(", ", Columns))
-					.Append(" ref-columns:")
-					.Append('(')
-					.Append(string.Join(", ", ReferencedColumnsReadOnly))
-					.Append(") as ")
-					.Append(Name);
-				return result.ToString();
-			}
+			if (IsReferenceToPrimaryKey)
+				return base.ToString();
 
-			return base.ToString();
+			var columns = string.Join(", ", Columns);
+			var refColumns = string.Join(", ", referencedColumns);
+			return $"{GetType().FullName}({Table.Name}{columns} ref-columns:({refColumns}) as {Name}";
 		}
 
 		public bool HasPhysicalConstraint
@@ -225,11 +215,6 @@ namespace NHibernate.Mapping
 				referencedColumns ??= new List<Column>(1);
 				return referencedColumns;
 			}
-		}
-
-		private IEnumerable<Column> ReferencedColumnsReadOnly
-		{
-			get { return referencedColumns ?? Enumerable.Empty<Column>(); }
 		}
 
 		public string ReferencedEntityName
@@ -253,7 +238,7 @@ namespace NHibernate.Mapping
 			if (dialect.SupportsNullInUnique || IsReferenceToPrimaryKey)
 				return true;
 
-			foreach (var column in ReferencedColumnsReadOnly)
+			foreach (var column in referencedColumns)
 			{
 				if (column.IsNullable)
 					return false;

--- a/src/NHibernate/Mapping/Index.cs
+++ b/src/NHibernate/Mapping/Index.cs
@@ -14,7 +14,7 @@ namespace NHibernate.Mapping
 	public class Index : IRelationalModel
 	{
 		private Table table;
-		private readonly List<Column> columns = new List<Column>();
+		private readonly List<Column> columns = new List<Column>(1);
 		private string name;
 
 		public static string BuildSqlCreateIndexString(Dialect.Dialect dialect, string name, Table table,

--- a/src/NHibernate/Mapping/SimpleValue.cs
+++ b/src/NHibernate/Mapping/SimpleValue.cs
@@ -15,7 +15,7 @@ namespace NHibernate.Mapping
 	[Serializable]
 	public class SimpleValue : IKeyValue
 	{
-		private readonly List<ISelectable> columns = new List<ISelectable>();
+		private readonly List<ISelectable> columns = new List<ISelectable>(1);
 		private IType type;
 		private IDictionary<string, string> typeParameters;
 

--- a/src/NHibernate/Mapping/Table.cs
+++ b/src/NHibernate/Mapping/Table.cs
@@ -1064,9 +1064,12 @@ namespace NHibernate.Mapping
 			{
 				this.referencedClassName = referencedClassName;
 				this.columns = new List<Column>(columns);
+				this.columns.TrimExcess();
+
 				if (referencedColumns != null)
 				{
 					this.referencedColumns = new List<Column>(referencedColumns);
+					this.referencedColumns.TrimExcess();
 				}
 				else
 				{

--- a/src/NHibernate/SqlCommand/SqlString.cs
+++ b/src/NHibernate/SqlCommand/SqlString.cs
@@ -215,6 +215,9 @@ namespace NHibernate.SqlCommand
 			_firstPartIndex = _parts.Count > 0 ? 0 : -1;
 			_lastPartIndex = _parts.Count - 1;
 			_length = sqlIndex;
+
+			_parts.TrimExcess();
+			_parameters.TrimExcess();
 		}
 
 		#endregion


### PR DESCRIPTION
Some sparse arrays exists after my app initialized related to NHib.

![image](https://github.com/user-attachments/assets/6d4cc1b3-e504-4933-9fb4-1e6669d3a402)

1
|Object type | Wasted | Wasted After | Count | Count After |
|---|---|---|---|---|
|System.Collections.Concurrent.ConcurrentDictionary+VolatileNode<System.Tuple<System.Int32, System.String>, System.String[][]>[] | 2,27 MB | 0 | 8047 | 0 | After |

![image](https://github.com/user-attachments/assets/45b078e5-8b37-4ef5-a2ab-c3bf9e96fe34)

Improved by making Loader._subclassEntityAliasesMap lazy initialized 
simple entities more frequent in data model then inheritance hierarchy

2
|Object type | Wasted | Wasted After | Count | Count After |
|---|---|---|---|---|
| NHibernate.SqlCommand.SqlString+Part[] | 736,47 KB | 17.48 KB | 20339 | 20343 |

![image](https://github.com/user-attachments/assets/b021b4aa-94d1-4100-8482-64063de22e7a)

|Object type | Wasted | Wasted After | Count | Count After |
|---|---|---|---|---|
| NHibernate.SqlCommand.Parameter[] | 410,4 KB | 23.58 KB | 20329 | 20331 | 

![image](https://github.com/user-attachments/assets/f77bd9fa-d239-417b-a4d2-d4d47c300d9a)

Improved by TrimExcess in internal SqlString(IEnumerable<object> parts) constructor

3
|Object type | Wasted | Wasted After | Count | Count After |
|---|---|---|---|---|
| NHibernate.Mapping.ISelectable[] | 440,4 KB | 9.07 KB | 18806 | 19966 |

![image](https://github.com/user-attachments/assets/30205321-d98f-47a0-868b-6ab9795a5be7)
![image](https://github.com/user-attachments/assets/bb15406d-cdaa-4c92-a41b-269238f0987e)

Improved by SimpleValue.columns 1 default list size (Most simple values mapped to 1 column in DB)

4.
|Object type | Wasted | Wasted After | Count | Count After |
|---|---|---|---|---|
| NHibernate.Mapping.Column[] | 332,78 KB | 1.4 KB | 14658 | 14658 | 

![image](https://github.com/user-attachments/assets/6c9386a2-9383-4788-95d0-cb234f99c200)
![image](https://github.com/user-attachments/assets/78c68cfb-c726-49b1-b681-ede592571849)
![image](https://github.com/user-attachments/assets/720f7825-a6e5-4ba5-9bf1-13042b73cdf9)

Improved by
Constraint.columns 1 default list size (Most FKs is 1 column)
Index.columns 1 default list size (indexes created for FK usually created by 1 column)
ForeignKey.referencedColumns  - make it lazy initialized as not used when referencing PK
ForeignKeyKey - TrimExcess on internal collections


