### PR TITLE
Throw a meaningful exception when a criteria is created directly on a component

### DIFF
--- a/src/NHibernate.Test/Async/Criteria/CriteriaQueryTest.cs
+++ b/src/NHibernate.Test/Async/Criteria/CriteriaQueryTest.cs
@@ -2528,6 +2528,18 @@ namespace NHibernate.Test.Criteria
 		}
 
 		[Test]
+		public void CriteriaOnComponentAsync()
+		{
+			using var session = OpenSession();
+			using var t = session.BeginTransaction();
+
+			var criteria = session.CreateCriteria(typeof(Student)).CreateCriteria("CityState");
+
+			var exception = Assert.ThrowsAsync<QueryException>(() => criteria.ListAsync());
+			Assert.That(exception.Message, Does.Contain("Criteria objects cannot be created directly on components"));
+		}
+
+		[Test]
 		public async Task PropertySubClassDiscriminatorAsync()
 		{
 			using (ISession s = OpenSession())

--- a/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
+++ b/src/NHibernate.Test/Criteria/CriteriaQueryTest.cs
@@ -2625,6 +2625,18 @@ namespace NHibernate.Test.Criteria
 		}
 
 		[Test]
+		public void CriteriaOnComponent()
+		{
+			using var session = OpenSession();
+			using var t = session.BeginTransaction();
+
+			var criteria = session.CreateCriteria(typeof(Student)).CreateCriteria("CityState");
+
+			var exception = Assert.Throws<QueryException>(() => criteria.List());
+			Assert.That(exception.Message, Does.Contain("Criteria objects cannot be created directly on components"));
+		}
+
+		[Test]
 		public void PropertySubClassDiscriminator()
 		{
 			using (ISession s = OpenSession())

--- a/src/NHibernate/Loader/Criteria/CriteriaQueryTranslator.cs
+++ b/src/NHibernate/Loader/Criteria/CriteriaQueryTranslator.cs
@@ -689,6 +689,13 @@ namespace NHibernate.Loader.Criteria
 				}
 			}
 
+			// A non-empty component path here means the path ended on a component instead of an association.
+			if (componentPath.Length > 0)
+			{
+				throw new QueryException(
+					"Criteria objects cannot be created directly on components. Create a criteria on owning entity and use a dotted property to access component property: " + path);
+			}
+
 			logger.Debug("returning entity name={0} for path={1} class={2}",
 				provider.Name, path, provider.GetType().Name);
 			return provider;


### PR DESCRIPTION
Throw a `QueryException` when a criteria is created directly on a component, naming the offending path and pointing at the dotted-property alternative.

Creating a criteria on a component path silently resolved to the owning entity, so the resulting query was wrong. It was difficult to find the cause.

Same change as the Hibernate fix for HHH-3646.

Closes #3455