### PR TITLE
Fixes query cache result transformer aliases issue

### DIFF
--- a/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
@@ -108,7 +108,7 @@ namespace NHibernate.Test.CacheTest
 		{
 			using (var s = OpenSession())
 			{
-				const string query = "select s.id_ as Id from Simple as s";
+				const string query = "select s.id_ as Id from Simple as s;";
 				var result1 = await (s
 					.CreateSQLQuery(query)
 					.SetCacheable(true)

--- a/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
@@ -11,6 +11,7 @@
 using System.Collections;
 using NHibernate.Cfg;
 using NHibernate.DomainModel;
+using NHibernate.Transform;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
 
@@ -100,6 +101,41 @@ namespace NHibernate.Test.CacheTest
 
 				Assert.That(result, Is.EqualTo(200012), "Unexpected cached result");
 			}
+		}
+
+		[Test]
+		public async Task QueryCacheWithAliasToBeanTransformerAsync()
+		{
+			using (var s = OpenSession())
+			{
+				const string query = "select s.id_ as Id from Simple as s";
+				var result1 = await (s
+					.CreateSQLQuery(query)
+					.SetCacheable(true)
+					.SetResultTransformer(Transformers.AliasToBean<SimpleDTO>())
+					.UniqueResultAsync());
+
+				Assert.That(result1, Is.InstanceOf<SimpleDTO>());
+				var dto1 = (SimpleDTO)result1;
+				Assert.That(dto1.Id, Is.EqualTo(1));
+
+				// Run a second time, just to test the query cache
+				var result2 = await (s
+					.CreateSQLQuery(query)
+					.SetCacheable(true)
+					.SetResultTransformer(Transformers.AliasToBean<SimpleDTO>())
+					.UniqueResultAsync());
+
+				Assert.That(result2, Is.InstanceOf<SimpleDTO>());
+				var dto2 = (SimpleDTO)result2;
+				Assert.That(dto2.Id, Is.EqualTo(1));
+			}
+		}
+
+		private class SimpleDTO
+		{
+			public long Id { get; set; }
+			public string Address { get; set; }
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
@@ -107,7 +107,10 @@ namespace NHibernate.Test.CacheTest
 		[Test]
 		public async Task QueryCacheWithAliasToBeanTransformerAsync()
 		{
-			const string query = "select s.id_ as Id from Simple as s;";
+			if (!TestDialect.HasActualIntegerTypes)
+				Assert.Ignore("Database does not support properly integers.");
+
+			const string query = "select s.id_ as Id from Simple s;";
 			Sfi.Statistics.Clear();
 
 			using (var s = OpenSession())

--- a/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
@@ -43,35 +43,48 @@ namespace NHibernate.Test.CacheTest
 		{
 			using var s = OpenSession();
 			using var t = s.BeginTransaction();
-				s.Delete("from Simple");
+			s.Delete("from Simple");
 			t.Commit();
 		}
 
 		[Test]
 		public async Task QueryCacheWithNullParametersAsync()
 		{
+			const string query = "from Simple s where s = :s or s.Name = :name or s.Address = :address";
+			Sfi.Statistics.Clear();
+			object simple;
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				const string query = "from Simple s where s = :s or s.Name = :name or s.Address = :address";
+				simple = await (s.LoadAsync(typeof(Simple), SimpleId));
 				await (s
 					.CreateQuery(query)
-					.SetEntity("s", await (s.LoadAsync(typeof(Simple), 1L)))
+					.SetEntity("s", simple)
 					.SetString("name", null)
 					.SetString("address", null)
 					.SetCacheable(true)
 					.UniqueResultAsync());
 
-				// Run a second time, just to test the query cache
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
+				await (t.CommitAsync());
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				// Run a second time, just to test the query cache.
 				var result = await (s
 					.CreateQuery(query)
-					.SetEntity("s", await (s.LoadAsync(typeof(Simple), 1L)))
+					.SetEntity("s", simple)
 					.SetString("name", null)
 					.SetString("address", null)
 					.SetCacheable(true)
 					.UniqueResultAsync());
 
 				Assert.That(result, Is.Not.Null);
-				Assert.That(s.GetIdentifier(result), Is.EqualTo(1));
+				Assert.That(s.GetIdentifier(result), Is.EqualTo(SimpleId));
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+				await (t.CommitAsync());
 			}
 		}
 
@@ -86,20 +99,31 @@ namespace NHibernate.Test.CacheTest
 			if (TestDialect.HasBrokenDecimalType)
 				Assert.Ignore("Database does not support properly decimals.");
 
+			const string query = "select cast(200012 as decimal) from Simple where id_ = 1";
+			Sfi.Statistics.Clear();
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				var result = await (s
-					.CreateSQLQuery("select cast(200012 as decimal) from Simple where id_ = 1")
+					.CreateSQLQuery(query)
 					.SetCacheable(true)
 					.UniqueResultAsync<decimal>());
 
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
 				Assert.That(result, Is.EqualTo(200012), "Unexpected non-cached result");
+				await (t.CommitAsync());
+			}
 
-				result = await (s
-					.CreateSQLQuery("select cast(200012 as decimal) from Simple where id_ = 1")
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+
+				var result = await (s
+					.CreateSQLQuery(query)
 					.SetCacheable(true)
 					.UniqueResultAsync<decimal>());
 
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
 				Assert.That(result, Is.EqualTo(200012), "Unexpected cached result");
 			}
 		}

--- a/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
@@ -30,20 +30,18 @@ namespace NHibernate.Test.CacheTest
 
 		protected override void OnSetUp()
 		{
-			using (var s = OpenSession())
-			{
+			using var s = OpenSession();
+			using var t = s.BeginTransaction();
 				s.Save(new Simple(), 1L);
-				s.Flush();
-			}
+			t.Commit();
 		}
 
 		protected override void OnTearDown()
 		{
-			using (var s = OpenSession())
-			{
+			using var s = OpenSession();
+			using var t = s.BeginTransaction();
 				s.Delete("from Simple");
-				s.Flush();
-			}
+			t.Commit();
 		}
 
 		[Test]
@@ -106,9 +104,11 @@ namespace NHibernate.Test.CacheTest
 		[Test]
 		public async Task QueryCacheWithAliasToBeanTransformerAsync()
 		{
+			const string query = "select s.id_ as Id from Simple as s;";
+
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				const string query = "select s.id_ as Id from Simple as s;";
 				var result1 = await (s
 					.CreateSQLQuery(query)
 					.SetCacheable(true)
@@ -116,10 +116,15 @@ namespace NHibernate.Test.CacheTest
 					.UniqueResultAsync());
 
 				Assert.That(result1, Is.InstanceOf<SimpleDTO>());
-				var dto1 = (SimpleDTO)result1;
+				var dto1 = (SimpleDTO) result1;
 				Assert.That(dto1.Id, Is.EqualTo(1));
+				await (t.CommitAsync());
+			}
 
-				// Run a second time, just to test the query cache
+			// Run a second time, just to test the query cache
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
 				var result2 = await (s
 					.CreateSQLQuery(query)
 					.SetCacheable(true)
@@ -127,8 +132,9 @@ namespace NHibernate.Test.CacheTest
 					.UniqueResultAsync());
 
 				Assert.That(result2, Is.InstanceOf<SimpleDTO>());
-				var dto2 = (SimpleDTO)result2;
+				var dto2 = (SimpleDTO) result2;
 				Assert.That(dto2.Id, Is.EqualTo(1));
+				await (t.CommitAsync());
 			}
 		}
 

--- a/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/Async/CacheTest/QueryCacheFixture.cs
@@ -26,13 +26,16 @@ namespace NHibernate.Test.CacheTest
 		protected override void Configure(Configuration configuration)
 		{
 			configuration.SetProperty(Environment.UseQueryCache, "true");
+			configuration.SetProperty(Environment.GenerateStatistics, "true");
 		}
+
+		private const long SimpleId = 1;
 
 		protected override void OnSetUp()
 		{
 			using var s = OpenSession();
 			using var t = s.BeginTransaction();
-				s.Save(new Simple(), 1L);
+			s.Save(new Simple(), SimpleId);
 			t.Commit();
 		}
 
@@ -105,6 +108,7 @@ namespace NHibernate.Test.CacheTest
 		public async Task QueryCacheWithAliasToBeanTransformerAsync()
 		{
 			const string query = "select s.id_ as Id from Simple as s;";
+			Sfi.Statistics.Clear();
 
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
@@ -117,11 +121,12 @@ namespace NHibernate.Test.CacheTest
 
 				Assert.That(result1, Is.InstanceOf<SimpleDTO>());
 				var dto1 = (SimpleDTO) result1;
-				Assert.That(dto1.Id, Is.EqualTo(1));
+				Assert.That(dto1.Id, Is.EqualTo(SimpleId), "Unexpected entity Id");
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0), "Unexpected query cache hit count");
 				await (t.CommitAsync());
 			}
 
-			// Run a second time, just to test the query cache
+			// Run a second time, just to test the query cache.
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
 			{
@@ -133,7 +138,8 @@ namespace NHibernate.Test.CacheTest
 
 				Assert.That(result2, Is.InstanceOf<SimpleDTO>());
 				var dto2 = (SimpleDTO) result2;
-				Assert.That(dto2.Id, Is.EqualTo(1));
+				Assert.That(dto2.Id, Is.EqualTo(SimpleId), "Unexpected entity Id");
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1), "Unexpected query cache hit count");
 				await (t.CommitAsync());
 			}
 		}

--- a/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using NHibernate.Cfg;
 using NHibernate.DomainModel;
+using NHibernate.Transform;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
 
@@ -89,6 +90,41 @@ namespace NHibernate.Test.CacheTest
 
 				Assert.That(result, Is.EqualTo(200012), "Unexpected cached result");
 			}
+		}
+
+		[Test]
+		public void QueryCacheWithAliasToBeanTransformer()
+		{
+			using (var s = OpenSession())
+			{
+				const string query = "select s.id_ as Id from Simple as s";
+				var result1 = s
+					.CreateSQLQuery(query)
+					.SetCacheable(true)
+					.SetResultTransformer(Transformers.AliasToBean<SimpleDTO>())
+					.UniqueResult();
+
+				Assert.That(result1, Is.InstanceOf<SimpleDTO>());
+				var dto1 = (SimpleDTO)result1;
+				Assert.That(dto1.Id, Is.EqualTo(1));
+
+				// Run a second time, just to test the query cache
+				var result2 = s
+					.CreateSQLQuery(query)
+					.SetCacheable(true)
+					.SetResultTransformer(Transformers.AliasToBean<SimpleDTO>())
+					.UniqueResult();
+
+				Assert.That(result2, Is.InstanceOf<SimpleDTO>());
+				var dto2 = (SimpleDTO)result2;
+				Assert.That(dto2.Id, Is.EqualTo(1));
+			}
+		}
+
+		private class SimpleDTO
+		{
+			public long Id { get; set; }
+			public string Address { get; set; }
 		}
 	}
 }

--- a/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
@@ -97,7 +97,7 @@ namespace NHibernate.Test.CacheTest
 		{
 			using (var s = OpenSession())
 			{
-				const string query = "select s.id_ as Id from Simple as s";
+				const string query = "select s.id_ as Id from Simple as s;";
 				var result1 = s
 					.CreateSQLQuery(query)
 					.SetCacheable(true)

--- a/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
@@ -96,7 +96,10 @@ namespace NHibernate.Test.CacheTest
 		[Test]
 		public void QueryCacheWithAliasToBeanTransformer()
 		{
-			const string query = "select s.id_ as Id from Simple as s;";
+			if (!TestDialect.HasActualIntegerTypes)
+				Assert.Ignore("Database does not support properly integers.");
+
+			const string query = "select s.id_ as Id from Simple s;";
 			Sfi.Statistics.Clear();
 
 			using (var s = OpenSession())

--- a/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
@@ -19,20 +19,18 @@ namespace NHibernate.Test.CacheTest
 
 		protected override void OnSetUp()
 		{
-			using (var s = OpenSession())
-			{
+			using var s = OpenSession();
+			using var t = s.BeginTransaction();
 				s.Save(new Simple(), 1L);
-				s.Flush();
-			}
+			t.Commit();
 		}
 
 		protected override void OnTearDown()
 		{
-			using (var s = OpenSession())
-			{
+			using var s = OpenSession();
+			using var t = s.BeginTransaction();
 				s.Delete("from Simple");
-				s.Flush();
-			}
+			t.Commit();
 		}
 
 		[Test]
@@ -95,9 +93,11 @@ namespace NHibernate.Test.CacheTest
 		[Test]
 		public void QueryCacheWithAliasToBeanTransformer()
 		{
+			const string query = "select s.id_ as Id from Simple as s;";
+
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				const string query = "select s.id_ as Id from Simple as s;";
 				var result1 = s
 					.CreateSQLQuery(query)
 					.SetCacheable(true)
@@ -105,10 +105,15 @@ namespace NHibernate.Test.CacheTest
 					.UniqueResult();
 
 				Assert.That(result1, Is.InstanceOf<SimpleDTO>());
-				var dto1 = (SimpleDTO)result1;
+				var dto1 = (SimpleDTO) result1;
 				Assert.That(dto1.Id, Is.EqualTo(1));
+				t.Commit();
+			}
 
-				// Run a second time, just to test the query cache
+			// Run a second time, just to test the query cache
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
 				var result2 = s
 					.CreateSQLQuery(query)
 					.SetCacheable(true)
@@ -116,8 +121,9 @@ namespace NHibernate.Test.CacheTest
 					.UniqueResult();
 
 				Assert.That(result2, Is.InstanceOf<SimpleDTO>());
-				var dto2 = (SimpleDTO)result2;
+				var dto2 = (SimpleDTO) result2;
 				Assert.That(dto2.Id, Is.EqualTo(1));
+				t.Commit();
 			}
 		}
 

--- a/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
@@ -15,13 +15,16 @@ namespace NHibernate.Test.CacheTest
 		protected override void Configure(Configuration configuration)
 		{
 			configuration.SetProperty(Environment.UseQueryCache, "true");
+			configuration.SetProperty(Environment.GenerateStatistics, "true");
 		}
+
+		private const long SimpleId = 1;
 
 		protected override void OnSetUp()
 		{
 			using var s = OpenSession();
 			using var t = s.BeginTransaction();
-				s.Save(new Simple(), 1L);
+			s.Save(new Simple(), SimpleId);
 			t.Commit();
 		}
 
@@ -94,6 +97,7 @@ namespace NHibernate.Test.CacheTest
 		public void QueryCacheWithAliasToBeanTransformer()
 		{
 			const string query = "select s.id_ as Id from Simple as s;";
+			Sfi.Statistics.Clear();
 
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
@@ -106,11 +110,12 @@ namespace NHibernate.Test.CacheTest
 
 				Assert.That(result1, Is.InstanceOf<SimpleDTO>());
 				var dto1 = (SimpleDTO) result1;
-				Assert.That(dto1.Id, Is.EqualTo(1));
+				Assert.That(dto1.Id, Is.EqualTo(SimpleId), "Unexpected entity Id");
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0), "Unexpected query cache hit count");
 				t.Commit();
 			}
 
-			// Run a second time, just to test the query cache
+			// Run a second time, just to test the query cache.
 			using (var s = OpenSession())
 			using (var t = s.BeginTransaction())
 			{
@@ -122,7 +127,8 @@ namespace NHibernate.Test.CacheTest
 
 				Assert.That(result2, Is.InstanceOf<SimpleDTO>());
 				var dto2 = (SimpleDTO) result2;
-				Assert.That(dto2.Id, Is.EqualTo(1));
+				Assert.That(dto2.Id, Is.EqualTo(SimpleId), "Unexpected entity Id");
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1), "Unexpected query cache hit count");
 				t.Commit();
 			}
 		}

--- a/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
+++ b/src/NHibernate.Test/CacheTest/QueryCacheFixture.cs
@@ -32,35 +32,48 @@ namespace NHibernate.Test.CacheTest
 		{
 			using var s = OpenSession();
 			using var t = s.BeginTransaction();
-				s.Delete("from Simple");
+			s.Delete("from Simple");
 			t.Commit();
 		}
 
 		[Test]
 		public void QueryCacheWithNullParameters()
 		{
+			const string query = "from Simple s where s = :s or s.Name = :name or s.Address = :address";
+			Sfi.Statistics.Clear();
+			object simple;
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				const string query = "from Simple s where s = :s or s.Name = :name or s.Address = :address";
+				simple = s.Load(typeof(Simple), SimpleId);
 				s
 					.CreateQuery(query)
-					.SetEntity("s", s.Load(typeof(Simple), 1L))
+					.SetEntity("s", simple)
 					.SetString("name", null)
 					.SetString("address", null)
 					.SetCacheable(true)
 					.UniqueResult();
 
-				// Run a second time, just to test the query cache
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
+				t.Commit();
+			}
+
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+				// Run a second time, just to test the query cache.
 				var result = s
 					.CreateQuery(query)
-					.SetEntity("s", s.Load(typeof(Simple), 1L))
+					.SetEntity("s", simple)
 					.SetString("name", null)
 					.SetString("address", null)
 					.SetCacheable(true)
 					.UniqueResult();
 
 				Assert.That(result, Is.Not.Null);
-				Assert.That(s.GetIdentifier(result), Is.EqualTo(1));
+				Assert.That(s.GetIdentifier(result), Is.EqualTo(SimpleId));
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
+				t.Commit();
 			}
 		}
 
@@ -75,20 +88,31 @@ namespace NHibernate.Test.CacheTest
 			if (TestDialect.HasBrokenDecimalType)
 				Assert.Ignore("Database does not support properly decimals.");
 
+			const string query = "select cast(200012 as decimal) from Simple where id_ = 1";
+			Sfi.Statistics.Clear();
 			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				var result = s
-					.CreateSQLQuery("select cast(200012 as decimal) from Simple where id_ = 1")
+					.CreateSQLQuery(query)
 					.SetCacheable(true)
 					.UniqueResult<decimal>();
 
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(0));
 				Assert.That(result, Is.EqualTo(200012), "Unexpected non-cached result");
+				t.Commit();
+			}
 
-				result = s
-					.CreateSQLQuery("select cast(200012 as decimal) from Simple where id_ = 1")
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
+			{
+
+				var result = s
+					.CreateSQLQuery(query)
 					.SetCacheable(true)
 					.UniqueResult<decimal>();
 
+				Assert.That(Sfi.Statistics.QueryCacheHitCount, Is.EqualTo(1));
 				Assert.That(result, Is.EqualTo(200012), "Unexpected cached result");
 			}
 		}

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -208,5 +208,10 @@ namespace NHibernate.Test
 		/// Some databases (MySql) don't support using main table aliases in subquery inside join ON clause
 		/// </summary>
 		public virtual bool SupportsCorrelatedColumnsInSubselectJoin => true;
+
+		/// <summary>
+		/// Some databases don't have actual integer types.
+		/// </summary>
+		public virtual bool HasActualIntegerTypes => true;
 	}
 }

--- a/src/NHibernate.Test/TestDialects/Oracle10gTestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/Oracle10gTestDialect.cs
@@ -30,5 +30,10 @@ namespace NHibernate.Test.TestDialects
 		/// <inheritdoc />
 		/// <remarks>Canceling a query hangs under Linux with OracleManagedDataClientDriver 21.6.1.</remarks>
 		public override bool SupportsCancelQuery => !RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+		/// <inheritdoc />
+		/// <remarks>Oracle does not have an actual integer type, it uses <c>number</c> instead, which is a
+		/// <c>decimal</c> type.</remarks>
+		public override bool HasActualIntegerTypes => false;
 	}
 }

--- a/src/NHibernate/Async/Loader/Loader.cs
+++ b/src/NHibernate/Async/Loader/Loader.cs
@@ -1391,6 +1391,7 @@ namespace NHibernate.Loader
 			else
 			{
 				result = queryCacheBuilder.GetResultList(result);
+				ApplyCachedMetadata(key.ResultTransformer);
 			}
 
 			result = TransformCacheableResults(queryParameters, key.ResultTransformer, result);

--- a/src/NHibernate/Loader/Custom/CustomLoader.cs
+++ b/src/NHibernate/Loader/Custom/CustomLoader.cs
@@ -380,6 +380,14 @@ namespace NHibernate.Loader.Custom
 					queryParameters.ResultTransformer, transformerAliases);
 		}
 
+		protected override void ApplyCachedMetadata(CacheableResultTransformer resultTransformer)
+		{
+			if (transformerAliases.Length == 0 && resultTransformer?.AutoDiscoveredAliases?.Length > 0)
+			{
+				transformerAliases = resultTransformer.AutoDiscoveredAliases;
+			}
+		}
+
 		protected override void ResetEffectiveExpectedType(IEnumerable<IParameterSpecification> parameterSpecs, QueryParameters queryParameters)
 		{
 			parameterSpecs.ResetEffectiveExpectedType(queryParameters);

--- a/src/NHibernate/Loader/Loader.cs
+++ b/src/NHibernate/Loader/Loader.cs
@@ -1894,11 +1894,16 @@ namespace NHibernate.Loader
 			else
 			{
 				result = queryCacheBuilder.GetResultList(result);
+				ApplyCachedMetadata(key.ResultTransformer);
 			}
 
 			result = TransformCacheableResults(queryParameters, key.ResultTransformer, result);
 
 			return GetResultList(result, queryParameters.ResultTransformer);
+		}
+
+		protected virtual void ApplyCachedMetadata(CacheableResultTransformer resultTransformer)
+		{
 		}
 
 		public IList TransformCacheableResults(QueryParameters queryParameters, CacheableResultTransformer transformer, IList result)


### PR DESCRIPTION
I don't know if this is the most elegant way to solve the issue, but it does solve it, at least for the case I found.
I'm not sure if other Loader sub-classes also need something similar.

fix #3713