### PR TITLE
Run required checks on merge queue branches

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -1,6 +1,12 @@
 name: .NET Core
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - gh-readonly-queue/**
+      - renovate/**
+  pull_request:
+  merge_group:
 
 jobs:
   db:


### PR DESCRIPTION
Add the `merge_group` trigger to prepare for enabling the merge queue on master. Exclude merge queue and Renovate branches from the push trigger to avoid duplicate runs.