### PR TITLE
NH-3570 - Enable tests in the fixture

### DIFF
--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3570/BiFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3570/BiFixture.cs
@@ -20,7 +20,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3570
 		private Guid id;
 
 		[Test]
-		[KnownBug("NH-3570")]
 		public async Task ShouldNotSaveRemoveChildAsync()
 		{
 			var parent = new BiParent();

--- a/src/NHibernate.Test/Async/NHSpecificTest/NH3570/UniFixture.cs
+++ b/src/NHibernate.Test/Async/NHSpecificTest/NH3570/UniFixture.cs
@@ -20,7 +20,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3570
 		private Guid id;
 
 		[Test]
-		[KnownBug("NH-3570")]
 		public async Task ShouldNotSaveRemoveChildAsync()
 		{
 			var parent = new UniParent();

--- a/src/NHibernate.Test/NHSpecificTest/NH3570/BiFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3570/BiFixture.cs
@@ -9,7 +9,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3570
 		private Guid id;
 
 		[Test]
-		[KnownBug("NH-3570")]
 		public void ShouldNotSaveRemoveChild()
 		{
 			var parent = new BiParent();

--- a/src/NHibernate.Test/NHSpecificTest/NH3570/UniFixture.cs
+++ b/src/NHibernate.Test/NHSpecificTest/NH3570/UniFixture.cs
@@ -9,7 +9,6 @@ namespace NHibernate.Test.NHSpecificTest.NH3570
 		private Guid id;
 
 		[Test]
-		[KnownBug("NH-3570")]
 		public void ShouldNotSaveRemoveChild()
 		{
 			var parent = new UniParent();


### PR DESCRIPTION
Enable the `ShouldNotSaveRemoveChild` tests in the NH-3570 fixture. 

Closes #1322