### PR TITLE
Migrate Firebird tests to the official firebirdsql/firebird image

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -45,12 +45,14 @@ jobs:
             CONNECTION_STRING: "DataSource=localhost;Database=nhibernate;User=SYSDBA;Password=nhibernate;charset=utf8;"
             OS: ubuntu-latest
             DB_INIT: |
-              docker run --name firebird -e EnableWireCrypt=true -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e ISC_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d jacobalberty/firebird:v3.0
+              # ISC_INET_SERVER_HOME points the server at the data directory, otherwise it resolves the relative database name under /tmp.
+              docker run --name firebird -e ISC_INET_SERVER_HOME=/var/lib/firebird/data -e FIREBIRD_CONF_WireCrypt=Enabled -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e FIREBIRD_ROOT_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d firebirdsql/firebird:3
           - DB: Firebird4
             CONNECTION_STRING: "DataSource=localhost;Database=nhibernate;User=SYSDBA;Password=nhibernate;charset=utf8;"
             OS: ubuntu-latest
             DB_INIT: |
-              docker run --name firebird -e EnableWireCrypt=true -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e ISC_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d jacobalberty/firebird:v4.0
+              # ISC_INET_SERVER_HOME points the server at the data directory, otherwise it resolves the relative database name under /tmp.
+              docker run --name firebird -e ISC_INET_SERVER_HOME=/var/lib/firebird/data -e FIREBIRD_CONF_WireCrypt=Enabled -e FIREBIRD_USER=nhibernate -e FIREBIRD_PASSWORD=nhibernate -e FIREBIRD_ROOT_PASSWORD=nhibernate -e FIREBIRD_DATABASE=nhibernate -p 3050:3050 -d firebirdsql/firebird:4
           # Windows runners can only run Windows containers, so the Linux Firebird image cannot be reused here.
           # MaxUnflushedWrites and MaxUnflushedWriteTime default to -1 everywhere but Windows, where they make the
           # engine flush the whole database file every 100 commits and every 5 seconds.

--- a/src/NHibernate.Test/TestContainerSetup.cs
+++ b/src/NHibernate.Test/TestContainerSetup.cs
@@ -2,6 +2,7 @@ namespace NHibernate.Test
 {
 	using System;
 	using System.Threading.Tasks;
+	using DotNet.Testcontainers.Builders;
 	using DotNet.Testcontainers.Containers;
 	using NUnit.Framework;
 	using Testcontainers.Db2;
@@ -16,7 +17,7 @@ namespace NHibernate.Test
 	public class TestContainerSetup
 	{
 		private const string Db2Image = "icr.io/db2_community/db2:12.1.0.0";
-		private const string FirebirdSqlImage = "jacobalberty/firebird:v4.0";
+		private const string FirebirdSqlImage = "firebirdsql/firebird:4";
 		private const string MariaDbImage = "mariadb:10.10";
 		private const string MsSqlImage = "mcr.microsoft.com/mssql/server:2019-latest";
 		private const string MySqlImage = "mysql:5.7";
@@ -56,7 +57,13 @@ namespace NHibernate.Test
 				case "db2":
 					return new Db2Builder(Db2Image).Build();
 				case "firebirdsql":
-					return new FirebirdSqlBuilder(FirebirdSqlImage).Build();
+					// The official image defines no health check to wait on, and resolves the relative
+					// database name of the connection string under /tmp unless ISC_INET_SERVER_HOME
+					// points at the data directory.
+					return new FirebirdSqlBuilder(FirebirdSqlImage)
+						.WithEnvironment("ISC_INET_SERVER_HOME", "/var/lib/firebird/data")
+						.WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(FirebirdSqlBuilder.FirebirdSqlPort))
+						.Build();
 				case "mariadb":
 					return new MariaDbBuilder(MariaDbImage).Build();
 				case "mssql":


### PR DESCRIPTION
`jacobalberty/firebird` is deprecated in favour of the official image.