### PR TITLE
Make Most of the Dictionaries in SessionFactoryImpl ReadOnly Improves #3657

### DIFF
--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -141,7 +141,7 @@ namespace NHibernate.Impl
 		private readonly Dictionary<string, IIdentifierGenerator> identifierGenerators;
 
 		[NonSerialized]
-		private readonly Dictionary<string, string> imports;
+		private readonly IDictionary<string, string> imports;
 
 		[NonSerialized]
 		private readonly IInterceptor interceptor;
@@ -357,7 +357,7 @@ namespace NHibernate.Impl
 			sqlResultSetMappings = new Dictionary<string, ResultSetMappingDefinition>(cfg.SqlResultSetMappings);
 			#endregion
 
-			imports = new Dictionary<string, string>(cfg.Imports);
+			imports = new ReadOnlyDictionary<string, string>(cfg.Imports);
 
 			#region after *all* persisters and named queries are registered
 			foreach (IEntityPersister persister in entityPersisters.Values)

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -150,7 +150,7 @@ namespace NHibernate.Impl
 		private readonly IReadOnlyDictionary<string, NamedQueryDefinition> namedQueries;
 
 		[NonSerialized]
-		private readonly Dictionary<string, NamedSQLQueryDefinition> namedSqlQueries;
+		private readonly IReadOnlyDictionary<string, NamedSQLQueryDefinition> namedSqlQueries;
 
 		[NonSerialized]
 		private readonly IDictionary<string, string> properties;
@@ -168,7 +168,7 @@ namespace NHibernate.Impl
 		[NonSerialized]
 		private readonly SQLFunctionRegistry sqlFunctionRegistry;
 		[NonSerialized]
-		private readonly Dictionary<string, ResultSetMappingDefinition> sqlResultSetMappings;
+		private readonly ReadOnlyDictionary<string, ResultSetMappingDefinition> sqlResultSetMappings;
 		[NonSerialized]
 		private readonly UpdateTimestampsCache updateTimestampsCache;
 		[NonSerialized]
@@ -353,8 +353,8 @@ namespace NHibernate.Impl
 
 			#region Named Queries
 			namedQueries = new ReadOnlyDictionary<string, NamedQueryDefinition>(cfg.NamedQueries);
-			namedSqlQueries = new Dictionary<string, NamedSQLQueryDefinition>(cfg.NamedSQLQueries);
-			sqlResultSetMappings = new Dictionary<string, ResultSetMappingDefinition>(cfg.SqlResultSetMappings);
+			namedSqlQueries = new ReadOnlyDictionary<string, NamedSQLQueryDefinition>(cfg.NamedSQLQueries);
+			sqlResultSetMappings = new ReadOnlyDictionary<string, ResultSetMappingDefinition>(cfg.SqlResultSetMappings);
 			#endregion
 
 			imports = new ReadOnlyDictionary<string, string>(cfg.Imports);

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -141,7 +141,7 @@ namespace NHibernate.Impl
 		private readonly Dictionary<string, IIdentifierGenerator> identifierGenerators;
 
 		[NonSerialized]
-		private readonly IDictionary<string, string> imports;
+		private readonly IReadOnlyDictionary<string, string> imports;
 
 		[NonSerialized]
 		private readonly IInterceptor interceptor;

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -147,7 +147,7 @@ namespace NHibernate.Impl
 		private readonly IInterceptor interceptor;
 		private readonly string name;
 		[NonSerialized]
-		private readonly Dictionary<string, NamedQueryDefinition> namedQueries;
+		private readonly IReadOnlyDictionary<string, NamedQueryDefinition> namedQueries;
 
 		[NonSerialized]
 		private readonly Dictionary<string, NamedSQLQueryDefinition> namedSqlQueries;
@@ -352,7 +352,7 @@ namespace NHibernate.Impl
 			#endregion
 
 			#region Named Queries
-			namedQueries = new Dictionary<string, NamedQueryDefinition>(cfg.NamedQueries);
+			namedQueries = new ReadOnlyDictionary<string, NamedQueryDefinition>(cfg.NamedQueries);
 			namedSqlQueries = new Dictionary<string, NamedSQLQueryDefinition>(cfg.NamedSQLQueries);
 			sqlResultSetMappings = new Dictionary<string, ResultSetMappingDefinition>(cfg.SqlResultSetMappings);
 			#endregion

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -105,10 +105,10 @@ namespace NHibernate.Impl
 			new ConcurrentDictionary<string, CacheBase>();
 
 		[NonSerialized]
-		private readonly IReadOnlyDictionary<string, IClassMetadata> classMetadata;
+		private readonly IDictionary<string, IClassMetadata> classMetadata;
 
 		[NonSerialized]
-		private readonly IReadOnlyDictionary<string, ICollectionMetadata> collectionMetadata;
+		private readonly IDictionary<string, ICollectionMetadata> collectionMetadata;
 		[NonSerialized]
 		private readonly IReadOnlyDictionary<string, ICollectionPersister> collectionPersisters;
 		[NonSerialized]
@@ -248,7 +248,7 @@ namespace NHibernate.Impl
 			#endregion
 
 			#region Generators
-			identifierGenerators = new Dictionary<string, IIdentifierGenerator>();
+			var tmpIdentifierGenerators = new Dictionary<string, IIdentifierGenerator>();
 			foreach (PersistentClass model in cfg.ClassMappings)
 			{
 				if (!model.IsInherited)
@@ -257,9 +257,10 @@ namespace NHibernate.Impl
 						model.Identifier.CreateIdentifierGenerator(settings.Dialect, settings.DefaultCatalogName,
 																   settings.DefaultSchemaName, (RootClass)model);
 
-					identifierGenerators[model.EntityName] = generator;
+					tmpIdentifierGenerators[model.EntityName] = generator;
 				}
 			}
+			identifierGenerators = new ReadOnlyDictionary<string, IIdentifierGenerator>(tmpIdentifierGenerators);
 			#endregion
 
 			#region Persisters

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -110,7 +110,7 @@ namespace NHibernate.Impl
 		[NonSerialized]
 		private readonly IDictionary<string, ICollectionMetadata> collectionMetadata;
 		[NonSerialized]
-		private readonly Dictionary<string, ICollectionPersister> collectionPersisters;
+		private readonly IDictionary<string, ICollectionPersister> collectionPersisters;
 		[NonSerialized]
 		private readonly ILookup<string, ICollectionPersister> collectionPersistersSpaces;
 
@@ -296,7 +296,7 @@ namespace NHibernate.Impl
 			classMetadata = new ReadOnlyDictionary<string, IClassMetadata>(classMeta);
 
 			Dictionary<string, ISet<string>> tmpEntityToCollectionRoleMap = new Dictionary<string, ISet<string>>();
-			collectionPersisters = new Dictionary<string, ICollectionPersister>();
+			var collPersisters = new Dictionary<string, ICollectionPersister>();
 			foreach (Mapping.Collection model in cfg.CollectionMappings)
 			{
 				var cache = GetCacheConcurrencyStrategy(
@@ -306,7 +306,7 @@ namespace NHibernate.Impl
 					model.OwnerEntityName,
 					caches);
 				var persister = PersisterFactory.CreateCollectionPersister(model, cache, this);
-				collectionPersisters[model.Role] = persister;
+				collPersisters[model.Role] = persister;
 				IType indexType = persister.IndexType;
 				if (indexType != null && indexType.IsAssociationType && !indexType.IsAnyType)
 				{
@@ -332,6 +332,8 @@ namespace NHibernate.Impl
 					roles.Add(persister.Role);
 				}
 			}
+
+			collectionPersisters = new ReadOnlyDictionary<string, ICollectionPersister>(collPersisters);
 
 			collectionPersistersSpaces = collectionPersisters
 				.SelectMany(x => x.Value.CollectionSpaces.Select(y => new { QuerySpace = y, Persister = x.Value }))

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -105,23 +105,23 @@ namespace NHibernate.Impl
 			new ConcurrentDictionary<string, CacheBase>();
 
 		[NonSerialized]
-		private readonly IDictionary<string, IClassMetadata> classMetadata;
+		private readonly IReadOnlyDictionary<string, IClassMetadata> classMetadata;
 
 		[NonSerialized]
-		private readonly IDictionary<string, ICollectionMetadata> collectionMetadata;
+		private readonly IReadOnlyDictionary<string, ICollectionMetadata> collectionMetadata;
 		[NonSerialized]
-		private readonly IDictionary<string, ICollectionPersister> collectionPersisters;
+		private readonly IReadOnlyDictionary<string, ICollectionPersister> collectionPersisters;
 		[NonSerialized]
 		private readonly ILookup<string, ICollectionPersister> collectionPersistersSpaces;
 
 		[NonSerialized]
-		private readonly IDictionary<string, ISet<string>> collectionRolesByEntityParticipant;
+		private readonly IReadOnlyDictionary<string, ISet<string>> collectionRolesByEntityParticipant;
 		[NonSerialized]
 		private readonly ICurrentSessionContext currentSessionContext;
 		[NonSerialized]
 		private readonly IEntityNotFoundDelegate entityNotFoundDelegate;
 		[NonSerialized]
-		private readonly IDictionary<string, IEntityPersister> entityPersisters;
+		private readonly IReadOnlyDictionary<string, IEntityPersister> entityPersisters;
 		[NonSerialized]
 		private readonly ILookup<string, IEntityPersister> entityPersistersSpaces;
 
@@ -130,7 +130,7 @@ namespace NHibernate.Impl
 		/// </summary>
 		/// <remarks>this is a shortcut.</remarks>
 		[NonSerialized]
-		private readonly IDictionary<System.Type, string> implementorToEntityName;
+		private readonly IReadOnlyDictionary<System.Type, string> implementorToEntityName;
 
 		[NonSerialized]
 		private readonly EventListeners eventListeners;
@@ -138,7 +138,7 @@ namespace NHibernate.Impl
 		[NonSerialized]
 		private readonly Dictionary<string, FilterDefinition> filters;
 		[NonSerialized]
-		private readonly Dictionary<string, IIdentifierGenerator> identifierGenerators;
+		private readonly IReadOnlyDictionary<string, IIdentifierGenerator> identifierGenerators;
 
 		[NonSerialized]
 		private readonly IReadOnlyDictionary<string, string> imports;

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -266,7 +266,7 @@ namespace NHibernate.Impl
 
 			var caches = new Dictionary<Tuple<string, string>, ICacheConcurrencyStrategy>();
 			var tmpEntityPersisters = new Dictionary<string, IEntityPersister>();
-			implementorToEntityName = new Dictionary<System.Type, string>();
+			var tmpImplementorToEntityName = new Dictionary<System.Type, string>();
 
 			Dictionary<string, IClassMetadata> classMeta = new Dictionary<string, IClassMetadata>();
 
@@ -285,11 +285,12 @@ namespace NHibernate.Impl
 
 				if (model.HasPocoRepresentation)
 				{
-					implementorToEntityName[model.MappedClass] = model.EntityName;
+					tmpImplementorToEntityName[model.MappedClass] = model.EntityName;
 				}
 			}
 
 			entityPersisters = new ReadOnlyDictionary<string, IEntityPersister>(tmpEntityPersisters);
+			implementorToEntityName = new ReadOnlyDictionary<System.Type, string>(tmpImplementorToEntityName);
 
 			entityPersistersSpaces = entityPersisters
 				.SelectMany(x => x.Value.QuerySpaces.Select(y => new { QuerySpace = y, Persister = x.Value }))

--- a/src/NHibernate/Impl/SessionFactoryObjectFactory.cs
+++ b/src/NHibernate/Impl/SessionFactoryObjectFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -21,8 +22,8 @@ namespace NHibernate.Impl
 	{
 		private static readonly INHibernateLogger log;
 
-		private static readonly IDictionary<string, ISessionFactory> Instances = new Dictionary<string, ISessionFactory>();
-		private static readonly IDictionary<string, ISessionFactory> NamedInstances = new Dictionary<string, ISessionFactory>();
+		private static readonly IDictionary<string, ISessionFactory> Instances = new ConcurrentDictionary<string, ISessionFactory>();
+		private static readonly IDictionary<string, ISessionFactory> NamedInstances = new ConcurrentDictionary<string, ISessionFactory>();
 
 		/// <summary></summary>
 		static SessionFactoryObjectFactory()


### PR DESCRIPTION
Requesting comments on this PR that improves a regression documented in #3657

The core of this is to make `SessionFactoryImpl` dictionary's read only - this makes the behavior easier to understand(and safer) for those who accidentally do it(in the issue I provided a case that a change to the NH source caused this to be a new behavior on the existing use of the API in a recommended/best practice way). It doesn't fully fix the "issue" - because `SessionFactoryImpl` is meant to not be created multiple at once, so it's not an issue in that way, but giving more deterministic and easier to debug behavior on a regression is an improvement here. It also means that instead of having a half constructed object(that has some Dictionary's populated and others half populated, it will either be null or set correctly).

There is also an unlike case of writing and reading from `[SessionFactoryObjectFactory.cs`'s dictionary's at the same time, which is documented as an undefined behavior - in practice it can cause very odd issues like dictionaries losing values.

I was sure what the NH team has set for rules on creating tests around these. Somewhat tough to create a failing test because of the non-deterministic behavior.

It would be appreciated if this could be in v5.5.y? I paid attention to keep the public API's the same and keep all existing behavior through the public API's.

Note: I did read through contributing and ran all the SqlServer tests. I have some failing local on both master and this branch that are the same(GH3516) - I assume it's an environment issue.