### PR TITLE
Support Math.Min and Math.Max in LINQ

### DIFF
--- a/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Async/Hql/HQLFunctions.cs
@@ -664,6 +664,33 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public async Task GreatestAndLeastAsync()
+		{
+			AssumeFunctionSupported("greatest");
+			AssumeFunctionSupported("least");
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				await (s.SaveAsync(new Animal("abcdef", 20)));
+				await (tx.CommitAsync());
+			}
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var hql = "select greatest(a.BodyWeight, 30.0), least(a.BodyWeight, 30.0) from Animal a";
+				var lresult = (object[]) await (s.CreateQuery(hql).UniqueResultAsync());
+				Assert.AreEqual(30f, lresult[0]);
+				Assert.AreEqual(20f, lresult[1]);
+
+				hql = "from Animal a where greatest(a.BodyWeight, 30.0) = 30 and least(a.BodyWeight, 30.0) = 20";
+				var result = (Animal) await (s.CreateQuery(hql).UniqueResultAsync());
+				Assert.AreEqual("abcdef", result.Description);
+
+				await (tx.CommitAsync());
+			}
+		}
+
+		[Test]
 		public async Task SqrtAsync()
 		{
 			AssumeFunctionSupported("sqrt");

--- a/src/NHibernate.Test/Hql/HQLFunctions.cs
+++ b/src/NHibernate.Test/Hql/HQLFunctions.cs
@@ -653,6 +653,33 @@ namespace NHibernate.Test.Hql
 		}
 
 		[Test]
+		public void GreatestAndLeast()
+		{
+			AssumeFunctionSupported("greatest");
+			AssumeFunctionSupported("least");
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				s.Save(new Animal("abcdef", 20));
+				tx.Commit();
+			}
+			using (var s = OpenSession())
+			using (var tx = s.BeginTransaction())
+			{
+				var hql = "select greatest(a.BodyWeight, 30.0), least(a.BodyWeight, 30.0) from Animal a";
+				var lresult = (object[]) s.CreateQuery(hql).UniqueResult();
+				Assert.AreEqual(30f, lresult[0]);
+				Assert.AreEqual(20f, lresult[1]);
+
+				hql = "from Animal a where greatest(a.BodyWeight, 30.0) = 30 and least(a.BodyWeight, 30.0) = 20";
+				var result = (Animal) s.CreateQuery(hql).UniqueResult();
+				Assert.AreEqual("abcdef", result.Description);
+
+				tx.Commit();
+			}
+		}
+
+		[Test]
 		public void Sqrt()
 		{
 			AssumeFunctionSupported("sqrt");

--- a/src/NHibernate.Test/Linq/MathFTests.cs
+++ b/src/NHibernate.Test/Linq/MathFTests.cs
@@ -119,6 +119,20 @@ namespace NHibernate.Test.Linq
 			Test(o => MathF.Round(MathF.Pow((float)o.Discount, 0.5f), 5));
 		}
 
+		[Test]
+		public void MinTest()
+		{
+			AssumeFunctionSupported("least");
+			Test(o => MathF.Min((float) o.UnitPrice, 20f));
+		}
+
+		[Test]
+		public void MaxTest()
+		{
+			AssumeFunctionSupported("greatest");
+			Test(o => MathF.Max((float) o.UnitPrice, 20f));
+		}
+
 		private void Test(Expression<Func<OrderLine, float>> selector)
 		{
 			var expected = _orderLines

--- a/src/NHibernate.Test/Linq/MathTests.cs
+++ b/src/NHibernate.Test/Linq/MathTests.cs
@@ -116,6 +116,69 @@ namespace NHibernate.Test.Linq
 			Test(o => Math.Round(Math.Pow((double)o.Discount, 0.5d), 5));
 		}
 
+		[Test]
+		public void MinTest()
+		{
+			AssumeFunctionSupported("least");
+			Test(o => Math.Min((double) o.UnitPrice, 20d));
+		}
+
+		[Test]
+		public void MaxTest()
+		{
+			AssumeFunctionSupported("greatest");
+			Test(o => Math.Max((double) o.UnitPrice, 20d));
+		}
+
+		[Test]
+		public void MinDecimalTest()
+		{
+			AssumeFunctionSupported("least");
+			TestExact(o => Math.Min(o.UnitPrice, 20m));
+		}
+
+		[Test]
+		public void MaxDecimalTest()
+		{
+			AssumeFunctionSupported("greatest");
+			TestExact(o => Math.Max(o.UnitPrice, 20m));
+		}
+
+		[Test]
+		public void MinInt32Test()
+		{
+			AssumeFunctionSupported("least");
+			TestExact(o => Math.Min(o.Quantity, 20));
+		}
+
+		[Test]
+		public void MaxInt32Test()
+		{
+			AssumeFunctionSupported("greatest");
+			TestExact(o => Math.Max(o.Quantity, 20));
+		}
+
+		[Test]
+		public void MinOnTwoColumnsTest()
+		{
+			AssumeFunctionSupported("least");
+			TestExact(o => Math.Min(o.UnitPrice, o.Discount));
+		}
+
+		[Test]
+		public void MaxOnTwoColumnsTest()
+		{
+			AssumeFunctionSupported("greatest");
+			TestExact(o => Math.Max(o.UnitPrice, o.Discount));
+		}
+
+		[Test]
+		public void NestedMinTest()
+		{
+			AssumeFunctionSupported("least");
+			TestExact(o => Math.Min(Math.Min(o.UnitPrice, o.Discount), 20m));
+		}
+
 		private void Test(Expression<Func<OrderLine, double>> selector)
 		{
 			var expected = _orderLines
@@ -131,6 +194,21 @@ namespace NHibernate.Test.Linq
 			Assert.AreEqual(expected.Count, actual.Count);
 			for (var i = 0; i < expected.Count; i++)
 				Assert.AreEqual(expected[i], actual[i], 0.000001);
+		}
+
+		private void TestExact<T>(Expression<Func<OrderLine, T>> selector)
+		{
+			var expected = _orderLines
+				.Select(selector)
+				.ToList();
+
+			var actual = db.OrderLines
+				.OrderBy(ol => ol.Id)
+				.Select(selector)
+				.Take(10)
+				.ToList();
+
+			Assert.That(actual, Is.EqualTo(expected));
 		}
 	}
 }

--- a/src/NHibernate/Dialect/Dialect.cs
+++ b/src/NHibernate/Dialect/Dialect.cs
@@ -103,6 +103,10 @@ namespace NHibernate.Dialect
 			RegisterFunction("extract", new AnsiExtractFunction());
 			RegisterFunction("concat", new VarArgsSQLFunction(NHibernateUtil.String, "(", " || ", ")"));
 
+			// Not standard SQL, emulated with a case. Dialects having a native support should override them.
+			RegisterFunction("greatest", new SQLFunctionTemplate(null, "(case when ?1 > ?2 then ?1 else ?2 end)"));
+			RegisterFunction("least", new SQLFunctionTemplate(null, "(case when ?1 < ?2 then ?1 else ?2 end)"));
+
 			// the syntax of current_timestamp is extracted from H3.2 tests 
 			// - test\hql\ASTParserLoadingTest.java
 			// - test\org\hibernate\test\hql\HQLTest.java

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -469,6 +469,8 @@ namespace NHibernate.Dialect
 			RegisterFunction("upper", new StandardSafeSQLFunction("upper", NHibernateUtil.String, 1));
 			// Modulo does not throw for decimal parameters but they are casted to int by Firebird, which produces unexpected results
 			RegisterFunction("mod", new ModulusFunction(false, false));
+			RegisterFunction("greatest", new StandardSQLFunction("maxvalue"));
+			RegisterFunction("least", new StandardSQLFunction("minvalue"));
 			RegisterFunction("str", new SQLFunctionTemplate(NHibernateUtil.String, "cast(?1 as VARCHAR(255))"));
 			RegisterFunction("strguid", new StandardSQLFunction("uuid_to_char", NHibernateUtil.String));
 			RegisterFunction("sysdate", new CastedFunction("today", NHibernateUtil.Date));

--- a/src/NHibernate/Dialect/MySQLDialect.cs
+++ b/src/NHibernate/Dialect/MySQLDialect.cs
@@ -278,7 +278,10 @@ namespace NHibernate.Dialect
 			RegisterFunction("random", new NoArgSQLFunction("rand", NHibernateUtil.Double));
 
 			RegisterFunction("power", new StandardSQLFunction("power", NHibernateUtil.Double));
-			
+
+			RegisterFunction("greatest", new StandardSQLFunction("greatest"));
+			RegisterFunction("least", new StandardSQLFunction("least"));
+
 			RegisterFunction("stddev", new StandardSQLFunction("stddev", NHibernateUtil.Double));
 			RegisterFunction("variance", new StandardSQLFunction("variance", NHibernateUtil.Double));
 

--- a/src/NHibernate/Dialect/Oracle8iDialect.cs
+++ b/src/NHibernate/Dialect/Oracle8iDialect.cs
@@ -299,6 +299,8 @@ namespace NHibernate.Dialect
 
 			// Multi-param numeric dialect functions...
 			RegisterFunction("atan2", new StandardSQLFunction("atan2", NHibernateUtil.Double));
+			RegisterFunction("greatest", new StandardSQLFunction("greatest"));
+			RegisterFunction("least", new StandardSQLFunction("least"));
 			RegisterFunction("log", new StandardSQLFunction("log", NHibernateUtil.Int32));
 			RegisterFunction("mod", new ModulusFunction(true, true));
 			RegisterFunction("nvl", new StandardSQLFunction("nvl"));

--- a/src/NHibernate/Dialect/PostgreSQLDialect.cs
+++ b/src/NHibernate/Dialect/PostgreSQLDialect.cs
@@ -89,6 +89,9 @@ namespace NHibernate.Dialect
 			RegisterFunction("power", new StandardSQLFunction("power", NHibernateUtil.Double));
 			RegisterFunction("bxor", new Function.BitwiseNativeOperation("#"));
 
+			RegisterFunction("greatest", new StandardSQLFunction("greatest"));
+			RegisterFunction("least", new StandardSQLFunction("least"));
+
 			RegisterFunction("floor", new StandardSQLFunction("floor"));
 			RegisterFunction("ceiling", new StandardSQLFunction("ceiling"));
 			RegisterFunction("ceil", new StandardSQLFunction("ceil"));

--- a/src/NHibernate/Dialect/SQLiteDialect.cs
+++ b/src/NHibernate/Dialect/SQLiteDialect.cs
@@ -122,6 +122,10 @@ namespace NHibernate.Dialect
 
 			RegisterFunction("round", new StandardSQLFunction("round"));
 
+			// SQLite max and min are scalar when called with more than one argument, aggregate otherwise.
+			RegisterFunction("greatest", new StandardSQLFunction("max"));
+			RegisterFunction("least", new StandardSQLFunction("min"));
+
 			// SQLite has no built-in support of bitwise xor, but can emulate it.
 			// http://sqlite.1065341.n5.nabble.com/XOR-operator-td98004.html
 			RegisterFunction("bxor", new SQLFunctionTemplate(null, "((?1 | ?2) - (?1 & ?2))"));

--- a/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
+++ b/src/NHibernate/Dialect/SybaseSQLAnywhere10Dialect.cs
@@ -333,10 +333,12 @@ namespace NHibernate.Dialect
 			RegisterFunction("get_identity", new VarArgsSQLFunction("get_identity(", ",", ")"));
 			RegisterFunction("graphical_plan", new VarArgsSQLFunction(NHibernateUtil.String, "graphical_plan(", ",", ")"));
 			RegisterFunction("greater", new StandardSQLFunction("greater"));
+			RegisterFunction("greatest", new StandardSQLFunction("greater"));
 			RegisterFunction("identity", new StandardSQLFunction("identity"));
 			RegisterFunction("ifnull", new VarArgsSQLFunction("ifnull(", ",", ")"));
 			RegisterFunction("index_estimate", new VarArgsSQLFunction("index_estimate(", ",", ")"));
 			RegisterFunction("isnull", new VarArgsSQLFunction("isnull(", ",", ")"));
+			RegisterFunction("least", new StandardSQLFunction("lesser"));
 			RegisterFunction("lesser", new StandardSQLFunction("lesser"));
 			RegisterFunction("newid", new NoArgSQLFunction("newid", NHibernateUtil.String, true));
 			RegisterFunction("new_uuid", new NoArgSQLFunction("newid", NHibernateUtil.Guid));

--- a/src/NHibernate/Linq/Functions/MathGenerator.cs
+++ b/src/NHibernate/Linq/Functions/MathGenerator.cs
@@ -55,6 +55,30 @@ namespace NHibernate.Linq.Functions
 
 				ReflectHelper.FastGetMethod(Math.Pow, default(double), default(double)),
 
+				ReflectHelper.FastGetMethod(Math.Min, default(decimal), default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Min, default(double), default(double)),
+				ReflectHelper.FastGetMethod(Math.Min, default(float), default(float)),
+				ReflectHelper.FastGetMethod(Math.Min, default(long), default(long)),
+				ReflectHelper.FastGetMethod(Math.Min, default(ulong), default(ulong)),
+				ReflectHelper.FastGetMethod(Math.Min, default(int), default(int)),
+				ReflectHelper.FastGetMethod(Math.Min, default(uint), default(uint)),
+				ReflectHelper.FastGetMethod(Math.Min, default(short), default(short)),
+				ReflectHelper.FastGetMethod(Math.Min, default(ushort), default(ushort)),
+				ReflectHelper.FastGetMethod(Math.Min, default(sbyte), default(sbyte)),
+				ReflectHelper.FastGetMethod(Math.Min, default(byte), default(byte)),
+
+				ReflectHelper.FastGetMethod(Math.Max, default(decimal), default(decimal)),
+				ReflectHelper.FastGetMethod(Math.Max, default(double), default(double)),
+				ReflectHelper.FastGetMethod(Math.Max, default(float), default(float)),
+				ReflectHelper.FastGetMethod(Math.Max, default(long), default(long)),
+				ReflectHelper.FastGetMethod(Math.Max, default(ulong), default(ulong)),
+				ReflectHelper.FastGetMethod(Math.Max, default(int), default(int)),
+				ReflectHelper.FastGetMethod(Math.Max, default(uint), default(uint)),
+				ReflectHelper.FastGetMethod(Math.Max, default(short), default(short)),
+				ReflectHelper.FastGetMethod(Math.Max, default(ushort), default(ushort)),
+				ReflectHelper.FastGetMethod(Math.Max, default(sbyte), default(sbyte)),
+				ReflectHelper.FastGetMethod(Math.Max, default(byte), default(byte)),
+
 #if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
 				ReflectHelper.FastGetMethod(MathF.Sin, default(float)),
 				ReflectHelper.FastGetMethod(MathF.Cos, default(float)),
@@ -80,6 +104,9 @@ namespace NHibernate.Linq.Functions
 				ReflectHelper.FastGetMethod(MathF.Ceiling, default(float)),
 
 				ReflectHelper.FastGetMethod(MathF.Pow, default(float), default(float)),
+
+				ReflectHelper.FastGetMethod(MathF.Min, default(float), default(float)),
+				ReflectHelper.FastGetMethod(MathF.Max, default(float), default(float)),
 #endif
 #if NET8_0_OR_GREATER
 				ReflectHelper.FastGetMethod(float.Sin, default(float)),
@@ -98,7 +125,9 @@ namespace NHibernate.Linq.Functions
 				ReflectHelper.FastGetMethod(float.Floor, default(float)),
 				ReflectHelper.FastGetMethod(float.Ceiling, default(float)),
 				ReflectHelper.FastGetMethod(float.Pow, default(float), default(float)),
-				
+				ReflectHelper.FastGetMethod(float.Min, default(float), default(float)),
+				ReflectHelper.FastGetMethod(float.Max, default(float), default(float)),
+
 				ReflectHelper.FastGetMethod(double.Sin, default(double)),
 				ReflectHelper.FastGetMethod(double.Cos, default(double)),
 				ReflectHelper.FastGetMethod(double.Tan, default(double)),
@@ -115,6 +144,8 @@ namespace NHibernate.Linq.Functions
 				ReflectHelper.FastGetMethod(double.Floor, default(double)),
 				ReflectHelper.FastGetMethod(double.Ceiling, default(double)),
 				ReflectHelper.FastGetMethod(double.Pow, default(double), default(double)),
+				ReflectHelper.FastGetMethod(double.Min, default(double), default(double)),
+				ReflectHelper.FastGetMethod(double.Max, default(double), default(double)),
 #endif
 			};
 		}
@@ -124,6 +155,9 @@ namespace NHibernate.Linq.Functions
 			var function = method.Name.ToLowerInvariant() switch
 			{
 				"pow" => "power",
+				// min and max are aggregates in HQL, their scalar counterparts are named greatest and least.
+				"min" => "least",
+				"max" => "greatest",
 				var f => f,
 			};
 


### PR DESCRIPTION
Adds `greatest` and `least` HQL functions, natively mapped where the database provides them and emulated with a case otherwise, and maps `Math.Min`/`Math.Max` onto them.

Closes #749