### PR TITLE
AbstractDateTimeType.Round is a Floor not a Round

### DIFF
--- a/src/NHibernate/Type/AbstractDateTimeType.cs
+++ b/src/NHibernate/Type/AbstractDateTimeType.cs
@@ -96,8 +96,11 @@ namespace NHibernate.Type
 		/// <param name="value">The value to round.</param>
 		/// <param name="resolution">The resolution in ticks (100ns).</param>
 		/// <returns>A rounded <see cref="DateTime"/>.</returns>
-		public static DateTime Round(DateTime value, long resolution) =>
-			value.AddTicks(-(value.Ticks % resolution));
+		public static DateTime Round(DateTime value, long resolution)
+		{
+            var remainder = value.Ticks % resolution;
+            return remainder * 2 >= resolution ? value.AddTicks(resolution - remainder) : value.AddTicks(-remainder);
+        }
 
 		/// <inheritdoc />
 		public virtual object Seed(ISessionImplementor session) =>

--- a/src/NHibernate/Type/AbstractDateTimeType.cs
+++ b/src/NHibernate/Type/AbstractDateTimeType.cs
@@ -98,9 +98,9 @@ namespace NHibernate.Type
 		/// <returns>A rounded <see cref="DateTime"/>.</returns>
 		public static DateTime Round(DateTime value, long resolution)
 		{
-            var remainder = value.Ticks % resolution;
-            return remainder * 2 >= resolution ? value.AddTicks(resolution - remainder) : value.AddTicks(-remainder);
-        }
+			var remainder = value.Ticks % resolution;
+			return remainder * 2 >= resolution ? value.AddTicks(resolution - remainder) : value.AddTicks(-remainder);
+		}
 
 		/// <inheritdoc />
 		public virtual object Seed(ISessionImplementor session) =>


### PR DESCRIPTION
I was messing around with `AbstractDateTimeType` and couldn't help but notice that the method `Round` is intended to Round but it actually is doing a floor. Thought I might quickly pop a PR in.