### PR TITLE
Add DateOnly and TimeOnly support

### DIFF
--- a/src/NHibernate.Test/TypesTest/AbstractTimeOnlyTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/AbstractTimeOnlyTypeFixture.cs
@@ -1,0 +1,23 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NHibernate.Type;
+
+namespace NHibernate.Test.TypesTest
+{
+	public class AbstractTimeOnlyTypeFixture<TType> : GenericTypeFixtureBase<TimeOnly, TType> where TType : IType
+	{
+		protected override IReadOnlyList<TimeOnly> TestValues => [new(12, 13, 14), new(23, 59, 59), new(0, 0, 0)];
+		protected override IEnumerable<Expression<Func<TimeOnly, object>>> PropertiesToTestWithLinq
+		{
+			get
+			{
+				yield return (TimeOnly x) => x.Hour;
+				yield return (TimeOnly x) => x.Minute;
+				yield return (TimeOnly x) => x.Second;
+			}
+		}
+	}
+}
+#endif

--- a/src/NHibernate.Test/TypesTest/AbstractTimeOnlyTypeWithScaleFixture.cs
+++ b/src/NHibernate.Test/TypesTest/AbstractTimeOnlyTypeWithScaleFixture.cs
@@ -1,0 +1,49 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using NHibernate.Mapping.ByCode;
+using NHibernate.Type;
+
+namespace NHibernate.Test.TypesTest
+{
+	public abstract class AbstractTimeOnlyTypeWithScaleFixture<TType> : AbstractTimeOnlyTypeFixture<TType> where TType : IType
+	{
+		private readonly bool _setMaxScale;
+		protected AbstractTimeOnlyTypeWithScaleFixture(bool setMaxScale)
+		{
+			_setMaxScale = setMaxScale;
+		}
+
+		/// <summary>
+		/// The resolution used when setMaxScale is true
+		/// </summary>
+		protected virtual long MaxTimestampResolutionInTicks => Dialect.TimestampResolutionInTicks;
+
+		/// <summary>
+		/// Add fractional seconds to the test values when setMaxScale is true
+		/// </summary>
+		protected override IReadOnlyList<TimeOnly> TestValues => [.. base.TestValues.Select(x => _setMaxScale ? AdjustTestValueWithFractionalSeconds(x) : x)];
+
+		private TimeOnly AdjustTestValueWithFractionalSeconds(TimeOnly value)
+		{
+			value = new TimeOnly(value.Hour,value.Minute,value.Second);
+			var ticks = value.Ticks + MaxTimestampResolutionInTicks;
+			if (ticks + MaxTimestampResolutionInTicks > TimeOnly.MaxValue.Ticks)
+			{
+				ticks = value.Ticks - MaxTimestampResolutionInTicks;
+			}
+			return new TimeOnly(ticks);
+		}
+
+		protected override void ConfigurePropertyMapping<TPersistentType>(IPropertyMapper propertyMapper)
+		{
+			if (_setMaxScale)
+			{
+				propertyMapper.Scale((short) Math.Floor(Math.Log10(TimeSpan.TicksPerSecond / MaxTimestampResolutionInTicks)));
+			}
+		}
+	}
+}
+#endif

--- a/src/NHibernate.Test/TypesTest/DateOnlyAsDateTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/DateOnlyAsDateTypeFixture.cs
@@ -1,0 +1,26 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NHibernate.Type;
+
+namespace NHibernate.Test.TypesTest
+{
+	public class DateOnlyAsDateTypeFixture : GenericTypeFixtureBase<DateOnly, DateOnlyAsDateType>
+	{
+		protected override IReadOnlyList<DateOnly> TestValues =>
+		[
+			DateOnly.FromDateTime(Sfi.ConnectionProvider.Driver.MinDate.AddDays(1)),
+			DateOnly.FromDateTime(DateTime.Now),
+			DateOnly.MaxValue.AddDays(-1)
+		];
+
+		protected override IList<Expression<Func<DateOnly, object>>> PropertiesToTestWithLinq =>
+		[
+			(DateOnly x) => x.Year,
+			(DateOnly x) => x.Month,
+			(DateOnly x) => x.Day
+		];
+	}
+}
+#endif

--- a/src/NHibernate.Test/TypesTest/GenericTypeFixtureBase.cs
+++ b/src/NHibernate.Test/TypesTest/GenericTypeFixtureBase.cs
@@ -224,7 +224,8 @@ namespace NHibernate.Test.TypesTest
 					var value = property.Compile()(testValue);
 					var where = Expression.Lambda<Func<TestEntity, bool>>(Expression.Equal(body.Replace(property.Parameters[0], prop), Expression.Constant(value)), param);
 					TestEntity entity = null;
-					Assert.DoesNotThrow(() => entity = session.Query<TestEntity>().FirstOrDefault(where), "Unable to query property " + member.Member.Name);
+					Assert.That(() => entity = session.Query<TestEntity>().FirstOrDefault(where), Throws.Nothing,
+						"Unable to query property " + member.Member.Name);
 					Assert.That(entity, Is.Not.Null, "Unable to query property " + member.Member.Name);
 				}
 			}

--- a/src/NHibernate.Test/TypesTest/GenericTypeFixtureBase.cs
+++ b/src/NHibernate.Test/TypesTest/GenericTypeFixtureBase.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NHibernate.Cfg;
+using NHibernate.Linq;
+using NHibernate.Linq.Visitors;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Type;
+using NUnit.Framework;
+
+namespace NHibernate.Test.TypesTest
+{
+	/// <summary>
+	/// Base class for fixtures testing individual types, created to avoid
+	/// code duplication in derived classes.
+	/// </summary>
+	public abstract class GenericTypeFixtureBase<TProperty, TType> : TestCase where TType : IType
+	{
+
+		protected override string MappingsAssembly
+		{
+			get { return "NHibernate.Test"; }
+		}
+
+		protected override string[] Mappings
+		{
+			get
+			{
+				return new string[] { };
+			}
+		}
+
+		/// <summary>
+		/// Creates a set of test values of type <typeparamref name="TProperty"/>.
+		/// </summary>
+		/// <returns>The test values</returns>
+		/// <remarks>If the type is IComparable, make sure that the first value
+		/// doesn't become invalid when incremented by <see cref="IncrementValue(TProperty)"/></remarks>
+		protected abstract IReadOnlyList<TProperty> TestValues { get; }
+
+		/// <summary>
+		/// Override in order to adjust the value of a property before comparisons.
+		/// May be necessary when dealing with expected precision losses
+		/// </summary>
+		/// <param name="value">The value to adjust</param>
+		/// <returns>The adjusted value</returns>
+		protected virtual TProperty AdjustValue(TProperty value) => value;
+
+		/// <summary>
+		/// Sub properties of <see cref="TType"/> which should be queryable using LINQ
+		/// </summary>
+		protected virtual IEnumerable<Expression<Func<TProperty, object>>> PropertiesToTestWithLinq => Enumerable.Empty<Expression<Func<TProperty, object>>>();
+
+		/// <summary>
+		/// Methods of <see cref="TType"/> which should be queryable using LINQ
+		/// </summary>
+		protected virtual IEnumerable<Expression<Func<TProperty, object>>> MethodsToTestWithLinq => Enumerable.Empty<Expression<Func<TProperty, object>>>();
+
+		[Test]
+		public virtual void CanPersist()
+		{
+			var testValues = GetAllTestValues();
+
+			Dictionary<Guid, TProperty> expectedValues = [];
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				foreach (var testValue in testValues)
+				{
+					var entity = new TestEntity { TestProperty = testValue };
+					session.Save(entity);
+					expectedValues[entity.Id] = testValue;
+				}
+				trans.Commit();
+			}
+
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				foreach (var expectedValue in expectedValues)
+				{
+					var entity = session.Get<TestEntity>(expectedValue.Key);
+					Assert.That(entity, Is.Not.Null);
+					Assert.That(AdjustValue(entity.TestProperty), Is.EqualTo(AdjustValue(expectedValue.Value)));
+				}
+			}
+		}
+
+		[Test]
+		public void CanQuery()
+		{
+			var testValue = GetFirstTestValue();
+			Guid id;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entity = new TestEntity { TestProperty = testValue };
+				session.Save(entity);
+				id = entity.Id;
+
+				trans.Commit();
+			}
+
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var param = Expression.Parameter(typeof(TestEntity));
+				var prop = Expression.Property(param, nameof(TestEntity.TestProperty));
+				var value = Expression.Constant(testValue);
+				var where = Expression.Lambda<Func<TestEntity, bool>>(Expression.Equal(prop, value), param);
+				var entity = session.Query<TestEntity>().Single(where);
+				Assert.That(entity, Is.Not.Null);
+				Assert.That(entity.Id, Is.EqualTo(id));
+			}
+		}
+
+		private TProperty GetFirstTestValue()
+		{
+			var testValues = TestValues;
+			if (testValues.Count == 0)
+			{
+				Assert.Ignore("No test values provided");
+			}
+			return testValues[0];
+		}
+
+		private IReadOnlyList<TProperty> GetAllTestValues()
+		{
+			var testValues = TestValues;
+			if (TestValues.Count == 0)
+			{
+				Assert.Ignore("No test values provided");
+			}
+			return testValues;
+		}
+
+		[Test]
+		public virtual void CanCompare()
+		{
+			if (!typeof(IComparable).IsAssignableFrom(typeof(TProperty)))
+			{
+				Assert.Ignore("Not IComparable");
+			}
+			var testValues = GetAllTestValues();
+
+			if (testValues.Count < 2)
+			{
+				Assert.Fail("At least 2 test values required to test comparison");
+			}
+			var testValue = testValues[0];
+			var biggerTestValue = testValues[1];
+			if (((IComparable) biggerTestValue).CompareTo(testValue) <= 0)
+			{
+				Assert.Fail("The second test value must be greater than the first");
+				return;
+			}
+			Guid id;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entity = new TestEntity { TestProperty = testValue };
+				session.Save(entity);
+				id = entity.Id;
+				entity = new TestEntity { TestProperty = biggerTestValue };
+				session.Save(entity);
+				trans.Commit();
+			}
+
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var param = Expression.Parameter(typeof(TestEntity));
+				var prop = Expression.Property(param, nameof(TestEntity.TestProperty));
+				var smallerValue = Expression.Constant(testValue, typeof(TProperty));
+				var biggerValue = Expression.Constant(biggerTestValue, typeof(TProperty));
+				var smallerWhere = Expression.Lambda<Func<TestEntity, bool>>(Expression.LessThan(prop, biggerValue), param);
+				var biggerWhere = Expression.Lambda<Func<TestEntity, bool>>(Expression.GreaterThan(prop, smallerValue), param);
+				var smaller = session.Query<TestEntity>().Single(smallerWhere);
+				var bigger = session.Query<TestEntity>().Single(biggerWhere);
+				Assert.That(smaller, Is.Not.Null);
+				Assert.That(smaller.Id, Is.EqualTo(id));
+				Assert.That(bigger, Is.Not.Null);
+				Assert.That(bigger.Id, Is.Not.EqualTo(id));
+			}
+		}
+
+		[Test]
+		public virtual void CanQueryProperties()
+		{
+			if (PropertiesToTestWithLinq?.Any() != true)
+			{
+				Assert.Ignore();
+			}
+
+			var testValue = GetFirstTestValue();
+			Guid id;
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				var entity = new TestEntity { TestProperty = testValue };
+				session.Save(entity);
+				id = entity.Id;
+				trans.Commit();
+			}
+
+			using (var session = OpenSession())
+			using (var trans = session.BeginTransaction())
+			{
+				foreach (var property in PropertiesToTestWithLinq)
+				{
+					var param = Expression.Parameter(typeof(TestEntity));
+					var body = property.Body;
+					if (body is UnaryExpression unaryExpression)
+					{
+						body = unaryExpression.Operand;
+					}
+					var member = body as MemberExpression;
+					if (member is null)
+					{
+						Assert.Fail(body + " did not expose a member");
+					}
+					var prop = Expression.Property(param, nameof(TestEntity.TestProperty));
+					var value = property.Compile()(testValue);
+					var where = Expression.Lambda<Func<TestEntity, bool>>(Expression.Equal(body.Replace(property.Parameters[0], prop), Expression.Constant(value)), param);
+					TestEntity entity = null;
+					Assert.DoesNotThrow(() => entity = session.Query<TestEntity>().FirstOrDefault(where), "Unable to query property " + member.Member.Name);
+					Assert.That(entity, Is.Not.Null, "Unable to query property " + member.Member.Name);
+				}
+			}
+		}
+
+		protected override void AddMappings(Configuration configuration)
+		{
+			var mapper = new ModelMapper();
+
+			mapper.Class<TestEntity>(m =>
+			{
+				m.Table("TestEntity");
+				m.EntityName("TestEntity");
+				m.Id(p => p.Id, p => p.Generator(Generators.Guid));
+				m.Property(p => p.TestProperty,
+					p =>
+					{
+						p.Type<TType>();
+						ConfigurePropertyMapping<TType>(p);
+					}
+				);
+			});
+
+			var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+			configuration.AddMapping(mapping);
+		}
+
+		protected virtual void ConfigurePropertyMapping<TPersistentType>(IPropertyMapper propertyMapper) { }
+
+		protected override void OnTearDown()
+		{
+			base.OnTearDown();
+
+			using var s = OpenSession();
+			using var t = s.BeginTransaction();
+			s.Query<TestEntity>().Delete();
+			t.Commit();
+		}
+		public class TestEntity
+		{
+			public virtual Guid Id { get; set; }
+			public virtual TProperty TestProperty { get; set; }
+		}
+
+		public class TypeConfiguration
+		{
+			public object Parameters { get; set; }
+			public short? Scale { get; set; }
+			public short? Precision { get; set; }
+		}
+	}
+}

--- a/src/NHibernate.Test/TypesTest/GenericTypeFixtureBase.cs
+++ b/src/NHibernate.Test/TypesTest/GenericTypeFixtureBase.cs
@@ -17,7 +17,6 @@ namespace NHibernate.Test.TypesTest
 	/// </summary>
 	public abstract class GenericTypeFixtureBase<TProperty, TType> : TestCase where TType : IType
 	{
-
 		protected override string MappingsAssembly
 		{
 			get { return "NHibernate.Test"; }
@@ -264,6 +263,7 @@ namespace NHibernate.Test.TypesTest
 			s.Query<TestEntity>().Delete();
 			t.Commit();
 		}
+
 		public class TestEntity
 		{
 			public virtual Guid Id { get; set; }

--- a/src/NHibernate.Test/TypesTest/TimeOnlyAsDateTimeTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TimeOnlyAsDateTimeTypeFixture.cs
@@ -1,0 +1,33 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Type;
+using NUnit.Framework;
+
+namespace NHibernate.Test.TypesTest
+{
+	[TestFixture(null, false)]
+	[TestFixture("1900-01-01", false)]
+	[TestFixture(null, true)]
+	public class TimeOnlyAsDateTimeTypeFixture : AbstractTimeOnlyTypeWithScaleFixture<TimeOnlyAsDateTimeType>
+	{
+		private readonly string _baseDate;
+
+		public TimeOnlyAsDateTimeTypeFixture(string baseDate, bool setMaxScale) : base(setMaxScale)
+		{
+			_baseDate = baseDate;
+		}
+
+		protected override void ConfigurePropertyMapping<TPersistentType>(IPropertyMapper propertyMapper)
+		{
+			base.ConfigurePropertyMapping<TPersistentType>(propertyMapper);
+			if (_baseDate != null)
+			{
+				propertyMapper.Type<TPersistentType>(new { BaseDateValue = _baseDate });
+			}
+		}
+	}
+}
+#endif

--- a/src/NHibernate.Test/TypesTest/TimeOnlyAsTicksTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TimeOnlyAsTicksTypeFixture.cs
@@ -1,0 +1,26 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+using NHibernate.Type;
+
+using NUnit.Framework;
+
+namespace NHibernate.Test.TypesTest
+{
+
+	[TestFixture(false)]
+	[TestFixture(true)]
+	public class TimeOnlyAsTicksTypeFixture : AbstractTimeOnlyTypeWithScaleFixture<TimeOnlyAsTicksType>
+	{
+		public TimeOnlyAsTicksTypeFixture(bool setMaxScale) : base(setMaxScale)
+		{
+		}
+
+		protected override long MaxTimestampResolutionInTicks => 1L;
+
+		protected override IEnumerable<Expression<Func<TimeOnly, object>>> PropertiesToTestWithLinq => null;
+	}
+}
+#endif

--- a/src/NHibernate.Test/TypesTest/TimeOnlyAsTicksTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TimeOnlyAsTicksTypeFixture.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace NHibernate.Test.TypesTest
 {
-
 	[TestFixture(false)]
 	[TestFixture(true)]
 	public class TimeOnlyAsTicksTypeFixture : AbstractTimeOnlyTypeWithScaleFixture<TimeOnlyAsTicksType>

--- a/src/NHibernate.Test/TypesTest/TimeOnlyAsTimeTypeFixture.cs
+++ b/src/NHibernate.Test/TypesTest/TimeOnlyAsTimeTypeFixture.cs
@@ -1,0 +1,30 @@
+#if NET6_0_OR_GREATER
+using NHibernate.Mapping.ByCode;
+using NHibernate.Type;
+using NUnit.Framework;
+
+namespace NHibernate.Test.TypesTest
+{
+	[TestFixture(null, false)]
+	[TestFixture("1900-01-01", false)]
+	[TestFixture(null, true)]
+	public class TimeOnlyAsTimeTypeFixture : AbstractTimeOnlyTypeWithScaleFixture<TimeOnlyAsTimeType>
+	{
+		private readonly string _baseDate;
+
+		public TimeOnlyAsTimeTypeFixture(string baseDate, bool setMaxScale) : base(setMaxScale)
+		{
+			_baseDate = baseDate;
+		}
+
+		protected override void ConfigurePropertyMapping<TPersistentType>(IPropertyMapper propertyMapper)
+		{
+			base.ConfigurePropertyMapping<TPersistentType>(propertyMapper);
+			if (_baseDate != null)
+			{
+				propertyMapper.Type<TPersistentType>(new { BaseDateValue = _baseDate });
+			}
+		}
+	}
+}
+#endif

--- a/src/NHibernate/Linq/Functions/DateTimePropertiesHqlGenerator.cs
+++ b/src/NHibernate/Linq/Functions/DateTimePropertiesHqlGenerator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using NHibernate.Engine;
 using NHibernate.Hql.Ast;
 using NHibernate.Linq.Visitors;
 using NHibernate.Util;
@@ -21,7 +20,7 @@ namespace NHibernate.Linq.Functions
 					ReflectHelper.GetProperty((DateTime x) => x.Minute),
 					ReflectHelper.GetProperty((DateTime x) => x.Second),
 					ReflectHelper.GetProperty((DateTime x) => x.Date),
-					
+
 					ReflectHelper.GetProperty((DateTimeOffset x) => x.Year),
 					ReflectHelper.GetProperty((DateTimeOffset x) => x.Month),
 					ReflectHelper.GetProperty((DateTimeOffset x) => x.Day),
@@ -29,7 +28,17 @@ namespace NHibernate.Linq.Functions
 					ReflectHelper.GetProperty((DateTimeOffset x) => x.Minute),
 					ReflectHelper.GetProperty((DateTimeOffset x) => x.Second),
 					ReflectHelper.GetProperty((DateTimeOffset x) => x.Date),
-				};
+
+#if NET6_0_OR_GREATER
+					ReflectHelper.GetProperty((DateOnly x) => x.Year),
+					ReflectHelper.GetProperty((DateOnly x) => x.Month),
+					ReflectHelper.GetProperty((DateOnly x) => x.Day),
+
+					ReflectHelper.GetProperty((TimeOnly x) => x.Hour),
+					ReflectHelper.GetProperty((TimeOnly x) => x.Minute),
+					ReflectHelper.GetProperty((TimeOnly x) => x.Second),
+#endif
+			};
 		}
 
 		public override HqlTreeNode BuildHql(MemberInfo member, Expression expression, HqlTreeBuilder treeBuilder, IHqlExpressionVisitor visitor)

--- a/src/NHibernate/NHibernateUtil.cs
+++ b/src/NHibernate/NHibernateUtil.cs
@@ -137,6 +137,12 @@ namespace NHibernate
 		/// </summary>
 		public static readonly DateType Date = new DateType();
 
+#if NET6_0_OR_GREATER
+		/// <summary>
+		/// NHibernate DateOnlyAsDate type
+		/// </summary>
+		public static readonly DateOnlyAsDateType DateOnlyAsDate = new();
+#endif
 		/// <summary>
 		/// NHibernate local date type
 		/// </summary>
@@ -244,6 +250,22 @@ namespace NHibernate
 		[Obsolete("Use DateTime instead.")]
 		public static readonly TimestampType Timestamp = new TimestampType();
 
+#if NET6_0_OR_GREATER
+		/// <summary>
+		/// NHibernate TimeOnlyAsDateTime type
+		/// </summary>
+		public static readonly TimeOnlyAsDateTimeType TimeOnlyAsDateTime = new();
+
+		/// <summary>
+		/// NHibernate TimeOnlyAsTicks type
+		/// </summary>
+		public static readonly TimeOnlyAsTicksType TimeOnlyAsTicks = new();
+
+		/// <summary>
+		/// NHibernate TimeOnlyAsTime type
+		/// </summary>
+		public static readonly TimeOnlyAsTimeType TimeOnlyAsTime = new();
+#endif
 		/// <summary>
 		/// NHibernate Timestamp type, seeded db side.
 		/// </summary>

--- a/src/NHibernate/Type/AbstractDateOnlyType.cs
+++ b/src/NHibernate/Type/AbstractDateOnlyType.cs
@@ -37,7 +37,7 @@ namespace NHibernate.Type
 			}
 			catch (Exception ex) when (ex is not FormatException)
 			{
-				throw new FormatException(string.Format("Input string '{0}' was not in the correct format.", rs[index]), ex);
+				throw new FormatException(string.Format("Input '{0}' was not convertible to DateOnly.", rs[index]), ex);
 			}
 		}
 
@@ -50,7 +50,7 @@ namespace NHibernate.Type
 		/// <inheritdoc />
 		public override void Set(DbCommand st, object value, int index, ISessionImplementor session)
 		{
-			st.Parameters[index].Value = GetParameterValueToSet((DateOnly) value,session);
+			st.Parameters[index].Value = GetParameterValueToSet((DateOnly) value, session);
 		}
 
 		/// <summary>
@@ -82,7 +82,6 @@ namespace NHibernate.Type
 		/// <inheritdoc />
 		public override string ToLoggableString(object value, ISessionFactoryImplementor factory) =>
 			value == null ? null : ((DateOnly) value).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-
 	}
 }
 #endif

--- a/src/NHibernate/Type/AbstractDateOnlyType.cs
+++ b/src/NHibernate/Type/AbstractDateOnlyType.cs
@@ -1,0 +1,88 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Data.Common;
+using System.Globalization;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+
+namespace NHibernate.Type
+{
+	/// <summary>
+	/// Base class for DateOnly types.
+	/// </summary>
+	[Serializable]
+	public abstract class AbstractDateOnlyType<TParameter> : PrimitiveType
+	{
+		protected AbstractDateOnlyType(SqlType sqlType) : base(sqlType)
+		{
+		}
+
+		public override string Name =>
+			GetType().Name.EndsWith("Type", StringComparison.Ordinal)
+				? GetType().Name[..^4]
+				: GetType().Name;
+
+		public override System.Type ReturnedClass => typeof(DateOnly);
+
+		public override System.Type PrimitiveClass => typeof(DateOnly);
+
+		public override object DefaultValue => DateOnly.MinValue;
+
+		/// <inheritdoc />
+		public override object Get(DbDataReader rs, int index, ISessionImplementor session)
+		{
+			try
+			{
+				return GetDateOnlyFromReader(rs, index, session);
+			}
+			catch (Exception ex) when (ex is not FormatException)
+			{
+				throw new FormatException(string.Format("Input string '{0}' was not in the correct format.", rs[index]), ex);
+			}
+		}
+
+		///// <inheritdoc />
+		//public override object Get(DbDataReader rs, string name, ISessionImplementor session)
+		//{
+		//	return Get(rs, rs.GetOrdinal(name), session);
+		//}
+
+		/// <inheritdoc />
+		public override void Set(DbCommand st, object value, int index, ISessionImplementor session)
+		{
+			st.Parameters[index].Value = GetParameterValueToSet((DateOnly) value,session);
+		}
+
+		/// <summary>
+		/// Get the DateOnly value from the <see cref="DbDataReader"/> at index <paramref name="index"/>
+		/// </summary>
+		/// <param name="rs"></param>
+		/// <param name="index"></param>
+		/// <param name="session"></param>
+		/// <returns></returns>
+		protected abstract DateOnly GetDateOnlyFromReader(DbDataReader rs, int index, ISessionImplementor session);
+
+		/// <summary>
+		/// Convert <paramref name="dateOnly"/> into the <typeparamref name="TParameter"/> which will be set on the parameter
+		/// </summary>
+		/// <param name="dateOnly"></param>
+		/// <param name="session"></param>
+		/// <returns></returns>
+		protected abstract TParameter GetParameterValueToSet(DateOnly dateOnly, ISessionImplementor session);
+
+		public override bool IsEqual(object x, object y)
+		{
+			if (ReferenceEquals(x, y)) return true;
+			if (x == null || y == null) return false;
+			return ((DateOnly) x).Equals((DateOnly) y);
+		}
+
+		public override int GetHashCode(object x) => ((DateOnly) x).GetHashCode();
+
+		/// <inheritdoc />
+		public override string ToLoggableString(object value, ISessionFactoryImplementor factory) =>
+			value == null ? null : ((DateOnly) value).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+	}
+}
+#endif

--- a/src/NHibernate/Type/AbstractDateOnlyType.cs
+++ b/src/NHibernate/Type/AbstractDateOnlyType.cs
@@ -41,12 +41,6 @@ namespace NHibernate.Type
 			}
 		}
 
-		///// <inheritdoc />
-		//public override object Get(DbDataReader rs, string name, ISessionImplementor session)
-		//{
-		//	return Get(rs, rs.GetOrdinal(name), session);
-		//}
-
 		/// <inheritdoc />
 		public override void Set(DbCommand st, object value, int index, ISessionImplementor session)
 		{

--- a/src/NHibernate/Type/AbstractTimeOnlyType.cs
+++ b/src/NHibernate/Type/AbstractTimeOnlyType.cs
@@ -1,0 +1,134 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Data.Common;
+using System.Globalization;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+
+namespace NHibernate.Type
+{
+	/// <summary>
+	/// Base class for TimeOnly types.
+	/// Fractional seconds precision:
+	///   null  => preserve full precision (no truncation)
+	///   0..6  => truncate (floor) to that many fractional digits
+	///   >=7   => preserve full precision
+	/// </summary>
+	[Serializable]
+	public abstract class AbstractTimeOnlyType<TParameter> : PrimitiveType
+	{
+		private static readonly int[] TicksPerPrecision = { 10_000_000, 1_000_000, 100_000, 10_000, 1_000, 100, 10 };
+		private readonly int _ticksForPrecision;
+		private readonly bool _truncate;
+		private readonly byte? _fractionalSecondsPrecision;
+
+		protected AbstractTimeOnlyType(byte? fractionalSecondsPrecision, SqlType sqlType) : base(sqlType)
+		{
+			_fractionalSecondsPrecision = fractionalSecondsPrecision;
+			if (fractionalSecondsPrecision is >= 0 and <= 6)
+			{
+				_ticksForPrecision = TicksPerPrecision[fractionalSecondsPrecision.Value];
+				_truncate = true;
+			}
+			else
+			{
+				// null or >=7 => full precision, no truncation
+				_ticksForPrecision = 1;
+				_truncate = false;
+			}
+		}
+
+
+		public override string Name => GetType().Name.EndsWith("Type", StringComparison.Ordinal)
+			? GetType().Name[..^4]
+			: GetType().Name;
+
+		public override System.Type ReturnedClass => typeof(TimeOnly);
+
+		public override System.Type PrimitiveClass => typeof(TimeOnly);
+
+		public override object DefaultValue => TimeOnly.MinValue;
+
+		/// <summary>
+		/// Truncate (floor) fractional seconds beyond declared precision.
+		/// Override to change behavior (e.g., implement rounding).
+		/// </summary>
+		protected virtual TimeOnly AdjustTimeOnly(TimeOnly timeOnly)
+		{
+			if (!_truncate)
+				return timeOnly;
+
+			long ticks = timeOnly.Ticks;
+			long remainder = ticks % _ticksForPrecision;
+			if (remainder == 0)
+				return timeOnly;
+
+			return new TimeOnly(ticks - remainder);
+		}
+
+		/// <summary>
+		/// Convert <paramref name="timeOnly"/> into the <typeparamref name="TParameter"/> which will be set on the parameter
+		/// </summary>
+		/// <param name="timeOnly"></param>
+		/// <param name="session"></param>
+		/// <returns></returns>
+		protected abstract TParameter GetParameterValueToSet(TimeOnly timeOnly, ISessionImplementor session);
+
+		///<inheritdoc/>
+		public override void Set(DbCommand st, object value, int index, ISessionImplementor session)
+		{
+			st.Parameters[index].Value = GetParameterValueToSet(AdjustTimeOnly((TimeOnly) value), session);
+		}
+
+		///<inheritdoc/>
+		public override object Get(DbDataReader rs, int index, ISessionImplementor session)
+		{
+			try
+			{
+				return AdjustTimeOnly(GetTimeOnlyFromReader(rs, index, session));
+			}
+			catch (Exception ex) when (ex is not FormatException)
+			{
+				throw new FormatException(string.Format("Input string '{0}' was not in the correct format.", rs[index]), ex);
+			}
+		}
+
+		/// <summary>
+		/// Get the <see cref="TimeOnly"/> value from the <see cref="DbDataReader"/> at index <paramref name="index"/>
+		/// </summary>
+		/// <param name="rs"></param>
+		/// <param name="index"></param>
+		/// <param name="session"></param>
+		/// <returns></returns>
+		protected abstract TimeOnly GetTimeOnlyFromReader(DbDataReader rs, int index, ISessionImplementor session);
+
+		public override bool IsEqual(object x, object y)
+		{
+			if (ReferenceEquals(x, y)) return true;
+			if (x == null || y == null) return false;
+
+			var t1 = (TimeOnly) x;
+			var t2 = (TimeOnly) y;
+
+			// Fast path: compare essential components first
+			if (t1.Hour != t2.Hour || t1.Minute != t2.Minute || t1.Second != t2.Second)
+				return false;
+
+			// Precision handling
+			if (!_fractionalSecondsPrecision.HasValue)
+				return t1 == t2; // full precision exact match
+
+			if (_fractionalSecondsPrecision == 0)
+				return true; // up to seconds already matched
+
+			return AdjustTimeOnly(t1) == AdjustTimeOnly(t2);
+		}
+
+		public override int GetHashCode(object x) => AdjustTimeOnly((TimeOnly) x).GetHashCode();
+
+		/// <inheritdoc />
+		public override string ToLoggableString(object value, ISessionFactoryImplementor factory) =>
+			value == null ? null : ((TimeOnly) value).ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
+	}
+}
+#endif

--- a/src/NHibernate/Type/AbstractTimeOnlyType.cs
+++ b/src/NHibernate/Type/AbstractTimeOnlyType.cs
@@ -38,7 +38,6 @@ namespace NHibernate.Type
 			}
 		}
 
-
 		public override string Name => GetType().Name.EndsWith("Type", StringComparison.Ordinal)
 			? GetType().Name[..^4]
 			: GetType().Name;
@@ -50,7 +49,7 @@ namespace NHibernate.Type
 		public override object DefaultValue => TimeOnly.MinValue;
 
 		/// <summary>
-		/// Truncate (floor) fractional seconds beyond declared precision.
+		/// Truncate (floor) fractional seconds according to the declared precision.
 		/// Override to change behavior (e.g., implement rounding).
 		/// </summary>
 		protected virtual TimeOnly AdjustTimeOnly(TimeOnly timeOnly)
@@ -89,7 +88,7 @@ namespace NHibernate.Type
 			}
 			catch (Exception ex) when (ex is not FormatException)
 			{
-				throw new FormatException(string.Format("Input string '{0}' was not in the correct format.", rs[index]), ex);
+				throw new FormatException(string.Format("Input '{0}' was not convertible to TimeOnly.", rs[index]), ex);
 			}
 		}
 

--- a/src/NHibernate/Type/DateOnlyAsDateType.cs
+++ b/src/NHibernate/Type/DateOnlyAsDateType.cs
@@ -28,10 +28,9 @@ namespace NHibernate.Type
 		protected override DateTime GetParameterValueToSet(DateOnly dateOnly, ISessionImplementor session) =>
 			dateOnly.ToDateTime(TimeOnly.MinValue);
 
-
 		/// <inheritdoc />
 		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
-			"'" + ((DateOnly) value).ToString("yyyy-MM-dd") + "'";
+			dialect.ToStringLiteral(((DateOnly) value).ToString("yyyy-MM-dd"), SqlTypeFactory.GetAnsiString(50));
 	}
 }
 #endif

--- a/src/NHibernate/Type/DateOnlyAsDateType.cs
+++ b/src/NHibernate/Type/DateOnlyAsDateType.cs
@@ -1,0 +1,37 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Data;
+using System.Data.Common;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+
+namespace NHibernate.Type
+{
+	/// <summary>
+	/// Maps a <see cref="DateOnly" /> property to a <see cref="DbType.Date"/> column
+	/// </summary>
+	[Serializable]
+	public class DateOnlyAsDateType : AbstractDateOnlyType<DateTime>
+	{
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
+		public DateOnlyAsDateType() : base(SqlTypeFactory.Date)
+		{
+		}
+
+		protected override DateOnly GetDateOnlyFromReader(DbDataReader rs, int index, ISessionImplementor session)
+		{
+			return DateOnly.FromDateTime(rs.GetDateTime(index));
+		}
+
+		protected override DateTime GetParameterValueToSet(DateOnly dateOnly, ISessionImplementor session) =>
+			dateOnly.ToDateTime(TimeOnly.MinValue);
+
+
+		/// <inheritdoc />
+		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
+			"'" + ((DateOnly) value).ToString("yyyy-MM-dd") + "'";
+	}
+}
+#endif

--- a/src/NHibernate/Type/TimeOnlyAsDateTimeType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsDateTimeType.cs
@@ -1,0 +1,67 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Globalization;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+using NHibernate.UserTypes;
+
+namespace NHibernate.Type
+{
+	/// <summary>
+	/// Maps a <see cref="System.TimeOnly" /> Property to a DateTime column that only stores the
+	/// time part of the DateTime as significant.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This defaults the Date to "1753-01-01" - which should not matter because
+	/// using this Type indicates that you don't care about the Date portion of the DateTime.
+	/// However, if you need to adjust this base value, you can specify the parameter 'BaseDateValue' on the type mapping,
+	/// using the date format 'yyyy-MM-dd'
+	/// </para>
+	/// </remarks>
+	[Serializable]
+	public class TimeOnlyAsDateTimeType : AbstractTimeOnlyType<DateTime>, IParameterizedType
+	{
+		private DateTime _baseDateValue = new(1753, 01, 01);
+		private readonly string _sqlFormat;
+		/// <summary>
+		/// Default constructor. Sets the fractional seconds precision (scale) to 0
+		/// </summary>
+		public TimeOnlyAsDateTimeType() : this(0)
+		{
+		}
+
+		/// <summary>
+		/// Constructor for specifying a time with a scale.
+		/// </summary>
+		/// <param name="fractionalSecondsPrecision">The sql type to use for the type.</param>
+		public TimeOnlyAsDateTimeType(byte fractionalSecondsPrecision) : base(fractionalSecondsPrecision, SqlTypeFactory.GetDateTime(fractionalSecondsPrecision))
+		{
+			_sqlFormat = "yyyy-MM-dd HH:mm:ss" + (fractionalSecondsPrecision > 0 ? "." + new string('F', Math.Min(7, (int) fractionalSecondsPrecision)) : "");
+		}
+
+		protected override TimeOnly GetTimeOnlyFromReader(DbDataReader rs, int index, ISessionImplementor session) => 
+			TimeOnly.FromTimeSpan(rs.GetDateTime(index).TimeOfDay);
+
+		protected override DateTime GetParameterValueToSet(TimeOnly timeOnly, ISessionImplementor session) => 
+			GetDateTimeFromTimeOnly(timeOnly);
+
+		private DateTime GetDateTimeFromTimeOnly(TimeOnly timeOnly) => 
+			_baseDateValue + timeOnly.ToTimeSpan();
+
+		void IParameterizedType.SetParameterValues(IDictionary<string, string> parameters)
+		{
+			if (parameters?.TryGetValue("BaseDateValue", out var stringVal) == true
+				&& !string.IsNullOrEmpty(stringVal))
+			{
+				_baseDateValue = DateTime.ParseExact(stringVal, "yyyy-MM-dd", CultureInfo.InvariantCulture).Date;
+			}
+		}
+
+		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
+			"'" + GetDateTimeFromTimeOnly(AdjustTimeOnly((TimeOnly) value)).ToString(_sqlFormat) + "'";
+	}
+}
+#endif

--- a/src/NHibernate/Type/TimeOnlyAsDateTimeType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsDateTimeType.cs
@@ -15,7 +15,7 @@ namespace NHibernate.Type
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	/// This defaults the Date to "1753-01-01" - which should not matter because
+	/// This defaults the Date to "2000-01-01" - which should not matter because
 	/// using this Type indicates that you don't care about the Date portion of the DateTime.
 	/// However, if you need to adjust this base value, you can specify the parameter 'BaseDateValue' on the type mapping,
 	/// using the date format 'yyyy-MM-dd'
@@ -24,7 +24,7 @@ namespace NHibernate.Type
 	[Serializable]
 	public class TimeOnlyAsDateTimeType : AbstractTimeOnlyType<DateTime>, IParameterizedType
 	{
-		private DateTime _baseDateValue = new(1753, 01, 01);
+		private DateTime _baseDateValue = new(2000, 01, 01);
 		private readonly string _sqlFormat;
 		/// <summary>
 		/// Default constructor. Sets the fractional seconds precision (scale) to 0

--- a/src/NHibernate/Type/TimeOnlyAsDateTimeType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsDateTimeType.cs
@@ -61,7 +61,7 @@ namespace NHibernate.Type
 		}
 
 		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
-			"'" + GetDateTimeFromTimeOnly(AdjustTimeOnly((TimeOnly) value)).ToString(_sqlFormat) + "'";
+			dialect.ToStringLiteral(GetDateTimeFromTimeOnly(AdjustTimeOnly((TimeOnly) value)).ToString(_sqlFormat), SqlTypeFactory.GetAnsiString(50));
 	}
 }
 #endif

--- a/src/NHibernate/Type/TimeOnlyAsTicksType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsTicksType.cs
@@ -14,7 +14,6 @@ using NHibernate.Util;
 
 namespace NHibernate.Type
 {
-
 	/// <summary>
 	/// Maps a <see cref="System.TimeOnly" /> property to a <see cref="DbType.Int64" /> column.
 	/// The value persisted is the Ticks property of the TimeOnly value.
@@ -48,7 +47,7 @@ namespace NHibernate.Type
 		protected override long GetParameterValueToSet(TimeOnly timeOnly, ISessionImplementor session) => timeOnly.Ticks;
 
 		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
-			AdjustTimeOnly((TimeOnly) value).Ticks.ToString();
+			dialect.ToStringLiteral(AdjustTimeOnly((TimeOnly) value).Ticks.ToString(), SqlTypeFactory.GetAnsiString(50));
 	}
 }
 #endif

--- a/src/NHibernate/Type/TimeOnlyAsTicksType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsTicksType.cs
@@ -1,0 +1,54 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq.Expressions;
+using System.Reflection;
+using NHibernate.Engine;
+using NHibernate.Hql.Ast;
+using NHibernate.Linq.Functions;
+using NHibernate.Linq.Visitors;
+using NHibernate.SqlTypes;
+using NHibernate.Util;
+
+namespace NHibernate.Type
+{
+
+	/// <summary>
+	/// Maps a <see cref="System.TimeOnly" /> property to a <see cref="DbType.Int64" /> column.
+	/// The value persisted is the Ticks property of the TimeOnly value.
+	/// </summary>
+	[Serializable]
+	public class TimeOnlyAsTicksType : AbstractTimeOnlyType<long>
+	{
+		private static MemberInfo[] _supportedProperties = new MemberInfo[]{
+			ReflectHelper.GetProperty((TimeOnly x) => x.Hour),
+			ReflectHelper.GetProperty((TimeOnly x) => x.Minute),
+			ReflectHelper.GetProperty((TimeOnly x) => x.Second)
+		};
+
+		/// <summary>
+		/// Default constructor. Sets the fractional seconds precision (scale) to 0
+		/// </summary>
+		public TimeOnlyAsTicksType() : this(0)
+		{
+		}
+
+		/// <summary>
+		/// Constructor for specifying a fractional seconds precision (scale).
+		/// </summary>
+		/// <param name="fractionalSecondsPrecision">The fractional seconds precision. Any value beyond 7 is pointless, since it's the maximum precision allowed by .NET</param>
+		public TimeOnlyAsTicksType(byte fractionalSecondsPrecision) : base(fractionalSecondsPrecision, SqlTypeFactory.Int64)
+		{
+		}
+
+		protected override TimeOnly GetTimeOnlyFromReader(DbDataReader rs, int index, ISessionImplementor session) => new(rs.GetInt64(index));
+
+		protected override long GetParameterValueToSet(TimeOnly timeOnly, ISessionImplementor session) => timeOnly.Ticks;
+
+		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
+			AdjustTimeOnly((TimeOnly) value).Ticks.ToString();
+	}
+}
+#endif

--- a/src/NHibernate/Type/TimeOnlyAsTimeType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsTimeType.cs
@@ -1,0 +1,78 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using NHibernate.Engine;
+using NHibernate.SqlTypes;
+using NHibernate.UserTypes;
+
+namespace NHibernate.Type
+{
+	/// <summary>
+	/// Maps a <see cref="System.TimeOnly" /> Property to a <see cref="DbType.Time"/> column.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Some DB drivers will use a <see cref="TimeSpan"/> value for the <see cref="DbType.Time"/> column, whereas
+	/// others will use a full <see cref="System.DateTime" />. In the latter case, the date part defaults to
+	/// to "1753-01-01" - which should not matter because using this Type indicates that you don't care about the Date portion of the DateTime.
+	/// However, if you need to adjust this base value, you can specify the parameter 'BaseDateValue' on the type mapping,
+	/// using the date format 'yyyy-MM-dd'
+	/// </para>
+	/// </remarks>
+	[Serializable]
+	public class TimeOnlyAsTimeType : AbstractTimeOnlyType<object>, IParameterizedType
+	{
+		private DateTime BaseDateValue = new(1753, 01, 01);
+		private readonly string _sqlFormat;
+		
+		/// <summary>
+		/// Default constructor. Sets the fractional seconds precision (scale) to 0
+		/// </summary>
+		public TimeOnlyAsTimeType() : this(0)
+		{
+		}
+
+		/// <summary>
+		/// Constructor for specifying a fractional seconds precision (scale).
+		/// </summary>
+		/// <param name="fractionalSecondsPrecision">The fractional seconds precision. Any value beyond 7 is pointless, since it's the maximum precision allowed by .NET</param>
+		public TimeOnlyAsTimeType(byte fractionalSecondsPrecision) : base(fractionalSecondsPrecision, SqlTypeFactory.GetTime(fractionalSecondsPrecision))
+		{
+			_sqlFormat = "HH:mm:ss" + (fractionalSecondsPrecision > 0 ? "." + new string('F', Math.Min(7, (int) fractionalSecondsPrecision)) : "");
+		}
+
+		protected override TimeOnly GetTimeOnlyFromReader(DbDataReader rs, int index, ISessionImplementor session)
+		{
+			if (rs.GetFieldType(index) == typeof(TimeSpan)) //For those dialects where DbType.Time means TimeSpan.
+			{
+				return new TimeOnly(((TimeSpan)rs[index]).Ticks);
+			}
+
+			var dbValue = rs.GetDateTime(index);
+			return TimeOnly.FromTimeSpan(dbValue.TimeOfDay);
+		}
+
+		protected override object GetParameterValueToSet(TimeOnly timeOnly, ISessionImplementor session)
+		{
+			if (session.Factory.ConnectionProvider.Driver.RequiresTimeSpanForTime)
+				return timeOnly.ToTimeSpan();
+			else
+				return BaseDateValue + timeOnly.ToTimeSpan();
+		}
+
+		void IParameterizedType.SetParameterValues(IDictionary<string, string> parameters)
+		{
+			if (parameters.TryGetValue("BaseDateValue", out var stringVal) && !string.IsNullOrEmpty(stringVal))
+			{
+				BaseDateValue = DateTime.ParseExact(stringVal, "yyyy-MM-dd", CultureInfo.InvariantCulture).Date;
+			}
+		}
+
+		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
+			"'" + (AdjustTimeOnly((TimeOnly) value)).ToString(_sqlFormat) + "'";
+	}
+}
+#endif

--- a/src/NHibernate/Type/TimeOnlyAsTimeType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsTimeType.cs
@@ -48,7 +48,7 @@ namespace NHibernate.Type
 		{
 			if (rs.GetFieldType(index) == typeof(TimeSpan)) //For those dialects where DbType.Time means TimeSpan.
 			{
-				return new TimeOnly(((TimeSpan)rs[index]).Ticks);
+				return new TimeOnly(((TimeSpan) rs[index]).Ticks);
 			}
 
 			var dbValue = rs.GetDateTime(index);
@@ -72,7 +72,7 @@ namespace NHibernate.Type
 		}
 
 		public override string ObjectToSQLString(object value, Dialect.Dialect dialect) =>
-			"'" + (AdjustTimeOnly((TimeOnly) value)).ToString(_sqlFormat) + "'";
+			dialect.ToStringLiteral(AdjustTimeOnly((TimeOnly) value).ToString(_sqlFormat), SqlTypeFactory.GetAnsiString(50));
 	}
 }
 #endif

--- a/src/NHibernate/Type/TimeOnlyAsTimeType.cs
+++ b/src/NHibernate/Type/TimeOnlyAsTimeType.cs
@@ -17,7 +17,7 @@ namespace NHibernate.Type
 	/// <para>
 	/// Some DB drivers will use a <see cref="TimeSpan"/> value for the <see cref="DbType.Time"/> column, whereas
 	/// others will use a full <see cref="System.DateTime" />. In the latter case, the date part defaults to
-	/// to "1753-01-01" - which should not matter because using this Type indicates that you don't care about the Date portion of the DateTime.
+	/// to "2000-01-01" - which should not matter because using this Type indicates that you don't care about the Date portion of the DateTime.
 	/// However, if you need to adjust this base value, you can specify the parameter 'BaseDateValue' on the type mapping,
 	/// using the date format 'yyyy-MM-dd'
 	/// </para>
@@ -25,7 +25,7 @@ namespace NHibernate.Type
 	[Serializable]
 	public class TimeOnlyAsTimeType : AbstractTimeOnlyType<object>, IParameterizedType
 	{
-		private DateTime BaseDateValue = new(1753, 01, 01);
+		private DateTime BaseDateValue = new(2000, 01, 01);
 		private readonly string _sqlFormat;
 		
 		/// <summary>

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -343,6 +343,15 @@ namespace NHibernate.Type
 			// object needs to have both class and serializable setup before it can
 			// be created.
 			RegisterType(typeof (Object), NHibernateUtil.Object, new[] {"object"});
+
+
+#if NET6_0_OR_GREATER
+			RegisterType(typeof(DateOnly), NHibernateUtil.DateOnlyAsDate, new[] { "dateonly", "dateonlyasdate" });
+
+			RegisterType(typeof(TimeOnly), NHibernateUtil.TimeOnlyAsTime, new[] { "timeonly", "timeonlyastime" },
+				s => GetType(NHibernateUtil.TimeOnlyAsTime, s, scale => new TimeOnlyAsTimeType((byte) scale)),
+				false);
+#endif
 		}
 
 		/// <summary>
@@ -397,6 +406,17 @@ namespace NHibernate.Type
 						 l =>
 						 GetType(NHibernateUtil.Serializable, l,
 								 len => new SerializableType(typeof (object), SqlTypeFactory.GetBinary(len))));
+
+#if NET6_0_OR_GREATER
+			RegisterType(NHibernateUtil.TimeOnlyAsDateTime, new[] { "timeonlyasdatetime" },
+				s => GetType(NHibernateUtil.TimeOnlyAsDateTime, s, scale => new TimeOnlyAsDateTimeType((byte) scale)),
+				false);
+
+			RegisterType(NHibernateUtil.TimeOnlyAsTicks, new[] { "timeonlyasticks" },
+				s => GetType(NHibernateUtil.TimeOnlyAsTicks, s, scale => new TimeOnlyAsTicksType((byte) scale)),
+				false);
+#endif
+
 		}
 
 		private static ICollectionTypeFactory CollectionTypeFactory =>
@@ -916,6 +936,38 @@ namespace NHibernate.Type
 			var key = GetKeyForLengthOrScaleBased(NHibernateUtil.Time.Name, fractionalSecondsPrecision);
 			return (NullableType)typeByTypeOfName.GetOrAdd(key, k => new TimeType(SqlTypeFactory.GetTime(fractionalSecondsPrecision)));
 		}
+#if NET6_0_OR_GREATER
+		/// <summary>
+		/// Gets a <see cref="TimeOnlyAsDateTimeType" /> with desired fractional seconds precision.
+		/// </summary>
+		/// <returns>The NHibernate type.</returns>
+		public static NullableType GetTimeOnlyAsDateTimeType(byte fractionalSecondsPrecision)
+		{
+			var key = GetKeyForLengthOrScaleBased(NHibernateUtil.TimeOnlyAsDateTime.Name, fractionalSecondsPrecision);
+			return (NullableType) typeByTypeOfName.GetOrAdd(key, k => new TimeOnlyAsDateTimeType(fractionalSecondsPrecision));
+		}
+
+		/// <summary>
+		/// Gets a <see cref="TimeOnlyAsTicksType" /> with desired fractional seconds precision.
+		/// </summary>
+		/// <returns>The NHibernate type.</returns>
+		public static NullableType GetTimeOnlyAsTicksType(byte fractionalSecondsPrecision)
+		{
+			var key = GetKeyForLengthOrScaleBased(NHibernateUtil.TimeOnlyAsTicks.Name, fractionalSecondsPrecision);
+			return (NullableType) typeByTypeOfName.GetOrAdd(key, k => new TimeOnlyAsTimeType(fractionalSecondsPrecision));
+		}
+
+		/// <summary>
+		/// Gets a <see cref="TimeOnlyAsTimeType" /> with desired fractional seconds precision.
+		/// </summary>
+		/// <param name="fractionalSecondsPrecision">The fractional seconds precision.</param>
+		/// <returns>The NHibernate type.</returns>
+		public static NullableType GetTimeOnlyAsTimeType(byte fractionalSecondsPrecision)
+		{
+			var key = GetKeyForLengthOrScaleBased(NHibernateUtil.TimeOnlyAsTime.Name, fractionalSecondsPrecision);
+			return (NullableType) typeByTypeOfName.GetOrAdd(key, k => new TimeOnlyAsTimeType(fractionalSecondsPrecision));
+		}
+#endif
 
 		// Association Types
 

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -342,8 +342,7 @@ namespace NHibernate.Type
 
 			// object needs to have both class and serializable setup before it can
 			// be created.
-			RegisterType(typeof (Object), NHibernateUtil.Object, new[] {"object"});
-
+RegisterType(typeof (Object), NHibernateUtil.Object, new[] {"object"});
 
 #if NET6_0_OR_GREATER
 			RegisterType(typeof(DateOnly), NHibernateUtil.DateOnlyAsDate, new[] { "dateonly", "dateonlyasdate" });
@@ -936,6 +935,7 @@ namespace NHibernate.Type
 			var key = GetKeyForLengthOrScaleBased(NHibernateUtil.Time.Name, fractionalSecondsPrecision);
 			return (NullableType)typeByTypeOfName.GetOrAdd(key, k => new TimeType(SqlTypeFactory.GetTime(fractionalSecondsPrecision)));
 		}
+
 #if NET6_0_OR_GREATER
 		/// <summary>
 		/// Gets a <see cref="TimeOnlyAsDateTimeType" /> with desired fractional seconds precision.

--- a/src/NHibernate/Type/TypeFactory.cs
+++ b/src/NHibernate/Type/TypeFactory.cs
@@ -342,7 +342,7 @@ namespace NHibernate.Type
 
 			// object needs to have both class and serializable setup before it can
 			// be created.
-RegisterType(typeof (Object), NHibernateUtil.Object, new[] {"object"});
+			RegisterType(typeof (Object), NHibernateUtil.Object, new[] {"object"});
 
 #if NET6_0_OR_GREATER
 			RegisterType(typeof(DateOnly), NHibernateUtil.DateOnlyAsDate, new[] { "dateonly", "dateonlyasdate" });


### PR DESCRIPTION
Supporting DateOnly and TimeOnly. #2912 

I have have working implementations of types that can store the values as int (20251028, 163215), but that may be something that should reside elsewhere.

I would very much like to support projecting properties like "Hour" and "Minute", even though a "ticks" based type is used. I had an implementation where the type itself could implement IHqlGeneratorForProperty, and the DateTimePropertiesHqlGenerator checked for this before going the default route. It worked well, but...

1. Extracting the mapped type from the member expression is cumbersome.
2. It would be nice to be able to support this in plain HQL as well. Not just LINQ.

