### PR TITLE
Switch macos-13 tests to macos-26-intel

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -8,8 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         DB: [SQLite]
-        # macos: SQLite.Core 1.x lacks an arm64 interop lib and so requires an intel macos image. Switching to SQLite 2
-        # (without .Core suffix) might allow to run on arm64. See https://system.data.sqlite.org
+        # macos: SQLite.Core 1.x lacks an arm64 interop lib and so requires an intel macos image. There are no latest
+        # such images, excepted -large but they require a paying GitHub account. https://github.com/actions/runner-images
+        # Switching to SQLite 2 (without .Core suffix) might allow to run on arm64. See https://system.data.sqlite.org
         OS: [ubuntu-latest, windows-latest, macos-26-intel]
         include:
           - DB: SqlServer2008

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -10,8 +10,7 @@ jobs:
         DB: [SQLite]
         # macos: SQLite.Core 1.x lacks an arm64 interop lib and so requires an intel macos image. Switching to SQLite 2
         # (without .Core suffix) might allow to run on arm64. See https://system.data.sqlite.org
-        # -large macos images are currently intel only. See https://github.com/actions/runner-images
-        OS: [ubuntu-latest, windows-latest, macos-latest-large]
+        OS: [ubuntu-latest, windows-latest, macos-26-intel]
         include:
           - DB: SqlServer2008
             CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         DB: [SQLite]
-        # macos: SQLite.Core 1.x lacks an arm64 interop lib and so requires an intel macos image. There are no latest
-        # such images, excepted -large but they require a paying GitHub account. https://github.com/actions/runner-images
-        # Switching to SQLite 2 (without .Core suffix) might allow to run on arm64. See https://system.data.sqlite.org
+        # macos: System.Data.SQLite.Core 1.x lacks an arm64 interop lib and so requires an intel macos image. There are
+        # no latest such images, excepted -large but they require a paying GitHub account. https://github.com/actions/runner-images
+        # Switching to System.Data.SQLite 2 (without .Core suffix) might allow to run on arm64. See https://system.data.sqlite.org
         OS: [ubuntu-latest, windows-latest, macos-26-intel]
         include:
           - DB: SqlServer2008

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         DB: [SQLite]
-        OS: [ubuntu-latest, windows-latest, macos-13]
+        OS: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - DB: SqlServer2008
             CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -8,7 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         DB: [SQLite]
-        OS: [ubuntu-latest, windows-latest, macos-latest]
+        # macos: SQLite.Core 1.x lacks an arm64 interop lib and so requires an intel macos image. Switching to SQLite 2
+        # (without .Core suffix) might allow to run on arm64. See https://system.data.sqlite.org
+        # -large macos images are currently intel only. See https://github.com/actions/runner-images
+        OS: [ubuntu-latest, windows-latest, macos-latest-large]
         include:
           - DB: SqlServer2008
             CONNECTION_STRING: "Server=localhost;initial catalog=nhibernate;User Id=sa;Password=P@ssw0rd;packet size=4096;"


### PR DESCRIPTION
macos-13 has been removed out of GitHub actions.