### PR TITLE
Add Check(string) to IClassAttributesMapper<TEntity>

### DIFF
--- a/src/NHibernate/Mapping/ByCode/IClassMapper.cs
+++ b/src/NHibernate/Mapping/ByCode/IClassMapper.cs
@@ -58,6 +58,7 @@ namespace NHibernate.Mapping.ByCode
 		void Discriminator(Action<IDiscriminatorMapper> discriminatorMapping);
 		void DiscriminatorValue(object value);
 		void Table(string tableName);
+		void Check(string check);
 		void Catalog(string catalogName);
 		void Schema(string schemaName);
 		void Mutable(bool isMutable);


### PR DESCRIPTION
In NHibernate.Mapping.ByCode, the class Check() method is implemented but not exposed for use.

Sample code:

```cs
            mapper.Class<Entity1>(m => {
                m.Check("arbitrary sql check");
            });
```

This commit adds the Check() method to correct interface for above sample to work.
