### PR TITLE
Update Microsoft.Data.SqlClient to v5

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -16,7 +16,7 @@ jobs:
             DB_INIT: |
               docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P@ssw0rd" -e "MSSQL_PID=Express" -p 1433:1433 -d --name sqlexpress mcr.microsoft.com/mssql/server:2019-latest;
           - DB: SqlServer2008-MicrosoftDataSqlClientDriver
-            CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"
+            CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;TrustServerCertificate=true;"
             OS: ubuntu-latest
             DB_INIT: |
               docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P@ssw0rd" -e "MSSQL_PID=Express" -p 1433:1433 -d --name sqlexpress mcr.microsoft.com/mssql/server:2019-latest;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   - DB: SqlServer2008
     CONNECTION_STRING: Server=(local)\SQL2017;User ID=sa;Password=Password12!;initial catalog=nhibernate;
   - DB: SqlServer2008-MicrosoftDataSqlClientDriver
-    CONNECTION_STRING: Server=(local)\SQL2017;User ID=sa;Password=Password12!;initial catalog=nhibernate;
+    CONNECTION_STRING: Server=(local)\SQL2017;User ID=sa;Password=Password12!;initial catalog=nhibernate;TrustServerCertificate=true;
   - DB: Firebird
   - DB: Firebird4
   - DB: MySQL

--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="3.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.7.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
     <PackageReference Include="NHibernate.Caches.CoreDistributedCache.Memory" Version="5.9.0" />
     <PackageReference Include="NHibernate.Caches.Util.JsonSerializer" Version="5.9.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.117" />

--- a/teamcity.build
+++ b/teamcity.build
@@ -72,6 +72,7 @@
 	<target name="setup-teamcity-sqlServer-MicrosoftDataSqlClientDriver">
 		<property name="db-service" value="MSSQL$SQLEXPRESS" />
 		<property name="nhibernate.connection.driver_class" value="NHibernate.Driver.MicrosoftDataSqlClientDriver" />
+		<property name="nhibernate.connection.connection_string" value="Server=(local);initial catalog=nhibernate;Integrated Security=SSPI;TrustServerCertificate=true;" />
 	</target>
 
 	<target name="setup-teamcity-sqlServer2012">


### PR DESCRIPTION
5.1.6 is the lowest version that is not deprecated and does not report vulnerabilities
