### PR TITLE
Fix GetValueOrDefault() for types having no valid HQL literal

### DIFF
--- a/src/NHibernate.Test/Async/Linq/ByMethod/GetValueOrDefaultTests.cs
+++ b/src/NHibernate.Test/Async/Linq/ByMethod/GetValueOrDefaultTests.cs
@@ -8,7 +8,9 @@
 //------------------------------------------------------------------------------
 
 
+using System;
 using System.Linq;
+using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Dialect;
 using NUnit.Framework;
 using NHibernate.Linq;
@@ -66,6 +68,62 @@ namespace NHibernate.Test.Linq.ByMethod
 						   .ToListAsync());
 
 			Assert.AreEqual(830, orders.Count);
+		}
+
+		[Test]
+		public async Task GetValueOrDefaultOnDateTimeInSelectAsync()
+		{
+			var dates = await (db.Orders
+						  .Select(x => x.ShippingDate.GetValueOrDefault())
+						  .ToListAsync());
+
+			Assert.That(dates, Has.Count.EqualTo(830));
+			Assert.That(dates, Has.Some.EqualTo(default(DateTime)), "Orders without a shipping date should default.");
+		}
+
+		[Test]
+		public async Task GetValueOrDefaultOnDateTimeInWhereAsync()
+		{
+			var orders = await (db.Orders
+						   .Where(x => x.ShippingDate.GetValueOrDefault() > new DateTime(1990, 1, 1))
+						   .ToListAsync());
+
+			Assert.That(orders, Has.Count.EqualTo(await (db.Orders.CountAsync(x => x.ShippingDate != null))));
+		}
+
+		[Test]
+		public async Task GetValueOrDefaultOnDateTimeInOrderByAsync()
+		{
+			var orders = await (db.Orders
+						   .OrderByDescending(x => x.ShippingDate.GetValueOrDefault())
+						   .ToListAsync());
+
+			Assert.That(orders, Has.Count.EqualTo(830));
+		}
+
+		[Test]
+		public async Task GetValueOrDefaultOnEnumStoredAsStringAsync()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			{
+				var users = await (db.Users
+							  .Where(x => x.NullableEnum1.GetValueOrDefault() == EnumStoredAsString.Medium)
+							  .ToListAsync());
+
+				Assert.That(users, Has.Count.EqualTo(2));
+				// The default value must be sent as a string, as the member is mapped as one.
+				Assert.That(sqlLog.GetWholeLog(), Does.Contain(nameof(EnumStoredAsString.Unspecified)));
+			}
+		}
+
+		[Test]
+		public async Task GetValueOrDefaultOnEnumStoredAsInt32Async()
+		{
+			var users = await (db.Users
+						  .Where(x => x.NullableEnum2.GetValueOrDefault() == EnumStoredAsInt32.Unspecified)
+						  .ToListAsync());
+
+			Assert.That(users, Has.Count.EqualTo(2));
 		}
 	}
 }

--- a/src/NHibernate.Test/Linq/ByMethod/GetValueOrDefaultTests.cs
+++ b/src/NHibernate.Test/Linq/ByMethod/GetValueOrDefaultTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Dialect;
 using NUnit.Framework;
 
@@ -54,6 +56,62 @@ namespace NHibernate.Test.Linq.ByMethod
 						   .ToList();
 
 			Assert.AreEqual(830, orders.Count);
+		}
+
+		[Test]
+		public void GetValueOrDefaultOnDateTimeInSelect()
+		{
+			var dates = db.Orders
+						  .Select(x => x.ShippingDate.GetValueOrDefault())
+						  .ToList();
+
+			Assert.That(dates, Has.Count.EqualTo(830));
+			Assert.That(dates, Has.Some.EqualTo(default(DateTime)), "Orders without a shipping date should default.");
+		}
+
+		[Test]
+		public void GetValueOrDefaultOnDateTimeInWhere()
+		{
+			var orders = db.Orders
+						   .Where(x => x.ShippingDate.GetValueOrDefault() > new DateTime(1990, 1, 1))
+						   .ToList();
+
+			Assert.That(orders, Has.Count.EqualTo(db.Orders.Count(x => x.ShippingDate != null)));
+		}
+
+		[Test]
+		public void GetValueOrDefaultOnDateTimeInOrderBy()
+		{
+			var orders = db.Orders
+						   .OrderByDescending(x => x.ShippingDate.GetValueOrDefault())
+						   .ToList();
+
+			Assert.That(orders, Has.Count.EqualTo(830));
+		}
+
+		[Test]
+		public void GetValueOrDefaultOnEnumStoredAsString()
+		{
+			using (var sqlLog = new SqlLogSpy())
+			{
+				var users = db.Users
+							  .Where(x => x.NullableEnum1.GetValueOrDefault() == EnumStoredAsString.Medium)
+							  .ToList();
+
+				Assert.That(users, Has.Count.EqualTo(2));
+				// The default value must be sent as a string, as the member is mapped as one.
+				Assert.That(sqlLog.GetWholeLog(), Does.Contain(nameof(EnumStoredAsString.Unspecified)));
+			}
+		}
+
+		[Test]
+		public void GetValueOrDefaultOnEnumStoredAsInt32()
+		{
+			var users = db.Users
+						  .Where(x => x.NullableEnum2.GetValueOrDefault() == EnumStoredAsInt32.Unspecified)
+						  .ToList();
+
+			Assert.That(users, Has.Count.EqualTo(2));
 		}
 	}
 }

--- a/src/NHibernate/Linq/ExpressionTransformers/AddGetValueOrDefaultArgument.cs
+++ b/src/NHibernate/Linq/ExpressionTransformers/AddGetValueOrDefaultArgument.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq.Expressions;
+using NHibernate.Linq.Functions;
+using NHibernate.Util;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace NHibernate.Linq.ExpressionTransformers
+{
+	/// <summary>
+	/// Supplies the implicit argument of the parameterless <c>Nullable&lt;T&gt;.GetValueOrDefault()</c> overload
+	/// whenever <c>default(T)</c> cannot be rendered as an HQL literal.
+	/// </summary>
+	/// <remarks>
+	/// The parameterless overload has no argument in the expression tree, so its default value is built at HQL
+	/// generation time and inlined as a literal by <see cref="Hql.Ast.HqlTreeBuilder.Constant"/>. That yields
+	/// invalid SQL for most types (e.g. <c>coalesce(col, '01/01/0001 00:00:00')</c> for a <see cref="DateTime"/>)
+	/// or is not supported at all. By adding the argument here, before the query is parameterized, the default
+	/// value goes through the usual constant to parameter conversion instead.
+	/// </remarks>
+	internal class AddGetValueOrDefaultArgument : IExpressionTransformer<MethodCallExpression>
+	{
+		public ExpressionType[] SupportedExpressionTypes { get; } = { ExpressionType.Call };
+
+		public Expression Transform(MethodCallExpression expression)
+		{
+			if (expression.Arguments.Count > 0 || !GetValueOrDefaultGenerator.IsGetValueOrDefaultMethod(expression.Method))
+				return expression;
+
+			var type = expression.Object.Type.NullableOf();
+			if (CanBeInlinedAsLiteral(type))
+				return expression;
+
+			return Expression.Call(
+				expression.Object,
+				expression.Method.DeclaringType.GetMethod(expression.Method.Name, new[] {type}),
+				Expression.Constant(Activator.CreateInstance(type), type));
+		}
+
+		/// <summary>
+		/// Whether <c>default(T)</c> is rendered correctly by <see cref="Hql.Ast.HqlTreeBuilder.Constant"/>.
+		/// </summary>
+		/// <remarks>
+		/// Enums are excluded although their type code is integral: they would be rendered by their member name.
+		/// Char and DateTime are excluded although handled, they would be rendered as an invalid, respectively
+		/// culture dependent, string literal. The remaining cases all default to zero or false, which is rendered
+		/// the same way whatever the culture.
+		/// </remarks>
+		private static bool CanBeInlinedAsLiteral(System.Type type)
+		{
+			if (type.IsEnum)
+				return false;
+
+			switch (System.Type.GetTypeCode(type))
+			{
+				case TypeCode.Int16:
+				case TypeCode.Int32:
+				case TypeCode.Int64:
+				case TypeCode.Single:
+				case TypeCode.Double:
+				case TypeCode.Decimal:
+				case TypeCode.Boolean:
+					return true;
+				default:
+					return false;
+			}
+		}
+	}
+}

--- a/src/NHibernate/Linq/Functions/GetValueOrDefaultGenerator.cs
+++ b/src/NHibernate/Linq/Functions/GetValueOrDefaultGenerator.cs
@@ -11,9 +11,14 @@ namespace NHibernate.Linq.Functions
 {
 	internal class GetValueOrDefaultGenerator : IHqlGeneratorForMethod, IRuntimeMethodHqlGenerator, IHqlGeneratorForMethodExtended
 	{
-		public bool SupportsMethod(MethodInfo method)
+		internal static bool IsGetValueOrDefaultMethod(MethodInfo method)
 		{
 			return method != null && String.Equals(method.Name, "GetValueOrDefault", StringComparison.OrdinalIgnoreCase) && method.IsMethodOf(typeof (Nullable<>));
+		}
+
+		public bool SupportsMethod(MethodInfo method)
+		{
+			return IsGetValueOrDefaultMethod(method);
 		}
 
 		public IHqlGeneratorForMethod GetMethodGenerator(MethodInfo method)

--- a/src/NHibernate/Linq/NhRelinqQueryParser.cs
+++ b/src/NHibernate/Linq/NhRelinqQueryParser.cs
@@ -87,6 +87,9 @@ namespace NHibernate.Linq
 			// NH-3247: must remove .Net compiler char to int conversion before
 			// parameterization occurs.
 			preTransformerRegistry.Register(new RemoveCharToIntConversion());
+			// NH-3799 (#1173): must supply the implicit GetValueOrDefault() default value before
+			// parameterization occurs, otherwise it gets inlined as a literal.
+			preTransformerRegistry.Register(new AddGetValueOrDefaultArgument());
 			expressionTransformerRegistrar?.Register(preTransformerRegistry);
 
 			return new TransformingExpressionTreeProcessor(preTransformerRegistry).Process;

--- a/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
+++ b/src/NHibernate/Linq/Visitors/ParameterTypeLocator.cs
@@ -263,6 +263,19 @@ namespace NHibernate.Linq.Visitors
 					return node;
 				}
 
+				if (GetValueOrDefaultGenerator.IsGetValueOrDefaultMethod(node.Method) && node.Arguments.Count == 1)
+				{
+					node = (MethodCallExpression) base.VisitMethodCall(node);
+					// GetValueOrDefault is translated to a coalesce, so relate its operands and its result the same
+					// way the coalesce operator does (e.g. o.NullableEnum.GetValueOrDefault() == MyEnum.Option ->
+					// both the default value and MyEnum.Option should have o.NullableEnum as a related expression).
+					var target = UnwrapUnary(node.Object);
+					AddRelatedExpression(null, target, UnwrapUnary(node.Arguments[0]));
+					AddRelatedExpression(null, target, node);
+
+					return node;
+				}
+
 				return base.VisitMethodCall(node);
 			}
 


### PR DESCRIPTION
Send the implicit default value as a parameter instead of inlining it as a literal, when the type has no valid HQL literal representation.

Closes #1173