### PR TITLE
Allow fork pull request checkout in the async generator workflow

### DIFF
--- a/.github/workflows/GenerateAsyncCode.yml
+++ b/.github/workflows/GenerateAsyncCode.yml
@@ -20,6 +20,8 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         persist-credentials: false
+        # The generator has to build the pull request's own code, this job has no write access to do so.
+        allow-unsafe-pr-checkout: true
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
@@ -65,6 +67,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
+        allow-unsafe-pr-checkout: true
 
     - name: Download patch
       uses: actions/download-artifact@v8


### PR DESCRIPTION
Floating official actions broke the async generator workflow. Now `actions/checkout` v6 refuses to check out fork code from a `pull_request_target workflow` unless `allow-unsafe-pr-checkout` is set.