### PR TITLE
Release 5.4.10

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -5,7 +5,7 @@
     <NhVersion     Condition="'$(NhVersion)' == ''"    >5.4</NhVersion>
     <VersionPatch  Condition="'$(VersionPatch)'  == ''">10</VersionPatch>
     <!-- Clear VersionSuffix for making release and set it to dev for making development builds -->
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">dev</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
     <LangVersion Condition="'$(MSBuildProjectExtension)' != '.vbproj'">9.0</LangVersion>
 
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(NhVersion).$(VersionPatch)</VersionPrefix>

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,4 +1,21 @@
-﻿Build 5.4.9
+﻿Build 5.4.10
+=============================
+
+Release notes - NHibernate - Version 5.4.10
+
+3 issues were resolved in this release.
+
+** Bug
+
+   * #3609 Fitering with a subquery on a many-to-one with property-ref generates invalid SQL
+   * #3607 Invalid ByCode serialization to XML for OneToOne mappings
+
+** Task
+
+   * #3688 Release 5.4.10
+
+
+Build 5.4.9
 =============================
 
 Release notes - NHibernate - Version 5.4.9


### PR DESCRIPTION
I consider releasing 5.4.10 in its current state, then proceed to release a new 5.5.x with these 5.4.10 fixes, then maybe release 5.6.

But it seems there are still some regressions in the backlog:
- #3652 (would be 5.2.0 regression, with a test case PR failing on master)
- #3669 (would be 5.4.0 regression, with some code for reproduction)
- Maybe #3643 (would be a regression somewhere between 5.2.7 (excluded) and 5.5.2.

The thing is, few people seem to have time looking into them. So, it could delay considerably the releases if we wait for these issues to be fixed or rejected.