### PR TITLE
Fixes #3654: small enhancement for polymorphic query evaluation

### DIFF
--- a/src/NHibernate.Test/NHSpecificTest/GH2614/Fixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/GH2614/Fixture.cs
@@ -10,8 +10,12 @@ namespace NHibernate.Test.NHSpecificTest.GH2614
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
 			{
-				s.Save(new ConcreteClass1 {Name = "C1"});
-				s.Save(new ConcreteClass2 {Name = "C2"});
+				s.Save(new ConcreteClass1 {Name = "C11"});
+				s.Save(new ConcreteClass1 {Name = "C12"});
+				s.Save(new ConcreteClass2 {Name = "C21"});
+				s.Save(new ConcreteClass2 {Name = "C22"});
+				s.Save(new ConcreteClass2 {Name = "C23"});
+				s.Save(new ConcreteClass2 {Name = "C24"});
 				t.Commit();
 			}
 		}
@@ -34,9 +38,67 @@ namespace NHibernate.Test.NHSpecificTest.GH2614
 			{
 				var query = s.CreateQuery(
 					@"SELECT Name FROM NHibernate.Test.NHSpecificTest.GH2614.BaseClass ROOT");
+				query.SetMaxResults(10);
+				var list = query.List();
+				Assert.That(list.Count, Is.EqualTo(6));
+			}
+		}
+
+		[Test]
+		public void PolymorphicListWithSmallMaxResultsReturnsCorrectResults()
+		{
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				var query = s.CreateQuery(
+					@"SELECT Name FROM NHibernate.Test.NHSpecificTest.GH2614.BaseClass ROOT");
+				query.SetMaxResults(1);
+				var list = query.List();
+				Assert.That(list.Count, Is.EqualTo(1));
+			}
+		}
+
+		[Test]
+		public void PolymorphicListWithSkipReturnsCorrectResults()
+		{
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				var query = s.CreateQuery(
+					@"SELECT Name FROM NHibernate.Test.NHSpecificTest.GH2614.BaseClass ROOT");
+				query.SetFirstResult(5);
 				query.SetMaxResults(5);
 				var list = query.List();
-				Assert.That(list.Count, Is.EqualTo(2));
+				Assert.That(list.Count, Is.EqualTo(1));
+			}
+		}
+
+		[Test]
+		public void PolymorphicListWithSkipManyReturnsCorrectResults()
+		{
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				var query = s.CreateQuery(
+					@"SELECT Name FROM NHibernate.Test.NHSpecificTest.GH2614.BaseClass ROOT");
+				query.SetFirstResult(6);
+				query.SetMaxResults(5);
+				var list = query.List();
+				Assert.That(list.Count, Is.EqualTo(0));
+			}
+		}
+
+		[Test]
+		public void PolymorphicListWithOrderByStillShowsWarning()
+		{
+			using (var s = OpenSession())
+			using (s.BeginTransaction())
+			{
+				var query = s.CreateQuery(
+					@"SELECT Name FROM NHibernate.Test.NHSpecificTest.GH2614.BaseClass ROOT ORDER BY ROOT.Name");
+				query.SetMaxResults(3);
+				var list = query.List();
+				Assert.That(list.Count, Is.EqualTo(3));
 			}
 		}
 	}

--- a/src/NHibernate/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
+++ b/src/NHibernate/Hql/Ast/ANTLR/QueryTranslatorImpl.cs
@@ -341,6 +341,15 @@ namespace NHibernate.Hql.Ast.ANTLR
 			}
 		}
 
+		public bool ContainsOrderByClause
+		{
+			get
+			{
+				ErrorIfDML();
+				return ((QueryNode)_sqlAst).GetOrderByClause()?.ChildCount > 0;
+			}
+		}
+
 		public ISet<ICollectionPersister> UncacheableCollectionPersisters
 		{
 			get

--- a/src/NHibernate/Hql/IQueryTranslator.cs
+++ b/src/NHibernate/Hql/IQueryTranslator.cs
@@ -113,6 +113,8 @@ namespace NHibernate.Hql
 		/// <returns>True if the query does contain collection fetched; false otherwise.</returns>
 		bool ContainsCollectionFetches { get; }
 
+		bool ContainsOrderByClause { get; }
+
 		bool IsManipulationStatement { get; }
 
 		// 6.0 TODO : replace by ILoader QueryLoader.


### PR DESCRIPTION
HQLQueryPlan for polymorphic query:
* Calculate a row selection in with the remaining number of rows as MaxRows
* Warn only in cases where correctness or performance may suffer
* Make includedCount zero-based