### PR TITLE
Fix #3725: DbBatchBatcher empty batch execution bug

### DIFF
--- a/src/NHibernate.Test/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/BatcherFixture.cs
@@ -306,44 +306,54 @@ namespace NHibernate.Test.Ado
 		}
 
 		[Test]
-		[Description("The batcher should handle empty batch execution without throwing exceptions.")]
-		public void EmptyBatchShouldNotThrowException()
+		[Description("Inserting exactly BatchSize entities should not throw on commit. See GH-3725.")]
+		public void InsertExactlyBatchSizeEntitiesShouldNotThrowOnCommit()
 		{
-			// This test verifies that batchers handle empty batches correctly
-			// DbBatchBatcher had a bug where ExecuteBatch was called on an empty batch,
-			// causing InvalidOperationException: CommandText property has not been initialized
-			// See GH-3725
+			// This test verifies that DbBatchBatcher handles empty batches correctly.
+			// The bug (GH-3725): When inserting exactly BatchSize entities, the batch auto-executes
+			// when full (via ExecuteBatchWithTiming), which clears _currentBatch but NOT _batchCommand.
+			// On commit, ExecuteBatch() is called, sees _batchCommand is set, and calls DoExecuteBatch
+			// on an empty _currentBatch, causing InvalidOperationException.
 
-			using var session = OpenSession();
-			using var transaction = session.BeginTransaction();
+			// BatchSize is configured as 10 in this fixture
+			const int batchSize = 10;
 
-			// Execute queries that don't add to the batch
-			_ = session.Query<VerySimple>().FirstOrDefault();
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				// Insert exactly BatchSize entities - this fills the batch and triggers auto-execution
+				for (int i = 0; i < batchSize; i++)
+				{
+					session.Save(new VerySimple { Id = 1000 + i, Name = $"Test{i}", Weight = i * 1.1 });
+				}
 
-			// Prepare a new command which triggers ExecuteBatch on any existing batch
-			// If the previous command didn't add anything to the batch, this would fail
-			// before the fix with InvalidOperationException
-			_ = session.Query<VerySimple>().FirstOrDefault();
+				// Commit triggers ExecuteBatch() which would fail on empty batch without the fix
+				transaction.Commit();
+			}
 
-			// Test passes if no exception is thrown
-			transaction.Commit();
+			Cleanup();
 		}
 
 		[Test]
-		[Description("Flush with no pending operations should handle empty batch correctly.")]
-		public void FlushEmptyBatchShouldNotThrowException()
+		[Description("Inserting a multiple of BatchSize entities should not throw on commit. See GH-3725.")]
+		public void InsertMultipleOfBatchSizeEntitiesShouldNotThrowOnCommit()
 		{
-			using var session = OpenSession();
-			using var transaction = session.BeginTransaction();
+			// Same issue as above but with multiple full batches
+			const int batchSize = 10;
+			const int multiplier = 3;
 
-			// Query without any modifications
-			var count = session.Query<VerySimple>().Count();
-			Assert.That(count, Is.GreaterThanOrEqualTo(0));
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				for (int i = 0; i < batchSize * multiplier; i++)
+				{
+					session.Save(new VerySimple { Id = 2000 + i, Name = $"Test{i}", Weight = i * 1.1 });
+				}
 
-			// Flush with no pending batch operations should not throw
-			Assert.DoesNotThrow(() => session.Flush());
+				transaction.Commit();
+			}
 
-			transaction.Commit();
+			Cleanup();
 		}
 	}
 }

--- a/src/NHibernate.Test/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/BatcherFixture.cs
@@ -27,11 +27,13 @@ namespace NHibernate.Test.Ado
 			get { return new[] { "Ado.VerySimple.hbm.xml", "Ado.AlmostSimple.hbm.xml" }; }
 		}
 
+		private const int BatchSize = 10;
+
 		protected override void Configure(Configuration configuration)
 		{
 			configuration.SetProperty(Environment.FormatSql, "true");
 			configuration.SetProperty(Environment.GenerateStatistics, "true");
-			configuration.SetProperty(Environment.BatchSize, "10");
+			configuration.SetProperty(Environment.BatchSize, BatchSize.ToString());
 			#if NET6_0_OR_GREATER
 			if (_useDbBatch)
 			{
@@ -315,19 +317,18 @@ namespace NHibernate.Test.Ado
 			// On commit, ExecuteBatch() is called, sees _batchCommand is set, and calls DoExecuteBatch
 			// on an empty _currentBatch, causing InvalidOperationException.
 
-			// BatchSize is configured as 10 in this fixture
-			const int batchSize = 10;
-
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
-				// Insert exactly BatchSize entities - this fills the batch and triggers auto-execution
-				for (int i = 0; i < batchSize; i++)
+				// Insert exactly BatchSize entities - this fills the batch and triggers auto-execution.
+				for (int i = 0; i < BatchSize; i++)
 				{
 					session.Save(new VerySimple { Id = 1000 + i, Name = $"Test{i}", Weight = i * 1.1 });
 				}
 
-				// Commit triggers ExecuteBatch() which would fail on empty batch without the fix
+				// Commit triggers ExecuteBatch() which would fail on empty batch without the fix,
+				// depending on the driver. It fails with Microsoft.Data.SqlClient by example, not with
+				// System.Data.SqlClient.
 				transaction.Commit();
 			}
 

--- a/src/NHibernate.Test/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/BatcherFixture.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NUnit.Framework;
@@ -302,6 +303,47 @@ namespace NHibernate.Test.Ado
 
 			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			Cleanup();
+		}
+
+		[Test]
+		[Description("The batcher should handle empty batch execution without throwing exceptions.")]
+		public void EmptyBatchShouldNotThrowException()
+		{
+			// This test verifies that batchers handle empty batches correctly
+			// DbBatchBatcher had a bug where ExecuteBatch was called on an empty batch,
+			// causing InvalidOperationException: CommandText property has not been initialized
+			// See GH-3725
+
+			using var session = OpenSession();
+			using var transaction = session.BeginTransaction();
+
+			// Execute queries that don't add to the batch
+			_ = session.Query<VerySimple>().FirstOrDefault();
+
+			// Prepare a new command which triggers ExecuteBatch on any existing batch
+			// If the previous command didn't add anything to the batch, this would fail
+			// before the fix with InvalidOperationException
+			_ = session.Query<VerySimple>().FirstOrDefault();
+
+			// Test passes if no exception is thrown
+			transaction.Commit();
+		}
+
+		[Test]
+		[Description("Flush with no pending operations should handle empty batch correctly.")]
+		public void FlushEmptyBatchShouldNotThrowException()
+		{
+			using var session = OpenSession();
+			using var transaction = session.BeginTransaction();
+
+			// Query without any modifications
+			var count = session.Query<VerySimple>().Count();
+			Assert.That(count, Is.GreaterThanOrEqualTo(0));
+
+			// Flush with no pending batch operations should not throw
+			Assert.DoesNotThrow(() => session.Flush());
+
+			transaction.Commit();
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
@@ -39,11 +39,13 @@ namespace NHibernate.Test.Ado
 			get { return new[] { "Ado.VerySimple.hbm.xml", "Ado.AlmostSimple.hbm.xml" }; }
 		}
 
+		private const int BatchSize = 10;
+
 		protected override void Configure(Configuration configuration)
 		{
 			configuration.SetProperty(Environment.FormatSql, "true");
 			configuration.SetProperty(Environment.GenerateStatistics, "true");
-			configuration.SetProperty(Environment.BatchSize, "10");
+			configuration.SetProperty(Environment.BatchSize, BatchSize.ToString());
 			#if NET6_0_OR_GREATER
 			if (_useDbBatch)
 			{
@@ -287,19 +289,18 @@ namespace NHibernate.Test.Ado
 			// On commit, ExecuteBatch() is called, sees _batchCommand is set, and calls DoExecuteBatch
 			// on an empty _currentBatch, causing InvalidOperationException.
 
-			// BatchSize is configured as 10 in this fixture
-			const int batchSize = 10;
-
 			using (var session = OpenSession())
 			using (var transaction = session.BeginTransaction())
 			{
-				// Insert exactly BatchSize entities - this fills the batch and triggers auto-execution
-				for (int i = 0; i < batchSize; i++)
+				// Insert exactly BatchSize entities - this fills the batch and triggers auto-execution.
+				for (int i = 0; i < BatchSize; i++)
 				{
 					await (session.SaveAsync(new VerySimple { Id = 1000 + i, Name = $"Test{i}", Weight = i * 1.1 }));
 				}
 
-				// Commit triggers ExecuteBatch() which would fail on empty batch without the fix
+				// Commit triggers ExecuteBatch() which would fail on empty batch without the fix,
+				// depending on the driver. It fails with Microsoft.Data.SqlClient by example, not with
+				// System.Data.SqlClient.
 				await (transaction.CommitAsync());
 			}
 

--- a/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
@@ -8,9 +8,11 @@
 //------------------------------------------------------------------------------
 
 
+using System.Linq;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using NHibernate.Linq;
 
 namespace NHibernate.Test.Ado
 {
@@ -274,6 +276,47 @@ namespace NHibernate.Test.Ado
 
 			Assert.That(Sfi.Statistics.PrepareStatementCount, Is.EqualTo(1));
 			await (CleanupAsync());
+		}
+
+		[Test]
+		[Description("The batcher should handle empty batch execution without throwing exceptions.")]
+		public async Task EmptyBatchShouldNotThrowExceptionAsync()
+		{
+			// This test verifies that batchers handle empty batches correctly
+			// DbBatchBatcher had a bug where ExecuteBatch was called on an empty batch,
+			// causing InvalidOperationException: CommandText property has not been initialized
+			// See GH-3725
+
+			using var session = OpenSession();
+			using var transaction = session.BeginTransaction();
+
+			// Execute queries that don't add to the batch
+			_ = await (session.Query<VerySimple>().FirstOrDefaultAsync());
+
+			// Prepare a new command which triggers ExecuteBatch on any existing batch
+			// If the previous command didn't add anything to the batch, this would fail
+			// before the fix with InvalidOperationException
+			_ = await (session.Query<VerySimple>().FirstOrDefaultAsync());
+
+			// Test passes if no exception is thrown
+			await (transaction.CommitAsync());
+		}
+
+		[Test]
+		[Description("Flush with no pending operations should handle empty batch correctly.")]
+		public async Task FlushEmptyBatchShouldNotThrowExceptionAsync()
+		{
+			using var session = OpenSession();
+			using var transaction = session.BeginTransaction();
+
+			// Query without any modifications
+			var count = await (session.Query<VerySimple>().CountAsync());
+			Assert.That(count, Is.GreaterThanOrEqualTo(0));
+
+			// Flush with no pending batch operations should not throw
+			Assert.DoesNotThrowAsync(() => session.FlushAsync());
+
+			await (transaction.CommitAsync());
 		}
 	}
 }

--- a/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
+++ b/src/NHibernate.Test/Async/Ado/BatcherFixture.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
 using NUnit.Framework;
-using NHibernate.Linq;
 
 namespace NHibernate.Test.Ado
 {
@@ -279,44 +278,54 @@ namespace NHibernate.Test.Ado
 		}
 
 		[Test]
-		[Description("The batcher should handle empty batch execution without throwing exceptions.")]
-		public async Task EmptyBatchShouldNotThrowExceptionAsync()
+		[Description("Inserting exactly BatchSize entities should not throw on commit. See GH-3725.")]
+		public async Task InsertExactlyBatchSizeEntitiesShouldNotThrowOnCommitAsync()
 		{
-			// This test verifies that batchers handle empty batches correctly
-			// DbBatchBatcher had a bug where ExecuteBatch was called on an empty batch,
-			// causing InvalidOperationException: CommandText property has not been initialized
-			// See GH-3725
+			// This test verifies that DbBatchBatcher handles empty batches correctly.
+			// The bug (GH-3725): When inserting exactly BatchSize entities, the batch auto-executes
+			// when full (via ExecuteBatchWithTiming), which clears _currentBatch but NOT _batchCommand.
+			// On commit, ExecuteBatch() is called, sees _batchCommand is set, and calls DoExecuteBatch
+			// on an empty _currentBatch, causing InvalidOperationException.
 
-			using var session = OpenSession();
-			using var transaction = session.BeginTransaction();
+			// BatchSize is configured as 10 in this fixture
+			const int batchSize = 10;
 
-			// Execute queries that don't add to the batch
-			_ = await (session.Query<VerySimple>().FirstOrDefaultAsync());
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				// Insert exactly BatchSize entities - this fills the batch and triggers auto-execution
+				for (int i = 0; i < batchSize; i++)
+				{
+					await (session.SaveAsync(new VerySimple { Id = 1000 + i, Name = $"Test{i}", Weight = i * 1.1 }));
+				}
 
-			// Prepare a new command which triggers ExecuteBatch on any existing batch
-			// If the previous command didn't add anything to the batch, this would fail
-			// before the fix with InvalidOperationException
-			_ = await (session.Query<VerySimple>().FirstOrDefaultAsync());
+				// Commit triggers ExecuteBatch() which would fail on empty batch without the fix
+				await (transaction.CommitAsync());
+			}
 
-			// Test passes if no exception is thrown
-			await (transaction.CommitAsync());
+			await (CleanupAsync());
 		}
 
 		[Test]
-		[Description("Flush with no pending operations should handle empty batch correctly.")]
-		public async Task FlushEmptyBatchShouldNotThrowExceptionAsync()
+		[Description("Inserting a multiple of BatchSize entities should not throw on commit. See GH-3725.")]
+		public async Task InsertMultipleOfBatchSizeEntitiesShouldNotThrowOnCommitAsync()
 		{
-			using var session = OpenSession();
-			using var transaction = session.BeginTransaction();
+			// Same issue as above but with multiple full batches
+			const int batchSize = 10;
+			const int multiplier = 3;
 
-			// Query without any modifications
-			var count = await (session.Query<VerySimple>().CountAsync());
-			Assert.That(count, Is.GreaterThanOrEqualTo(0));
+			using (var session = OpenSession())
+			using (var transaction = session.BeginTransaction())
+			{
+				for (int i = 0; i < batchSize * multiplier; i++)
+				{
+					await (session.SaveAsync(new VerySimple { Id = 2000 + i, Name = $"Test{i}", Weight = i * 1.1 }));
+				}
 
-			// Flush with no pending batch operations should not throw
-			Assert.DoesNotThrowAsync(() => session.FlushAsync());
+				await (transaction.CommitAsync());
+			}
 
-			await (transaction.CommitAsync());
+			await (CleanupAsync());
 		}
 	}
 }

--- a/src/NHibernate/AdoNet/DbBatchBatcher.cs
+++ b/src/NHibernate/AdoNet/DbBatchBatcher.cs
@@ -115,6 +115,12 @@ namespace NHibernate.AdoNet
 
 		protected override void DoExecuteBatch(DbCommand ps)
 		{
+			if (_currentBatch.BatchCommands.Count == 0)
+			{
+				Expectations.VerifyOutcomeBatched(_totalExpectedRowsAffected, 0, ps);
+				return;
+			}
+
 			try
 			{
 				Log.Debug("Executing batch");
@@ -145,6 +151,12 @@ namespace NHibernate.AdoNet
 		protected override async Task DoExecuteBatchAsync(DbCommand ps, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
+			if (_currentBatch.BatchCommands.Count == 0)
+			{
+				Expectations.VerifyOutcomeBatched(_totalExpectedRowsAffected, 0, ps);
+				return;
+			}
+
 			try
 			{
 				Log.Debug("Executing batch");


### PR DESCRIPTION
Fixes #3725

  ## Description

  `DbBatchBatcher` throws `InvalidOperationException` when attempting to execute an empty batch, while
  `GenericBatchingBatcher` and `SqlClientBatchingBatcher` handle this scenario correctly.

  ## Root Cause

  `DbBatchBatcher.DoExecuteBatch()` and `DoExecuteBatchAsync()` lack empty batch validation. When `ExecuteBatch()`
  is called with an empty batch (`_currentBatch.BatchCommands.Count == 0`), the code attempts to execute a `DbBatch`
   with no commands, causing:

  System.InvalidOperationException: ExecuteNonQuery: CommandText property has not been initialized

  ## Changes

  Added empty batch check at the beginning of both methods, matching the pattern used in `GenericBatchingBatcher`:

  ```csharp
  if (_currentBatch.BatchCommands.Count == 0)
  {
      Expectations.VerifyOutcomeBatched(_totalExpectedRowsAffected, 0, ps);
      return;
  }
```
  Modified:
  - src/NHibernate/AdoNet/DbBatchBatcher.cs - Added guard clauses to DoExecuteBatch() and DoExecuteBatchAsync()

  Added:
  - Test cases in src/NHibernate.Test/Ado/BatcherFixture.cs verifying the fix
  - Generated async test counterparts
