### PR TITLE
Upgrade Npgsql to 8.0.9 on .NET Framework and 9.0.5 on .NET

### DIFF
--- a/src/NHibernate.Test/NHibernate.Test.csproj
+++ b/src/NHibernate.Test/NHibernate.Test.csproj
@@ -65,7 +65,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="9.1.1" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="MySql.Data" Version="8.0.30" />
     <PackageReference Include="Testcontainers.Db2" Version="4.13.0" />
     <PackageReference Include="Testcontainers.FirebirdSql" Version="4.13.0" />
@@ -82,6 +81,7 @@
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Data.OracleClient" />
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
+    <PackageReference Include="Npgsql" Version="8.0.9" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="21.14.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
@@ -93,6 +93,7 @@
       <ExcludeAssets>compile</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="10.0.0" />
+    <PackageReference Include="Npgsql" Version="9.0.5" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.140" />
     <PackageReference Include="NUnitLite" Version="3.14.0" />
   </ItemGroup>


### PR DESCRIPTION
Npgsql 9 does not support .NET Framework, so the net48 target stays on the latest 8.x.