### PR TITLE
Rebase Renovate branches only when conflicted

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   "pruneStaleBranches": false,
   "automerge": true,
   "platformAutomerge": true,
-  "rebaseWhen": "never",
+  "rebaseWhen": "conflicted",
   "labels": [
     "dependencies",
     "p: Lowest",


### PR DESCRIPTION
Set `rebaseWhen` to `conflicted` in the Renovate configuration. 

The new behaviour for Renovate will be:
- rebase a branch only when the branch has a merge conflict.
- update an open pull request when a new dependency version is available.