### PR TITLE
Select a constant for root Any/All Linq queries

### DIFF
--- a/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Async/Linq/MethodCallTests.cs
@@ -36,6 +36,55 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task CanExecuteAllAsync()
+		{
+			var result = await (db.Users.AllAsync(u => u.Name != "user-does-not-exist"));
+			Assert.IsTrue(result);
+		}
+
+		[Test(Description = "GH-833")]
+		public async Task AnyDoesNotReadAnyColumnAsync()
+		{
+			using var spy = new SqlLogSpy();
+
+			var result = await (db.Users.AnyAsync());
+
+			Assert.That(result, Is.True);
+			AssertNoColumnIsRead(spy);
+		}
+
+		[Test(Description = "GH-833")]
+		public async Task AllDoesNotReadAnyColumnAsync()
+		{
+			using var spy = new SqlLogSpy();
+
+			var result = await (db.Users.AllAsync(u => u.Name != "user-does-not-exist"));
+
+			Assert.That(result, Is.True);
+			AssertNoColumnIsRead(spy);
+		}
+
+		[Test(Description = "GH-833")]
+		public async Task AnyOnProjectionDoesNotReadProjectedColumnsAsync()
+		{
+			using var spy = new SqlLogSpy();
+
+			var result = await (db.Users.Select(u => new { u.Name, u.RegisteredAt }).AnyAsync());
+
+			Assert.That(result, Is.True);
+			AssertNoColumnIsRead(spy);
+		}
+
+		// "Name" is left out of the checked columns, the restriction of the All case does use it.
+		private static void AssertNoColumnIsRead(SqlLogSpy spy)
+		{
+			var sql = spy.GetWholeLog();
+			Assert.That(sql, Does.Contain("Users"), "The query should still target the Users table.");
+			Assert.That(sql, Does.Not.Contain("UserId").And.Not.Contain("RegisteredAt"),
+				"An existence check should not read the columns of the tested entity.");
+		}
+
+		[Test]
 		public async Task CanExecuteContainsAsync()
 		{
 			var user = await (db.Users.FirstOrDefaultAsync());

--- a/src/NHibernate.Test/Linq/MethodCallTests.cs
+++ b/src/NHibernate.Test/Linq/MethodCallTests.cs
@@ -24,6 +24,55 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void CanExecuteAll()
+		{
+			var result = db.Users.All(u => u.Name != "user-does-not-exist");
+			Assert.IsTrue(result);
+		}
+
+		[Test(Description = "GH-833")]
+		public void AnyDoesNotReadAnyColumn()
+		{
+			using var spy = new SqlLogSpy();
+
+			var result = db.Users.Any();
+
+			Assert.That(result, Is.True);
+			AssertNoColumnIsRead(spy);
+		}
+
+		[Test(Description = "GH-833")]
+		public void AllDoesNotReadAnyColumn()
+		{
+			using var spy = new SqlLogSpy();
+
+			var result = db.Users.All(u => u.Name != "user-does-not-exist");
+
+			Assert.That(result, Is.True);
+			AssertNoColumnIsRead(spy);
+		}
+
+		[Test(Description = "GH-833")]
+		public void AnyOnProjectionDoesNotReadProjectedColumns()
+		{
+			using var spy = new SqlLogSpy();
+
+			var result = db.Users.Select(u => new { u.Name, u.RegisteredAt }).Any();
+
+			Assert.That(result, Is.True);
+			AssertNoColumnIsRead(spy);
+		}
+
+		// "Name" is left out of the checked columns, the restriction of the All case does use it.
+		private static void AssertNoColumnIsRead(SqlLogSpy spy)
+		{
+			var sql = spy.GetWholeLog();
+			Assert.That(sql, Does.Contain("Users"), "The query should still target the Users table.");
+			Assert.That(sql, Does.Not.Contain("UserId").And.Not.Contain("RegisteredAt"),
+				"An existence check should not read the columns of the tested entity.");
+		}
+
+		[Test]
 		public void CanExecuteContains()
 		{
 			var user = db.Users.FirstOrDefault();

--- a/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
+++ b/src/NHibernate/Linq/Visitors/QueryModelVisitor.cs
@@ -36,6 +36,9 @@ namespace NHibernate.Linq.Visitors
 			{
 				// This expander works recursively
 				SubQueryConditionalExpander.ReWrite(queryModel);
+
+				// Strip the projection of a query which only tests for the existence of rows
+				ReplaceDiscardedProjection(queryModel);
 			}
 
 			NestedSelectRewriter.ReWrite(queryModel, parameters.SessionFactory);
@@ -108,6 +111,20 @@ namespace NHibernate.Linq.Visitors
 			visitor.Visit();
 
 			return visitor._hqlTree.GetTranslation();
+		}
+
+		/// <summary>
+		/// GH-833: a root <c>Any</c> or <c>All</c> only tells whether the query yields any row, its selected
+		/// values are discarded. Select a constant instead, so that no column has to be read at all.
+		/// </summary>
+		private static void ReplaceDiscardedProjection(QueryModel queryModel)
+		{
+			var lastOperator = queryModel.ResultOperators.LastOrDefault();
+			if (!(lastOperator is AnyResultOperator || lastOperator is AllResultOperator))
+				return;
+
+			// The nomination wrapper is required, plain constants are otherwise not projected into the select clause.
+			queryModel.SelectClause.Selector = new NhNominatedExpression(Expression.Constant(1));
 		}
 
 		private readonly IntermediateHqlTree _hqlTree;


### PR DESCRIPTION
A root `Any()` or `All()` query now selects a constant instead of the columns of the entity.

Closes #833