### PR TITLE
InternalsVisibleTo NHibernate.Test

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -47,6 +47,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublicKey>
+      002400000480000094000000060200000024000052534131000400000100010097dcf11f130a2a2ac4df89be27a41d403258c943574cd324c819f20798506b9ffadf8870efae2c40073b6cd97076e88a3c80dfe5011d259de719e85d68d1673720f6a36476a3a25b6a6277dd8bc3ce394f5c2a7b04bda884edc8d4c9d6e1d376b509ba68ae64031cab45b0b1a4ea95933258722a3a4ee98f1c6b4c8571e3b8a5
+    </PublicKey>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />

--- a/src/NHibernate.DomainModel/NHibernate.DomainModel.csproj
+++ b/src/NHibernate.DomainModel/NHibernate.DomainModel.csproj
@@ -6,6 +6,10 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);3001;3002;3003;3005</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\NHibernate.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="**\*.hbm.xml" />
   </ItemGroup>

--- a/src/NHibernate.Test/ExceptionsTest/OracleClientExceptionConverterExample.cs
+++ b/src/NHibernate.Test/ExceptionsTest/OracleClientExceptionConverterExample.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data.OracleClient;
 using NHibernate.Exceptions;
 
 namespace NHibernate.Test.ExceptionsTest
@@ -10,14 +9,15 @@ namespace NHibernate.Test.ExceptionsTest
 
 		public Exception Convert(AdoExceptionContextInfo exInfo)
 		{
-			var sqle = ADOExceptionHelper.ExtractDbException(exInfo.SqlException) as OracleException;
-			if (sqle != null)
+			var sqle = ADOExceptionHelper.ExtractDbException(exInfo.SqlException);
+			if (sqle != null && sqle.GetType().Name == "OracleException")
 			{
-				if (sqle.Code == 1036)
+				var code = (int)sqle.GetType().GetProperty("Code").GetValue(sqle);
+				if (code == 1036)
 				{
 					return new ConstraintViolationException(exInfo.Message, sqle.InnerException, exInfo.Sql, null);
 				}
-				if (sqle.Code == 942)
+				if (code == 942)
 				{
 					return new SQLGrammarException(exInfo.Message, sqle.InnerException, exInfo.Sql);
 				}

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -8,6 +8,10 @@
     <ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\NHibernate.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -50,18 +54,6 @@
     <Compile Remove="**\NHSpecificTest\NH3121\**" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\NHibernate\Hql\Ast\ANTLR\CaseInsensitiveStringStream.cs">
-      <Link>Hql\Parser\CaseInsensitiveStringStream.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate\Util\AsyncReaderWriterLock.cs">
-      <Link>UtilityTest\AsyncReaderWriterLock.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate\Util\LinkHashMap.cs" Link="UtilityTest\LinkHashMap.cs" />
-    <Compile Include="..\NHibernate\Collection\Generic\SetHelpers\SetSnapShot.cs">
-      <Link>UtilityTest\SetSnapShot.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="log4net" Version="3.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.7.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.5" />
@@ -91,7 +83,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="System.Data.OracleClient" Version="1.0.8" />
+    <PackageReference Include="System.Data.OracleClient" Version="1.0.8">
+      <ExcludeAssets>compile</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.140" />
     <PackageReference Include="System.Data.Odbc" Version="4.7.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -100,4 +100,12 @@
       Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'"
     />
   </Target>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>
+        NHibernate.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010097dcf11f130a2a2ac4df89be27a41d403258c943574cd324c819f20798506b9ffadf8870efae2c40073b6cd97076e88a3c80dfe5011d259de719e85d68d1673720f6a36476a3a25b6a6277dd8bc3ce394f5c2a7b04bda884edc8d4c9d6e1d376b509ba68ae64031cab45b0b1a4ea95933258722a3a4ee98f1c6b4c8571e3b8a5
+      </_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -102,10 +102,6 @@
   </Target>
 
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>
-        NHibernate.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010097dcf11f130a2a2ac4df89be27a41d403258c943574cd324c819f20798506b9ffadf8870efae2c40073b6cd97076e88a3c80dfe5011d259de719e85d68d1673720f6a36476a3a25b6a6277dd8bc3ce394f5c2a7b04bda884edc8d4c9d6e1d376b509ba68ae64031cab45b0b1a4ea95933258722a3a4ee98f1c6b4c8571e3b8a5
-      </_Parameter1>
-    </AssemblyAttribute>
+    <InternalsVisibleTo Include="NHibernate.Test" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Allowing the test project to access internal types and members in the main project opens up for cleaner and less brittle tests, without having to resort to file linking or reflection. It potentially triggers internalizing things that ideally should be private, but I think that's a smaller issue. 

Since the NHibernate assembly is strong named, this required the same thing for NHibernate.Test and NHibernate.DomainModel. Potentially, the entire strong naming could be toggled off in build scenarios where it's not needed. Not done here, but the PropertyGroups etc. have been kept separate, so that they can be made conditional.