### PR TITLE
Register `localtimestamp` as `current_timestamp` in Oracle9iDialect

### DIFF
--- a/src/NHibernate/Dialect/Oracle9iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle9iDialect.cs
@@ -10,14 +10,7 @@ namespace NHibernate.Dialect
 		public override string CurrentTimestampSelectString =>
 			$"select {CurrentTimestampSQLFunctionName} from dual";
 
-		public override string CurrentTimestampSQLFunctionName
-		{
-			get
-			{
-				// the standard SQL function name is current_timestamp...
-				return "current_timestamp";
-			}
-		}
+		public override string CurrentTimestampSQLFunctionName => "localtimestamp";
 
 		// Current_timestamp is a timestamp with time zone, so it can always be converted back to UTC.
 		/// <inheritdoc />
@@ -44,6 +37,9 @@ namespace NHibernate.Dialect
 		{
 			base.RegisterFunctions();
 
+			RegisterFunction(
+				"current_timestamp",
+				new NoArgSQLFunction("localtimestamp", NHibernateUtil.LocalDateTime, false));
 			RegisterFunction(
 				"current_utctimestamp",
 				new SQLFunctionTemplate(NHibernateUtil.UtcDateTime, "SYS_EXTRACT_UTC(current_timestamp)"));

--- a/src/NHibernate/Dialect/Oracle9iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle9iDialect.cs
@@ -7,10 +7,8 @@ namespace NHibernate.Dialect
 {
 	public class Oracle9iDialect : Oracle8iDialect
 	{
-		public override string CurrentTimestampSelectString
-		{
-			get { return "select systimestamp from dual"; }
-		}
+		public override string CurrentTimestampSelectString =>
+			$"select {CurrentTimestampSQLFunctionName} from dual";
 
 		public override string CurrentTimestampSQLFunctionName
 		{


### PR DESCRIPTION
In Oracle `current_timestamp` and `systimestamp` return `TIMESTAMP WITH TIME ZONE` type, which in Oracle ManagedDataAccess v23 turns into `DateTimeOffset` of expected `DateTime`, so [some tests fail](https://github.com/nhibernate/nhibernate-core/actions/runs/17997173671/job/51198821791).

Switching it to `localtimestamp` to fix the problem.


