### PR TITLE
Add Firebird3Dialect using standard offset/fetch paging

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -1453,6 +1453,19 @@ in the parameter binding.</programlisting>
                             </entry>
                         </row>
                         <row>
+                            <entry>Firebird 3</entry>
+                            <entry><literal>NHibernate.Dialect.Firebird3Dialect</literal></entry>
+                            <entry>
+                                Uses the SQL standard <literal>offset</literal>/<literal>fetch</literal>
+                                clause for paging.
+                            </entry>
+                        </row>
+                        <row>
+                            <entry>Firebird 4</entry>
+                            <entry><literal>NHibernate.Dialect.Firebird4Dialect</literal></entry>
+                            <entry></entry>
+                        </row>
+                        <row>
                             <entry>Informix</entry>
                             <entry><literal>NHibernate.Dialect.InformixDialect</literal></entry>
                             <entry></entry>

--- a/src/NHibernate.Test/Async/DriverTest/FirebirdClientDriverFixture.cs
+++ b/src/NHibernate.Test/Async/DriverTest/FirebirdClientDriverFixture.cs
@@ -238,6 +238,20 @@ namespace NHibernate.Test.DriverTest
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType, paramType });
 		}
 
+		private DbCommand BuildOffsetFetchPagingCommand(SqlType paramType)
+		{
+			var sqlString =
+				new SqlStringBuilder()
+					.Add("select col1 from table offset ")
+					.AddParameter()
+					.Add(" rows fetch first ")
+					.AddParameter()
+					.Add(" rows only")
+					.ToSqlString();
+
+			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType, paramType });
+		}
+
 		private DbCommand BuildInCommand(SqlType paramType)
 		{
 			var sqlString =

--- a/src/NHibernate.Test/Async/Hql/Ast/LimitClauseFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/LimitClauseFixture.cs
@@ -123,30 +123,29 @@ namespace NHibernate.Test.Hql.Ast
 			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
 			const string hql = "from Human h order by h.bodyWeight skip :pSkip take :pTake";
 
-			using (var s = OpenSession())
-			using (var txn = s.BeginTransaction())
-			{
-				var actual = (await (s.CreateQuery(hql)
-					.SetInt32("pSkip", 1)
-					.SetInt32("pTake", 3).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
+			using var s = OpenSession();
+			using var txn = s.BeginTransaction();
 
-				// Same query string, so same query plan, but other paging values.
-				actual = (await (s.CreateQuery(hql)
-					.SetInt32("pSkip", 2)
-					.SetInt32("pTake", 2).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
+			var actual = (await (s.CreateQuery(hql)
+				.SetInt32("pSkip", 1)
+				.SetInt32("pTake", 3).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
 
-				// Same query instance, re-executed with other paging values.
-				var query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
-				actual = (await (query.ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
+			// Same query string, so same query plan, but other paging values.
+			actual = (await (s.CreateQuery(hql)
+				.SetInt32("pSkip", 2)
+				.SetInt32("pTake", 2).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
 
-				actual = (await (query.SetInt32("pSkip", 0).SetInt32("pTake", 2).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {5f, 6f}), "fourth execution");
+			// Same query instance, re-executed with other paging values.
+			var query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
+			actual = (await (query.ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
 
-				await (txn.CommitAsync());
-			}
+			actual = (await (query.SetInt32("pSkip", 0).SetInt32("pTake", 2).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {5f, 6f}), "fourth execution");
+
+			await (txn.CommitAsync());
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Async/Hql/Ast/LimitClauseFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/LimitClauseFixture.cs
@@ -117,6 +117,39 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
+		public async Task SkipTakeWithParameterReExecutedWithOtherValuesAsync()
+		{
+			// NH-2731: the limit parameters must be recomputed, according to the dialect
+			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
+			const string hql = "from Human h order by h.bodyWeight skip :pSkip take :pTake";
+
+			using (ISession s = OpenSession())
+			using (ITransaction txn = s.BeginTransaction())
+			{
+				float[] actual = (await (s.CreateQuery(hql)
+					.SetInt32("pSkip", 1)
+					.SetInt32("pTake", 3).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
+
+				// Same query string, so same query plan, but other paging values.
+				actual = (await (s.CreateQuery(hql)
+					.SetInt32("pSkip", 2)
+					.SetInt32("pTake", 2).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
+
+				// Same query instance, re-executed with other paging values.
+				IQuery query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
+				actual = (await (query.ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
+
+				actual = (await (query.SetInt32("pSkip", 0).SetInt32("pTake", 2).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {5f, 6f}), "fourth execution");
+
+				await (txn.CommitAsync());
+			}
+		}
+
+		[Test]
 		public async Task SkipTakeWithParameterListAsync()
 		{
 			ISession s = OpenSession();

--- a/src/NHibernate.Test/Async/Hql/Ast/LimitClauseFixture.cs
+++ b/src/NHibernate.Test/Async/Hql/Ast/LimitClauseFixture.cs
@@ -123,10 +123,10 @@ namespace NHibernate.Test.Hql.Ast
 			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
 			const string hql = "from Human h order by h.bodyWeight skip :pSkip take :pTake";
 
-			using (ISession s = OpenSession())
-			using (ITransaction txn = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var txn = s.BeginTransaction())
 			{
-				float[] actual = (await (s.CreateQuery(hql)
+				var actual = (await (s.CreateQuery(hql)
 					.SetInt32("pSkip", 1)
 					.SetInt32("pTake", 3).ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
 				Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
@@ -138,7 +138,7 @@ namespace NHibernate.Test.Hql.Ast
 				Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
 
 				// Same query instance, re-executed with other paging values.
-				IQuery query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
+				var query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
 				actual = (await (query.ListAsync<Human>())).Select(h => h.BodyWeight).ToArray();
 				Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
 

--- a/src/NHibernate.Test/Async/Pagination/PaginationFixture.cs
+++ b/src/NHibernate.Test/Async/Pagination/PaginationFixture.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Linq;
 using NHibernate.Cfg;
 using NHibernate.Criterion;
 using NHibernate.Dialect;
@@ -73,6 +74,57 @@ namespace NHibernate.Test.Pagination
 			}
 
 			using(ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				await (s.DeleteAsync("from DataPoint"));
+				await (t.CommitAsync());
+			}
+		}
+
+		[Test]
+		public async Task PagingParametersUpdatedOnEachExecution_NH2731Async()
+		{
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				for (int i = 4; i <= 8; i++)
+				{
+					await (s.SaveAsync(new DataPoint { X = i }));
+				}
+				await (t.CommitAsync());
+			}
+
+			// NH-2731: the limit parameters must be recomputed, according to the dialect
+			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				var query = s.CreateQuery("from DataPoint dp order by dp.X").SetFirstResult(1).SetMaxResults(2);
+				Assert.That(
+					(await (query.ListAsync<DataPoint>())).Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 5d, 6d }),
+					"first execution");
+
+				Assert.That(
+					(await (query.SetFirstResult(3).SetMaxResults(1).ListAsync<DataPoint>())).Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 7d }),
+					"second execution");
+
+				var criteria = s.CreateCriteria<DataPoint>().AddOrder(Order.Asc("X")).SetFirstResult(2).SetMaxResults(2);
+				Assert.That(
+					(await (criteria.ListAsync<DataPoint>())).Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 6d, 7d }),
+					"first criteria execution");
+
+				Assert.That(
+					(await (criteria.SetFirstResult(0).SetMaxResults(3).ListAsync<DataPoint>())).Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 4d, 5d, 6d }),
+					"second criteria execution");
+
+				await (t.CommitAsync());
+			}
+
+			using (ISession s = OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				await (s.DeleteAsync("from DataPoint"));

--- a/src/NHibernate.Test/Async/Pagination/PaginationFixture.cs
+++ b/src/NHibernate.Test/Async/Pagination/PaginationFixture.cs
@@ -84,10 +84,10 @@ namespace NHibernate.Test.Pagination
 		[Test]
 		public async Task PagingParametersUpdatedOnEachExecution_NH2731Async()
 		{
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				for (int i = 4; i <= 8; i++)
+				for (var i = 4; i <= 8; i++)
 				{
 					await (s.SaveAsync(new DataPoint { X = i }));
 				}
@@ -96,8 +96,8 @@ namespace NHibernate.Test.Pagination
 
 			// NH-2731: the limit parameters must be recomputed, according to the dialect
 			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				var query = s.CreateQuery("from DataPoint dp order by dp.X").SetFirstResult(1).SetMaxResults(2);
 				Assert.That(
@@ -124,8 +124,8 @@ namespace NHibernate.Test.Pagination
 				await (t.CommitAsync());
 			}
 
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				await (s.DeleteAsync("from DataPoint"));
 				await (t.CommitAsync());

--- a/src/NHibernate.Test/DialectTest/Firebird3DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/Firebird3DialectFixture.cs
@@ -1,0 +1,56 @@
+using NHibernate.Dialect;
+using NHibernate.SqlCommand;
+using NUnit.Framework;
+
+namespace NHibernate.Test.DialectTest
+{
+	[TestFixture]
+	public class Firebird3DialectFixture
+	{
+		private readonly Firebird3Dialect _dialect = new Firebird3Dialect();
+
+		[Test]
+		public void GetLimitStringWithLimitOnly()
+		{
+			var str = _dialect.GetLimitString(new SqlString("select * from fish"), null, new SqlString("10"));
+			Assert.That(str.ToString(), Is.EqualTo("select * from fish fetch first 10 rows only"));
+		}
+
+		[Test]
+		public void GetLimitStringWithOffsetOnly()
+		{
+			var str = _dialect.GetLimitString(new SqlString("select * from fish order by name"), new SqlString("5"), null);
+			Assert.That(str.ToString(), Is.EqualTo("select * from fish order by name offset 5 rows"));
+		}
+
+		[Test]
+		public void GetLimitStringWithOffsetAndLimit()
+		{
+			var str = _dialect.GetLimitString(new SqlString("select * from fish order by name"), new SqlString("5"), new SqlString("15"));
+			Assert.That(str.ToString(), Is.EqualTo("select * from fish order by name offset 5 rows fetch first 15 rows only"));
+		}
+
+		[Test]
+		public void GetLimitStringWithParameters()
+		{
+			var str = _dialect.GetLimitString(
+				new SqlString("select * from fish order by name"),
+				5,
+				15,
+				Parameter.Placeholder,
+				Parameter.Placeholder);
+
+			Assert.That(str.ToString(), Is.EqualTo("select * from fish order by name offset ? rows fetch first ? rows only"));
+		}
+
+		[Test]
+		public void LimitAndOffsetAreNotAdjusted()
+		{
+			// The standard offset/fetch clause takes a zero based offset and a row count.
+			Assert.That(_dialect.OffsetStartsAtOne, Is.False, "OffsetStartsAtOne");
+			Assert.That(_dialect.UseMaxForLimit, Is.False, "UseMaxForLimit");
+			Assert.That(_dialect.SupportsVariableLimit, Is.True, "SupportsVariableLimit");
+			Assert.That(_dialect.SupportsLimitOffset, Is.True, "SupportsLimitOffset");
+		}
+	}
+}

--- a/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
@@ -200,6 +200,20 @@ namespace NHibernate.Test.DriverTest
 		}
 
 		[Test]
+		public void AdjustCommand_ParameterWithinOffsetFetchPaging_ParameterIsNotCasted()
+		{
+			// Firebird only accepts an integer literal or a parameter in the offset/fetch clause,
+			// casts are a syntax error there.
+			using (var cmd = BuildOffsetFetchPagingCommand(SqlTypeFactory.Int32))
+			{
+				_driver.AdjustCommand(cmd);
+
+				var expected = "select col1 from table offset @p0 rows fetch first @p1 rows only";
+				Assert.That(cmd.CommandText, Is.EqualTo(expected));
+			}
+		}
+
+		[Test]
 		public void AdjustCommand_ParameterWithinIn_ParameterIsNotCasted()
 		{
 			using (var cmd = BuildInCommand(SqlTypeFactory.GetString(255)))
@@ -403,6 +417,20 @@ namespace NHibernate.Test.DriverTest
 					.Add(" skip ")
 					.AddParameter()
 					.Add(" col1 from table")
+					.ToSqlString();
+
+			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType, paramType });
+		}
+
+		private DbCommand BuildOffsetFetchPagingCommand(SqlType paramType)
+		{
+			var sqlString =
+				new SqlStringBuilder()
+					.Add("select col1 from table offset ")
+					.AddParameter()
+					.Add(" rows fetch first ")
+					.AddParameter()
+					.Add(" rows only")
 					.ToSqlString();
 
 			return _driver.GenerateCommand(CommandType.Text, sqlString, new[] { paramType, paramType });

--- a/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
+++ b/src/NHibernate.Test/DriverTest/FirebirdClientDriverFixture.cs
@@ -204,13 +204,12 @@ namespace NHibernate.Test.DriverTest
 		{
 			// Firebird only accepts an integer literal or a parameter in the offset/fetch clause,
 			// casts are a syntax error there.
-			using (var cmd = BuildOffsetFetchPagingCommand(SqlTypeFactory.Int32))
-			{
-				_driver.AdjustCommand(cmd);
+			using var cmd = BuildOffsetFetchPagingCommand(SqlTypeFactory.Int32);
 
-				var expected = "select col1 from table offset @p0 rows fetch first @p1 rows only";
-				Assert.That(cmd.CommandText, Is.EqualTo(expected));
-			}
+			_driver.AdjustCommand(cmd);
+
+			var expected = "select col1 from table offset @p0 rows fetch first @p1 rows only";
+			Assert.That(cmd.CommandText, Is.EqualTo(expected));
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Hql/Ast/LimitClauseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/LimitClauseFixture.cs
@@ -112,10 +112,10 @@ namespace NHibernate.Test.Hql.Ast
 			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
 			const string hql = "from Human h order by h.bodyWeight skip :pSkip take :pTake";
 
-			using (ISession s = OpenSession())
-			using (ITransaction txn = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var txn = s.BeginTransaction())
 			{
-				float[] actual = s.CreateQuery(hql)
+				var actual = s.CreateQuery(hql)
 					.SetInt32("pSkip", 1)
 					.SetInt32("pTake", 3).List<Human>().Select(h => h.BodyWeight).ToArray();
 				Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
@@ -127,7 +127,7 @@ namespace NHibernate.Test.Hql.Ast
 				Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
 
 				// Same query instance, re-executed with other paging values.
-				IQuery query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
+				var query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
 				actual = query.List<Human>().Select(h => h.BodyWeight).ToArray();
 				Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
 

--- a/src/NHibernate.Test/Hql/Ast/LimitClauseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/LimitClauseFixture.cs
@@ -106,6 +106,39 @@ namespace NHibernate.Test.Hql.Ast
 		}
 
 		[Test]
+		public void SkipTakeWithParameterReExecutedWithOtherValues()
+		{
+			// NH-2731: the limit parameters must be recomputed, according to the dialect
+			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
+			const string hql = "from Human h order by h.bodyWeight skip :pSkip take :pTake";
+
+			using (ISession s = OpenSession())
+			using (ITransaction txn = s.BeginTransaction())
+			{
+				float[] actual = s.CreateQuery(hql)
+					.SetInt32("pSkip", 1)
+					.SetInt32("pTake", 3).List<Human>().Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
+
+				// Same query string, so same query plan, but other paging values.
+				actual = s.CreateQuery(hql)
+					.SetInt32("pSkip", 2)
+					.SetInt32("pTake", 2).List<Human>().Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
+
+				// Same query instance, re-executed with other paging values.
+				IQuery query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
+				actual = query.List<Human>().Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
+
+				actual = query.SetInt32("pSkip", 0).SetInt32("pTake", 2).List<Human>().Select(h => h.BodyWeight).ToArray();
+				Assert.That(actual, Is.EqualTo(new[] {5f, 6f}), "fourth execution");
+
+				txn.Commit();
+			}
+		}
+
+		[Test]
 		public void SkipTakeWithParameterList()
 		{
 			ISession s = OpenSession();

--- a/src/NHibernate.Test/Hql/Ast/LimitClauseFixture.cs
+++ b/src/NHibernate.Test/Hql/Ast/LimitClauseFixture.cs
@@ -112,30 +112,29 @@ namespace NHibernate.Test.Hql.Ast
 			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
 			const string hql = "from Human h order by h.bodyWeight skip :pSkip take :pTake";
 
-			using (var s = OpenSession())
-			using (var txn = s.BeginTransaction())
-			{
-				var actual = s.CreateQuery(hql)
-					.SetInt32("pSkip", 1)
-					.SetInt32("pTake", 3).List<Human>().Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
+			using var s = OpenSession();
+			using var txn = s.BeginTransaction();
 
-				// Same query string, so same query plan, but other paging values.
-				actual = s.CreateQuery(hql)
-					.SetInt32("pSkip", 2)
-					.SetInt32("pTake", 2).List<Human>().Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
+			var actual = s.CreateQuery(hql)
+				.SetInt32("pSkip", 1)
+				.SetInt32("pTake", 3).List<Human>().Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {6f, 10f, 15f}), "first execution");
 
-				// Same query instance, re-executed with other paging values.
-				var query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
-				actual = query.List<Human>().Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
+			// Same query string, so same query plan, but other paging values.
+			actual = s.CreateQuery(hql)
+				.SetInt32("pSkip", 2)
+				.SetInt32("pTake", 2).List<Human>().Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {10f, 15f}), "second execution");
 
-				actual = query.SetInt32("pSkip", 0).SetInt32("pTake", 2).List<Human>().Select(h => h.BodyWeight).ToArray();
-				Assert.That(actual, Is.EqualTo(new[] {5f, 6f}), "fourth execution");
+			// Same query instance, re-executed with other paging values.
+			var query = s.CreateQuery(hql).SetInt32("pSkip", 3).SetInt32("pTake", 1);
+			actual = query.List<Human>().Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {15f}), "third execution");
 
-				txn.Commit();
-			}
+			actual = query.SetInt32("pSkip", 0).SetInt32("pTake", 2).List<Human>().Select(h => h.BodyWeight).ToArray();
+			Assert.That(actual, Is.EqualTo(new[] {5f, 6f}), "fourth execution");
+
+			txn.Commit();
 		}
 
 		[Test]

--- a/src/NHibernate.Test/Pagination/PaginationFixture.cs
+++ b/src/NHibernate.Test/Pagination/PaginationFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Linq;
 using NHibernate.Cfg;
 using NHibernate.Criterion;
 using NHibernate.Dialect;
@@ -62,6 +63,57 @@ namespace NHibernate.Test.Pagination
 			}
 
 			using(ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				s.Delete("from DataPoint");
+				t.Commit();
+			}
+		}
+
+		[Test]
+		public void PagingParametersUpdatedOnEachExecution_NH2731()
+		{
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				for (int i = 4; i <= 8; i++)
+				{
+					s.Save(new DataPoint { X = i });
+				}
+				t.Commit();
+			}
+
+			// NH-2731: the limit parameters must be recomputed, according to the dialect
+			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
+			using (ISession s = OpenSession())
+			using (ITransaction t = s.BeginTransaction())
+			{
+				var query = s.CreateQuery("from DataPoint dp order by dp.X").SetFirstResult(1).SetMaxResults(2);
+				Assert.That(
+					query.List<DataPoint>().Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 5d, 6d }),
+					"first execution");
+
+				Assert.That(
+					query.SetFirstResult(3).SetMaxResults(1).List<DataPoint>().Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 7d }),
+					"second execution");
+
+				var criteria = s.CreateCriteria<DataPoint>().AddOrder(Order.Asc("X")).SetFirstResult(2).SetMaxResults(2);
+				Assert.That(
+					criteria.List<DataPoint>().Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 6d, 7d }),
+					"first criteria execution");
+
+				Assert.That(
+					criteria.SetFirstResult(0).SetMaxResults(3).List<DataPoint>().Select(dp => dp.X).ToArray(),
+					Is.EqualTo(new[] { 4d, 5d, 6d }),
+					"second criteria execution");
+
+				t.Commit();
+			}
+
+			using (ISession s = OpenSession())
 			using (ITransaction t = s.BeginTransaction())
 			{
 				s.Delete("from DataPoint");

--- a/src/NHibernate.Test/Pagination/PaginationFixture.cs
+++ b/src/NHibernate.Test/Pagination/PaginationFixture.cs
@@ -73,10 +73,10 @@ namespace NHibernate.Test.Pagination
 		[Test]
 		public void PagingParametersUpdatedOnEachExecution_NH2731()
 		{
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
-				for (int i = 4; i <= 8; i++)
+				for (var i = 4; i <= 8; i++)
 				{
 					s.Save(new DataPoint { X = i });
 				}
@@ -85,8 +85,8 @@ namespace NHibernate.Test.Pagination
 
 			// NH-2731: the limit parameters must be recomputed, according to the dialect
 			// UseMaxForLimit and OffsetStartsAtOne settings, on each execution.
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				var query = s.CreateQuery("from DataPoint dp order by dp.X").SetFirstResult(1).SetMaxResults(2);
 				Assert.That(
@@ -113,8 +113,8 @@ namespace NHibernate.Test.Pagination
 				t.Commit();
 			}
 
-			using (ISession s = OpenSession())
-			using (ITransaction t = s.BeginTransaction())
+			using (var s = OpenSession())
+			using (var t = s.BeginTransaction())
 			{
 				s.Delete("from DataPoint");
 				t.Commit();

--- a/src/NHibernate.Test/TestDialects/Firebird3TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/Firebird3TestDialect.cs
@@ -1,0 +1,9 @@
+namespace NHibernate.Test.TestDialects
+{
+	public class Firebird3TestDialect : FirebirdTestDialect
+	{
+		public Firebird3TestDialect(Dialect.Dialect dialect) : base(dialect)
+		{
+		}
+	}
+}

--- a/src/NHibernate.Test/TestDialects/Firebird4TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/Firebird4TestDialect.cs
@@ -1,6 +1,6 @@
 ﻿namespace NHibernate.Test.TestDialects
 {
-	public class Firebird4TestDialect : FirebirdTestDialect
+	public class Firebird4TestDialect : Firebird3TestDialect
 	{
 		public Firebird4TestDialect(Dialect.Dialect dialect) : base(dialect)
 		{

--- a/src/NHibernate/Dialect/Firebird3Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird3Dialect.cs
@@ -1,0 +1,32 @@
+using NHibernate.SqlCommand;
+
+namespace NHibernate.Dialect
+{
+	/// <summary>
+	/// A dialect for Firebird 3 and above.
+	/// </summary>
+	/// <remarks>
+	/// Firebird 3 supports the SQL standard <c>OFFSET</c>/<c>FETCH</c> clause. Unlike the
+	/// <c>FIRST</c>/<c>SKIP</c> clause used by <see cref="FirebirdDialect" />, it is placed at the end of
+	/// the statement and applies to the whole query, including unions.
+	/// </remarks>
+	public class Firebird3Dialect : FirebirdDialect
+	{
+		public override SqlString GetLimitString(SqlString queryString, SqlString offset, SqlString limit)
+		{
+			var result = new SqlStringBuilder(queryString);
+
+			if (offset != null)
+			{
+				result.Add(" offset ").Add(offset).Add(" rows");
+			}
+
+			if (limit != null)
+			{
+				result.Add(" fetch first ").Add(limit).Add(" rows only");
+			}
+
+			return result.ToSqlString();
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -2,7 +2,7 @@ using NHibernate.Dialect.Function;
 
 namespace NHibernate.Dialect
 {
-	public class Firebird4Dialect: FirebirdDialect
+	public class Firebird4Dialect: Firebird3Dialect
 	{
 		public override string CurrentTimestampSelectString => "select LOCALTIMESTAMP from RDB$DATABASE";
 

--- a/src/NHibernate/Driver/FirebirdClientDriver.cs
+++ b/src/NHibernate/Driver/FirebirdClientDriver.cs
@@ -26,7 +26,7 @@ namespace NHibernate.Driver
 			// a comparison,
 			@"[=<>]\s*" +
 			// or a paging instruction,
-			@"|\bfirst\s+|\bskip\s+" +
+			@"|\bfirst\s+|\bskip\s+|\boffset\s+" +
 			// or a "between" condition,
 			@"|\bbetween\s+|\bbetween\s+@p\w+\s+and\s+" +
 			// or a "in" condition.

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+NHibernate.Dialect.Firebird3Dialect
+NHibernate.Dialect.Firebird3Dialect.Firebird3Dialect() -> void
+override NHibernate.Dialect.Firebird3Dialect.GetLimitString(NHibernate.SqlCommand.SqlString queryString, NHibernate.SqlCommand.SqlString offset, NHibernate.SqlCommand.SqlString limit) -> NHibernate.SqlCommand.SqlString


### PR DESCRIPTION
This adds a `Firebird3Dialect` that uses the standard `offset ? rows fetch first ? rows only` clause for paging. `Firebird4Dialect` now extends the new dialect.

`FirebirdClientDriver` casts a parameter when Firebird cannot find its type. Firebird permits only an integer or a parameter after `offset`, and it finds the type there. The driver now ignores these parameters. It already does this for `first` and `skip`.

This also adds tests for #1009, which execute a query again with different paging values. But on the dialects that have `UseMaxForLimit`, NHibernate does not adjust the value correctly when you mix a constant and a parameter, for example `skip 1 take :t`. We cannot close #1009 yet.

Closes #731
