### PR TITLE
Replaced IdentityMap with IdentityMap<TK, TV>

### DIFF
--- a/src/NHibernate.Test/UtilityTest/IdentityMapGenericFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/IdentityMapGenericFixture.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest;
+
+/// <summary>
+/// Tests for the generic <see cref="IdentityMap{TKey,TValue}"/>, mirroring
+/// <see cref="IdentityMapFixture"/>.
+/// </summary>
+[TestFixture]
+public class IdentityMapGenericFixture
+{
+	protected MutableHashCode item1;
+	protected MutableHashCode item2;
+
+	protected NoHashCode noHashCode1;
+	protected NoHashCode noHashCode2;
+
+	protected object value1;
+	protected object value2;
+
+	[SetUp]
+	public void SetUp()
+	{
+		item1 = new MutableHashCode(1);
+		item2 = new MutableHashCode(2);
+
+		value1 = new object();
+		value2 = new object();
+
+		noHashCode1 = new NoHashCode();
+		noHashCode2 = new NoHashCode();
+	}
+
+	protected virtual IDictionary<object, object> GetIdentityMap() => IdentityMapUtils.Instantiate<object, object>(10);
+
+	/// <summary>
+	/// Verify that the object being added as the Key does not have its GetHashCode
+	/// method called.
+	/// </summary>
+	[Test]
+	public void AddNoHashCode()
+	{
+		var map = GetIdentityMap();
+		map.Add(noHashCode1, value1);
+
+		Assert.AreEqual(1, map.Count, "The item was added succesfully");
+	}
+
+	/// <summary>
+	/// An IdentityMap can not use a ValueType as the Key because of the boxing/unboxing
+	/// that occurs with them. This verifies that an Exception is thrown if a ValueType
+	/// is used as the key.
+	/// </summary>
+	[Test]
+	public void AddValueTypeException()
+	{
+		var map = GetIdentityMap();
+		object intKey = 3;
+		object objectValue = new object();
+		Assert.Throws<ArgumentException>(() => map.Add(intKey, objectValue));
+	}
+
+	[Test]
+	public void Count()
+	{
+		var map = GetIdentityMap();
+		map.Add(new object(), new object());
+		map.Add(new object(), new object());
+
+		Assert.AreEqual(2, map.Count, "Expect 2 items in the IdentityMap");
+	}
+
+	/// <summary>
+	/// Test that two different references to the same object passed to ContainsKey
+	/// both return true.
+	/// </summary>
+	[Test]
+	public void ContainsSameObjectByRef()
+	{
+		var map = GetIdentityMap();
+
+		var item1Copy = item1;
+
+		map.Add(item1, new object());
+
+		Assert.AreSame(item1, item1Copy);
+		Assert.IsTrue(map.ContainsKey(item1Copy), "We should be able to get the same object out of the IdentityMap with " +
+		                                          "two different references to the same object.");
+	}
+
+	/// <summary>
+	/// Test that even though the HashCode and Equals of the same reference have been changed
+	/// that ContainsKey still recognizes it by the Identity of the object - not the values.
+	/// </summary>
+	[Test]
+	public void ContainsSameObjectWithDiffEquals()
+	{
+		var map = GetIdentityMap();
+
+		map.Add(item1, new object());
+
+		item1.HashCodeField = 5;
+
+		Assert.IsTrue(map.ContainsKey(item1),
+		              "Even though item1's HashCode field change the IdentityMap.ContainsKey() should still return true");
+	}
+
+	/// <summary>
+	/// Test to make sure that two objects that are equal by the Equals definition of the class MutableHashCode
+	/// do not get translated to the same key because they are different objects.
+	/// </summary>
+	[Test]
+	public void ContainsDiffObjectWithEquals()
+	{
+		var map = GetIdentityMap();
+		item1.HashCodeField = 4;
+		item2.HashCodeField = 4;
+
+		map.Add(item1, new object());
+
+		Assert.AreEqual(item1, item2, "They should be equal.");
+		Assert.IsFalse(map.ContainsKey(item2), "Even though item1.Equals(item2) IdentityMap should not find by item2");
+	}
+
+	/// <summary>
+	/// Add the same MutableHashCode class twice and ensure there is only
+	/// one item in the IdentityMap.
+	/// </summary>
+	[Test]
+	public void SetItemChangedHashCodeTwice()
+	{
+		var actualMap = GetIdentityMap();
+
+		actualMap[item1] = value1;
+
+		// change the Property that GetHashCode method uses
+		item1.HashCodeField = 2;
+		actualMap[item1] = value1;
+		Assert.AreEqual(1, actualMap.Count, "Should only be 1 item in the IdentityMap");
+	}
+
+	/// <summary>
+	/// Adds two different objects that are Equal() to each other to verify that
+	/// it does not use the objects Equal() but instead the IdentityMap's reference identity.
+	/// </summary>
+	[Test]
+	public void SetItemsEqualHashCodeDiffIdentity()
+	{
+		var actualMap = GetIdentityMap();
+
+		item1.HashCodeField = 3;
+		item2.HashCodeField = 3;
+
+		Assert.AreEqual(item1, item2, "The two objects are equal");
+		Assert.IsTrue(item1 != item2, "The two items are different objects in memory");
+
+		actualMap[item1] = value1;
+		actualMap[item2] = value2;
+
+		Assert.AreEqual(2, actualMap.Count, "The IdentityMap should have 2 elements");
+	}
+
+	/// <summary>
+	/// Verify the Keys returns the object passed as the key, not some transformed identity key.
+	/// </summary>
+	[Test]
+	public void Keys()
+	{
+		var map = GetIdentityMap();
+		map.Add(item1, value1);
+		map.Add(item2, value2);
+
+		Assert.AreEqual(2, map.Keys.Count, "Same number of Keys");
+		CollectionAssert.Contains(map.Keys, item1);
+		CollectionAssert.Contains(map.Keys, item2);
+	}
+
+	/// <summary>
+	/// Verify that GetEntries returns a snapshot that contains the same
+	/// Keys/Values as originally added into the IdentityMap.
+	/// </summary>
+	[Test]
+	public void GetEntries()
+	{
+		var map = GetIdentityMap();
+
+		map.Add(noHashCode1, value1);
+		map.Add(noHashCode2, value2);
+
+		var snapshot = IdentityMapUtils.GetSnapshot(map);
+
+		Assert.AreEqual(2, snapshot.Count, "There are two elements in the snapshot");
+		foreach (var de in snapshot)
+		{
+			Assert.IsTrue(map.ContainsKey(de.Key), "The Key in the snapshot should have been in the original map's Keys");
+			Assert.IsTrue(de.Value == map[de.Key],
+			              "The Value identified by the Key in the snapshot should be the same as the IdentityMap");
+		}
+	}
+
+	/// <summary>
+	/// Tests that it is safe to modify the IdentityMap while iterating through GetEntries,
+	/// and that the snapshot's contents stay fixed even as the underlying map keeps changing
+	/// (i.e. it does not observe writes that occur after it was created, whether those writes
+	/// happen before or after the snapshot is frozen).
+	/// </summary>
+	[Test]
+	public void GetEntriesModification()
+	{
+		var noHashCode3 = new NoHashCode();
+		var value3 = new object();
+
+		var noHashCode4 = new NoHashCode();
+		var value4 = new object();
+
+		var map = GetIdentityMap();
+		map.Add(noHashCode1, value1);
+		map.Add(noHashCode2, value2);
+
+		var snapshot = IdentityMapUtils.GetSnapshot(map);
+
+		for (var i = 0; i < 2; i++)
+		{
+			if (i == 0) map.Add(noHashCode3, value3);
+			if (i == 1) map.Add(noHashCode4, value4);
+
+			Assert.AreEqual(2, snapshot.Count, "Snapshot should still have 2 items even after the map is modified");
+			Assert.AreEqual(2 + i + 1, map.Count, "Should be " + (2 + i + 1) + " items in the IdentityMap");
+		}
+
+		CollectionAssert.AreEquivalent(
+			new object[] { noHashCode1, noHashCode2 },
+			snapshot.KeyList().ToList(),
+			"Snapshot keys should be exactly the ones present when it was created");
+	}
+}

--- a/src/NHibernate.Test/UtilityTest/IdentityMapGenericFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/IdentityMapGenericFixture.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest;
+
+/// <summary>
+/// Tests for the generic <see cref="IdentityMap{TKey,TValue}"/>, mirroring
+/// <see cref="IdentityMapFixture"/>.
+/// </summary>
+[TestFixture]
+public class IdentityMapGenericFixture
+{
+	protected MutableHashCode item1;
+	protected MutableHashCode item2;
+
+	protected NoHashCode noHashCode1;
+	protected NoHashCode noHashCode2;
+
+	protected object value1;
+	protected object value2;
+
+	[SetUp]
+	public void SetUp()
+	{
+		item1 = new MutableHashCode(1);
+		item2 = new MutableHashCode(2);
+
+		value1 = new object();
+		value2 = new object();
+
+		noHashCode1 = new NoHashCode();
+		noHashCode2 = new NoHashCode();
+	}
+
+	protected virtual IDictionary<object, object> GetIdentityMap() => IdentityMapUtils.Instantiate<object, object>(10);
+
+	/// <summary>
+	/// Verify that the object being added as the Key does not have its GetHashCode
+	/// method called.
+	/// </summary>
+	[Test]
+	public void AddNoHashCode()
+	{
+		var map = GetIdentityMap();
+		map.Add(noHashCode1, value1);
+
+		Assert.AreEqual(1, map.Count, "The item was added succesfully");
+	}
+
+	/// <summary>
+	/// An IdentityMap can not use a ValueType as the Key because of the boxing/unboxing
+	/// that occurs with them. This verifies that an Exception is thrown if a ValueType
+	/// is used as the key.
+	/// </summary>
+	[Test]
+	public void AddValueTypeException()
+	{
+		var map = GetIdentityMap();
+		object intKey = 3;
+		object objectValue = new object();
+		Assert.Throws<ArgumentException>(() => map.Add(intKey, objectValue));
+	}
+
+	[Test]
+	public void Count()
+	{
+		var map = GetIdentityMap();
+		map.Add(new object(), new object());
+		map.Add(new object(), new object());
+
+		Assert.AreEqual(2, map.Count, "Expect 2 items in the IdentityMap");
+	}
+
+	/// <summary>
+	/// Test that two different references to the same object passed to ContainsKey
+	/// both return true.
+	/// </summary>
+	[Test]
+	public void ContainsSameObjectByRef()
+	{
+		var map = GetIdentityMap();
+
+		var item1Copy = item1;
+
+		map.Add(item1, new object());
+
+		Assert.AreSame(item1, item1Copy);
+		Assert.IsTrue(map.ContainsKey(item1Copy), "We should be able to get the same object out of the IdentityMap with " +
+												  "two different references to the same object.");
+	}
+
+	/// <summary>
+	/// Test that even though the HashCode and Equals of the same reference have been changed
+	/// that ContainsKey still recognizes it by the Identity of the object - not the values.
+	/// </summary>
+	[Test]
+	public void ContainsSameObjectWithDiffEquals()
+	{
+		var map = GetIdentityMap();
+
+		map.Add(item1, new object());
+
+		item1.HashCodeField = 5;
+
+		Assert.IsTrue(map.ContainsKey(item1),
+					  "Even though item1's HashCode field change the IdentityMap.ContainsKey() should still return true");
+	}
+
+	/// <summary>
+	/// Test to make sure that two objects that are equal by the Equals definition of the class MutableHashCode
+	/// do not get translated to the same key because they are different objects.
+	/// </summary>
+	[Test]
+	public void ContainsDiffObjectWithEquals()
+	{
+		var map = GetIdentityMap();
+		item1.HashCodeField = 4;
+		item2.HashCodeField = 4;
+
+		map.Add(item1, new object());
+
+		Assert.AreEqual(item1, item2, "They should be equal.");
+		Assert.IsFalse(map.ContainsKey(item2), "Even though item1.Equals(item2) IdentityMap should not find by item2");
+	}
+
+	/// <summary>
+	/// Add the same MutableHashCode class twice and ensure there is only
+	/// one item in the IdentityMap.
+	/// </summary>
+	[Test]
+	public void SetItemChangedHashCodeTwice()
+	{
+		var actualMap = GetIdentityMap();
+
+		actualMap[item1] = value1;
+
+		// change the Property that GetHashCode method uses
+		item1.HashCodeField = 2;
+		actualMap[item1] = value1;
+		Assert.AreEqual(1, actualMap.Count, "Should only be 1 item in the IdentityMap");
+	}
+
+	/// <summary>
+	/// Adds two different objects that are Equal() to each other to verify that
+	/// it does not use the objects Equal() but instead the IdentityMap's reference identity.
+	/// </summary>
+	[Test]
+	public void SetItemsEqualHashCodeDiffIdentity()
+	{
+		var actualMap = GetIdentityMap();
+
+		item1.HashCodeField = 3;
+		item2.HashCodeField = 3;
+
+		Assert.AreEqual(item1, item2, "The two objects are equal");
+		Assert.IsTrue(item1 != item2, "The two items are different objects in memory");
+
+		actualMap[item1] = value1;
+		actualMap[item2] = value2;
+
+		Assert.AreEqual(2, actualMap.Count, "The IdentityMap should have 2 elements");
+	}
+
+	/// <summary>
+	/// Verify the Keys returns the object passed as the key, not some transformed identity key.
+	/// </summary>
+	[Test]
+	public void Keys()
+	{
+		var map = GetIdentityMap();
+		map.Add(item1, value1);
+		map.Add(item2, value2);
+
+		Assert.AreEqual(2, map.Keys.Count, "Same number of Keys");
+		CollectionAssert.Contains(map.Keys, item1);
+		CollectionAssert.Contains(map.Keys, item2);
+	}
+
+	/// <summary>
+	/// Verify that GetEntries returns a snapshot that contains the same
+	/// Keys/Values as originally added into the IdentityMap.
+	/// </summary>
+	[Test]
+	public void GetEntries()
+	{
+		var map = GetIdentityMap();
+
+		map.Add(noHashCode1, value1);
+		map.Add(noHashCode2, value2);
+
+		var snapshot = IdentityMapUtils.GetSnapshot(map);
+
+		Assert.AreEqual(2, snapshot.Count, "There are two elements in the snapshot");
+		foreach (var de in snapshot)
+		{
+			Assert.IsTrue(map.ContainsKey(de.Key), "The Key in the snapshot should have been in the original map's Keys");
+			Assert.IsTrue(de.Value == map[de.Key],
+						  "The Value identified by the Key in the snapshot should be the same as the IdentityMap");
+		}
+	}
+
+	/// <summary>
+	/// Tests that it is safe to modify the IdentityMap while iterating through GetEntries,
+	/// and that the snapshot's contents stay fixed even as the underlying map keeps changing
+	/// (i.e. it does not observe writes that occur after it was created, whether those writes
+	/// happen before or after the snapshot is frozen).
+	/// </summary>
+	[Test]
+	public void GetEntriesModification()
+	{
+		var noHashCode3 = new NoHashCode();
+		var value3 = new object();
+
+		var noHashCode4 = new NoHashCode();
+		var value4 = new object();
+
+		var map = GetIdentityMap();
+		map.Add(noHashCode1, value1);
+		map.Add(noHashCode2, value2);
+
+		var snapshot = IdentityMapUtils.GetSnapshot(map);
+
+		for (var i = 0; i < 2; i++)
+		{
+			if (i == 0) map.Add(noHashCode3, value3);
+			if (i == 1) map.Add(noHashCode4, value4);
+
+			Assert.AreEqual(2, snapshot.Count, "Snapshot should still have 2 items even after the map is modified");
+			Assert.AreEqual(2 + i + 1, map.Count, "Should be " + (2 + i + 1) + " items in the IdentityMap");
+		}
+
+		CollectionAssert.AreEquivalent(
+			new object[] { noHashCode1, noHashCode2 },
+			snapshot.KeyList().ToList(),
+			"Snapshot keys should be exactly the ones present when it was created");
+	}
+}

--- a/src/NHibernate.Test/UtilityTest/IdentityMapGenericSequencedFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/IdentityMapGenericSequencedFixture.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest;
+
+/// <summary>
+/// Runs every <see cref="IdentityMapGenericFixture"/> reference-identity test against the
+/// sequenced backing store, and adds the ordering guarantees that only
+/// <see cref="IdentityMapUtils.InstantiateSequenced"/> makes.
+/// </summary>
+[TestFixture]
+public class IdentityMapGenericSequencedFixture : IdentityMapGenericFixture
+{
+	protected override IDictionary<object, object> GetIdentityMap() => IdentityMapUtils.InstantiateSequenced<object, object>(10);
+
+	[Test]
+	public void IteratesInInsertionOrder()
+	{
+		var map = GetIdentityMap();
+		var keys = Enumerable.Range(0, 30).Select(_ => new object()).ToArray();
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.Select(kv => kv.Key), Is.EqualTo(keys));
+		Assert.That(map.Keys, Is.EqualTo(keys));
+	}
+
+	/// <summary>
+	/// Matches the legacy <see cref="IdentityMap.InstantiateSequenced"/> behaviour, where
+	/// overwriting a value moved the key to the end of the iteration order.
+	/// </summary>
+	[Test]
+	public void OverwritingAValueMovesTheKeyToTheEnd()
+	{
+		var map = GetIdentityMap();
+		var keys = Enumerable.Range(0, 4).Select(_ => new object()).ToArray();
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		map[keys[0]] = "rewritten";
+
+		Assert.That(map.Keys, Is.EqualTo(new[] { keys[1], keys[2], keys[3], keys[0] }));
+		Assert.That(map.Count, Is.EqualTo(4));
+	}
+
+	[Test]
+	public void SnapshotPreservesOrder()
+	{
+		var map = GetIdentityMap();
+		var keys = Enumerable.Range(0, 10).Select(_ => new object()).ToArray();
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = IdentityMapUtils.GetSnapshot(map);
+
+		map.Add(new object(), "added");
+		map[keys[0]] = "rewritten";
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+	}
+}

--- a/src/NHibernate.Test/UtilityTest/SequencedSnapshotDictionaryFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/SequencedSnapshotDictionaryFixture.cs
@@ -1,0 +1,1240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest;
+
+/// <summary>
+/// Tests for the insertion-ordered <see cref="SequencedSnapshotDictionary{TKey,TValue}"/>
+/// that backs <see cref="IdentityMap{TKey,TValue}.InstantiateSequenced"/>.
+/// </summary>
+[TestFixture]
+public class SequencedSnapshotDictionaryFixture
+{
+	private ISerializationStrategy _initialStrategy;
+
+	[SetUp]
+	public void SetUp()
+	{
+		_initialStrategy = SerializationConfiguration.Strategy;
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		SerializationConfiguration.Strategy = _initialStrategy;
+	}
+
+	[Test]
+	public void AddsIterateInInsertionOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(50);
+
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+		Assert.That(map.Keys, Is.EqualTo(keys));
+		Assert.That(map.Values, Is.EqualTo(keys));
+	}
+
+	/// <summary>
+	/// The <see cref="SequencedHashMap"/> this type replaces removes and re-inserts an entry
+	/// whenever its value is overwritten through the indexer, so the key moves to the end.
+	/// That behaviour is deliberately preserved.
+	/// </summary>
+	[Test]
+	public void OverwritingExistingKeyMovesItToTheEnd()
+	{
+		var map = NewMap();
+		var keys = Keys(4);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		map[keys[1]] = "rewritten";
+
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[0], keys[2], keys[3], keys[1] }));
+		Assert.That(map[keys[1]], Is.EqualTo("rewritten"));
+		Assert.That(map.Count, Is.EqualTo(4), "an overwrite must not change the live count");
+	}
+
+	[Test]
+	public void OverwritingTheLastKeyLeavesItLast()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		map[keys[2]] = "rewritten";
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void RepeatedOverwritesKeepMovingTheKeyToTheEnd()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, 0);
+		}
+
+		map[keys[0]] = 1;
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[1], keys[2], keys[0] }));
+
+		map[keys[1]] = 1;
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[2], keys[0], keys[1] }));
+
+		map[keys[2]] = 1;
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[0], keys[1], keys[2] }));
+	}
+
+	[Test]
+	public void AddThrowsOnDuplicateKeyWithoutDisturbingOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		Assert.Throws<ArgumentException>(() => map.Add(keys[0], "again"));
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+		Assert.That(map[keys[0]], Is.EqualTo("initial"));
+		Assert.That(map.Count, Is.EqualTo(3));
+	}
+
+	[Test]
+	public void RemovalPreservesTheOrderOfTheRemainingEntries()
+	{
+		var map = NewMap();
+		var keys = Keys(6);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.Remove(keys[0]), Is.True);
+		Assert.That(map.Remove(keys[3]), Is.True);
+		Assert.That(map.Remove(keys[5]), Is.True);
+
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[1], keys[2], keys[4] }));
+	}
+
+	[Test]
+	public void ReAddingARemovedKeyPutsItAtTheEnd()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		map.Remove(keys[0]);
+		map.Add(keys[0], keys[0]);
+
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[1], keys[2], keys[0] }));
+	}
+
+	[Test]
+	public void OrderSurvivesBucketGrowth()
+	{
+		var map = NewMap(1);
+		var keys = Keys(500);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+		foreach (var key in keys)
+		{
+			Assert.That(map[key], Is.SameAs(key));
+		}
+	}
+
+	[Test]
+	public void OrderSurvivesHeavyOverwriteChurn()
+	{
+		var map = NewMap();
+		var keys = Keys(40);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		var slotsAfterFill = map.EntrySlotCount;
+
+		var expected = new List<object>(keys);
+		for (var round = 0; round < 20; round++)
+		{
+			foreach (var key in keys)
+			{
+				map[key] = round;
+				expected.Remove(key);
+				expected.Add(key);
+			}
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(expected));
+		Assert.That(map.Count, Is.EqualTo(keys.Length));
+		Assert.That(map.EntrySlotCount, Is.EqualTo(slotsAfterFill));
+	}
+
+	[Test]
+	public void KeysAndValuesEnumerateInOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(5);
+		for (var i = 0; i < keys.Length; i++)
+		{
+			map.Add(keys[i], i);
+		}
+
+		map[keys[0]] = 99; // moves keys[0] to the end
+
+		Assert.That(map.Keys, Is.EqualTo(new[] { keys[1], keys[2], keys[3], keys[4], keys[0] }));
+		Assert.That(map.Values, Is.EqualTo(new object[] { 1, 2, 3, 4, 99 }));
+	}
+
+	[Test]
+	public void CopyToWritesEntriesInOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(4);
+		for (var i = 0; i < keys.Length; i++)
+		{
+			map.Add(keys[i], i);
+		}
+
+		map.Remove(keys[1]);
+		map[keys[0]] = 42; // moves keys[0] to the end
+
+		var target = new KeyValuePair<object, object>[3];
+		map.CopyTo(target, 0);
+
+		Assert.That(target.Select(kv => kv.Key), Is.EqualTo(new[] { keys[2], keys[3], keys[0] }));
+		Assert.That(target.Select(kv => kv.Value), Is.EqualTo(new object[] { 2, 3, 42 }));
+	}
+
+	[Test]
+	public void AddRemoveChurnRecyclesSlots()
+	{
+		var map = NewMap();
+
+		for (var i = 0; i < 5000; i++)
+		{
+			var key = new object();
+			map.Add(key, i);
+			map.Remove(key);
+		}
+
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(map.EntrySlotCount, Is.LessThanOrEqualTo(1),
+					"add/remove churn must reuse the freed slot instead of consuming new ones");
+	}
+
+	[Test]
+	public void RemovingKeepsSnapshotsIsolated()
+	{
+		var map = NewMap();
+		var keys = Keys(10);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		for (var i = 0; i < 500; i++)
+		{
+			map[keys[i % keys.Length]] = i;
+		}
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys), "the snapshot must keep its original order");
+		foreach (var key in keys)
+		{
+			Assert.That(snapshot.ValueFor(key), Is.EqualTo("initial"));
+		}
+	}
+
+	[Test]
+	public void SnapshotHonoursComparer()
+	{
+		var map = NewMap();
+		var a = new MutableHashCode(7);
+		var b = new MutableHashCode(7); // equal by value, different reference
+		var value = new object();
+
+		map[a] = value;
+		using var snapshot = map.GetSnapshot();
+
+		Assert.That(map.ContainsKey(b), Is.False, "the live map must use identity, not value equality");
+		Assert.That(snapshot.HasKey(b), Is.False, "the snapshot must use identity, not value equality");
+		Assert.That(snapshot.HasKey(a), Is.True);
+		Assert.That(snapshot.ValueFor(a), Is.SameAs(value));
+	}
+
+	[Test]
+	public void SnapshotEnumeratesInTheSameOrderAsTheMap()
+	{
+		var map = NewMap();
+		var keys = Keys(30);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		map[keys[0]] = "moved";
+
+		using var snapshot = map.GetSnapshot();
+
+		Assert.That(snapshot.KeyList(), Is.EqualTo(KeyOrder(map)));
+	}
+
+	[Test]
+	public void SnapshotIsUnaffectedByLaterReordering()
+	{
+		var map = NewMap();
+		var keys = Keys(5);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		map[keys[0]] = "moved";
+		map[keys[1]] = "moved";
+		map.Remove(keys[4]);
+		map.Add(new object(), "added");
+
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys), "the snapshot keeps its frozen order");
+		Assert.That(snapshot.ValueList(), Is.EqualTo(Enumerable.Repeat("initial", 5)));
+	}
+
+	[Test]
+	public void SnapshotIsIsolatedFromClear()
+	{
+		var map = NewMap();
+		var keys = Keys(10);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		map.Clear();
+
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(snapshot.Count, Is.EqualTo(10));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void SnapshotIsIsolatedFromAppend()
+	{
+		var map = NewMap(4);
+		var keys = Keys(4);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		var added = Keys(4);
+		foreach (var key in added)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(snapshot.Count, Is.EqualTo(4));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		foreach (var key in added)
+		{
+			Assert.That(snapshot.HasKey(key), Is.False,
+						"entries appended after the freeze must not be reachable through the snapshot's chains");
+		}
+	}
+
+	[Test]
+	public void RemovingAnEntryAppendedAfterTheSnapshotLeavesTheSnapshotUntouched()
+	{
+		var map = NewMap(4);
+		var keys = Keys(4);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		var extra = new object();
+		map.Add(extra, extra);
+		map.Remove(extra);
+
+		Assert.That(snapshot.Count, Is.EqualTo(4));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		Assert.That(map.Count, Is.EqualTo(4));
+	}
+
+	[Test]
+	public void ChainedAppendsNeverLeakIntoAnEarlierSnapshot()
+	{
+		var map = NewMap();
+		var initialKeys = Keys(3);
+		foreach (var key in initialKeys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshotA = map.GetSnapshot();
+		var beforeAppends = map.CopyOnWriteCount;
+
+		var d = new object();
+		map.Add(d, d);
+
+		using var snapshotB = map.GetSnapshot();
+
+		var e = new object();
+		map.Add(e, e);
+		var f = new object();
+		map.Add(f, f);
+
+		Assert.That(snapshotA.KeyList(), Is.EqualTo(initialKeys));
+		Assert.That(snapshotB.KeyList(), Is.EqualTo(new[] { initialKeys[0], initialKeys[1], initialKeys[2], d }));
+		Assert.That(map.Keys, Is.EqualTo(new[] { initialKeys[0], initialKeys[1], initialKeys[2], d, e, f }));
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(beforeAppends));
+	}
+
+	[Test]
+	public void RehashAndChainChurnUnderAnOutstandingSnapshotCopyNothingAndAreInvisible()
+	{
+		// Start small so growing to 400 entries forces several rehashes.
+		var map = NewMap(1);
+		var original = Keys(20);
+		foreach (var key in original)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+		var copiesAfterSnapshot = map.CopyOnWriteCount;
+
+		// Force repeated rehashes (and growth) while the snapshot is outstanding.
+		var added = Keys(380);
+		foreach (var key in added)
+		{
+			map.Add(key, key);
+		}
+
+		// Growth and rehashing touch only the hash structure, which no snapshot reads
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(copiesAfterSnapshot));
+
+		// Now remove the entries that were added, which unlinks them from their bucket chains.
+		// These slots are all at or beyond the snapshot, so this must stay copy-free too.
+		foreach (var key in added)
+		{
+			map.Remove(key);
+		}
+
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(copiesAfterSnapshot));
+
+		Assert.That(snapshot.Count, Is.EqualTo(original.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(original));
+		Assert.That(snapshot.ValueList(), Is.EqualTo(original));
+
+		Assert.That(map.Count, Is.EqualTo(original.Length));
+		Assert.That(KeyOrder(map), Is.EqualTo(original));
+		foreach (var key in original)
+		{
+			Assert.That(map[key], Is.SameAs(key));
+		}
+
+		foreach (var key in added)
+		{
+			Assert.That(map.ContainsKey(key), Is.False);
+		}
+	}
+
+	[Test]
+	public void RemovalsWithinSnapshotCopyAndStayIsolated()
+	{
+		var map = NewMap(1);
+		var keys = Keys(20);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+		var before = map.CopyOnWriteCount;
+
+		foreach (var key in keys)
+		{
+			map.Remove(key);
+		}
+
+		// +1 copy for slots
+		// +1 copy for values
+		// +1 copy for orderNext
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before + 3),
+					"removing entries the snapshot can see must pay the copy-on-write cost");
+		Assert.That(map.Count, Is.EqualTo(0));
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		Assert.That(snapshot.ValueList(), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void UpdatesWithinSnapshotCopyAndStayIsolated()
+	{
+		var map = NewMap(1);
+		var keys = Keys(20);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+		var before = map.CopyOnWriteCount;
+
+		foreach (var key in keys)
+		{
+			map[key] = new object();
+		}
+
+		// +1 copy for values
+		// +1 copy for orderNext
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before + 2),
+					"updating entries the snapshot can see must pay the copy-on-write cost");
+		Assert.That(map.Count, Is.EqualTo(keys.Length));
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		Assert.That(snapshot.ValueList(), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void OverlappingSnapshotsAreEachIsolated()
+	{
+		var map = NewMap(4, new FewBucketsComparer());
+		var initialKeys = Keys(3);
+		foreach (var key in initialKeys)
+		{
+			map.Add(key, "v1");
+		}
+
+		using var snapshotA = map.GetSnapshot();
+
+		map[initialKeys[0]] = "v2";
+		var keyAddedAfterSnapshotA = new object();
+		map.Add(keyAddedAfterSnapshotA, "v2");
+
+		using var snapshotB = map.GetSnapshot();
+
+		map[initialKeys[1]] = "v3";
+		map.Remove(initialKeys[2]);
+
+		Assert.That(map[initialKeys[1]], Is.EqualTo("v3"));
+
+		Assert.That(snapshotA.Count, Is.EqualTo(3));
+		Assert.That(snapshotA.KeyList(), Is.EqualTo(initialKeys));
+		Assert.That(snapshotA.ValueList(), Is.EqualTo(new object[] { "v1", "v1", "v1" }));
+
+		Assert.That(snapshotB.Count, Is.EqualTo(4));
+		Assert.That(snapshotB.KeyList(), Is.EqualTo(new[] { initialKeys[1], initialKeys[2], initialKeys[0], keyAddedAfterSnapshotA }));
+		Assert.That(snapshotB.ValueFor(initialKeys[0]), Is.EqualTo("v2"));
+		Assert.That(snapshotB.ValueFor(initialKeys[1]), Is.EqualTo("v1"));
+	}
+
+	[Test]
+	public void AppendsAfterSnapshotCopyNothing()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(8))
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		var before = map.CopyOnWriteCount;
+		foreach (var key in Keys(32))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.CopyOnWriteCount - before, Is.EqualTo(0),
+					"appends while a snapshot is outstanding must not copy any array");
+		Assert.That(snapshot.Count, Is.EqualTo(8));
+	}
+
+	[Test]
+	public void DisposingSnapshotAvoidsCopyOnWriteOnSubsequentWrites()
+	{
+		var map = NewMap();
+		var keys = Keys(8);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		using (var snapshot = map.GetSnapshot())
+		{
+			Assert.That(map.OutstandingSnapshots, Is.EqualTo(1));
+			Assert.That(snapshot.Count, Is.EqualTo(8));
+		}
+
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(0));
+
+		var before = map.CopyOnWriteCount;
+		foreach (var key in keys)
+		{
+			map[key] = "rewritten";
+		}
+		map.Add(new object(), "added");
+		map.Remove(keys[0]);
+
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before),
+					"once every snapshot is released, writes must go back to being fully in place");
+	}
+
+	[Test]
+	public void LeavingSnapshotUndisposedCausesSubsequentWritesToCopy()
+	{
+		var map = NewMap();
+		var keys = Keys(8);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		var snapshot = map.GetSnapshot(); // deliberately not disposed
+
+		var before = map.CopyOnWriteCount;
+		map[keys[0]] = "rewritten";
+
+		Assert.That(map.CopyOnWriteCount, Is.GreaterThan(before));
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(1));
+		Assert.That(snapshot.ValueFor(keys[0]), Is.EqualTo("initial"));
+	}
+
+	[Test]
+	public void OverlappingSnapshotsOnlyStopCopyingOnceAllAreDisposed()
+	{
+		var map = NewMap();
+		var keys = Keys(8);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		var first = map.GetSnapshot();
+		var second = map.GetSnapshot();
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(2));
+
+		first.Dispose();
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(1));
+
+		var before = map.CopyOnWriteCount;
+		map[keys[0]] = "rewritten";
+		Assert.That(map.CopyOnWriteCount, Is.GreaterThan(before),
+					"one snapshot is still outstanding, so writes must still copy");
+
+		second.Dispose();
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(0));
+
+		before = map.CopyOnWriteCount;
+		map[keys[1]] = "rewritten";
+		map.Add(new object(), "added");
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before));
+	}
+
+	[Test]
+	public void ReadsAfterDisposeThrowObjectDisposedException()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		var snapshot = map.GetSnapshot();
+		snapshot.Dispose();
+
+		Assert.Throws<ObjectDisposedException>(() => { var _ = snapshot.Count; });
+		Assert.Throws<ObjectDisposedException>(() => { var _ = snapshot.ValueFor(key); });
+		Assert.Throws<ObjectDisposedException>(() => snapshot.TryGetValueByIdentity(key, out _));
+		Assert.Throws<ObjectDisposedException>(() => snapshot.HasKey(key));
+		Assert.Throws<ObjectDisposedException>(() => snapshot.GetEnumerator());
+	}
+
+	[Test]
+	public void DisposeIsIdempotent()
+	{
+		var map = NewMap();
+		map.Add(new object(), "value");
+
+		var snapshot = map.GetSnapshot();
+		snapshot.Dispose();
+		snapshot.Dispose();
+		snapshot.Dispose();
+
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(0),
+					"repeated disposal must not drive the refcount negative");
+	}
+
+	[Test]
+	public void DisposingSnapshotMidEnumerationThrowsOnNextMoveNext()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		var snapshot = map.GetSnapshot();
+		using var enumerator = snapshot.GetEnumerator();
+
+		Assert.That(enumerator.MoveNext(), Is.True);
+		snapshot.Dispose();
+
+		Assert.Throws<ObjectDisposedException>(() => enumerator.MoveNext());
+	}
+
+	[Test]
+	public void EnumerationThrowsWhenMapIsModified()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map)
+			{
+				map.Add(new object(), "added");
+			}
+		});
+	}
+
+	[Test]
+	public void EnumerationThrowsWhenAValueIsOverwritten()
+	{
+		var map = NewMap();
+		var keys = Keys(5);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map)
+			{
+				map[keys[0]] = "rewritten";
+			}
+		});
+	}
+
+	[Test]
+	public void KeysEnumerationThrowsWhenMapIsModified()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map.Keys)
+			{
+				map.Add(new object(), "added");
+			}
+		});
+	}
+
+	[Test]
+	public void ValuesEnumerationThrowsWhenMapIsModified()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map.Values)
+			{
+				map.Add(new object(), "added");
+			}
+		});
+	}
+
+	[Test]
+	public void NegativeCapacityThrows()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(
+			() => new SequencedSnapshotDictionary<object, object>(-1, ReferenceComparer<object>.Instance));
+	}
+
+	[Test]
+	public void ZeroCapacityStillAcceptsEntries()
+	{
+		var map = NewMap(0);
+		var keys = Keys(20);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.Count, Is.EqualTo(20));
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void IndexerGetThrowsForMissingKey()
+	{
+		var map = NewMap();
+		Assert.Throws<KeyNotFoundException>(() => { var _ = map[new object()]; });
+	}
+
+	[Test]
+	public void RemovingAbsentKeyIsANoOp()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		Assert.That(map.Remove(new object()), Is.False);
+		Assert.That(map.Count, Is.EqualTo(1));
+		Assert.That(map[key], Is.EqualTo("value"));
+	}
+
+	[Test]
+	public void ContainsAndRemoveByPairMatchOnValueToo()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		Assert.That(map.Contains(new KeyValuePair<object, object>(key, "value")), Is.True);
+		Assert.That(map.Contains(new KeyValuePair<object, object>(key, "other")), Is.False);
+
+		Assert.That(map.Remove(new KeyValuePair<object, object>(key, "other")), Is.False);
+		Assert.That(map.Count, Is.EqualTo(1));
+
+		Assert.That(map.Remove(new KeyValuePair<object, object>(key, "value")), Is.True);
+		Assert.That(map.Count, Is.EqualTo(0));
+	}
+
+	[Test]
+	public void ClearedMapIsStillUsable()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(10))
+		{
+			map.Add(key, key);
+		}
+
+		map.Clear();
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(map, Is.Empty);
+
+		var after = Keys(5);
+		foreach (var key in after)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(after));
+	}
+
+	[Test]
+	public void KeysAndValuesAreCachedAcrossAccesses()
+	{
+		var map = NewMap();
+		var keys = map.Keys;
+		var values = map.Values;
+
+		Assert.That(map.Keys, Is.SameAs(keys));
+		Assert.That(map.Values, Is.SameAs(values));
+	}
+
+	[Test]
+	public void CopyToThrowsForNullArray()
+	{
+		var map = NewMap();
+		Assert.Throws<ArgumentNullException>(() => map.CopyTo(null, 0));
+		Assert.Throws<ArgumentNullException>(() => map.Keys.CopyTo(null, 0));
+		Assert.Throws<ArgumentNullException>(() => map.Values.CopyTo(null, 0));
+	}
+
+	[Test]
+	public void CopyToThrowsForNegativeIndex()
+	{
+		var map = NewMap();
+		Assert.Throws<ArgumentOutOfRangeException>(() => map.CopyTo(new KeyValuePair<object, object>[1], -1));
+		Assert.Throws<ArgumentOutOfRangeException>(() => map.Keys.CopyTo(new object[1], -1));
+		Assert.Throws<ArgumentOutOfRangeException>(() => map.Values.CopyTo(new object[1], -1));
+	}
+
+	[Test]
+	public void CopyToThrowsForInsufficientSpace()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(3))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<ArgumentException>(() => map.CopyTo(new KeyValuePair<object, object>[2], 0));
+		Assert.Throws<ArgumentException>(() => map.CopyTo(new KeyValuePair<object, object>[3], 1));
+		Assert.Throws<ArgumentException>(() => map.Keys.CopyTo(new object[2], 0));
+		Assert.Throws<ArgumentException>(() => map.Values.CopyTo(new object[2], 0));
+	}
+
+	[Test]
+	public void KeysAndValuesCollectionsAreReadOnly()
+	{
+		var map = NewMap();
+		Assert.That(map.Keys.IsReadOnly, Is.True);
+		Assert.That(map.Values.IsReadOnly, Is.True);
+		Assert.Throws<NotSupportedException>(() => map.Keys.Add(new object()));
+		Assert.Throws<NotSupportedException>(() => map.Keys.Clear());
+		Assert.Throws<NotSupportedException>(() => map.Keys.Remove(new object()));
+		Assert.Throws<NotSupportedException>(() => map.Values.Add(new object()));
+		Assert.Throws<NotSupportedException>(() => map.Values.Clear());
+		Assert.Throws<NotSupportedException>(() => map.Values.Remove(new object()));
+	}
+
+	[Test]
+	public void KeysAndValuesContainsWork()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		Assert.That(map.Keys.Contains(key), Is.True);
+		Assert.That(map.Keys.Contains(new object()), Is.False);
+		Assert.That(map.Values.Contains("value"), Is.True);
+		Assert.That(map.Values.Contains("other"), Is.False);
+
+		map.Remove(key);
+		Assert.That(map.Keys.Contains(key), Is.False);
+		Assert.That(map.Values.Contains("value"), Is.False);
+	}
+
+	[Test]
+	public void RemovedEntryDoesNotRetainKeyOrValueReferences()
+	{
+		var map = NewMap();
+		var weak = PopulateAndRemove(map);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.That(weak.IsAlive, Is.False);
+	}
+
+	private static WeakReference PopulateAndRemove(SequencedSnapshotDictionary<object, object> map)
+	{
+		var key = new object();
+		var value = new object();
+		map.Add(key, value);
+		var weak = new WeakReference(value);
+		map.Remove(key);
+		return weak;
+	}
+
+	[Test]
+	public void OverwrittenValueIsNotRetained()
+	{
+		var map = NewMap();
+		var key = new object();
+		var weak = PopulateAndOverwrite(map, key);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.That(weak.IsAlive, Is.False);
+	}
+
+	private static WeakReference PopulateAndOverwrite(SequencedSnapshotDictionary<object, object> map, object key)
+	{
+		var original = new object();
+		map.Add(key, original);
+		var weak = new WeakReference(original);
+		map[key] = new object();
+		return weak;
+	}
+
+	[Test]
+	public void ClearedEntriesDoNotRetainKeyOrValueReferences()
+	{
+		var map = NewMap();
+		var weak = PopulateAndClear(map);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.That(weak.IsAlive, Is.False);
+	}
+
+	private static WeakReference PopulateAndClear(SequencedSnapshotDictionary<object, object> map)
+	{
+		var key = new object();
+		var value = new object();
+		map.Add(key, value);
+		var weak = new WeakReference(value);
+		map.Clear();
+		return weak;
+	}
+
+	[Test]
+	public void SerializationRoundTripPreservesOrderContentsAndIdentitySemantics()
+	{
+		TestConfigurationHelper.UseTestSerialization();
+
+		var map = NewMap();
+		var a = new MutableHashCode(1);
+		var b = new MutableHashCode(1);
+		var c = new MutableHashCode(2);
+		map.Add(a, "valueA");
+		map.Add(b, "valueB");
+		map.Add(c, "valueC");
+		map[a] = "valueA"; // move a to the end, so order is b, c, a
+		map.Remove(c);
+
+		using var unusedSnapshot = map.GetSnapshot();
+
+		var bytes = SerializationHelper.Serialize(map);
+		var restored = (SequencedSnapshotDictionary<object, object>) SerializationHelper.Deserialize(bytes);
+		((IDeserializationCallback) restored).OnDeserialization(null);
+
+		Assert.That(restored.Count, Is.EqualTo(2));
+		Assert.That(restored.Values, Is.EqualTo(new object[] { "valueB", "valueA" }),
+					"iteration order, including the move-to-end, must survive the round trip");
+		Assert.That(restored.OutstandingSnapshots, Is.EqualTo(0),
+					"a freshly deserialized instance must start with no outstanding snapshots");
+
+		// A round trip necessarily produces new key instances, so the live `a`/`b` references
+		// can never be reference-equal to anything inside `restored`. What must hold is that
+		// identity semantics still apply to the deserialized keys, and that each is findable by
+		// reference after the post-deserialization rehash (proving the rehash used each key's
+		// own bucket, not its pre-serialization one).
+		var restoredKeys = restored.Keys.ToArray();
+		Assert.That(restoredKeys, Has.Length.EqualTo(2));
+		Assert.That(restored.ContainsKey(new MutableHashCode(1)), Is.False,
+					"the restored map must still use identity, not value equality");
+		foreach (var key in restoredKeys)
+		{
+			Assert.That(restored.ContainsKey(key), Is.True);
+		}
+
+		// Writes right after deserialization must not pay any copy-on-write cost, since
+		// OnDeserialization reset the snapshot bookkeeping to a clean state.
+		var copiesBeforeWrite = restored.CopyOnWriteCount;
+		restored[restoredKeys[0]] = "rewritten";
+		Assert.That(restored.CopyOnWriteCount, Is.EqualTo(copiesBeforeWrite),
+					"writes right after deserialization must not pay any copy-on-write cost");
+
+		// still writable and enumerable after the rehash
+		var extra = new object();
+		restored.Add(extra, "valueD");
+		Assert.That(restored.Count, Is.EqualTo(3));
+		Assert.That(restored.Keys, Is.EqualTo(new[] { restoredKeys[1], restoredKeys[0], extra }));
+	}
+
+	[Test]
+	public void RandomizedOrderAndSnapshotIsolationStress() => RunRandomizedStress(seed: 20260806, comparer: null);
+
+	[Test]
+	public void RandomizedOrderAndSnapshotIsolationStressWithForcedBucketCollisions() => RunRandomizedStress(seed: 20260806, comparer: new FewBucketsComparer());
+
+	[Test, Explicit]
+	public void RandomizedOrderAndSnapshotIsolationStress_100kIter() => RunRandomizedStress(seed: 20260806, comparer: null, iterCount: 100_000);
+
+	[Test, Explicit]
+	public void RandomizedOrderAndSnapshotIsolationStress_100kStep() => RunRandomizedStress(seed: 20260806, comparer: null, stepCount: 100_000);
+
+	/// <summary>
+	/// Randomised model-based check. The model is an ordered list of key/value pairs mutated
+	/// with exactly the semantics this dictionary promises: append on add, move-to-end on
+	/// overwrite, remove in place.
+	/// Every snapshot taken along the way must keep exactly the contents and order it had when
+	/// it was created, regardless of what happens to the live map afterwards.
+	/// </summary>
+	private static void RunRandomizedStress(int seed, IEqualityComparer<object> comparer, int iterCount = 100, int stepCount = 500)
+	{
+		var rnd = new Random(seed);
+
+		for (var iter = 0; iter < iterCount; iter++)
+		{
+			var map = new SequencedSnapshotDictionary<object, object>(
+				1 << rnd.Next(0, 5),
+				comparer ?? ReferenceComparer<object>.Instance);
+
+			var model = new List<KeyValuePair<object, object>>();
+			var pool = Keys(30);
+
+			// Snapshots still held, each with the model as it was when the snapshot was taken.
+			var outstanding = new List<(ISnapshotView<object, object> View,
+				List<KeyValuePair<object, object>> Expected)>();
+
+			for (var step = 0; step < stepCount; step++)
+			{
+				switch (rnd.Next(0, 10))
+				{
+					case 0:
+					case 1:
+					case 2:
+					case 3:
+						{
+							// Add or overwrite.
+							var key = pool[rnd.Next(pool.Length)];
+							var value = rnd.Next(1000);
+							var at = model.FindIndex(kv => ReferenceEquals(kv.Key, key));
+							if (at >= 0)
+							{
+								model.RemoveAt(at); // overwrite moves the key to the end
+							}
+							model.Add(new KeyValuePair<object, object>(key, value));
+							map[key] = value;
+							break;
+						}
+					case 4:
+					case 5:
+						{
+							// Remove, sometimes an absent key.
+							var key = pool[rnd.Next(pool.Length)];
+							var at = model.FindIndex(kv => ReferenceEquals(kv.Key, key));
+							var expected = at >= 0;
+							if (expected)
+							{
+								model.RemoveAt(at);
+							}
+
+							Assert.That(map.Remove(key), Is.EqualTo(expected));
+							break;
+						}
+					case 6:
+						{
+							if (rnd.Next(0, 20) == 0)
+							{
+								model.Clear();
+								map.Clear();
+							}
+							break;
+						}
+					case 7:
+						{
+							outstanding.Add((map.GetSnapshot(), [.. model]));
+							break;
+						}
+					case 8:
+						{
+							if (outstanding.Count > 0)
+							{
+								var idx = rnd.Next(outstanding.Count);
+								outstanding[idx].View.Dispose();
+								outstanding.RemoveAt(idx);
+							}
+							break;
+						}
+					default:
+						{
+							// Read-back check against the model.
+							var key = pool[rnd.Next(pool.Length)];
+							var at = model.FindIndex(kv => ReferenceEquals(kv.Key, key));
+							if (at >= 0)
+							{
+								Assert.That(map.TryGetValue(key, out var actual), Is.True);
+								Assert.That(actual, Is.EqualTo(model[at].Value));
+							}
+							else
+							{
+								Assert.That(map.ContainsKey(key), Is.False);
+							}
+							break;
+						}
+				}
+
+				Assert.That(map.Count, Is.EqualTo(model.Count));
+
+				// Every outstanding snapshot must still match the model as of its creation,
+				// including ordering.
+				foreach (var (view, expected) in outstanding)
+				{
+					Assert.That(view.Count, Is.EqualTo(expected.Count));
+					Assert.That(view.KeyList(), Is.EqualTo(expected.Select(kv => kv.Key)));
+					Assert.That(view.ValueList(), Is.EqualTo(expected.Select(kv => kv.Value)));
+				}
+			}
+
+			// The live map must match the model in both contents and order.
+			Assert.That(map.Keys, Is.EqualTo(model.Select(kv => kv.Key)));
+			Assert.That(map.Values, Is.EqualTo(model.Select(kv => kv.Value)));
+
+			// Slot usage must stay bounded by the key pool rather than by how many operations
+			// were performed (overwrites consume nothing and removals recycle).
+			Assert.That(map.EntrySlotCount, Is.LessThanOrEqualTo(pool.Length),
+						"slot usage must track the live high-water mark, not the write volume");
+
+			Assert.That(map.OutstandingSnapshots, Is.EqualTo(outstanding.Count));
+			foreach (var (view, _) in outstanding)
+			{
+				view.Dispose();
+			}
+
+			Assert.That(map.OutstandingSnapshots, Is.EqualTo(0));
+		}
+	}
+
+	private static SequencedSnapshotDictionary<object, object> NewMap(
+		int capacity = 16,
+		IEqualityComparer<object> comparer = null) =>
+		new(capacity, comparer ?? ReferenceComparer<object>.Instance);
+
+	private static object[] Keys(int count) => [.. Enumerable.Range(0, count).Select(_ => new object())];
+
+	private static List<object> KeyOrder(IEnumerable<KeyValuePair<object, object>> map) =>
+		[.. map.Select(kv => kv.Key)];
+
+	private sealed class FewBucketsComparer : IEqualityComparer<object>
+	{
+		private readonly int _bucketCount;
+		public FewBucketsComparer(int bucketCount = 2) => _bucketCount = bucketCount;
+
+		public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+
+		public int GetHashCode(object obj) =>
+			System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj) % _bucketCount;
+	}
+}

--- a/src/NHibernate.Test/UtilityTest/SequencedSnapshotDictionaryFixture.cs
+++ b/src/NHibernate.Test/UtilityTest/SequencedSnapshotDictionaryFixture.cs
@@ -1,0 +1,1240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using NHibernate.Util;
+using NUnit.Framework;
+
+namespace NHibernate.Test.UtilityTest;
+
+/// <summary>
+/// Tests for the insertion-ordered <see cref="SequencedSnapshotDictionary{TKey,TValue}"/>
+/// that backs <see cref="IdentityMap{TKey,TValue}.InstantiateSequenced"/>.
+/// </summary>
+[TestFixture]
+public class SequencedSnapshotDictionaryFixture
+{
+	private ISerializationStrategy _initialStrategy;
+
+	[SetUp]
+	public void SetUp()
+	{
+		_initialStrategy = SerializationConfiguration.Strategy;
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		SerializationConfiguration.Strategy = _initialStrategy;
+	}
+	
+	[Test]
+	public void AddsIterateInInsertionOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(50);
+
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+		
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+		Assert.That(map.Keys, Is.EqualTo(keys));
+		Assert.That(map.Values, Is.EqualTo(keys));
+	}
+
+	/// <summary>
+	/// The <see cref="SequencedHashMap"/> this type replaces removes and re-inserts an entry
+	/// whenever its value is overwritten through the indexer, so the key moves to the end.
+	/// That behaviour is deliberately preserved.
+	/// </summary>
+	[Test]
+	public void OverwritingExistingKeyMovesItToTheEnd()
+	{
+		var map = NewMap();
+		var keys = Keys(4);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		map[keys[1]] = "rewritten";
+
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[0], keys[2], keys[3], keys[1] }));
+		Assert.That(map[keys[1]], Is.EqualTo("rewritten"));
+		Assert.That(map.Count, Is.EqualTo(4), "an overwrite must not change the live count");
+	}
+
+	[Test]
+	public void OverwritingTheLastKeyLeavesItLast()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		map[keys[2]] = "rewritten";
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void RepeatedOverwritesKeepMovingTheKeyToTheEnd()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, 0);
+		}
+
+		map[keys[0]] = 1;
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[1], keys[2], keys[0] }));
+
+		map[keys[1]] = 1;
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[2], keys[0], keys[1] }));
+
+		map[keys[2]] = 1;
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[0], keys[1], keys[2] }));
+	}
+
+	[Test]
+	public void AddThrowsOnDuplicateKeyWithoutDisturbingOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		Assert.Throws<ArgumentException>(() => map.Add(keys[0], "again"));
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+		Assert.That(map[keys[0]], Is.EqualTo("initial"));
+		Assert.That(map.Count, Is.EqualTo(3));
+	}
+
+	[Test]
+	public void RemovalPreservesTheOrderOfTheRemainingEntries()
+	{
+		var map = NewMap();
+		var keys = Keys(6);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.Remove(keys[0]), Is.True);
+		Assert.That(map.Remove(keys[3]), Is.True);
+		Assert.That(map.Remove(keys[5]), Is.True);
+
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[1], keys[2], keys[4] }));
+	}
+
+	[Test]
+	public void ReAddingARemovedKeyPutsItAtTheEnd()
+	{
+		var map = NewMap();
+		var keys = Keys(3);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		map.Remove(keys[0]);
+		map.Add(keys[0], keys[0]);
+
+		Assert.That(KeyOrder(map), Is.EqualTo(new[] { keys[1], keys[2], keys[0] }));
+	}
+
+	[Test]
+	public void OrderSurvivesBucketGrowth()
+	{
+		var map = NewMap(1);
+		var keys = Keys(500);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+		foreach (var key in keys)
+		{
+			Assert.That(map[key], Is.SameAs(key));
+		}
+	}
+
+	[Test]
+	public void OrderSurvivesHeavyOverwriteChurn()
+	{
+		var map = NewMap();
+		var keys = Keys(40);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		var slotsAfterFill = map.EntrySlotCount;
+
+		var expected = new List<object>(keys);
+		for (var round = 0; round < 20; round++)
+		{
+			foreach (var key in keys)
+			{
+				map[key] = round;
+				expected.Remove(key);
+				expected.Add(key);
+			}
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(expected));
+		Assert.That(map.Count, Is.EqualTo(keys.Length));
+		Assert.That(map.EntrySlotCount, Is.EqualTo(slotsAfterFill));
+	}
+
+	[Test]
+	public void KeysAndValuesEnumerateInOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(5);
+		for (var i = 0; i < keys.Length; i++)
+		{
+			map.Add(keys[i], i);
+		}
+
+		map[keys[0]] = 99; // moves keys[0] to the end
+
+		Assert.That(map.Keys, Is.EqualTo(new[] { keys[1], keys[2], keys[3], keys[4], keys[0] }));
+		Assert.That(map.Values, Is.EqualTo(new object[] { 1, 2, 3, 4, 99 }));
+	}
+
+	[Test]
+	public void CopyToWritesEntriesInOrder()
+	{
+		var map = NewMap();
+		var keys = Keys(4);
+		for (var i = 0; i < keys.Length; i++)
+		{
+			map.Add(keys[i], i);
+		}
+
+		map.Remove(keys[1]);
+		map[keys[0]] = 42; // moves keys[0] to the end
+
+		var target = new KeyValuePair<object, object>[3];
+		map.CopyTo(target, 0);
+
+		Assert.That(target.Select(kv => kv.Key), Is.EqualTo(new[] { keys[2], keys[3], keys[0] }));
+		Assert.That(target.Select(kv => kv.Value), Is.EqualTo(new object[] { 2, 3, 42 }));
+	}
+
+	[Test]
+	public void AddRemoveChurnRecyclesSlots()
+	{
+		var map = NewMap();
+
+		for (var i = 0; i < 5000; i++)
+		{
+			var key = new object();
+			map.Add(key, i);
+			map.Remove(key);
+		}
+
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(map.EntrySlotCount, Is.LessThanOrEqualTo(1),
+		            "add/remove churn must reuse the freed slot instead of consuming new ones");
+	}
+
+	[Test]
+	public void RemovingKeepsSnapshotsIsolated()
+	{
+		var map = NewMap();
+		var keys = Keys(10);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		for (var i = 0; i < 500; i++)
+		{
+			map[keys[i % keys.Length]] = i;
+		}
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys), "the snapshot must keep its original order");
+		foreach (var key in keys)
+		{
+			Assert.That(snapshot.ValueFor(key), Is.EqualTo("initial"));
+		}
+	}
+
+	[Test]
+	public void SnapshotHonoursComparer()
+	{
+		var map = NewMap();
+		var a = new MutableHashCode(7);
+		var b = new MutableHashCode(7); // equal by value, different reference
+		var value = new object();
+
+		map[a] = value;
+		using var snapshot = map.GetSnapshot();
+
+		Assert.That(map.ContainsKey(b), Is.False, "the live map must use identity, not value equality");
+		Assert.That(snapshot.HasKey(b), Is.False, "the snapshot must use identity, not value equality");
+		Assert.That(snapshot.HasKey(a), Is.True);
+		Assert.That(snapshot.ValueFor(a), Is.SameAs(value));
+	}
+
+	[Test]
+	public void SnapshotEnumeratesInTheSameOrderAsTheMap()
+	{
+		var map = NewMap();
+		var keys = Keys(30);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		map[keys[0]] = "moved";
+
+		using var snapshot = map.GetSnapshot();
+
+		Assert.That(snapshot.KeyList(), Is.EqualTo(KeyOrder(map)));
+	}
+
+	[Test]
+	public void SnapshotIsUnaffectedByLaterReordering()
+	{
+		var map = NewMap();
+		var keys = Keys(5);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		map[keys[0]] = "moved";
+		map[keys[1]] = "moved";
+		map.Remove(keys[4]);
+		map.Add(new object(), "added");
+
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys), "the snapshot keeps its frozen order");
+		Assert.That(snapshot.ValueList(), Is.EqualTo(Enumerable.Repeat("initial", 5)));
+	}
+
+	[Test]
+	public void SnapshotIsIsolatedFromClear()
+	{
+		var map = NewMap();
+		var keys = Keys(10);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		map.Clear();
+
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(snapshot.Count, Is.EqualTo(10));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void SnapshotIsIsolatedFromAppend()
+	{
+		var map = NewMap(4);
+		var keys = Keys(4);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		var added = Keys(4);
+		foreach (var key in added)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(snapshot.Count, Is.EqualTo(4));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		foreach (var key in added)
+		{
+			Assert.That(snapshot.HasKey(key), Is.False,
+			            "entries appended after the freeze must not be reachable through the snapshot's chains");
+		}
+	}
+
+	[Test]
+	public void RemovingAnEntryAppendedAfterTheSnapshotLeavesTheSnapshotUntouched()
+	{
+		var map = NewMap(4);
+		var keys = Keys(4);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		var extra = new object();
+		map.Add(extra, extra);
+		map.Remove(extra);
+
+		Assert.That(snapshot.Count, Is.EqualTo(4));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		Assert.That(map.Count, Is.EqualTo(4));
+	}
+
+	[Test]
+	public void ChainedAppendsNeverLeakIntoAnEarlierSnapshot()
+	{
+		var map = NewMap();
+		var initialKeys = Keys(3);
+		foreach (var key in initialKeys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshotA = map.GetSnapshot();
+		var beforeAppends = map.CopyOnWriteCount;
+
+		var d = new object();
+		map.Add(d, d);
+
+		using var snapshotB = map.GetSnapshot();
+
+		var e = new object();
+		map.Add(e, e);
+		var f = new object();
+		map.Add(f, f);
+		
+		Assert.That(snapshotA.KeyList(), Is.EqualTo(initialKeys));
+		Assert.That(snapshotB.KeyList(), Is.EqualTo(new[] { initialKeys[0], initialKeys[1], initialKeys[2], d }));
+		Assert.That(map.Keys, Is.EqualTo(new[] { initialKeys[0], initialKeys[1], initialKeys[2], d, e, f }));
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(beforeAppends));
+	}
+
+	[Test]
+	public void RehashAndChainChurnUnderAnOutstandingSnapshotCopyNothingAndAreInvisible()
+	{
+		// Start small so growing to 400 entries forces several rehashes.
+		var map = NewMap(1);
+		var original = Keys(20);
+		foreach (var key in original)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+		var copiesAfterSnapshot = map.CopyOnWriteCount;
+
+		// Force repeated rehashes (and growth) while the snapshot is outstanding.
+		var added = Keys(380);
+		foreach (var key in added)
+		{
+			map.Add(key, key);
+		}
+
+		// Growth and rehashing touch only the hash structure, which no snapshot reads
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(copiesAfterSnapshot));
+
+		// Now remove the entries that were added, which unlinks them from their bucket chains.
+		// These slots are all at or beyond the snapshot, so this must stay copy-free too.
+		foreach (var key in added)
+		{
+			map.Remove(key);
+		}
+
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(copiesAfterSnapshot));
+
+		Assert.That(snapshot.Count, Is.EqualTo(original.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(original));
+		Assert.That(snapshot.ValueList(), Is.EqualTo(original));
+
+		Assert.That(map.Count, Is.EqualTo(original.Length));
+		Assert.That(KeyOrder(map), Is.EqualTo(original));
+		foreach (var key in original)
+		{
+			Assert.That(map[key], Is.SameAs(key));
+		}
+		
+		foreach (var key in added)
+		{
+			Assert.That(map.ContainsKey(key), Is.False);
+		}
+	}
+
+	[Test]
+	public void RemovalsWithinSnapshotCopyAndStayIsolated()
+	{
+		var map = NewMap(1);
+		var keys = Keys(20);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+		var before = map.CopyOnWriteCount;
+
+		foreach (var key in keys)
+		{
+			map.Remove(key);
+		}
+
+		// +1 copy for slots
+		// +1 copy for values
+		// +1 copy for orderNext
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before+3),
+		            "removing entries the snapshot can see must pay the copy-on-write cost");
+		Assert.That(map.Count, Is.EqualTo(0));
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		Assert.That(snapshot.ValueList(), Is.EqualTo(keys));
+	}
+	
+	[Test]
+	public void UpdatesWithinSnapshotCopyAndStayIsolated()
+	{
+		var map = NewMap(1);
+		var keys = Keys(20);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+		var before = map.CopyOnWriteCount;
+
+		foreach (var key in keys)
+		{
+			map[key] = new object();
+		}
+
+		// +1 copy for values
+		// +1 copy for orderNext
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before+2),
+		            "updating entries the snapshot can see must pay the copy-on-write cost");
+		Assert.That(map.Count, Is.EqualTo(keys.Length));
+
+		Assert.That(snapshot.Count, Is.EqualTo(keys.Length));
+		Assert.That(snapshot.KeyList(), Is.EqualTo(keys));
+		Assert.That(snapshot.ValueList(), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void OverlappingSnapshotsAreEachIsolated()
+	{
+		var map = NewMap(4, new FewBucketsComparer());
+		var initialKeys = Keys(3);
+		foreach (var key in initialKeys)
+		{
+			map.Add(key, "v1");
+		}
+
+		using var snapshotA = map.GetSnapshot();
+
+		map[initialKeys[0]] = "v2";
+		var keyAddedAfterSnapshotA = new object();
+		map.Add(keyAddedAfterSnapshotA, "v2");
+
+		using var snapshotB = map.GetSnapshot();
+
+		map[initialKeys[1]] = "v3";
+		map.Remove(initialKeys[2]);
+
+		Assert.That(map[initialKeys[1]], Is.EqualTo("v3"));
+
+		Assert.That(snapshotA.Count, Is.EqualTo(3));
+		Assert.That(snapshotA.KeyList(), Is.EqualTo(initialKeys));
+		Assert.That(snapshotA.ValueList(), Is.EqualTo(new object[] { "v1", "v1", "v1" }));
+
+		Assert.That(snapshotB.Count, Is.EqualTo(4));
+		Assert.That(snapshotB.KeyList(), Is.EqualTo(new[] { initialKeys[1], initialKeys[2], initialKeys[0], keyAddedAfterSnapshotA }));
+		Assert.That(snapshotB.ValueFor(initialKeys[0]), Is.EqualTo("v2"));
+		Assert.That(snapshotB.ValueFor(initialKeys[1]), Is.EqualTo("v1"));
+	}
+
+	[Test]
+	public void AppendsAfterSnapshotCopyNothing()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(8))
+		{
+			map.Add(key, key);
+		}
+
+		using var snapshot = map.GetSnapshot();
+
+		var before = map.CopyOnWriteCount;
+		foreach (var key in Keys(32))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.CopyOnWriteCount - before, Is.EqualTo(0),
+		            "appends while a snapshot is outstanding must not copy any array");
+		Assert.That(snapshot.Count, Is.EqualTo(8));
+	}
+
+	[Test]
+	public void DisposingSnapshotAvoidsCopyOnWriteOnSubsequentWrites()
+	{
+		var map = NewMap();
+		var keys = Keys(8);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		using (var snapshot = map.GetSnapshot())
+		{
+			Assert.That(map.OutstandingSnapshots, Is.EqualTo(1));
+			Assert.That(snapshot.Count, Is.EqualTo(8));
+		}
+
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(0));
+
+		var before = map.CopyOnWriteCount;
+		foreach (var key in keys)
+		{
+			map[key] = "rewritten";
+		}
+		map.Add(new object(), "added");
+		map.Remove(keys[0]);
+
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before),
+		            "once every snapshot is released, writes must go back to being fully in place");
+	}
+
+	[Test]
+	public void LeavingSnapshotUndisposedCausesSubsequentWritesToCopy()
+	{
+		var map = NewMap();
+		var keys = Keys(8);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		var snapshot = map.GetSnapshot(); // deliberately not disposed
+
+		var before = map.CopyOnWriteCount;
+		map[keys[0]] = "rewritten";
+
+		Assert.That(map.CopyOnWriteCount, Is.GreaterThan(before));
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(1));
+		Assert.That(snapshot.ValueFor(keys[0]), Is.EqualTo("initial"));
+	}
+
+	[Test]
+	public void OverlappingSnapshotsOnlyStopCopyingOnceAllAreDisposed()
+	{
+		var map = NewMap();
+		var keys = Keys(8);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		var first = map.GetSnapshot();
+		var second = map.GetSnapshot();
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(2));
+
+		first.Dispose();
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(1));
+
+		var before = map.CopyOnWriteCount;
+		map[keys[0]] = "rewritten";
+		Assert.That(map.CopyOnWriteCount, Is.GreaterThan(before),
+		            "one snapshot is still outstanding, so writes must still copy");
+
+		second.Dispose();
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(0));
+
+		before = map.CopyOnWriteCount;
+		map[keys[1]] = "rewritten";
+		map.Add(new object(), "added");
+		Assert.That(map.CopyOnWriteCount, Is.EqualTo(before));
+	}
+
+	[Test]
+	public void ReadsAfterDisposeThrowObjectDisposedException()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		var snapshot = map.GetSnapshot();
+		snapshot.Dispose();
+
+		Assert.Throws<ObjectDisposedException>(() => { var _ = snapshot.Count; });
+		Assert.Throws<ObjectDisposedException>(() => { var _ = snapshot.ValueFor(key); });
+		Assert.Throws<ObjectDisposedException>(() => snapshot.TryGetValueByIdentity(key, out _));
+		Assert.Throws<ObjectDisposedException>(() => snapshot.HasKey(key));
+		Assert.Throws<ObjectDisposedException>(() => snapshot.GetEnumerator());
+	}
+
+	[Test]
+	public void DisposeIsIdempotent()
+	{
+		var map = NewMap();
+		map.Add(new object(), "value");
+
+		var snapshot = map.GetSnapshot();
+		snapshot.Dispose();
+		snapshot.Dispose();
+		snapshot.Dispose();
+
+		Assert.That(map.OutstandingSnapshots, Is.EqualTo(0),
+		            "repeated disposal must not drive the refcount negative");
+	}
+
+	[Test]
+	public void DisposingSnapshotMidEnumerationThrowsOnNextMoveNext()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		var snapshot = map.GetSnapshot();
+		using var enumerator = snapshot.GetEnumerator();
+
+		Assert.That(enumerator.MoveNext(), Is.True);
+		snapshot.Dispose();
+
+		Assert.Throws<ObjectDisposedException>(() => enumerator.MoveNext());
+	}
+
+	[Test]
+	public void EnumerationThrowsWhenMapIsModified()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map)
+			{
+				map.Add(new object(), "added");
+			}
+		});
+	}
+
+	[Test]
+	public void EnumerationThrowsWhenAValueIsOverwritten()
+	{
+		var map = NewMap();
+		var keys = Keys(5);
+		foreach (var key in keys)
+		{
+			map.Add(key, "initial");
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map)
+			{
+				map[keys[0]] = "rewritten";
+			}
+		});
+	}
+
+	[Test]
+	public void KeysEnumerationThrowsWhenMapIsModified()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map.Keys)
+			{
+				map.Add(new object(), "added");
+			}
+		});
+	}
+
+	[Test]
+	public void ValuesEnumerationThrowsWhenMapIsModified()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(5))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			foreach (var _ in map.Values)
+			{
+				map.Add(new object(), "added");
+			}
+		});
+	}
+
+	[Test]
+	public void NegativeCapacityThrows()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(
+			() => new SequencedSnapshotDictionary<object, object>(-1, ReferenceComparer<object>.Instance));
+	}
+
+	[Test]
+	public void ZeroCapacityStillAcceptsEntries()
+	{
+		var map = NewMap(0);
+		var keys = Keys(20);
+		foreach (var key in keys)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(map.Count, Is.EqualTo(20));
+		Assert.That(KeyOrder(map), Is.EqualTo(keys));
+	}
+
+	[Test]
+	public void IndexerGetThrowsForMissingKey()
+	{
+		var map = NewMap();
+		Assert.Throws<KeyNotFoundException>(() => { var _ = map[new object()]; });
+	}
+
+	[Test]
+	public void RemovingAbsentKeyIsANoOp()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		Assert.That(map.Remove(new object()), Is.False);
+		Assert.That(map.Count, Is.EqualTo(1));
+		Assert.That(map[key], Is.EqualTo("value"));
+	}
+
+	[Test]
+	public void ContainsAndRemoveByPairMatchOnValueToo()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		Assert.That(map.Contains(new KeyValuePair<object, object>(key, "value")), Is.True);
+		Assert.That(map.Contains(new KeyValuePair<object, object>(key, "other")), Is.False);
+
+		Assert.That(map.Remove(new KeyValuePair<object, object>(key, "other")), Is.False);
+		Assert.That(map.Count, Is.EqualTo(1));
+
+		Assert.That(map.Remove(new KeyValuePair<object, object>(key, "value")), Is.True);
+		Assert.That(map.Count, Is.EqualTo(0));
+	}
+
+	[Test]
+	public void ClearedMapIsStillUsable()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(10))
+		{
+			map.Add(key, key);
+		}
+
+		map.Clear();
+		Assert.That(map.Count, Is.EqualTo(0));
+		Assert.That(map, Is.Empty);
+
+		var after = Keys(5);
+		foreach (var key in after)
+		{
+			map.Add(key, key);
+		}
+
+		Assert.That(KeyOrder(map), Is.EqualTo(after));
+	}
+
+	[Test]
+	public void KeysAndValuesAreCachedAcrossAccesses()
+	{
+		var map = NewMap();
+		var keys = map.Keys;
+		var values = map.Values;
+
+		Assert.That(map.Keys, Is.SameAs(keys));
+		Assert.That(map.Values, Is.SameAs(values));
+	}
+
+	[Test]
+	public void CopyToThrowsForNullArray()
+	{
+		var map = NewMap();
+		Assert.Throws<ArgumentNullException>(() => map.CopyTo(null, 0));
+		Assert.Throws<ArgumentNullException>(() => map.Keys.CopyTo(null, 0));
+		Assert.Throws<ArgumentNullException>(() => map.Values.CopyTo(null, 0));
+	}
+
+	[Test]
+	public void CopyToThrowsForNegativeIndex()
+	{
+		var map = NewMap();
+		Assert.Throws<ArgumentOutOfRangeException>(() => map.CopyTo(new KeyValuePair<object, object>[1], -1));
+		Assert.Throws<ArgumentOutOfRangeException>(() => map.Keys.CopyTo(new object[1], -1));
+		Assert.Throws<ArgumentOutOfRangeException>(() => map.Values.CopyTo(new object[1], -1));
+	}
+
+	[Test]
+	public void CopyToThrowsForInsufficientSpace()
+	{
+		var map = NewMap();
+		foreach (var key in Keys(3))
+		{
+			map.Add(key, key);
+		}
+
+		Assert.Throws<ArgumentException>(() => map.CopyTo(new KeyValuePair<object, object>[2], 0));
+		Assert.Throws<ArgumentException>(() => map.CopyTo(new KeyValuePair<object, object>[3], 1));
+		Assert.Throws<ArgumentException>(() => map.Keys.CopyTo(new object[2], 0));
+		Assert.Throws<ArgumentException>(() => map.Values.CopyTo(new object[2], 0));
+	}
+
+	[Test]
+	public void KeysAndValuesCollectionsAreReadOnly()
+	{
+		var map = NewMap();
+		Assert.That(map.Keys.IsReadOnly, Is.True);
+		Assert.That(map.Values.IsReadOnly, Is.True);
+		Assert.Throws<NotSupportedException>(() => map.Keys.Add(new object()));
+		Assert.Throws<NotSupportedException>(() => map.Keys.Clear());
+		Assert.Throws<NotSupportedException>(() => map.Keys.Remove(new object()));
+		Assert.Throws<NotSupportedException>(() => map.Values.Add(new object()));
+		Assert.Throws<NotSupportedException>(() => map.Values.Clear());
+		Assert.Throws<NotSupportedException>(() => map.Values.Remove(new object()));
+	}
+
+	[Test]
+	public void KeysAndValuesContainsWork()
+	{
+		var map = NewMap();
+		var key = new object();
+		map.Add(key, "value");
+
+		Assert.That(map.Keys.Contains(key), Is.True);
+		Assert.That(map.Keys.Contains(new object()), Is.False);
+		Assert.That(map.Values.Contains("value"), Is.True);
+		Assert.That(map.Values.Contains("other"), Is.False);
+
+		map.Remove(key);
+		Assert.That(map.Keys.Contains(key), Is.False);
+		Assert.That(map.Values.Contains("value"), Is.False);
+	}
+
+	[Test]
+	public void RemovedEntryDoesNotRetainKeyOrValueReferences()
+	{
+		var map = NewMap();
+		var weak = PopulateAndRemove(map);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.That(weak.IsAlive, Is.False);
+	}
+
+	private static WeakReference PopulateAndRemove(SequencedSnapshotDictionary<object, object> map)
+	{
+		var key = new object();
+		var value = new object();
+		map.Add(key, value);
+		var weak = new WeakReference(value);
+		map.Remove(key);
+		return weak;
+	}
+
+	[Test]
+	public void OverwrittenValueIsNotRetained()
+	{
+		var map = NewMap();
+		var key = new object();
+		var weak = PopulateAndOverwrite(map, key);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.That(weak.IsAlive, Is.False);
+	}
+
+	private static WeakReference PopulateAndOverwrite(SequencedSnapshotDictionary<object, object> map, object key)
+	{
+		var original = new object();
+		map.Add(key, original);
+		var weak = new WeakReference(original);
+		map[key] = new object();
+		return weak;
+	}
+
+	[Test]
+	public void ClearedEntriesDoNotRetainKeyOrValueReferences()
+	{
+		var map = NewMap();
+		var weak = PopulateAndClear(map);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.That(weak.IsAlive, Is.False);
+	}
+
+	private static WeakReference PopulateAndClear(SequencedSnapshotDictionary<object, object> map)
+	{
+		var key = new object();
+		var value = new object();
+		map.Add(key, value);
+		var weak = new WeakReference(value);
+		map.Clear();
+		return weak;
+	}
+
+	[Test]
+	public void SerializationRoundTripPreservesOrderContentsAndIdentitySemantics()
+	{
+		TestConfigurationHelper.UseTestSerialization();
+
+		var map = NewMap();
+		var a = new MutableHashCode(1);
+		var b = new MutableHashCode(1);
+		var c = new MutableHashCode(2);
+		map.Add(a, "valueA");
+		map.Add(b, "valueB");
+		map.Add(c, "valueC");
+		map[a] = "valueA"; // move a to the end, so order is b, c, a
+		map.Remove(c);
+
+		using var unusedSnapshot = map.GetSnapshot();
+
+		var bytes = SerializationHelper.Serialize(map);
+		var restored = (SequencedSnapshotDictionary<object, object>)SerializationHelper.Deserialize(bytes);
+		((IDeserializationCallback)restored).OnDeserialization(null);
+
+		Assert.That(restored.Count, Is.EqualTo(2));
+		Assert.That(restored.Values, Is.EqualTo(new object[] { "valueB", "valueA" }),
+		            "iteration order, including the move-to-end, must survive the round trip");
+		Assert.That(restored.OutstandingSnapshots, Is.EqualTo(0),
+		            "a freshly deserialized instance must start with no outstanding snapshots");
+
+		// A round trip necessarily produces new key instances, so the live `a`/`b` references
+		// can never be reference-equal to anything inside `restored`. What must hold is that
+		// identity semantics still apply to the deserialized keys, and that each is findable by
+		// reference after the post-deserialization rehash (proving the rehash used each key's
+		// own bucket, not its pre-serialization one).
+		var restoredKeys = restored.Keys.ToArray();
+		Assert.That(restoredKeys, Has.Length.EqualTo(2));
+		Assert.That(restored.ContainsKey(new MutableHashCode(1)), Is.False,
+		            "the restored map must still use identity, not value equality");
+		foreach (var key in restoredKeys)
+		{
+			Assert.That(restored.ContainsKey(key), Is.True);
+		}
+
+		// Writes right after deserialization must not pay any copy-on-write cost, since
+		// OnDeserialization reset the snapshot bookkeeping to a clean state.
+		var copiesBeforeWrite = restored.CopyOnWriteCount;
+		restored[restoredKeys[0]] = "rewritten";
+		Assert.That(restored.CopyOnWriteCount, Is.EqualTo(copiesBeforeWrite),
+		            "writes right after deserialization must not pay any copy-on-write cost");
+
+		// still writable and enumerable after the rehash
+		var extra = new object();
+		restored.Add(extra, "valueD");
+		Assert.That(restored.Count, Is.EqualTo(3));
+		Assert.That(restored.Keys, Is.EqualTo(new[] { restoredKeys[1], restoredKeys[0], extra }));
+	}
+
+	[Test]
+	public void RandomizedOrderAndSnapshotIsolationStress() => RunRandomizedStress(seed: 20260806, comparer: null);
+
+	[Test]
+	public void RandomizedOrderAndSnapshotIsolationStressWithForcedBucketCollisions() => RunRandomizedStress(seed: 20260806, comparer: new FewBucketsComparer());
+		
+	[Test, Explicit]
+	public void RandomizedOrderAndSnapshotIsolationStress_100kIter() => RunRandomizedStress(seed: 20260806, comparer: null, iterCount: 100_000);
+	
+	[Test, Explicit]
+	public void RandomizedOrderAndSnapshotIsolationStress_100kStep() => RunRandomizedStress(seed: 20260806, comparer: null, stepCount: 100_000);
+
+	/// <summary>
+	/// Randomised model-based check. The model is an ordered list of key/value pairs mutated
+	/// with exactly the semantics this dictionary promises: append on add, move-to-end on
+	/// overwrite, remove in place.
+	/// Every snapshot taken along the way must keep exactly the contents and order it had when
+	/// it was created, regardless of what happens to the live map afterwards.
+	/// </summary>
+	private static void RunRandomizedStress(int seed, IEqualityComparer<object> comparer, int iterCount = 100, int stepCount = 500)
+	{
+		var rnd = new Random(seed);
+
+		for (var iter = 0; iter < iterCount; iter++)
+		{
+			var map = new SequencedSnapshotDictionary<object, object>(
+				1 << rnd.Next(0, 5),
+				comparer ?? ReferenceComparer<object>.Instance);
+
+			var model = new List<KeyValuePair<object, object>>();
+			var pool = Keys(30);
+
+			// Snapshots still held, each with the model as it was when the snapshot was taken.
+			var outstanding = new List<(ISnapshotView<object, object> View, 
+				List<KeyValuePair<object, object>> Expected)>();
+
+			for (var step = 0; step < stepCount; step++)
+			{
+				switch (rnd.Next(0, 10))
+				{
+					case 0:
+					case 1:
+					case 2:
+					case 3:
+					{
+						// Add or overwrite.
+						var key = pool[rnd.Next(pool.Length)];
+						var value = rnd.Next(1000);
+						var at = model.FindIndex(kv => ReferenceEquals(kv.Key, key));
+						if (at >= 0)
+						{
+							model.RemoveAt(at); // overwrite moves the key to the end
+						}
+						model.Add(new KeyValuePair<object, object>(key, value));
+						map[key] = value;
+						break;
+					}
+					case 4:
+					case 5:
+					{
+						// Remove, sometimes an absent key.
+						var key = pool[rnd.Next(pool.Length)];
+						var at = model.FindIndex(kv => ReferenceEquals(kv.Key, key));
+						var expected = at >= 0;
+						if (expected)
+						{
+							model.RemoveAt(at);
+						}
+
+						Assert.That(map.Remove(key), Is.EqualTo(expected));
+						break;
+					}
+					case 6:
+					{
+						if (rnd.Next(0, 20) == 0)
+						{
+							model.Clear();
+							map.Clear();
+						}
+						break;
+					}
+					case 7:
+					{
+						outstanding.Add((map.GetSnapshot(), [.. model]));
+						break;
+					}
+					case 8:
+					{
+						if (outstanding.Count > 0)
+						{
+							var idx = rnd.Next(outstanding.Count);
+							outstanding[idx].View.Dispose();
+							outstanding.RemoveAt(idx);
+						}
+						break;
+					}
+					default:
+					{
+						// Read-back check against the model.
+						var key = pool[rnd.Next(pool.Length)];
+						var at = model.FindIndex(kv => ReferenceEquals(kv.Key, key));
+						if (at >= 0)
+						{
+							Assert.That(map.TryGetValue(key, out var actual), Is.True);
+							Assert.That(actual, Is.EqualTo(model[at].Value));
+						}
+						else
+						{
+							Assert.That(map.ContainsKey(key), Is.False);
+						}
+						break;
+					}
+				}
+
+				Assert.That(map.Count, Is.EqualTo(model.Count));
+
+				// Every outstanding snapshot must still match the model as of its creation,
+				// including ordering.
+				foreach (var (view, expected) in outstanding)
+				{
+					Assert.That(view.Count, Is.EqualTo(expected.Count));
+					Assert.That(view.KeyList(), Is.EqualTo(expected.Select(kv => kv.Key)));
+					Assert.That(view.ValueList(), Is.EqualTo(expected.Select(kv => kv.Value)));
+				}
+			}
+
+			// The live map must match the model in both contents and order.
+			Assert.That(map.Keys, Is.EqualTo(model.Select(kv => kv.Key)));
+			Assert.That(map.Values, Is.EqualTo(model.Select(kv => kv.Value)));
+
+			// Slot usage must stay bounded by the key pool rather than by how many operations
+			// were performed (overwrites consume nothing and removals recycle).
+			Assert.That(map.EntrySlotCount, Is.LessThanOrEqualTo(pool.Length),
+			            "slot usage must track the live high-water mark, not the write volume");
+
+			Assert.That(map.OutstandingSnapshots, Is.EqualTo(outstanding.Count));
+			foreach (var (view, _) in outstanding)
+			{
+				view.Dispose();
+			}
+
+			Assert.That(map.OutstandingSnapshots, Is.EqualTo(0));
+		}
+	}
+	
+	private static SequencedSnapshotDictionary<object, object> NewMap(
+		int capacity = 16,
+		IEqualityComparer<object> comparer = null) =>
+		new(capacity, comparer ?? ReferenceComparer<object>.Instance);
+
+	private static object[] Keys(int count) => [.. Enumerable.Range(0, count).Select(_ => new object())];
+
+	private static List<object> KeyOrder(IEnumerable<KeyValuePair<object, object>> map) =>
+		[.. map.Select(kv => kv.Key)];
+
+	private sealed class FewBucketsComparer : IEqualityComparer<object>
+	{
+		private readonly int _bucketCount;
+		public FewBucketsComparer(int bucketCount = 2) => _bucketCount = bucketCount;
+
+		public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+
+		public int GetHashCode(object obj) =>
+			System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj) % _bucketCount;
+	}
+}

--- a/src/NHibernate.Test/UtilityTest/SnapshotViewTestExtensions.cs
+++ b/src/NHibernate.Test/UtilityTest/SnapshotViewTestExtensions.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NHibernate.Test.UtilityTest;
+
+internal static class SnapshotViewTestExtensions
+{
+	extension<TKey, TValue>(IReadOnlyCollection<KeyValuePair<TKey, TValue>> view) where TKey : class
+	{
+		internal List<TKey> KeyList() =>
+			[.. view.Select(kv => kv.Key)];
+
+		internal List<TValue> ValueList() =>
+			[.. view.Select(kv => kv.Value)];
+
+		internal bool HasKey(TKey key) =>
+			view.Any(kv => ReferenceEquals(kv.Key, key));
+
+		/// <summary>
+		/// The value the snapshot froze for <paramref name="key"/>. Throws if the key is absent, so a
+		/// mistaken assertion fails loudly instead of silently comparing against a default.
+		/// </summary>
+		internal TValue ValueFor(TKey key) =>
+			view.Single(kv => ReferenceEquals(kv.Key, key)).Value;
+
+		internal bool TryGetValueByIdentity(
+			TKey key,
+			out TValue value)
+		{
+			foreach (var kv in view)
+			{
+				if (ReferenceEquals(kv.Key, key))
+				{
+					value = kv.Value;
+					return true;
+				}
+			}
+
+			value = default;
+			return false;
+		}
+	}
+}

--- a/src/NHibernate/Async/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Async/Engine/StatefulPersistenceContext.cs
@@ -44,7 +44,7 @@ namespace NHibernate.Engine
 			object cached;
 			if (entitySnapshotsByKey.TryGetValue(key, out cached))
 			{
-				return cached == NoRow ? null : (object[])cached;
+				return cached == NoRow ? null : (object[]) cached;
 			}
 			else
 			{
@@ -126,8 +126,8 @@ namespace NHibernate.Engine
 				//}
 				if (maybeProxy.IsProxy())
 				{
-					var proxy = maybeProxy as INHibernateProxy; 
-					
+					var proxy = maybeProxy as INHibernateProxy;
+
 					ILazyInitializer li = proxy.HibernateLazyInitializer;
 					ReassociateProxy(li, proxy);
 					return li.GetImplementationAsync(cancellationToken); //initialize + unwrap the object

--- a/src/NHibernate/Async/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Async/Event/Default/AbstractFlushingEventListener.cs
@@ -90,13 +90,15 @@ namespace NHibernate.Event.Default
 			cancellationToken.ThrowIfCancellationRequested();
 			log.Debug("Processing unreferenced collections");
 
-			var list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
-			foreach (var me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries))
 			{
-				var ce = (CollectionEntry) me.Value;
-				if (!ce.IsReached && !ce.IsIgnore)
+				foreach (var me in list)
 				{
-					await (Collections.ProcessUnreachableCollectionAsync((IPersistentCollection) me.Key, session, cancellationToken)).ConfigureAwait(false);
+					var ce = (CollectionEntry) me.Value;
+					if (!ce.IsReached && !ce.IsIgnore)
+					{
+						await (Collections.ProcessUnreachableCollectionAsync((IPersistentCollection) me.Key, session, cancellationToken)).ConfigureAwait(false);
+					}
 				}
 			}
 
@@ -104,29 +106,31 @@ namespace NHibernate.Event.Default
 
 			log.Debug("Scheduling collection removes/(re)creates/updates");
 
-			list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
 			ActionQueue actionQueue = session.ActionQueue;
-			foreach (DictionaryEntry me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries))
 			{
-				IPersistentCollection coll = (IPersistentCollection) me.Key;
-				CollectionEntry ce = (CollectionEntry) me.Value;
+				foreach (var me in list)
+				{
+					IPersistentCollection coll = (IPersistentCollection) me.Key;
+					CollectionEntry ce = (CollectionEntry) me.Value;
 
-				if (ce.IsDorecreate)
-				{
-					session.Interceptor.OnCollectionRecreate(coll, ce.CurrentKey);
-					actionQueue.AddAction(new CollectionRecreateAction(coll, ce.CurrentPersister, ce.CurrentKey, session));
-				}
-				if (ce.IsDoremove)
-				{
-					session.Interceptor.OnCollectionRemove(coll, ce.LoadedKey);
-					actionQueue.AddAction(
-						new CollectionRemoveAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
-				}
-				if (ce.IsDoupdate)
-				{
-					session.Interceptor.OnCollectionUpdate(coll, ce.LoadedKey);
-					actionQueue.AddAction(
-						new CollectionUpdateAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					if (ce.IsDorecreate)
+					{
+						session.Interceptor.OnCollectionRecreate(coll, ce.CurrentKey);
+						actionQueue.AddAction(new CollectionRecreateAction(coll, ce.CurrentPersister, ce.CurrentKey, session));
+					}
+					if (ce.IsDoremove)
+					{
+						session.Interceptor.OnCollectionRemove(coll, ce.LoadedKey);
+						actionQueue.AddAction(
+							new CollectionRemoveAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					}
+					if (ce.IsDoupdate)
+					{
+						session.Interceptor.OnCollectionUpdate(coll, ce.LoadedKey);
+						actionQueue.AddAction(
+							new CollectionUpdateAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					}
 				}
 			}
 			actionQueue.SortCollectionActions();
@@ -148,20 +152,22 @@ namespace NHibernate.Event.Default
 			// It is safe because of how IdentityMap implements entrySet()
 			var source = @event.Session;
 
-			var list = IdentityMap.GetEntries(source.PersistenceContext.EntityEntries);
-			foreach (var me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(source.PersistenceContext.EntityEntries))
 			{
-				// Update the status of the object and if necessary, schedule an update
-				var entry = (EntityEntry) me.Value;
-				var status = entry.Status;
-
-				if (status != Status.Loading && status != Status.Gone)
+				foreach (var me in list)
 				{
-					var entityEvent = new FlushEntityEvent(source, me.Key, entry);
-					var listeners = source.Listeners.FlushEntityEventListeners;
-					foreach (var listener in listeners)
+					// Update the status of the object and if necessary, schedule an update
+					var entry = (EntityEntry) me.Value;
+					var status = entry.Status;
+
+					if (status != Status.Loading && status != Status.Gone)
 					{
-						await (listener.OnFlushEntityAsync(entityEvent, cancellationToken)).ConfigureAwait(false);
+						var entityEvent = new FlushEntityEvent(source, me.Key, entry);
+						var listeners = source.Listeners.FlushEntityEventListeners;
+						foreach (var listener in listeners)
+						{
+							await (listener.OnFlushEntityAsync(entityEvent, cancellationToken)).ConfigureAwait(false);
+						}
 					}
 				}
 			}
@@ -176,7 +182,7 @@ namespace NHibernate.Event.Default
 			// and reset reached, doupdate, etc.
 			log.Debug("dirty checking collections");
 
-			var list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
+			using var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries);
 			foreach (var entry in list)
 			{
 				await (((CollectionEntry) entry.Value).PreFlushAsync((IPersistentCollection) entry.Key, cancellationToken)).ConfigureAwait(false);
@@ -192,7 +198,7 @@ namespace NHibernate.Event.Default
 			log.Debug("processing flush-time cascades");
 
 			var anything = Anything;
-			var list = IdentityMap.GetEntries(session.PersistenceContext.EntityEntries);
+			using var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.EntityEntries);
 			//safe from concurrent modification because of how entryList() is implemented on IdentityMap
 			foreach (var me in list)
 			{

--- a/src/NHibernate/Engine/Loading/LoadContexts.cs
+++ b/src/NHibernate/Engine/Loading/LoadContexts.cs
@@ -9,7 +9,7 @@ using NHibernate.Persister.Collection;
 using NHibernate.Util;
 
 namespace NHibernate.Engine.Loading
-{	
+{
 	/// <summary> 
 	/// Maps <see cref="DbDataReader"/> to specific contextual data
 	/// related to processing that <see cref="DbDataReader"/>.
@@ -30,7 +30,7 @@ namespace NHibernate.Engine.Loading
 
 		[NonSerialized]
 		private readonly IPersistenceContext persistenceContext;
-		private IDictionary collectionLoadContexts;
+		private IDictionary<DbDataReader, CollectionLoadContext> collectionLoadContexts;
 
 		private Dictionary<CollectionKey, LoadingCollectionEntry> xrefLoadingCollectionEntries;
 
@@ -71,7 +71,7 @@ namespace NHibernate.Engine.Loading
 		{
 			if (collectionLoadContexts != null)
 			{
-				CollectionLoadContext collectionLoadContext = (CollectionLoadContext)collectionLoadContexts[resultSet];
+				collectionLoadContexts.TryGetValue(resultSet, out var collectionLoadContext);
 				collectionLoadContext.Cleanup();
 				collectionLoadContexts.Remove(resultSet);
 			}
@@ -112,7 +112,7 @@ namespace NHibernate.Engine.Loading
 		/// </summary>
 		public bool HasRegisteredLoadingCollectionEntries
 		{
-				get { return (xrefLoadingCollectionEntries != null && xrefLoadingCollectionEntries.Count != 0); }
+			get { return (xrefLoadingCollectionEntries != null && xrefLoadingCollectionEntries.Count != 0); }
 		}
 
 		/// <summary> 
@@ -126,11 +126,11 @@ namespace NHibernate.Engine.Loading
 			CollectionLoadContext context = null;
 			if (collectionLoadContexts == null)
 			{
-				collectionLoadContexts = IdentityMap.Instantiate(8);
+				collectionLoadContexts = IdentityMapUtils.Instantiate<DbDataReader, CollectionLoadContext>(8);
 			}
 			else
 			{
-				context = (CollectionLoadContext)collectionLoadContexts[resultSet];
+				collectionLoadContexts.TryGetValue(resultSet, out context);
 			}
 			if (context == null)
 			{

--- a/src/NHibernate/Engine/Loading/LoadContexts.cs
+++ b/src/NHibernate/Engine/Loading/LoadContexts.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Engine.Loading
 
 		[NonSerialized]
 		private readonly IPersistenceContext persistenceContext;
-		private IDictionary collectionLoadContexts;
+		private IDictionary<DbDataReader, CollectionLoadContext> collectionLoadContexts;
 
 		private Dictionary<CollectionKey, LoadingCollectionEntry> xrefLoadingCollectionEntries;
 
@@ -71,7 +71,7 @@ namespace NHibernate.Engine.Loading
 		{
 			if (collectionLoadContexts != null)
 			{
-				CollectionLoadContext collectionLoadContext = (CollectionLoadContext)collectionLoadContexts[resultSet];
+				collectionLoadContexts.TryGetValue(resultSet, out var collectionLoadContext);
 				collectionLoadContext.Cleanup();
 				collectionLoadContexts.Remove(resultSet);
 			}
@@ -126,11 +126,11 @@ namespace NHibernate.Engine.Loading
 			CollectionLoadContext context = null;
 			if (collectionLoadContexts == null)
 			{
-				collectionLoadContexts = IdentityMap.Instantiate(8);
+				collectionLoadContexts = IdentityMapUtils.Instantiate<DbDataReader, CollectionLoadContext>(8);
 			}
 			else
 			{
-				context = (CollectionLoadContext)collectionLoadContexts[resultSet];
+				collectionLoadContexts.TryGetValue(resultSet, out context);
 			}
 			if (context == null)
 			{

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -46,7 +46,7 @@ namespace NHibernate.Engine
 		private readonly Dictionary<EntityUniqueKey, object> entitiesByUniqueKey;
 
 		// Identity map of EntityEntry instances, by the entity instance
-		private readonly IDictionary entityEntries;
+		private readonly IdentityMap<object, object> entityEntries;
 
 		// Entity proxies, by EntityKey
 		private readonly Dictionary<EntityKey, INHibernateProxy> proxiesByKey;
@@ -56,10 +56,10 @@ namespace NHibernate.Engine
 		private readonly Dictionary<EntityKey, object> entitySnapshotsByKey;
 
 		// Identity map of array holder ArrayHolder instances, by the array instance
-		private readonly IDictionary arrayHolders;
+		private readonly IDictionary<object, IPersistentCollection> arrayHolders;
 
 		// Identity map of CollectionEntry instances, by the collection wrapper
-		private readonly IDictionary collectionEntries;
+		private readonly IdentityMap<object, object> collectionEntries;
 
 		// Collection wrappers, by the CollectionKey
 		private readonly Dictionary<CollectionKey, IPersistentCollection> collectionsByKey;
@@ -84,7 +84,7 @@ namespace NHibernate.Engine
 		// Parent entities cache by their child for cascading
 		// May be empty or not contains all relation
 		[NonSerialized]
-		private IDictionary parentsByChild;
+		private IDictionary<object, object> parentsByChild;
 
 		[NonSerialized]
 		private int cascading;
@@ -116,11 +116,11 @@ namespace NHibernate.Engine
 			entitiesByUniqueKey = new Dictionary<EntityUniqueKey, object>(InitCollectionSize);
 			proxiesByKey = new Dictionary<EntityKey, INHibernateProxy>(InitCollectionSize);
 			entitySnapshotsByKey = new Dictionary<EntityKey, object>(InitCollectionSize);
-			entityEntries = IdentityMap.InstantiateSequenced(InitCollectionSize);
-			collectionEntries = IdentityMap.InstantiateSequenced(InitCollectionSize);
+			entityEntries = IdentityMapUtils.InstantiateSequenced<object, object>(InitCollectionSize);
+			collectionEntries = IdentityMapUtils.InstantiateSequenced<object, object>(InitCollectionSize);
 			collectionsByKey = new Dictionary<CollectionKey, IPersistentCollection>(InitCollectionSize);
-			arrayHolders = IdentityMap.Instantiate(InitCollectionSize);
-			parentsByChild = IdentityMap.Instantiate(InitCollectionSize);
+			arrayHolders = IdentityMapUtils.Instantiate<object, IPersistentCollection>(InitCollectionSize);
+			parentsByChild = IdentityMapUtils.Instantiate<object, object>(InitCollectionSize);
 			nullifiableEntityKeys = new HashSet<EntityKey>();
 			InitTransientState();
 		}
@@ -188,16 +188,10 @@ namespace NHibernate.Engine
 		}
 
 		/// <summary> Get the mapping from entity instance to entity entry</summary>
-		public IDictionary EntityEntries
-		{
-			get { return entityEntries; }
-		}
+		public IDictionary EntityEntries => entityEntries;
 
 		/// <summary> Get the mapping from collection instance to collection entry</summary>
-		public IDictionary CollectionEntries
-		{
-			get { return collectionEntries; }
-		}
+		public IDictionary CollectionEntries => collectionEntries;
 
 		/// <summary> Get the mapping from collection key to collection instance</summary>
 		public IDictionary<CollectionKey, IPersistentCollection> CollectionsByKey
@@ -252,10 +246,13 @@ namespace NHibernate.Engine
 				li.UnsetSession();
 			}
 
-			var collectionEntryArray = IdentityMap.GetEntries(collectionEntries);
-			foreach (var entry in collectionEntryArray)
+			
+			using (var collectionEntryArray = collectionEntries.GetSnapshot())
 			{
-				((IPersistentCollection)entry.Key).UnsetSession(Session);
+				foreach (var entry in collectionEntryArray)
+				{
+					((IPersistentCollection)entry.Key).UnsetSession(Session);
+				}
 			}
 
 			arrayHolders.Clear();
@@ -487,27 +484,40 @@ namespace NHibernate.Engine
 		/// <returns> The EntityEntry for the given entity. </returns>
 		public EntityEntry GetEntry(object entity)
 		{
-			return (EntityEntry)entityEntries[entity];
+			if (entityEntries.TryGetValue(entity, out var entry))
+			{
+				return (EntityEntry)entry;
+			}
+			return null;
 		}
 
 		/// <summary> Remove an entity entry from the session cache</summary>
 		public EntityEntry RemoveEntry(object entity)
 		{
-			EntityEntry tempObject = (EntityEntry)entityEntries[entity];
-			entityEntries.Remove(entity);
-			return tempObject;
+			if (entityEntries.TryGetValue(entity, out var tempObject))
+			{
+				entityEntries.Remove(entity);
+				return (EntityEntry)tempObject;
+			}
+
+			return null;
 		}
 
 		/// <summary> Is there an EntityEntry for this instance?</summary>
 		public bool IsEntryFor(object entity)
 		{
-			return entityEntries.Contains(entity);
+			return entityEntries.ContainsKey(entity);
 		}
 
 		/// <summary> Get the collection entry for a persistent collection</summary>
 		public CollectionEntry GetCollectionEntry(IPersistentCollection coll)
 		{
-			return (CollectionEntry)collectionEntries[coll];
+			if (collectionEntries.TryGetValue(coll, out var entry))
+			{
+				return (CollectionEntry)entry;
+			}
+
+			return null;
 		}
 
 		/// <summary> Adds an entity to the internal caches.</summary>
@@ -571,7 +581,7 @@ namespace NHibernate.Engine
 		/// <summary> Is the given collection associated with this persistence context?</summary>
 		public bool ContainsCollection(IPersistentCollection collection)
 		{
-			return collectionEntries.Contains(collection);
+			return collectionEntries.ContainsKey(collection);
 		}
 
 		/// <summary> Is the given proxy associated with this persistence context?</summary>
@@ -1015,7 +1025,12 @@ namespace NHibernate.Engine
 		/// <summary> Get the <tt>PersistentCollection</tt> object for an array</summary>
 		public IPersistentCollection GetCollectionHolder(object array)
 		{
-			return (IPersistentCollection)arrayHolders[array];
+			if (arrayHolders.TryGetValue(array, out var holder))
+			{
+				return holder;
+			}
+			
+			return null;
 		}
 
 		/// <summary> Register a <tt>PersistentCollection</tt> object for an array.
@@ -1033,9 +1048,13 @@ namespace NHibernate.Engine
 		/// </summary>
 		public IPersistentCollection RemoveCollectionHolder(object array)
 		{
-			IPersistentCollection tempObject = (IPersistentCollection)arrayHolders[array];
-			arrayHolders.Remove(array);
-			return tempObject;
+			if (arrayHolders.TryGetValue(array, out var tempObject))
+			{
+				arrayHolders.Remove(array);
+				return tempObject;
+			}
+			
+			return null;
 		}
 
 		/// <summary> Get the snapshot of the pre-flush collection state</summary>
@@ -1135,7 +1154,7 @@ namespace NHibernate.Engine
 			IEntityPersister persister = session.Factory.GetEntityPersister(entityName);
 			ICollectionPersister collectionPersister = session.Factory.GetCollectionPersister(collectionRole);
 
-			object parent = parentsByChild[childEntity];
+			object parent = parentsByChild.TryGetValue(childEntity, out var p) ? p : null;
 			if (parent != null)
 			{
 				var entityEntry = (EntityEntry) entityEntries[parent];
@@ -1148,7 +1167,7 @@ namespace NHibernate.Engine
 			}
 
 			// iterate all the entities currently associated with the persistence context.
-			foreach (DictionaryEntry entry in entityEntries)
+			foreach (var entry in entityEntries)
 			{
 				var entityEntry = (EntityEntry) entry.Value;
 				// does this entity entry pertain to the entity persister in which we are interested (owner)?
@@ -1221,7 +1240,7 @@ namespace NHibernate.Engine
 			ICollectionPersister cp = session.Factory.GetCollectionPersister(entity + '.' + property);
 
 			// try cache lookup first
-			object parent = parentsByChild[childEntity];
+			object parent = parentsByChild.TryGetValue(childEntity, out var p) ? p : null;
 			if (parent != null)
 			{
 				var entityEntry = (EntityEntry) entityEntries[parent];
@@ -1251,7 +1270,7 @@ namespace NHibernate.Engine
 			}
 
 			//Not found in cache, proceed
-			foreach (DictionaryEntry me in entityEntries)
+			foreach (var me in entityEntries)
 			{
 				var ee = (EntityEntry) me.Value;
 				if (persister.IsSubclassEntityName(ee.EntityName))
@@ -1442,7 +1461,7 @@ namespace NHibernate.Engine
 			// collections to this session, as well as the EntityEntry and
 			// CollectionEntry instances; these associations are transient
 			// because serialization is used for different things.
-			parentsByChild = IdentityMap.Instantiate(InitCollectionSize);
+			parentsByChild = IdentityMapUtils.Instantiate<object, object>(InitCollectionSize);
 
 			// OnDeserialization() must be called manually on all Dictionaries and Hashtables,
 			// otherwise they are still empty at this point (the .NET deserialization code calls
@@ -1466,7 +1485,7 @@ namespace NHibernate.Engine
 			}
 
 			// TODO NH: "reconnect" EntityKey with session.factory and create a test for serialization of StatefulPersistenceContext
-			foreach (DictionaryEntry collectionEntry in collectionEntries)
+			foreach (var collectionEntry in collectionEntries)
 			{
 				try
 				{
@@ -1531,11 +1550,11 @@ namespace NHibernate.Engine
 			cascading = 0;
 			entitiesByKey = (Dictionary<EntityKey, object>)info.GetValue("context.entitiesByKey", typeof(Dictionary<EntityKey, object>));
 			entitiesByUniqueKey = (Dictionary<EntityUniqueKey, object>)info.GetValue("context.entitiesByUniqueKey", typeof(Dictionary<EntityUniqueKey, object>));
-			entityEntries = (IdentityMap)info.GetValue("context.entityEntries", typeof(IdentityMap));
+			entityEntries = (IdentityMap<object, object>)info.GetValue("context.entityEntries", typeof(IdentityMap<object, object>));
 			proxiesByKey = (Dictionary<EntityKey, INHibernateProxy>)info.GetValue("context.proxiesByKey", typeof(Dictionary<EntityKey, INHibernateProxy>));
 			entitySnapshotsByKey = (Dictionary<EntityKey, object>)info.GetValue("context.entitySnapshotsByKey", typeof(Dictionary<EntityKey, object>));
-			arrayHolders = (IdentityMap)info.GetValue("context.arrayHolders", typeof(IdentityMap));
-			collectionEntries = (IdentityMap)info.GetValue("context.collectionEntries", typeof(IdentityMap));
+			arrayHolders = (IdentityMap<object, IPersistentCollection>)info.GetValue("context.arrayHolders", typeof(IdentityMap<object, IPersistentCollection>));
+			collectionEntries = (IdentityMap<object, object>)info.GetValue("context.collectionEntries", typeof(IdentityMap<object, object>));
 			collectionsByKey = (Dictionary<CollectionKey, IPersistentCollection>)info.GetValue("context.collectionsByKey", typeof(Dictionary<CollectionKey, IPersistentCollection>));
 			nullifiableEntityKeys = (HashSet<EntityKey>)info.GetValue("context.nullifiableEntityKeys", typeof(HashSet<EntityKey>));
 			unownedCollections = (Dictionary<CollectionKey, IPersistentCollection>)info.GetValue("context.unownedCollections", typeof(Dictionary<CollectionKey, IPersistentCollection>));
@@ -1551,11 +1570,11 @@ namespace NHibernate.Engine
 
 			info.AddValue("context.entitiesByKey", entitiesByKey, typeof(Dictionary<EntityKey, object>));
 			info.AddValue("context.entitiesByUniqueKey", entitiesByUniqueKey, typeof(Dictionary<EntityUniqueKey, object>));
-			info.AddValue("context.entityEntries", entityEntries, typeof(IdentityMap));
+			info.AddValue("context.entityEntries", entityEntries, typeof(IdentityMap<object, object>));
 			info.AddValue("context.proxiesByKey", proxiesByKey, typeof(Dictionary<EntityKey, INHibernateProxy>));
 			info.AddValue("context.entitySnapshotsByKey", entitySnapshotsByKey, typeof(Dictionary<EntityKey, object>));
-			info.AddValue("context.arrayHolders", arrayHolders, typeof(IdentityMap));
-			info.AddValue("context.collectionEntries", collectionEntries, typeof(IdentityMap));
+			info.AddValue("context.arrayHolders", arrayHolders, typeof(IdentityMap<object, IPersistentCollection>));
+			info.AddValue("context.collectionEntries", collectionEntries, typeof(IdentityMap<object, object>));
 			info.AddValue("context.collectionsByKey", collectionsByKey, typeof(Dictionary<CollectionKey, IPersistentCollection>));
 			info.AddValue("context.nullifiableEntityKeys", nullifiableEntityKeys, typeof(HashSet<EntityKey>));
 			info.AddValue("context.unownedCollections", unownedCollections, typeof(Dictionary<CollectionKey, IPersistentCollection>));

--- a/src/NHibernate/Engine/StatefulPersistenceContext.cs
+++ b/src/NHibernate/Engine/StatefulPersistenceContext.cs
@@ -46,7 +46,7 @@ namespace NHibernate.Engine
 		private readonly Dictionary<EntityUniqueKey, object> entitiesByUniqueKey;
 
 		// Identity map of EntityEntry instances, by the entity instance
-		private readonly IDictionary entityEntries;
+		private readonly IdentityMap<object, EntityEntry> entityEntries;
 
 		// Entity proxies, by EntityKey
 		private readonly Dictionary<EntityKey, INHibernateProxy> proxiesByKey;
@@ -56,10 +56,10 @@ namespace NHibernate.Engine
 		private readonly Dictionary<EntityKey, object> entitySnapshotsByKey;
 
 		// Identity map of array holder ArrayHolder instances, by the array instance
-		private readonly IDictionary arrayHolders;
+		private readonly IDictionary<object, IPersistentCollection> arrayHolders;
 
 		// Identity map of CollectionEntry instances, by the collection wrapper
-		private readonly IDictionary collectionEntries;
+		private readonly IdentityMap<IPersistentCollection, CollectionEntry> collectionEntries;
 
 		// Collection wrappers, by the CollectionKey
 		private readonly Dictionary<CollectionKey, IPersistentCollection> collectionsByKey;
@@ -80,11 +80,11 @@ namespace NHibernate.Engine
 		private Dictionary<CollectionKey, IPersistentCollection> unownedCollections;
 
 		private bool hasNonReadOnlyEntities;
-		
+
 		// Parent entities cache by their child for cascading
 		// May be empty or not contains all relation
 		[NonSerialized]
-		private IDictionary parentsByChild;
+		private IDictionary<object, object> parentsByChild;
 
 		[NonSerialized]
 		private int cascading;
@@ -102,7 +102,7 @@ namespace NHibernate.Engine
 		private BatchFetchQueue batchFetchQueue;
 
 		private bool defaultReadOnly;
-		
+
 		/// <summary> Constructs a PersistentContext, bound to the given session. </summary>
 		/// <param name="session">The session "owning" this context. </param>
 		public StatefulPersistenceContext(ISessionImplementor session)
@@ -116,11 +116,11 @@ namespace NHibernate.Engine
 			entitiesByUniqueKey = new Dictionary<EntityUniqueKey, object>(InitCollectionSize);
 			proxiesByKey = new Dictionary<EntityKey, INHibernateProxy>(InitCollectionSize);
 			entitySnapshotsByKey = new Dictionary<EntityKey, object>(InitCollectionSize);
-			entityEntries = IdentityMap.InstantiateSequenced(InitCollectionSize);
-			collectionEntries = IdentityMap.InstantiateSequenced(InitCollectionSize);
+			entityEntries = IdentityMapUtils.InstantiateSequenced<object, EntityEntry>(InitCollectionSize);
+			collectionEntries = IdentityMapUtils.InstantiateSequenced<IPersistentCollection, CollectionEntry>(InitCollectionSize);
 			collectionsByKey = new Dictionary<CollectionKey, IPersistentCollection>(InitCollectionSize);
-			arrayHolders = IdentityMap.Instantiate(InitCollectionSize);
-			parentsByChild = IdentityMap.Instantiate(InitCollectionSize);
+			arrayHolders = IdentityMapUtils.Instantiate<object, IPersistentCollection>(InitCollectionSize);
+			parentsByChild = IdentityMapUtils.Instantiate<object, object>(InitCollectionSize);
 			nullifiableEntityKeys = new HashSet<EntityKey>();
 			InitTransientState();
 		}
@@ -188,16 +188,10 @@ namespace NHibernate.Engine
 		}
 
 		/// <summary> Get the mapping from entity instance to entity entry</summary>
-		public IDictionary EntityEntries
-		{
-			get { return entityEntries; }
-		}
+		public IDictionary EntityEntries => entityEntries;
 
 		/// <summary> Get the mapping from collection instance to collection entry</summary>
-		public IDictionary CollectionEntries
-		{
-			get { return collectionEntries; }
-		}
+		public IDictionary CollectionEntries => collectionEntries;
 
 		/// <summary> Get the mapping from collection key to collection instance</summary>
 		public IDictionary<CollectionKey, IPersistentCollection> CollectionsByKey
@@ -252,10 +246,13 @@ namespace NHibernate.Engine
 				li.UnsetSession();
 			}
 
-			var collectionEntryArray = IdentityMap.GetEntries(collectionEntries);
-			foreach (var entry in collectionEntryArray)
+
+			using (var collectionEntryArray = collectionEntries.GetSnapshot())
 			{
-				((IPersistentCollection)entry.Key).UnsetSession(Session);
+				foreach (var entry in collectionEntryArray)
+				{
+					((IPersistentCollection) entry.Key).UnsetSession(Session);
+				}
 			}
 
 			arrayHolders.Clear();
@@ -289,7 +286,7 @@ namespace NHibernate.Engine
 		{
 			get { return hasNonReadOnlyEntities; }
 		}
-		
+
 		/// <inheritdoc />
 		public bool DefaultReadOnly
 		{
@@ -330,7 +327,7 @@ namespace NHibernate.Engine
 			object cached;
 			if (entitySnapshotsByKey.TryGetValue(key, out cached))
 			{
-				return cached == NoRow ? null : (object[])cached;
+				return cached == NoRow ? null : (object[]) cached;
 			}
 			else
 			{
@@ -362,7 +359,7 @@ namespace NHibernate.Engine
 			{
 				throw new HibernateException("persistence context reported no row snapshot for " + MessageHelper.InfoString(key.EntityName, key.Identifier));
 			}
-			return (object[])snapshot;
+			return (object[]) snapshot;
 		}
 
 		/// <summary>
@@ -487,27 +484,40 @@ namespace NHibernate.Engine
 		/// <returns> The EntityEntry for the given entity. </returns>
 		public EntityEntry GetEntry(object entity)
 		{
-			return (EntityEntry)entityEntries[entity];
+			if (entityEntries.TryGetValue(entity, out var entry))
+			{
+				return (EntityEntry) entry;
+			}
+			return null;
 		}
 
 		/// <summary> Remove an entity entry from the session cache</summary>
 		public EntityEntry RemoveEntry(object entity)
 		{
-			EntityEntry tempObject = (EntityEntry)entityEntries[entity];
-			entityEntries.Remove(entity);
-			return tempObject;
+			if (entityEntries.TryGetValue(entity, out var tempObject))
+			{
+				entityEntries.Remove(entity);
+				return (EntityEntry) tempObject;
+			}
+
+			return null;
 		}
 
 		/// <summary> Is there an EntityEntry for this instance?</summary>
 		public bool IsEntryFor(object entity)
 		{
-			return entityEntries.Contains(entity);
+			return entityEntries.ContainsKey(entity);
 		}
 
 		/// <summary> Get the collection entry for a persistent collection</summary>
 		public CollectionEntry GetCollectionEntry(IPersistentCollection coll)
 		{
-			return (CollectionEntry)collectionEntries[coll];
+			if (collectionEntries.TryGetValue(coll, out var entry))
+			{
+				return (CollectionEntry) entry;
+			}
+
+			return null;
 		}
 
 		/// <summary> Adds an entity to the internal caches.</summary>
@@ -524,8 +534,8 @@ namespace NHibernate.Engine
 
 		/// <summary> Adds an entity to the internal caches.</summary>
 		public EntityEntry AddEntity(object entity, Status status, object[] loadedState, EntityKey entityKey, object version,
-		                             LockMode lockMode, bool existsInDatabase, IEntityPersister persister,
-		                             bool disableVersionIncrement)
+									 LockMode lockMode, bool existsInDatabase, IEntityPersister persister,
+									 bool disableVersionIncrement)
 		{
 			AddEntity(entityKey, entity);
 
@@ -556,12 +566,12 @@ namespace NHibernate.Engine
 		/// to the event source's internal caches.
 		/// </summary>
 		public EntityEntry AddEntry(object entity, Status status, object[] loadedState, object rowId, object id,
-		                            object version, LockMode lockMode, bool existsInDatabase, IEntityPersister persister,
-		                            bool disableVersionIncrement)
+									object version, LockMode lockMode, bool existsInDatabase, IEntityPersister persister,
+									bool disableVersionIncrement)
 		{
 			EntityEntry e =
 				new EntityEntry(status, loadedState, rowId, id, version, lockMode, existsInDatabase, persister,
-				                disableVersionIncrement);
+								disableVersionIncrement);
 			entityEntries[entity] = e;
 
 			SetHasNonReadOnlyEnties(status);
@@ -571,7 +581,7 @@ namespace NHibernate.Engine
 		/// <summary> Is the given collection associated with this persistence context?</summary>
 		public bool ContainsCollection(IPersistentCollection collection)
 		{
-			return collectionEntries.Contains(collection);
+			return collectionEntries.ContainsKey(collection);
 		}
 
 		/// <summary> Is the given proxy associated with this persistence context?</summary>
@@ -596,7 +606,7 @@ namespace NHibernate.Engine
 
 			if (!NHibernateUtil.IsInitialized(value))
 			{
-				INHibernateProxy proxy = (INHibernateProxy)value;
+				INHibernateProxy proxy = (INHibernateProxy) value;
 				ReassociateProxy(proxy.HibernateLazyInitializer, proxy);
 				return true;
 			}
@@ -620,8 +630,8 @@ namespace NHibernate.Engine
 			//}
 			if (value.IsProxy())
 			{
-				var proxy = value as INHibernateProxy; 
-				
+				var proxy = value as INHibernateProxy;
+
 				if (log.IsDebugEnabled())
 				{
 					log.Debug("setting proxy identifier: {0}", id);
@@ -668,8 +678,8 @@ namespace NHibernate.Engine
 
 			if (maybeProxy.IsProxy())
 			{
-				INHibernateProxy proxy = maybeProxy as INHibernateProxy; 
-				
+				INHibernateProxy proxy = maybeProxy as INHibernateProxy;
+
 				ILazyInitializer li = proxy.HibernateLazyInitializer;
 				if (li.IsUninitialized)
 					throw new PersistentObjectException("object was an uninitialized proxy for " + li.PersistentClass.FullName);
@@ -697,8 +707,8 @@ namespace NHibernate.Engine
 			//}
 			if (maybeProxy.IsProxy())
 			{
-				var proxy = maybeProxy as INHibernateProxy; 
-				
+				var proxy = maybeProxy as INHibernateProxy;
+
 				ILazyInitializer li = proxy.HibernateLazyInitializer;
 				ReassociateProxy(li, proxy);
 				return li.GetImplementation(); //initialize + unwrap the object
@@ -754,7 +764,7 @@ namespace NHibernate.Engine
 				}
 				else
 				{
-					proxy = (INHibernateProxy)persister.CreateProxy(key.Identifier, session);
+					proxy = (INHibernateProxy) persister.CreateProxy(key.Identifier, session);
 					INHibernateProxy proxyOrig = proxiesByKey[key];
 					proxiesByKey[key] = proxy; //overwrite old proxy
 					if (proxyOrig != null)
@@ -1015,7 +1025,12 @@ namespace NHibernate.Engine
 		/// <summary> Get the <tt>PersistentCollection</tt> object for an array</summary>
 		public IPersistentCollection GetCollectionHolder(object array)
 		{
-			return (IPersistentCollection)arrayHolders[array];
+			if (arrayHolders.TryGetValue(array, out var holder))
+			{
+				return holder;
+			}
+
+			return null;
 		}
 
 		/// <summary> Register a <tt>PersistentCollection</tt> object for an array.
@@ -1033,9 +1048,13 @@ namespace NHibernate.Engine
 		/// </summary>
 		public IPersistentCollection RemoveCollectionHolder(object array)
 		{
-			IPersistentCollection tempObject = (IPersistentCollection)arrayHolders[array];
-			arrayHolders.Remove(array);
-			return tempObject;
+			if (arrayHolders.TryGetValue(array, out var tempObject))
+			{
+				arrayHolders.Remove(array);
+				return tempObject;
+			}
+
+			return null;
 		}
 
 		/// <summary> Get the snapshot of the pre-flush collection state</summary>
@@ -1135,7 +1154,7 @@ namespace NHibernate.Engine
 			IEntityPersister persister = session.Factory.GetEntityPersister(entityName);
 			ICollectionPersister collectionPersister = session.Factory.GetCollectionPersister(collectionRole);
 
-			object parent = parentsByChild[childEntity];
+			object parent = parentsByChild.TryGetValue(childEntity, out var p) ? p : null;
 			if (parent != null)
 			{
 				var entityEntry = (EntityEntry) entityEntries[parent];
@@ -1148,7 +1167,7 @@ namespace NHibernate.Engine
 			}
 
 			// iterate all the entities currently associated with the persistence context.
-			foreach (DictionaryEntry entry in entityEntries)
+			foreach (var entry in entityEntries)
 			{
 				var entityEntry = (EntityEntry) entry.Value;
 				// does this entity entry pertain to the entity persister in which we are interested (owner)?
@@ -1221,7 +1240,7 @@ namespace NHibernate.Engine
 			ICollectionPersister cp = session.Factory.GetCollectionPersister(entity + '.' + property);
 
 			// try cache lookup first
-			object parent = parentsByChild[childEntity];
+			object parent = parentsByChild.TryGetValue(childEntity, out var p) ? p : null;
 			if (parent != null)
 			{
 				var entityEntry = (EntityEntry) entityEntries[parent];
@@ -1251,7 +1270,7 @@ namespace NHibernate.Engine
 			}
 
 			//Not found in cache, proceed
-			foreach (DictionaryEntry me in entityEntries)
+			foreach (var me in entityEntries)
 			{
 				var ee = (EntityEntry) me.Value;
 				if (persister.IsSubclassEntityName(ee.EntityName))
@@ -1307,13 +1326,13 @@ namespace NHibernate.Engine
 		{
 			if (entityOrProxy == null)
 				throw new ArgumentNullException("entityOrProxy");
-		
+
 			if (IsReadOnly(entityOrProxy) == readOnly)
 				return;
-	
+
 			if (entityOrProxy is INHibernateProxy)
 			{
-				INHibernateProxy proxy = (INHibernateProxy)entityOrProxy;
+				INHibernateProxy proxy = (INHibernateProxy) entityOrProxy;
 				SetProxyReadOnly(proxy, readOnly);
 				if (NHibernateUtil.IsInitialized(proxy))
 				{
@@ -1323,17 +1342,17 @@ namespace NHibernate.Engine
 			else
 			{
 				SetEntityReadOnly(entityOrProxy, readOnly);
-				
+
 				// PersistenceContext.proxyFor( entity ) returns entity if there is no proxy for that entity
 				// so need to check the return value to be sure it is really a proxy
 				object maybeProxy = this.Session.PersistenceContext.ProxyFor(entityOrProxy);
-				if (maybeProxy is INHibernateProxy )
+				if (maybeProxy is INHibernateProxy)
 				{
-					SetProxyReadOnly((INHibernateProxy)maybeProxy, readOnly);
+					SetProxyReadOnly((INHibernateProxy) maybeProxy, readOnly);
 				}
 			}
 		}
-		
+
 		private void SetProxyReadOnly(INHibernateProxy proxy, bool readOnly)
 		{
 			if (proxy.HibernateLazyInitializer.Session != this.Session)
@@ -1353,7 +1372,7 @@ namespace NHibernate.Engine
 			entry.SetReadOnly(readOnly, entity);
 			hasNonReadOnlyEntities |= !readOnly;
 		}
-		
+
 		/// <inheritdoc />
 		public bool IsReadOnly(object entityOrProxy)
 		{
@@ -1364,20 +1383,20 @@ namespace NHibernate.Engine
 			bool isReadOnly;
 			if (entityOrProxy is INHibernateProxy)
 			{
-				isReadOnly = ((INHibernateProxy)entityOrProxy).HibernateLazyInitializer.ReadOnly;
+				isReadOnly = ((INHibernateProxy) entityOrProxy).HibernateLazyInitializer.ReadOnly;
 			}
 			else
 			{
 				EntityEntry ee = GetEntry(entityOrProxy);
 				if (ee == null)
 				{
-					throw new TransientObjectException("Instance was not associated with this persistence context" );
+					throw new TransientObjectException("Instance was not associated with this persistence context");
 				}
 				isReadOnly = ee.IsReadOnly;
 			}
 			return isReadOnly;
 		}
-		
+
 		public void ReplaceDelayedEntityIdentityInsertKeys(EntityKey oldKey, object generatedId)
 		{
 			if (!entitiesByKey.Remove(oldKey, out var tempObject))
@@ -1442,18 +1461,18 @@ namespace NHibernate.Engine
 			// collections to this session, as well as the EntityEntry and
 			// CollectionEntry instances; these associations are transient
 			// because serialization is used for different things.
-			parentsByChild = IdentityMap.Instantiate(InitCollectionSize);
+			parentsByChild = IdentityMapUtils.Instantiate<object, object>(InitCollectionSize);
 
 			// OnDeserialization() must be called manually on all Dictionaries and Hashtables,
 			// otherwise they are still empty at this point (the .NET deserialization code calls
 			// OnDeserialization() on them AFTER it calls the current method).
 			entitiesByKey.OnDeserialization(sender);
 			entitiesByUniqueKey.OnDeserialization(sender);
-			((IDeserializationCallback)entityEntries).OnDeserialization(sender);
+			((IDeserializationCallback) entityEntries).OnDeserialization(sender);
 			proxiesByKey.OnDeserialization(sender);
 			entitySnapshotsByKey.OnDeserialization(sender);
-			((IDeserializationCallback)arrayHolders).OnDeserialization(sender);
-			((IDeserializationCallback)collectionEntries).OnDeserialization(sender);
+			((IDeserializationCallback) arrayHolders).OnDeserialization(sender);
+			((IDeserializationCallback) collectionEntries).OnDeserialization(sender);
 			collectionsByKey.OnDeserialization(sender);
 
 			// If nullifiableEntityKeys is once used in the current method, HashSets will need
@@ -1466,12 +1485,12 @@ namespace NHibernate.Engine
 			}
 
 			// TODO NH: "reconnect" EntityKey with session.factory and create a test for serialization of StatefulPersistenceContext
-			foreach (DictionaryEntry collectionEntry in collectionEntries)
+			foreach (var collectionEntry in collectionEntries)
 			{
 				try
 				{
-					((IPersistentCollection)collectionEntry.Key).SetCurrentSession(session);
-					CollectionEntry ce = (CollectionEntry)collectionEntry.Value;
+					((IPersistentCollection) collectionEntry.Key).SetCurrentSession(session);
+					CollectionEntry ce = (CollectionEntry) collectionEntry.Value;
 					if (ce.Role != null)
 					{
 						ce.AfterDeserialize(Session.Factory);
@@ -1529,16 +1548,16 @@ namespace NHibernate.Engine
 			loadCounter = 0;
 			flushing = false;
 			cascading = 0;
-			entitiesByKey = (Dictionary<EntityKey, object>)info.GetValue("context.entitiesByKey", typeof(Dictionary<EntityKey, object>));
-			entitiesByUniqueKey = (Dictionary<EntityUniqueKey, object>)info.GetValue("context.entitiesByUniqueKey", typeof(Dictionary<EntityUniqueKey, object>));
-			entityEntries = (IdentityMap)info.GetValue("context.entityEntries", typeof(IdentityMap));
-			proxiesByKey = (Dictionary<EntityKey, INHibernateProxy>)info.GetValue("context.proxiesByKey", typeof(Dictionary<EntityKey, INHibernateProxy>));
-			entitySnapshotsByKey = (Dictionary<EntityKey, object>)info.GetValue("context.entitySnapshotsByKey", typeof(Dictionary<EntityKey, object>));
-			arrayHolders = (IdentityMap)info.GetValue("context.arrayHolders", typeof(IdentityMap));
-			collectionEntries = (IdentityMap)info.GetValue("context.collectionEntries", typeof(IdentityMap));
-			collectionsByKey = (Dictionary<CollectionKey, IPersistentCollection>)info.GetValue("context.collectionsByKey", typeof(Dictionary<CollectionKey, IPersistentCollection>));
-			nullifiableEntityKeys = (HashSet<EntityKey>)info.GetValue("context.nullifiableEntityKeys", typeof(HashSet<EntityKey>));
-			unownedCollections = (Dictionary<CollectionKey, IPersistentCollection>)info.GetValue("context.unownedCollections", typeof(Dictionary<CollectionKey, IPersistentCollection>));
+			entitiesByKey = (Dictionary<EntityKey, object>) info.GetValue("context.entitiesByKey", typeof(Dictionary<EntityKey, object>));
+			entitiesByUniqueKey = (Dictionary<EntityUniqueKey, object>) info.GetValue("context.entitiesByUniqueKey", typeof(Dictionary<EntityUniqueKey, object>));
+			entityEntries = (IdentityMap<object, EntityEntry>) info.GetValue("context.entityEntries", typeof(IdentityMap<object, EntityEntry>));
+			proxiesByKey = (Dictionary<EntityKey, INHibernateProxy>) info.GetValue("context.proxiesByKey", typeof(Dictionary<EntityKey, INHibernateProxy>));
+			entitySnapshotsByKey = (Dictionary<EntityKey, object>) info.GetValue("context.entitySnapshotsByKey", typeof(Dictionary<EntityKey, object>));
+			arrayHolders = (IdentityMap<object, IPersistentCollection>) info.GetValue("context.arrayHolders", typeof(IdentityMap<object, IPersistentCollection>));
+			collectionEntries = (IdentityMap<IPersistentCollection, CollectionEntry>) info.GetValue("context.collectionEntries", typeof(IdentityMap<IPersistentCollection, CollectionEntry>));
+			collectionsByKey = (Dictionary<CollectionKey, IPersistentCollection>) info.GetValue("context.collectionsByKey", typeof(Dictionary<CollectionKey, IPersistentCollection>));
+			nullifiableEntityKeys = (HashSet<EntityKey>) info.GetValue("context.nullifiableEntityKeys", typeof(HashSet<EntityKey>));
+			unownedCollections = (Dictionary<CollectionKey, IPersistentCollection>) info.GetValue("context.unownedCollections", typeof(Dictionary<CollectionKey, IPersistentCollection>));
 			hasNonReadOnlyEntities = info.GetBoolean("context.hasNonReadOnlyEntities");
 			defaultReadOnly = info.GetBoolean("context.defaultReadOnly");
 			InitTransientState();
@@ -1551,11 +1570,11 @@ namespace NHibernate.Engine
 
 			info.AddValue("context.entitiesByKey", entitiesByKey, typeof(Dictionary<EntityKey, object>));
 			info.AddValue("context.entitiesByUniqueKey", entitiesByUniqueKey, typeof(Dictionary<EntityUniqueKey, object>));
-			info.AddValue("context.entityEntries", entityEntries, typeof(IdentityMap));
+			info.AddValue("context.entityEntries", entityEntries, typeof(IdentityMap<object, EntityEntry>));
 			info.AddValue("context.proxiesByKey", proxiesByKey, typeof(Dictionary<EntityKey, INHibernateProxy>));
 			info.AddValue("context.entitySnapshotsByKey", entitySnapshotsByKey, typeof(Dictionary<EntityKey, object>));
-			info.AddValue("context.arrayHolders", arrayHolders, typeof(IdentityMap));
-			info.AddValue("context.collectionEntries", collectionEntries, typeof(IdentityMap));
+			info.AddValue("context.arrayHolders", arrayHolders, typeof(IdentityMap<object, IPersistentCollection>));
+			info.AddValue("context.collectionEntries", collectionEntries, typeof(IdentityMap<IPersistentCollection, CollectionEntry>));
 			info.AddValue("context.collectionsByKey", collectionsByKey, typeof(Dictionary<CollectionKey, IPersistentCollection>));
 			info.AddValue("context.nullifiableEntityKeys", nullifiableEntityKeys, typeof(HashSet<EntityKey>));
 			info.AddValue("context.unownedCollections", unownedCollections, typeof(Dictionary<CollectionKey, IPersistentCollection>));

--- a/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
@@ -90,13 +90,15 @@ namespace NHibernate.Event.Default
 		{
 			log.Debug("Processing unreferenced collections");
 
-			var list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
-			foreach (var me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries))
 			{
-				var ce = (CollectionEntry) me.Value;
-				if (!ce.IsReached && !ce.IsIgnore)
+				foreach (var me in list)
 				{
-					Collections.ProcessUnreachableCollection((IPersistentCollection) me.Key, session);
+					var ce = (CollectionEntry) me.Value;
+					if (!ce.IsReached && !ce.IsIgnore)
+					{
+						Collections.ProcessUnreachableCollection((IPersistentCollection) me.Key, session);
+					}
 				}
 			}
 
@@ -104,29 +106,31 @@ namespace NHibernate.Event.Default
 
 			log.Debug("Scheduling collection removes/(re)creates/updates");
 
-			list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
 			ActionQueue actionQueue = session.ActionQueue;
-			foreach (DictionaryEntry me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries))
 			{
-				IPersistentCollection coll = (IPersistentCollection) me.Key;
-				CollectionEntry ce = (CollectionEntry) me.Value;
+				foreach (var me in list)
+				{
+					IPersistentCollection coll = (IPersistentCollection) me.Key;
+					CollectionEntry ce = (CollectionEntry) me.Value;
 
-				if (ce.IsDorecreate)
-				{
-					session.Interceptor.OnCollectionRecreate(coll, ce.CurrentKey);
-					actionQueue.AddAction(new CollectionRecreateAction(coll, ce.CurrentPersister, ce.CurrentKey, session));
-				}
-				if (ce.IsDoremove)
-				{
-					session.Interceptor.OnCollectionRemove(coll, ce.LoadedKey);
-					actionQueue.AddAction(
-						new CollectionRemoveAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
-				}
-				if (ce.IsDoupdate)
-				{
-					session.Interceptor.OnCollectionUpdate(coll, ce.LoadedKey);
-					actionQueue.AddAction(
-						new CollectionUpdateAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					if (ce.IsDorecreate)
+					{
+						session.Interceptor.OnCollectionRecreate(coll, ce.CurrentKey);
+						actionQueue.AddAction(new CollectionRecreateAction(coll, ce.CurrentPersister, ce.CurrentKey, session));
+					}
+					if (ce.IsDoremove)
+					{
+						session.Interceptor.OnCollectionRemove(coll, ce.LoadedKey);
+						actionQueue.AddAction(
+							new CollectionRemoveAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					}
+					if (ce.IsDoupdate)
+					{
+						session.Interceptor.OnCollectionUpdate(coll, ce.LoadedKey);
+						actionQueue.AddAction(
+							new CollectionUpdateAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					}
 				}
 			}
 			actionQueue.SortCollectionActions();
@@ -147,20 +151,22 @@ namespace NHibernate.Event.Default
 			// It is safe because of how IdentityMap implements entrySet()
 			var source = @event.Session;
 
-			var list = IdentityMap.GetEntries(source.PersistenceContext.EntityEntries);
-			foreach (var me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(source.PersistenceContext.EntityEntries))
 			{
-				// Update the status of the object and if necessary, schedule an update
-				var entry = (EntityEntry) me.Value;
-				var status = entry.Status;
-
-				if (status != Status.Loading && status != Status.Gone)
+				foreach (var me in list)
 				{
-					var entityEvent = new FlushEntityEvent(source, me.Key, entry);
-					var listeners = source.Listeners.FlushEntityEventListeners;
-					foreach (var listener in listeners)
+					// Update the status of the object and if necessary, schedule an update
+					var entry = (EntityEntry) me.Value;
+					var status = entry.Status;
+
+					if (status != Status.Loading && status != Status.Gone)
 					{
-						listener.OnFlushEntity(entityEvent);
+						var entityEvent = new FlushEntityEvent(source, me.Key, entry);
+						var listeners = source.Listeners.FlushEntityEventListeners;
+						foreach (var listener in listeners)
+						{
+							listener.OnFlushEntity(entityEvent);
+						}
 					}
 				}
 			}
@@ -174,7 +180,7 @@ namespace NHibernate.Event.Default
 			// and reset reached, doupdate, etc.
 			log.Debug("dirty checking collections");
 
-			var list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
+			using var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries);
 			foreach (var entry in list)
 			{
 				((CollectionEntry) entry.Value).PreFlush((IPersistentCollection) entry.Key);
@@ -189,7 +195,7 @@ namespace NHibernate.Event.Default
 			log.Debug("processing flush-time cascades");
 
 			var anything = Anything;
-			var list = IdentityMap.GetEntries(session.PersistenceContext.EntityEntries);
+			using var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.EntityEntries);
 			//safe from concurrent modification because of how entryList() is implemented on IdentityMap
 			foreach (var me in list)
 			{
@@ -276,36 +282,34 @@ namespace NHibernate.Event.Default
 				log.Debug("post flush");
 			}
 
-			IPersistenceContext persistenceContext = session.PersistenceContext;
+			var persistenceContext = session.PersistenceContext;
 			persistenceContext.CollectionsByKey.Clear();
 			persistenceContext.BatchFetchQueue.ClearSubselects();
 			//the database has changed now, so the subselect results need to be invalidated
 
 			// NH Different implementation: In NET an iterator is immutable;
 			// we need something to hold the persistent collection to remove, and it must be less intrusive as possible
-			IDictionary cEntries = persistenceContext.CollectionEntries;
-			List<IPersistentCollection> keysToRemove = new List<IPersistentCollection>(cEntries.Count);
-			foreach (DictionaryEntry me in cEntries)
+			using (var cEntries = IdentityMapUtils.GetSnapshot<object, object>(persistenceContext.CollectionEntries))
 			{
-				CollectionEntry collectionEntry = (CollectionEntry) me.Value;
-				IPersistentCollection persistentCollection = (IPersistentCollection) me.Key;
-				collectionEntry.PostFlush(persistentCollection);
-				if (collectionEntry.LoadedPersister == null)
+				foreach (var me in cEntries)
 				{
-					keysToRemove.Add(persistentCollection);
-				}
-				else
-				{
-					//otherwise recreate the mapping between the collection and its key
-					CollectionKey collectionKey =
-						new CollectionKey(collectionEntry.LoadedPersister, collectionEntry.LoadedKey);
-					persistenceContext.CollectionsByKey[collectionKey] = persistentCollection;
+					var collectionEntry = (CollectionEntry) me.Value;
+					var persistentCollection = (IPersistentCollection) me.Key;
+					collectionEntry.PostFlush(persistentCollection);
+					if (collectionEntry.LoadedPersister == null)
+					{
+						persistenceContext.CollectionEntries.Remove(persistentCollection);
+					}
+					else
+					{
+						//otherwise recreate the mapping between the collection and its key
+						var collectionKey =
+							new CollectionKey(collectionEntry.LoadedPersister, collectionEntry.LoadedKey);
+						persistenceContext.CollectionsByKey[collectionKey] = persistentCollection;
+					}
 				}
 			}
-			foreach (IPersistentCollection key in keysToRemove)
-			{
-				persistenceContext.CollectionEntries.Remove(key);
-			}
+			
 			session.Interceptor.PostFlush((ICollection) persistenceContext.EntitiesByKey.Values);
 		}
 	}

--- a/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
+++ b/src/NHibernate/Event/Default/AbstractFlushingEventListener.cs
@@ -19,7 +19,7 @@ namespace NHibernate.Event.Default
 	[Serializable]
 	public abstract partial class AbstractFlushingEventListener
 	{
-		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof (AbstractFlushingEventListener));
+		private static readonly INHibernateLogger log = NHibernateLogger.For(typeof(AbstractFlushingEventListener));
 
 		protected virtual object Anything
 		{
@@ -90,13 +90,15 @@ namespace NHibernate.Event.Default
 		{
 			log.Debug("Processing unreferenced collections");
 
-			var list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
-			foreach (var me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries))
 			{
-				var ce = (CollectionEntry) me.Value;
-				if (!ce.IsReached && !ce.IsIgnore)
+				foreach (var me in list)
 				{
-					Collections.ProcessUnreachableCollection((IPersistentCollection) me.Key, session);
+					var ce = (CollectionEntry) me.Value;
+					if (!ce.IsReached && !ce.IsIgnore)
+					{
+						Collections.ProcessUnreachableCollection((IPersistentCollection) me.Key, session);
+					}
 				}
 			}
 
@@ -104,29 +106,31 @@ namespace NHibernate.Event.Default
 
 			log.Debug("Scheduling collection removes/(re)creates/updates");
 
-			list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
 			ActionQueue actionQueue = session.ActionQueue;
-			foreach (DictionaryEntry me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries))
 			{
-				IPersistentCollection coll = (IPersistentCollection) me.Key;
-				CollectionEntry ce = (CollectionEntry) me.Value;
+				foreach (var me in list)
+				{
+					IPersistentCollection coll = (IPersistentCollection) me.Key;
+					CollectionEntry ce = (CollectionEntry) me.Value;
 
-				if (ce.IsDorecreate)
-				{
-					session.Interceptor.OnCollectionRecreate(coll, ce.CurrentKey);
-					actionQueue.AddAction(new CollectionRecreateAction(coll, ce.CurrentPersister, ce.CurrentKey, session));
-				}
-				if (ce.IsDoremove)
-				{
-					session.Interceptor.OnCollectionRemove(coll, ce.LoadedKey);
-					actionQueue.AddAction(
-						new CollectionRemoveAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
-				}
-				if (ce.IsDoupdate)
-				{
-					session.Interceptor.OnCollectionUpdate(coll, ce.LoadedKey);
-					actionQueue.AddAction(
-						new CollectionUpdateAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					if (ce.IsDorecreate)
+					{
+						session.Interceptor.OnCollectionRecreate(coll, ce.CurrentKey);
+						actionQueue.AddAction(new CollectionRecreateAction(coll, ce.CurrentPersister, ce.CurrentKey, session));
+					}
+					if (ce.IsDoremove)
+					{
+						session.Interceptor.OnCollectionRemove(coll, ce.LoadedKey);
+						actionQueue.AddAction(
+							new CollectionRemoveAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					}
+					if (ce.IsDoupdate)
+					{
+						session.Interceptor.OnCollectionUpdate(coll, ce.LoadedKey);
+						actionQueue.AddAction(
+							new CollectionUpdateAction(coll, ce.LoadedPersister, ce.LoadedKey, ce.IsSnapshotEmpty(coll), session));
+					}
 				}
 			}
 			actionQueue.SortCollectionActions();
@@ -147,20 +151,22 @@ namespace NHibernate.Event.Default
 			// It is safe because of how IdentityMap implements entrySet()
 			var source = @event.Session;
 
-			var list = IdentityMap.GetEntries(source.PersistenceContext.EntityEntries);
-			foreach (var me in list)
+			using (var list = IdentityMapUtils.GetSnapshot<object, object>(source.PersistenceContext.EntityEntries))
 			{
-				// Update the status of the object and if necessary, schedule an update
-				var entry = (EntityEntry) me.Value;
-				var status = entry.Status;
-
-				if (status != Status.Loading && status != Status.Gone)
+				foreach (var me in list)
 				{
-					var entityEvent = new FlushEntityEvent(source, me.Key, entry);
-					var listeners = source.Listeners.FlushEntityEventListeners;
-					foreach (var listener in listeners)
+					// Update the status of the object and if necessary, schedule an update
+					var entry = (EntityEntry) me.Value;
+					var status = entry.Status;
+
+					if (status != Status.Loading && status != Status.Gone)
 					{
-						listener.OnFlushEntity(entityEvent);
+						var entityEvent = new FlushEntityEvent(source, me.Key, entry);
+						var listeners = source.Listeners.FlushEntityEventListeners;
+						foreach (var listener in listeners)
+						{
+							listener.OnFlushEntity(entityEvent);
+						}
 					}
 				}
 			}
@@ -174,7 +180,7 @@ namespace NHibernate.Event.Default
 			// and reset reached, doupdate, etc.
 			log.Debug("dirty checking collections");
 
-			var list = IdentityMap.GetEntries(session.PersistenceContext.CollectionEntries);
+			using var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.CollectionEntries);
 			foreach (var entry in list)
 			{
 				((CollectionEntry) entry.Value).PreFlush((IPersistentCollection) entry.Key);
@@ -189,7 +195,7 @@ namespace NHibernate.Event.Default
 			log.Debug("processing flush-time cascades");
 
 			var anything = Anything;
-			var list = IdentityMap.GetEntries(session.PersistenceContext.EntityEntries);
+			using var list = IdentityMapUtils.GetSnapshot<object, object>(session.PersistenceContext.EntityEntries);
 			//safe from concurrent modification because of how entryList() is implemented on IdentityMap
 			foreach (var me in list)
 			{
@@ -276,36 +282,34 @@ namespace NHibernate.Event.Default
 				log.Debug("post flush");
 			}
 
-			IPersistenceContext persistenceContext = session.PersistenceContext;
+			var persistenceContext = session.PersistenceContext;
 			persistenceContext.CollectionsByKey.Clear();
 			persistenceContext.BatchFetchQueue.ClearSubselects();
 			//the database has changed now, so the subselect results need to be invalidated
 
 			// NH Different implementation: In NET an iterator is immutable;
 			// we need something to hold the persistent collection to remove, and it must be less intrusive as possible
-			IDictionary cEntries = persistenceContext.CollectionEntries;
-			List<IPersistentCollection> keysToRemove = new List<IPersistentCollection>(cEntries.Count);
-			foreach (DictionaryEntry me in cEntries)
+			using (var cEntries = IdentityMapUtils.GetSnapshot<object, object>(persistenceContext.CollectionEntries))
 			{
-				CollectionEntry collectionEntry = (CollectionEntry) me.Value;
-				IPersistentCollection persistentCollection = (IPersistentCollection) me.Key;
-				collectionEntry.PostFlush(persistentCollection);
-				if (collectionEntry.LoadedPersister == null)
+				foreach (var me in cEntries)
 				{
-					keysToRemove.Add(persistentCollection);
-				}
-				else
-				{
-					//otherwise recreate the mapping between the collection and its key
-					CollectionKey collectionKey =
-						new CollectionKey(collectionEntry.LoadedPersister, collectionEntry.LoadedKey);
-					persistenceContext.CollectionsByKey[collectionKey] = persistentCollection;
+					var collectionEntry = (CollectionEntry) me.Value;
+					var persistentCollection = (IPersistentCollection) me.Key;
+					collectionEntry.PostFlush(persistentCollection);
+					if (collectionEntry.LoadedPersister == null)
+					{
+						persistenceContext.CollectionEntries.Remove(persistentCollection);
+					}
+					else
+					{
+						//otherwise recreate the mapping between the collection and its key
+						var collectionKey =
+							new CollectionKey(collectionEntry.LoadedPersister, collectionEntry.LoadedKey);
+						persistenceContext.CollectionsByKey[collectionKey] = persistentCollection;
+					}
 				}
 			}
-			foreach (IPersistentCollection key in keysToRemove)
-			{
-				persistenceContext.CollectionEntries.Remove(key);
-			}
+
 			session.Interceptor.PostFlush((ICollection) persistenceContext.EntitiesByKey.Values);
 		}
 	}

--- a/src/NHibernate/Event/Default/EventCache.cs
+++ b/src/NHibernate/Event/Default/EventCache.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NHibernate.Util;
@@ -7,16 +7,16 @@ namespace NHibernate.Event.Default
 {
 	public class EventCache : IDictionary
 	{
-		private IDictionary entityToCopyMap = IdentityMap.Instantiate(10);
+		private IDictionary<object, object> entityToCopyMap = IdentityMapUtils.Instantiate<object, object>(10);
 		// key is an entity involved with the operation performed by the listener;
 		// value can be either a copy of the entity or the entity itself
-	
-		private IDictionary entityToOperatedOnFlagMap = IdentityMap.Instantiate(10);
+
+		private IDictionary<object, object> entityToOperatedOnFlagMap = IdentityMapUtils.Instantiate<object, object>(10);
 		// key is an entity involved with the operation performed by the listener;
 		// value is a flag indicating if the listener explicitly operates on the entity
-		
+
 		#region ICollection Implementation
-		
+
 		/// <summary>
 		/// Returns the number of entity-copy mappings in this EventCache
 		/// </summary>
@@ -24,17 +24,17 @@ namespace NHibernate.Event.Default
 		{
 			get { return entityToCopyMap.Count; }
 		}
-		
+
 		public bool IsSynchronized
 		{
 			get { return false; }
 		}
-		
+
 		public object SyncRoot
 		{
 			get { return this; }
 		}
-		
+
 		public void CopyTo(Array array, int index)
 		{
 			if (array == null)
@@ -43,90 +43,70 @@ namespace NHibernate.Event.Default
 				throw new ArgumentOutOfRangeException("arrayIndex is less than 0");
 			if (entityToCopyMap.Count + index + 1 > array.Length)
 				throw new ArgumentException("The number of elements in the source ICollection<T> is greater than the available space from arrayIndex to the end of the destination array.");
-		
-			entityToCopyMap.CopyTo(array, index);
-		}
-		
-		#endregion
-		
-		#region IEnumerable implementation
-		
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return ((IEnumerable)entityToCopyMap).GetEnumerator();
+
+			var i = index;
+			foreach (var entry in entityToCopyMap)
+			{
+				array.SetValue(new DictionaryEntry(entry.Key, entry.Value), i++);
+			}
 		}
 
 		#endregion
-		
+
+		#region IEnumerable implementation
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		#endregion
+
 		#region IDictionary implementation
-		
+
 		public object this[object key]
 		{
-			get 
-			{
-				return entityToCopyMap[key];
-			}
-			set
-			{
-				this.Add(key, value);
-			}
-		}
-		
-		public bool IsReadOnly
-		{
-			get { return false; }
-		}
-		
-		public bool IsFixedSize
-		{
-			get { return false; }
+			get => entityToCopyMap.TryGetValue(key, out var value) ? value : null;
+			set => Add(key, value);
 		}
 
-		public ICollection Keys
-		{
-			get { return entityToCopyMap.Keys; }
-		}
-		
-		public ICollection Values
-		{
-			get { return entityToCopyMap.Values; }
-		}
-		
+		public bool IsReadOnly => false;
+
+		public bool IsFixedSize => false;
+
+		public ICollection Keys => new CollectionAdapter(entityToCopyMap.Keys);
+
+		public ICollection Values => new CollectionAdapter(entityToCopyMap.Values);
+
 		public void Add(object key, object value)
 		{
 			if (key == null)
 				throw new ArgumentNullException("key");
 			if (value == null)
 				throw new ArgumentNullException("value");
-			
+
 			entityToCopyMap.Add(key, value);
 			entityToOperatedOnFlagMap.Add(key, false);
 		}
-		
+
 		public bool Contains(object key)
 		{
-			return entityToCopyMap.Contains(key);
+			return entityToCopyMap.ContainsKey(key);
 		}
-		
+
 		public void Remove(object key)
 		{
 			entityToCopyMap.Remove(key);
 			entityToOperatedOnFlagMap.Remove(key);
 		}
-		
-		public IDictionaryEnumerator GetEnumerator()
-		{
-			return entityToCopyMap.GetEnumerator();
-		}
-		
+
+		public IDictionaryEnumerator GetEnumerator() => new DictionaryEnumeratorAdapter(entityToCopyMap.GetEnumerator());
+
 		public void Clear()
 		{
 			entityToCopyMap.Clear();
 			entityToOperatedOnFlagMap.Clear();
 		}
-		
+
 		#endregion
-		
+
 		/// <summary>
 		/// Associates the specified entity with the specified copy in this EventCache;
 		/// </summary>
@@ -139,20 +119,25 @@ namespace NHibernate.Event.Default
 				throw new ArgumentNullException("null entities are not supported", "entity");
 			if (copy == null)
 				throw new ArgumentNullException("null entity copies are not supported", "copy");
-			
+
 			entityToCopyMap.Add(entity, copy);
 			entityToOperatedOnFlagMap.Add(entity, isOperatedOn);
 		}
-		
+
 		/// <summary>
 		/// Returns copy-entity mappings
 		/// </summary>
 		/// <returns></returns>
 		public IDictionary InvertMap()
 		{
-			return IdentityMap.Invert(entityToCopyMap);
+			IDictionary result = IdentityMap.Instantiate(entityToCopyMap.Count);
+			foreach (var entry in entityToCopyMap)
+			{
+				result[entry.Value] = entry.Key;
+			}
+			return result;
 		}
-		
+
 		/// <summary>
 		/// Returns true if the listener is performing the operation on the specified entity.
 		/// </summary>
@@ -163,9 +148,9 @@ namespace NHibernate.Event.Default
 			if (entity == null)
 				throw new ArgumentNullException("null entities are not supported", "entity");
 
-			return (bool)entityToOperatedOnFlagMap[entity];
+			return (bool) entityToOperatedOnFlagMap[entity];
 		}
-		
+
 		/// <summary>
 		/// Set flag to indicate if the listener is performing the operation on the specified entity.
 		/// </summary>
@@ -176,10 +161,61 @@ namespace NHibernate.Event.Default
 			if (entity == null)
 				throw new ArgumentNullException("null entities are not supported", "entity");
 
-			if (!entityToOperatedOnFlagMap.Contains(entity) || !entityToCopyMap.Contains(entity))
+			if (!entityToOperatedOnFlagMap.ContainsKey(entity) || !entityToCopyMap.ContainsKey(entity))
 				throw new AssertionFailure("called EventCache.SetOperatedOn() for entity not found in EventCache");
 
 			entityToOperatedOnFlagMap[entity] = isOperatedOn;
+		}
+
+		/// <summary>
+		/// Adapts a generic <see cref="IEnumerator{T}"/> over <see cref="KeyValuePair{TKey,TValue}"/> to the
+		/// classic <see cref="IDictionaryEnumerator"/> shape expected by consumers of <see cref="EventCache"/>'s
+		/// public non-generic <see cref="IDictionary"/> implementation.
+		/// </summary>
+		private sealed class DictionaryEnumeratorAdapter : IDictionaryEnumerator
+		{
+			private readonly IEnumerator<KeyValuePair<object, object>> _wrapped;
+
+			public DictionaryEnumeratorAdapter(IEnumerator<KeyValuePair<object, object>> wrapped) => _wrapped = wrapped;
+
+			public bool MoveNext() => _wrapped.MoveNext();
+
+			public void Reset() => _wrapped.Reset();
+
+			public object Current => Entry;
+
+			public DictionaryEntry Entry => new(_wrapped.Current.Key, _wrapped.Current.Value);
+
+			public object Key => _wrapped.Current.Key;
+
+			public object Value => _wrapped.Current.Value;
+		}
+
+		/// <summary>
+		/// Adapts a generic <see cref="ICollection{T}"/> to the classic non-generic <see cref="ICollection"/>
+		/// shape expected for <see cref="EventCache"/>'s public <see cref="IDictionary.Keys"/>/<see cref="IDictionary.Values"/>.
+		/// </summary>
+		private sealed class CollectionAdapter : ICollection
+		{
+			private readonly ICollection<object> _wrapped;
+
+			public CollectionAdapter(ICollection<object> wrapped) => _wrapped = wrapped;
+
+			public int Count => _wrapped.Count;
+
+			public bool IsSynchronized => false;
+
+			public object SyncRoot => this;
+
+			public void CopyTo(Array array, int index)
+			{
+				foreach (var item in _wrapped)
+				{
+					array.SetValue(item, index++);
+				}
+			}
+
+			public IEnumerator GetEnumerator() => _wrapped.GetEnumerator();
 		}
 	}
 }

--- a/src/NHibernate/Event/Default/EventCache.cs
+++ b/src/NHibernate/Event/Default/EventCache.cs
@@ -7,11 +7,11 @@ namespace NHibernate.Event.Default
 {
 	public class EventCache : IDictionary
 	{
-		private IDictionary entityToCopyMap = IdentityMap.Instantiate(10);
+		private IDictionary<object, object> entityToCopyMap = IdentityMapUtils.Instantiate<object, object>(10);
 		// key is an entity involved with the operation performed by the listener;
 		// value can be either a copy of the entity or the entity itself
 	
-		private IDictionary entityToOperatedOnFlagMap = IdentityMap.Instantiate(10);
+		private IDictionary<object, object> entityToOperatedOnFlagMap = IdentityMapUtils.Instantiate<object, object>(10);
 		// key is an entity involved with the operation performed by the listener;
 		// value is a flag indicating if the listener explicitly operates on the entity
 		
@@ -44,17 +44,18 @@ namespace NHibernate.Event.Default
 			if (entityToCopyMap.Count + index + 1 > array.Length)
 				throw new ArgumentException("The number of elements in the source ICollection<T> is greater than the available space from arrayIndex to the end of the destination array.");
 		
-			entityToCopyMap.CopyTo(array, index);
+			var i = index;
+			foreach (var entry in entityToCopyMap)
+			{
+				array.SetValue(new DictionaryEntry(entry.Key, entry.Value), i++);
+			}
 		}
 		
 		#endregion
 		
 		#region IEnumerable implementation
 		
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return ((IEnumerable)entityToCopyMap).GetEnumerator();
-		}
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 		#endregion
 		
@@ -62,36 +63,18 @@ namespace NHibernate.Event.Default
 		
 		public object this[object key]
 		{
-			get 
-			{
-				return entityToCopyMap[key];
-			}
-			set
-			{
-				this.Add(key, value);
-			}
+			get => entityToCopyMap.TryGetValue(key, out var value) ? value : null;
+			set => Add(key, value);
 		}
 		
-		public bool IsReadOnly
-		{
-			get { return false; }
-		}
-		
-		public bool IsFixedSize
-		{
-			get { return false; }
-		}
+		public bool IsReadOnly => false;
 
-		public ICollection Keys
-		{
-			get { return entityToCopyMap.Keys; }
-		}
-		
-		public ICollection Values
-		{
-			get { return entityToCopyMap.Values; }
-		}
-		
+		public bool IsFixedSize => false;
+
+		public ICollection Keys => new CollectionAdapter(entityToCopyMap.Keys);
+
+		public ICollection Values => new CollectionAdapter(entityToCopyMap.Values);
+
 		public void Add(object key, object value)
 		{
 			if (key == null)
@@ -105,7 +88,7 @@ namespace NHibernate.Event.Default
 		
 		public bool Contains(object key)
 		{
-			return entityToCopyMap.Contains(key);
+			return entityToCopyMap.ContainsKey(key);
 		}
 		
 		public void Remove(object key)
@@ -114,11 +97,8 @@ namespace NHibernate.Event.Default
 			entityToOperatedOnFlagMap.Remove(key);
 		}
 		
-		public IDictionaryEnumerator GetEnumerator()
-		{
-			return entityToCopyMap.GetEnumerator();
-		}
-		
+		public IDictionaryEnumerator GetEnumerator() => new DictionaryEnumeratorAdapter(entityToCopyMap.GetEnumerator());
+
 		public void Clear()
 		{
 			entityToCopyMap.Clear();
@@ -150,7 +130,12 @@ namespace NHibernate.Event.Default
 		/// <returns></returns>
 		public IDictionary InvertMap()
 		{
-			return IdentityMap.Invert(entityToCopyMap);
+			IDictionary result = IdentityMap.Instantiate(entityToCopyMap.Count);
+			foreach (var entry in entityToCopyMap)
+			{
+				result[entry.Value] = entry.Key;
+			}
+			return result;
 		}
 		
 		/// <summary>
@@ -176,10 +161,61 @@ namespace NHibernate.Event.Default
 			if (entity == null)
 				throw new ArgumentNullException("null entities are not supported", "entity");
 
-			if (!entityToOperatedOnFlagMap.Contains(entity) || !entityToCopyMap.Contains(entity))
+			if (!entityToOperatedOnFlagMap.ContainsKey(entity) || !entityToCopyMap.ContainsKey(entity))
 				throw new AssertionFailure("called EventCache.SetOperatedOn() for entity not found in EventCache");
 
 			entityToOperatedOnFlagMap[entity] = isOperatedOn;
+		}
+
+		/// <summary>
+		/// Adapts a generic <see cref="IEnumerator{T}"/> over <see cref="KeyValuePair{TKey,TValue}"/> to the
+		/// classic <see cref="IDictionaryEnumerator"/> shape expected by consumers of <see cref="EventCache"/>'s
+		/// public non-generic <see cref="IDictionary"/> implementation.
+		/// </summary>
+		private sealed class DictionaryEnumeratorAdapter : IDictionaryEnumerator
+		{
+			private readonly IEnumerator<KeyValuePair<object, object>> _wrapped;
+
+			public DictionaryEnumeratorAdapter(IEnumerator<KeyValuePair<object, object>> wrapped) => _wrapped = wrapped;
+
+			public bool MoveNext() => _wrapped.MoveNext();
+
+			public void Reset() => _wrapped.Reset();
+
+			public object Current => Entry;
+
+			public DictionaryEntry Entry => new(_wrapped.Current.Key, _wrapped.Current.Value);
+
+			public object Key => _wrapped.Current.Key;
+
+			public object Value => _wrapped.Current.Value;
+		}
+
+		/// <summary>
+		/// Adapts a generic <see cref="ICollection{T}"/> to the classic non-generic <see cref="ICollection"/>
+		/// shape expected for <see cref="EventCache"/>'s public <see cref="IDictionary.Keys"/>/<see cref="IDictionary.Values"/>.
+		/// </summary>
+		private sealed class CollectionAdapter : ICollection
+		{
+			private readonly ICollection<object> _wrapped;
+
+			public CollectionAdapter(ICollection<object> wrapped) => _wrapped = wrapped;
+
+			public int Count => _wrapped.Count;
+
+			public bool IsSynchronized => false;
+
+			public object SyncRoot => this;
+
+			public void CopyTo(Array array, int index)
+			{
+				foreach (var item in _wrapped)
+				{
+					array.SetValue(item, index++);
+				}
+			}
+
+			public IEnumerator GetEnumerator() => _wrapped.GetEnumerator();
 		}
 	}
 }

--- a/src/NHibernate/Event/Default/EvictVisitor.cs
+++ b/src/NHibernate/Event/Default/EvictVisitor.cs
@@ -34,7 +34,7 @@ namespace NHibernate.Event.Default
 			}
 			else if (value is IPersistentCollection)
 			{
-				pc = (IPersistentCollection)value;
+				pc = (IPersistentCollection) value;
 			}
 			else
 			{
@@ -48,7 +48,7 @@ namespace NHibernate.Event.Default
 
 		private void EvictCollection(IPersistentCollection collection)
 		{
-			CollectionEntry ce = (CollectionEntry)Session.PersistenceContext.CollectionEntries[collection];
+			var ce = (CollectionEntry) Session.PersistenceContext.CollectionEntries[collection];
 			Session.PersistenceContext.CollectionEntries.Remove(collection);
 			if (log.IsDebugEnabled())
 				log.Debug("evicting collection: {0}", MessageHelper.CollectionInfoString(ce.LoadedPersister, collection, ce.LoadedKey, Session));

--- a/src/NHibernate/Event/Default/EvictVisitor.cs
+++ b/src/NHibernate/Event/Default/EvictVisitor.cs
@@ -48,7 +48,7 @@ namespace NHibernate.Event.Default
 
 		private void EvictCollection(IPersistentCollection collection)
 		{
-			CollectionEntry ce = (CollectionEntry)Session.PersistenceContext.CollectionEntries[collection];
+			var ce = (CollectionEntry)Session.PersistenceContext.CollectionEntries[collection];
 			Session.PersistenceContext.CollectionEntries.Remove(collection);
 			if (log.IsDebugEnabled())
 				log.Debug("evicting collection: {0}", MessageHelper.CollectionInfoString(ce.LoadedPersister, collection, ce.LoadedKey, Session));

--- a/src/NHibernate/Util/IdentityMap.cs
+++ b/src/NHibernate/Util/IdentityMap.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace NHibernate.Util
@@ -61,17 +62,17 @@ namespace NHibernate.Util
 		/// <param name="map">The IDictionary to get the enumeration safe list.</param>
 		/// <returns>A Collection of DictionaryEntries</returns>
 		// Since v5.8.
-		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]		
+		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
 		public static ICollection ConcurrentEntries(IDictionary map)
 		{
-			return ((IdentityMap)map).EntryList;
+			return ((IdentityMap) map).EntryList;
 		}
 
 		// Since v5.8.
-		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]		
+		[Obsolete("This method has no more usage in NHibernate and will be removed in a future version.")]
 		public static ICollection Entries(IDictionary map)
 		{
-			return ((IdentityMap)map).EntryList;
+			return ((IdentityMap) map).EntryList;
 		}
 
 		/// <summary>
@@ -81,7 +82,7 @@ namespace NHibernate.Util
 		/// </summary>
 		/// <param name="map">The IDictionary to get the enumeration safe list.</param>
 		/// <returns>A typed list of DictionaryEntries, avoiding boxing when built and enumerated.</returns>
-		internal static List<DictionaryEntry> GetEntries(IDictionary map) => ((IdentityMap)map).GetEntries();
+		internal static List<DictionaryEntry> GetEntries(IDictionary map) => ((IdentityMap) map).GetEntries();
 
 		/// <summary>
 		/// Create the IdentityMap class with the correct class for the IDictionary.
@@ -301,7 +302,317 @@ namespace NHibernate.Util
 
 		public void OnDeserialization(object sender)
 		{
-			((IDeserializationCallback)map).OnDeserialization(sender);
+			((IDeserializationCallback) map).OnDeserialization(sender);
+		}
+	}
+
+	internal static class IdentityMapUtils
+	{
+		/// <summary>
+		/// Create a new instance of the IdentityMap that has no iteration order.
+		/// </summary>
+		/// <remarks>
+		/// A new IdentityMap based on <see cref="Dictionary{TKey,TValue}"/>, comparing keys by
+		/// reference identity.
+		/// </remarks>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="size">The initial capacity of the map.</param>
+		/// <returns>A new IdentityMap comparing keys by reference identity.</returns>
+		internal static IdentityMap<TKey, TValue> Instantiate<TKey, TValue>(int size)
+		where TKey : class
+		where TValue : class
+		{
+			return new IdentityMap<TKey, TValue>(new Dictionary<TKey, TValue>(size, ReferenceComparer<TKey>.Instance));
+		}
+
+		/// <summary>
+		/// Create a new instance of the IdentityMap that has an iteration order of the order the
+		/// objects were added to the map, with a key moved back to the end whenever its value is
+		/// overwritten through the indexer.
+		/// </summary>
+		/// <remarks>
+		/// A new IdentityMap based on <see cref="SequencedSnapshotDictionary{TKey,TValue}"/>, comparing keys
+		/// by reference identity.
+		/// </remarks>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="size">The initial capacity of the map.</param>
+		/// <returns>
+		/// A new IdentityMap comparing keys by reference identity and preserving insertion order.
+		/// </returns>
+		internal static IdentityMap<TKey, TValue> InstantiateSequenced<TKey, TValue>(int size)
+			where TKey : class
+			where TValue : class
+		{
+			return new IdentityMap<TKey, TValue>(new SequencedSnapshotDictionary<TKey, TValue>(size, ReferenceComparer<TKey>.Instance));
+		}
+
+		/// <summary>
+		/// Creates an identity map with the keys and values reversed.
+		/// </summary>
+		/// <typeparam name="TValue">The type of the source map's values and result map's keys.</typeparam>
+		/// <typeparam name="TKey">The type of the source map's keys and result map's values.</typeparam>
+		/// <param name="map">The map to invert.</param>
+		/// <returns>A new identity map containing the source map's values as keys.</returns>
+		internal static IDictionary<TValue, TKey> Invert<TValue, TKey>(IDictionary<TKey, TValue> map)
+			where TKey : class
+			where TValue : class
+		{
+			IDictionary<TValue, TKey> result = Instantiate<TValue, TKey>(map.Count);
+			foreach (var me in map)
+			{
+				result[me.Value] = me.Key;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Gets a snapshot view of a non-generic dictionary.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="map">The dictionary to snapshot.</param>
+		/// <returns>A snapshot view of the dictionary contents.</returns>
+		internal static ISnapshotView<TKey, TValue> GetSnapshot<TKey, TValue>(IDictionary map)
+			where TKey : class
+			where TValue : class
+		{
+			if (map is IdentityMap<TKey, TValue> identityMap)
+			{
+				return identityMap.GetSnapshot();
+			}
+
+			return new DictionarySnapshotViewAdapter<TKey, TValue>(map);
+		}
+
+		/// <summary>
+		/// Gets a snapshot view of a generic dictionary.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="map">The dictionary to snapshot.</param>
+		/// <returns>A snapshot view of the dictionary contents.</returns>
+		internal static ISnapshotView<TKey, TValue> GetSnapshot<TKey, TValue>(IDictionary<TKey, TValue> map)
+			where TKey : class
+			where TValue : class
+		{
+			if (map is IdentityMap<TKey, TValue> identityMap)
+			{
+				return identityMap.GetSnapshot();
+			}
+
+			return new SnapshotViewAdapter<TKey, TValue>(map.ToList());
+		}
+	}
+
+	/// <summary>
+	/// A dictionary whose keys are compared by reference identity rather than value equality.
+	/// </summary>
+	/// <typeparam name="TKey">The reference type used for keys.</typeparam>
+	/// <typeparam name="TValue">The reference type used for values.</typeparam>
+	[Serializable]
+	internal sealed class IdentityMap<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IDeserializationCallback
+		where TKey : class
+		where TValue : class
+	{
+		// key = IdentityKey of the passed in Key
+		// value = object passed in
+		private readonly IDictionary<TKey, TValue> _genericMap;
+		[NonSerialized]
+		private IDictionary _nonGenericMap;
+
+		/// <summary>
+		/// Creates an IdentityMap using the supplied dictionary for storage.
+		/// </summary>
+		/// <param name="underlyingMap">
+		/// The dictionary used to store the objects. It must implement <see cref="IDictionary"/>.
+		/// </param>
+		internal IdentityMap(IDictionary<TKey, TValue> underlyingMap)
+		{
+			if (underlyingMap is not IDictionary nonGenericUnderlyingMap)
+			{
+				throw new ArgumentException(
+					$"{nameof(underlyingMap)} must implement {nameof(IDictionary)}",
+					nameof(underlyingMap));
+			}
+
+			_genericMap = underlyingMap;
+			_nonGenericMap = nonGenericUnderlyingMap;
+		}
+
+		/// <summary>
+		/// Gets a snapshot view of the current contents of the map.
+		/// </summary>
+		/// <returns>A snapshot view that is independent of subsequent map changes.</returns>
+		internal ISnapshotView<TKey, TValue> GetSnapshot()
+		{
+			if (_genericMap is SequencedSnapshotDictionary<TKey, TValue> snapshotDictionary)
+			{
+				return snapshotDictionary.GetSnapshot();
+			}
+
+			return new SnapshotViewAdapter<TKey, TValue>(_genericMap.ToList());
+		}
+
+		/// <summary>
+		/// Verifies that a key is not a value type.
+		/// </summary>
+		/// <typeparam name="Tk">The type of the key.</typeparam>
+		/// <param name="key">The key to validate.</param>
+		/// <returns>The validated key.</returns>
+		/// <exception cref="ArgumentException">Thrown when the key is a value type.</exception>
+		private static Tk VerifyValidKey<Tk>(Tk key)
+		{
+			if (key is ValueType)
+			{
+				throw new ArgumentException(
+					"There is a problem with your mappings.  You are probably trying to map a System.ValueType to " +
+					"a <class> which NHibernate does not allow or you are incorrectly using the " +
+					"IDictionary that is mapped to a <set>.  \n\n" +
+					"A ValueType (" + key.GetType() + ") can not be used with IdentityKey.  " +
+					"The thread at google has a good description about what happens with boxing " +
+					"and unboxing ValueTypes and why they can not be used as an IdentityKey: " +
+					"http://groups.google.com/groups?hl=en&lr=&ie=UTF-8&oe=UTF-8&threadm=bds2rm%24ruc%241%40charly.heeg.de&rnum=1&prev=/groups%3Fhl%3Den%26lr%3D%26ie%3DUTF-8%26oe%3DUTF-8%26q%3DSystem.Runtime.CompilerServices.RuntimeHelpers.GetHashCode%26sa%3DN%26tab%3Dwg"
+					, nameof(key));
+			}
+
+			return key;
+		}
+
+		/// <inheritdoc />
+		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+		{
+			return _genericMap.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return ((IEnumerable) _genericMap).GetEnumerator();
+		}
+
+		/// <inheritdoc />
+		public void Add(KeyValuePair<TKey, TValue> item)
+		{
+			_genericMap.Add(VerifyValidKey(item.Key), item.Value);
+		}
+
+		/// <inheritdoc cref="ICollection{T}.Clear" />
+		public void Clear()
+		{
+			_genericMap.Clear();
+		}
+
+		/// <inheritdoc />
+		public bool Contains(KeyValuePair<TKey, TValue> item)
+		{
+			VerifyValidKey(item.Key);
+			return _genericMap.Contains(item);
+		}
+
+		/// <inheritdoc />
+		public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+		{
+			_genericMap.CopyTo(array, arrayIndex);
+		}
+
+		/// <inheritdoc />
+		public bool Remove(KeyValuePair<TKey, TValue> item)
+		{
+			VerifyValidKey(item.Key);
+			return _genericMap.Remove(item);
+		}
+
+		/// <inheritdoc cref="ICollection{T}.Count" />
+		public int Count => _genericMap.Count;
+
+		/// <inheritdoc cref="ICollection{T}.IsReadOnly" />
+		public bool IsReadOnly => _genericMap.IsReadOnly;
+
+		/// <inheritdoc />
+		public bool ContainsKey(TKey key)
+		{
+			return _genericMap.ContainsKey(VerifyValidKey(key));
+		}
+
+		/// <inheritdoc />
+		public void Add(TKey key, TValue value)
+		{
+			_genericMap.Add(VerifyValidKey(key), value);
+		}
+
+		/// <inheritdoc />
+		public bool Remove(TKey key)
+		{
+			return _genericMap.Remove(VerifyValidKey(key));
+		}
+
+		/// <inheritdoc />
+		public bool TryGetValue(TKey key, out TValue value)
+		{
+			return _genericMap.TryGetValue(VerifyValidKey(key), out value);
+		}
+
+		/// <inheritdoc />
+		public TValue this[TKey key]
+		{
+			get => _genericMap[VerifyValidKey(key)];
+			set => _genericMap[VerifyValidKey(key)] = value;
+		}
+
+		/// <inheritdoc />
+		public ICollection<TKey> Keys => _genericMap.Keys;
+
+		/// <inheritdoc />
+		public ICollection<TValue> Values => _genericMap.Values;
+
+		// --- IDictionary explicit members ---
+
+		IDictionaryEnumerator IDictionary.GetEnumerator()
+		{
+			return _nonGenericMap.GetEnumerator();
+		}
+
+		void IDictionary.Remove(object key)
+		{
+			_nonGenericMap.Remove(VerifyValidKey(key));
+		}
+
+		object IDictionary.this[object key]
+		{
+			get => _nonGenericMap[VerifyValidKey(key)];
+			set => _nonGenericMap[VerifyValidKey(key)] = value;
+		}
+
+		bool IDictionary.Contains(object key)
+		{
+			return _nonGenericMap.Contains(key);
+		}
+
+		void IDictionary.Add(object key, object value)
+		{
+			_nonGenericMap.Add(key, value);
+		}
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			_nonGenericMap.CopyTo(array, index);
+		}
+
+		object ICollection.SyncRoot => _nonGenericMap.SyncRoot;
+
+		bool ICollection.IsSynchronized => _nonGenericMap.IsSynchronized;
+
+		ICollection IDictionary.Values => _nonGenericMap.Values;
+
+		bool IDictionary.IsFixedSize => _nonGenericMap.IsFixedSize;
+
+		ICollection IDictionary.Keys => _nonGenericMap.Keys;
+
+		void IDeserializationCallback.OnDeserialization(object sender)
+		{
+			((IDeserializationCallback) _genericMap).OnDeserialization(sender);
+			_nonGenericMap = (IDictionary) _genericMap;
 		}
 	}
 }

--- a/src/NHibernate/Util/IdentityMap.cs
+++ b/src/NHibernate/Util/IdentityMap.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace NHibernate.Util
@@ -302,6 +303,316 @@ namespace NHibernate.Util
 		public void OnDeserialization(object sender)
 		{
 			((IDeserializationCallback)map).OnDeserialization(sender);
+		}
+	}
+
+	internal static class IdentityMapUtils
+	{
+		/// <summary>
+		/// Create a new instance of the IdentityMap that has no iteration order.
+		/// </summary>
+		/// <remarks>
+		/// A new IdentityMap based on <see cref="Dictionary{TKey,TValue}"/>, comparing keys by
+		/// reference identity.
+		/// </remarks>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="size">The initial capacity of the map.</param>
+		/// <returns>A new IdentityMap comparing keys by reference identity.</returns>
+		internal static IdentityMap<TKey, TValue> Instantiate<TKey, TValue>(int size) 
+		where TKey: class
+		where TValue: class
+		{
+			return new IdentityMap<TKey, TValue>(new Dictionary<TKey, TValue>(size, ReferenceComparer<TKey>.Instance));
+		}
+
+		/// <summary>
+		/// Create a new instance of the IdentityMap that has an iteration order of the order the
+		/// objects were added to the map, with a key moved back to the end whenever its value is
+		/// overwritten through the indexer.
+		/// </summary>
+		/// <remarks>
+		/// A new IdentityMap based on <see cref="SequencedSnapshotDictionary{TKey,TValue}"/>, comparing keys
+		/// by reference identity.
+		/// </remarks>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="size">The initial capacity of the map.</param>
+		/// <returns>
+		/// A new IdentityMap comparing keys by reference identity and preserving insertion order.
+		/// </returns>
+		internal static IdentityMap<TKey, TValue> InstantiateSequenced<TKey, TValue>(int size) 
+			where TKey: class
+			where TValue: class
+		{
+			return new IdentityMap<TKey, TValue>(new SequencedSnapshotDictionary<TKey, TValue>(size, ReferenceComparer<TKey>.Instance));
+		}
+
+		/// <summary>
+		/// Creates an identity map with the keys and values reversed.
+		/// </summary>
+		/// <typeparam name="TValue">The type of the source map's values and result map's keys.</typeparam>
+		/// <typeparam name="TKey">The type of the source map's keys and result map's values.</typeparam>
+		/// <param name="map">The map to invert.</param>
+		/// <returns>A new identity map containing the source map's values as keys.</returns>
+		internal static IDictionary<TValue, TKey> Invert<TValue, TKey>(IDictionary<TKey, TValue> map)
+			where TKey: class
+			where TValue: class
+		{
+			IDictionary<TValue, TKey> result = Instantiate<TValue, TKey>(map.Count);
+			foreach (var me in map)
+			{
+				result[me.Value] = me.Key;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Gets a snapshot view of a non-generic dictionary.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="map">The dictionary to snapshot.</param>
+		/// <returns>A snapshot view of the dictionary contents.</returns>
+		internal static ISnapshotView<TKey, TValue> GetSnapshot<TKey, TValue>(IDictionary map)
+			where TKey : class
+			where TValue : class
+		{
+			if (map is IdentityMap<TKey, TValue> identityMap)
+			{
+				return identityMap.GetSnapshot();
+			}
+
+			return new DictionarySnapshotViewAdapter<TKey, TValue>(map);
+		}
+
+		/// <summary>
+		/// Gets a snapshot view of a generic dictionary.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys.</typeparam>
+		/// <typeparam name="TValue">The type of the values.</typeparam>
+		/// <param name="map">The dictionary to snapshot.</param>
+		/// <returns>A snapshot view of the dictionary contents.</returns>
+		internal static ISnapshotView<TKey, TValue> GetSnapshot<TKey, TValue>(IDictionary<TKey, TValue> map)
+			where TKey : class
+			where TValue : class
+		{
+			if (map is IdentityMap<TKey, TValue> identityMap)
+			{
+				return identityMap.GetSnapshot();
+			}
+
+			return new SnapshotViewAdapter<TKey, TValue>(map.ToList());
+		}
+	}
+
+	/// <summary>
+	/// A dictionary whose keys are compared by reference identity rather than value equality.
+	/// </summary>
+	/// <typeparam name="TKey">The reference type used for keys.</typeparam>
+	/// <typeparam name="TValue">The reference type used for values.</typeparam>
+	[Serializable]
+	internal sealed class IdentityMap<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IDeserializationCallback
+		where TKey : class
+		where TValue : class
+	{
+		// key = IdentityKey of the passed in Key
+		// value = object passed in
+		private readonly IDictionary<TKey, TValue> _genericMap;
+		[NonSerialized]
+		private IDictionary _nonGenericMap;
+
+		/// <summary>
+		/// Creates an IdentityMap using the supplied dictionary for storage.
+		/// </summary>
+		/// <param name="underlyingMap">
+		/// The dictionary used to store the objects. It must implement <see cref="IDictionary"/>.
+		/// </param>
+		internal IdentityMap(IDictionary<TKey, TValue> underlyingMap)
+		{
+			if (underlyingMap is not IDictionary nonGenericUnderlyingMap)
+			{
+				throw new ArgumentException(
+					$"{nameof(underlyingMap)} must implement {nameof(IDictionary)}",
+					nameof(underlyingMap));
+			}
+			
+			_genericMap = underlyingMap;
+			_nonGenericMap = nonGenericUnderlyingMap;
+		}
+
+		/// <summary>
+		/// Gets a snapshot view of the current contents of the map.
+		/// </summary>
+		/// <returns>A snapshot view that is independent of subsequent map changes.</returns>
+		internal ISnapshotView<TKey, TValue> GetSnapshot()
+		{
+			if (_genericMap is SequencedSnapshotDictionary<TKey, TValue> snapshotDictionary)
+			{
+				return snapshotDictionary.GetSnapshot();
+			}
+
+			return new SnapshotViewAdapter<TKey, TValue>(_genericMap.ToList());
+		}
+
+		/// <summary>
+		/// Verifies that a key is not a value type.
+		/// </summary>
+		/// <typeparam name="Tk">The type of the key.</typeparam>
+		/// <param name="key">The key to validate.</param>
+		/// <returns>The validated key.</returns>
+		/// <exception cref="ArgumentException">Thrown when the key is a value type.</exception>
+		private static Tk VerifyValidKey<Tk>(Tk key)
+		{
+			if (key is ValueType)
+			{
+				throw new ArgumentException(
+					"There is a problem with your mappings.  You are probably trying to map a System.ValueType to " +
+					"a <class> which NHibernate does not allow or you are incorrectly using the " +
+					"IDictionary that is mapped to a <set>.  \n\n" +
+					"A ValueType (" + key.GetType() + ") can not be used with IdentityKey.  " +
+					"The thread at google has a good description about what happens with boxing " +
+					"and unboxing ValueTypes and why they can not be used as an IdentityKey: " +
+					"http://groups.google.com/groups?hl=en&lr=&ie=UTF-8&oe=UTF-8&threadm=bds2rm%24ruc%241%40charly.heeg.de&rnum=1&prev=/groups%3Fhl%3Den%26lr%3D%26ie%3DUTF-8%26oe%3DUTF-8%26q%3DSystem.Runtime.CompilerServices.RuntimeHelpers.GetHashCode%26sa%3DN%26tab%3Dwg"
+					, nameof(key));
+			}
+
+			return key;
+		}
+
+		/// <inheritdoc />
+		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+		{
+			return _genericMap.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return ((IEnumerable) _genericMap).GetEnumerator();
+		}
+
+		/// <inheritdoc />
+		public void Add(KeyValuePair<TKey, TValue> item)
+		{
+			_genericMap.Add(VerifyValidKey(item.Key), item.Value);
+		}
+
+		/// <inheritdoc cref="ICollection{T}.Clear" />
+		public void Clear()
+		{
+			_genericMap.Clear();
+		}
+
+		/// <inheritdoc />
+		public bool Contains(KeyValuePair<TKey, TValue> item)
+		{
+			VerifyValidKey(item.Key);
+			return _genericMap.Contains(item);
+		}
+
+		/// <inheritdoc />
+		public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+		{
+			_genericMap.CopyTo(array, arrayIndex);
+		}
+
+		/// <inheritdoc />
+		public bool Remove(KeyValuePair<TKey, TValue> item)
+		{
+			VerifyValidKey(item.Key);
+			return _genericMap.Remove(item);
+		}
+
+		/// <inheritdoc cref="ICollection{T}.Count" />
+		public int Count => _genericMap.Count;
+
+		/// <inheritdoc cref="ICollection{T}.IsReadOnly" />
+		public bool IsReadOnly => _genericMap.IsReadOnly;
+
+		/// <inheritdoc />
+		public bool ContainsKey(TKey key)
+		{
+			return _genericMap.ContainsKey(VerifyValidKey(key));
+		}
+
+		/// <inheritdoc />
+		public void Add(TKey key, TValue value)
+		{
+			_genericMap.Add(VerifyValidKey(key), value);
+		}
+
+		/// <inheritdoc />
+		public bool Remove(TKey key)
+		{
+			return _genericMap.Remove(VerifyValidKey(key));
+		}
+
+		/// <inheritdoc />
+		public bool TryGetValue(TKey key, out TValue value)
+		{
+			return _genericMap.TryGetValue(VerifyValidKey(key), out value);
+		}
+
+		/// <inheritdoc />
+		public TValue this[TKey key]
+		{
+			get => _genericMap[VerifyValidKey(key)];
+			set => _genericMap[VerifyValidKey(key)] = value;
+		}
+
+		/// <inheritdoc />
+		public ICollection<TKey> Keys => _genericMap.Keys;
+
+		/// <inheritdoc />
+		public ICollection<TValue> Values => _genericMap.Values;
+
+		// --- IDictionary explicit members ---
+
+		IDictionaryEnumerator IDictionary.GetEnumerator()
+		{
+			return _nonGenericMap.GetEnumerator();
+		}
+
+		void IDictionary.Remove(object key)
+		{
+			_nonGenericMap.Remove(VerifyValidKey(key));
+		}
+
+		object IDictionary.this[object key]
+		{
+			get => _nonGenericMap[VerifyValidKey(key)];
+			set => _nonGenericMap[VerifyValidKey(key)] = value;
+		}
+
+		bool IDictionary.Contains(object key)
+		{
+			return _nonGenericMap.Contains(key);
+		}
+
+		void IDictionary.Add(object key, object value)
+		{
+			_nonGenericMap.Add(key, value);
+		}
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			_nonGenericMap.CopyTo(array, index);
+		}
+
+		object ICollection.SyncRoot => _nonGenericMap.SyncRoot;
+
+		bool ICollection.IsSynchronized => _nonGenericMap.IsSynchronized;
+
+		ICollection IDictionary.Values => _nonGenericMap.Values;
+
+		bool IDictionary.IsFixedSize => _nonGenericMap.IsFixedSize;
+
+		ICollection IDictionary.Keys => _nonGenericMap.Keys;
+
+		void IDeserializationCallback.OnDeserialization(object sender)
+		{
+			((IDeserializationCallback) _genericMap).OnDeserialization(sender);
+			_nonGenericMap = (IDictionary) _genericMap;
 		}
 	}
 }

--- a/src/NHibernate/Util/SequencedSnapshotDictionary.cs
+++ b/src/NHibernate/Util/SequencedSnapshotDictionary.cs
@@ -1,0 +1,1242 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace NHibernate.Util;
+
+/// <summary>
+/// A read-only view of a dictionary. Dispose it as soon as possible.
+/// </summary>
+internal interface ISnapshotView<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IDisposable;
+
+/// <summary>
+/// A dictionary with whose entries are sequenced based on the order in which they were
+/// added or modified and implements snapshotting with copy-on-write.
+/// </summary>
+/// <remarks>
+/// This class is not thread safe.
+/// The core dictionary implementation is based on <see cref="System.Collections.Generic.Dictionary{TKey,TValue}" />
+/// </remarks>
+/// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+[Serializable]
+internal sealed class SequencedSnapshotDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IDeserializationCallback
+	where TKey : notnull
+{
+	/// <summary>
+	/// The hot half of an entry: everything a lookup probe needs, and nothing else. Kept deliberately
+	/// narrow.
+	/// </summary>
+	[Serializable]
+	private struct Slot
+	{
+		public TKey Key;
+
+		// Index of the next entry in the same bucket chain, -1 for the end of the chain. Doubles as
+		// the free-list link while the slot is unused.
+		public int HashNext;
+	}
+
+	private readonly IEqualityComparer<TKey> _comparer;
+
+	// Physical slot order is meaningless. Iteration order is the _orderPrev/_orderNext list.
+	private Slot[] _slots;
+	private TValue[] _values;
+	private int[] _orderNext;
+	private int[] _orderPrev;
+
+	// Ends of the iteration-order list, -1 when empty.
+	private int _orderHead;
+	private int _orderTail;
+
+	// Head of the free-slot list (-1 when empty) and its length.
+	private int _freeListHead;
+	private int _freeListCount;
+
+	// Per-bucket chain head stored as (entry index + 1), so the default 0 means "empty" and a
+	// freshly allocated array needs no initialization pass. Must be rebuilt on deserialization
+	// as hash codes are not stable.
+	[NonSerialized]
+	private int[] _buckets;
+
+	// Epoch each array was last (re)created at. An array whose epoch is <= _latestSnapshotEpoch is
+	// potentially shared with an outstanding snapshot and must be copied before it can be written.
+	// Only the three arrays a snapshot actually reads need one.
+	[NonSerialized]
+	private int _slotsEpoch;
+	[NonSerialized]
+	private int _valuesEpoch;
+	[NonSerialized]
+	private int _orderNextEpoch;
+
+	// Only increments whenever a snapshot is taken
+	[NonSerialized]
+	private int _epoch;
+
+	// Arrays with epoch <= this must be copied before mutation. -1 when there are no active snapshots.
+	// Only the latest snapshot is tracked as the snapshot constraint of the latest snapshot includes
+	// the constraints of any snapshot before it. A change that would affect an earlier snapshot will
+	// always affect a newer snapshot (so any change that affects any snapshot will always affect the
+	// latest snapshot).
+	[NonSerialized]
+	private int _latestSnapshotEpoch;
+
+	// EntrySlotCount as of the latest GetSnapshot(). A write is observable (and requires cloning) if
+	// its epoch <= latestSnapshotEpoch AND index < _latestSnapshotEntrySlotCount.
+	[NonSerialized]
+	private int _latestSnapshotEntrySlotCount;
+
+	// _orderTail as of the latest GetSnapshot(). Tracked for an optimization in _orderNext updates where
+	// if index == _latestSnapshotTail then the update to _orderNext is not meaningfully observable by
+	// any outstanding snapshot.
+	[NonSerialized]
+	private int _latestSnapshotOrderTail;
+
+	[NonSerialized]
+	private int _version; // bumped on every mutation to fail enumerate-and-update scenarios
+
+	[NonSerialized]
+	private int _outstandingSnapshots;
+
+	// Number of array copies performed to preserve isolation for an outstanding snapshot. Exposed for
+	// tests to verify that disposing snapshots promptly avoids this cost; not incremented by
+	// growth/rehash, which are unrelated to snapshotting.
+	[NonSerialized]
+	internal int CopyOnWriteCount;
+
+	[NonSerialized]
+	private KeyCollection _keys;
+	[NonSerialized]
+	private ValueCollection _valuesView;
+
+	public SequencedSnapshotDictionary(int capacity = 16, IEqualityComparer<TKey> comparer = null)
+	{
+		if (capacity < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(capacity));
+		}
+
+		_comparer = comparer ?? EqualityComparer<TKey>.Default;
+		InitializeEmpty(BucketCountFor(capacity), CapacityFor(capacity));
+	}
+
+	private static int BucketCountFor(int liveCount)
+	{
+		var bucketCount = 1;
+		while (bucketCount < liveCount)
+		{
+			bucketCount <<= 1;
+		}
+
+		return bucketCount;
+	}
+
+	private static int CapacityFor(int neededCount)
+	{
+		if (neededCount <= 0)
+		{
+			return 0;
+		}
+
+		var capacity = 4;
+		while (capacity < neededCount)
+		{
+			capacity <<= 1;
+		}
+
+		return capacity;
+	}
+
+	private void InitializeEmpty(int bucketCount, int capacity)
+	{
+		_buckets = new int[bucketCount];
+		if (capacity == 0)
+		{
+			_slots = [];
+			_values = [];
+			_orderNext = [];
+			_orderPrev = [];
+		}
+		else
+		{
+			_slots = new Slot[capacity];
+			_values = new TValue[capacity];
+			_orderNext = new int[capacity];
+			_orderPrev = new int[capacity];
+		}
+
+		EntrySlotCount = 0;
+		Count = 0;
+		_orderHead = -1;
+		_orderTail = -1;
+		_freeListHead = -1;
+		_freeListCount = 0;
+
+		_epoch = 0;
+		_slotsEpoch = 0;
+		_valuesEpoch = 0;
+		_orderNextEpoch = 0;
+		_latestSnapshotEpoch = -1;
+		_latestSnapshotEntrySlotCount = 0;
+		_latestSnapshotOrderTail = -1;
+		_version = 0;
+		_outstandingSnapshots = 0;
+		CopyOnWriteCount = 0;
+		_keys = null;
+		_valuesView = null;
+	}
+
+	public int Count { get; private set; }
+
+	// Number of SnapshotView instances handed out that have not yet been
+	// disposed. Should return to zero once every taken snapshot has been released.
+	// Exposed for tests.
+	internal int OutstandingSnapshots => _outstandingSnapshots;
+
+	// How many slots have ever been handed out. Free-list reuse is what keeps this
+	// pinned to the high-water mark of live entries instead of growing with write volume.
+	// This number only ever goes up in Insert up or gets reset to 0 in Clear.
+	// Exposed for tests.
+	internal int EntrySlotCount { get; private set; }
+
+	/// <summary>
+	/// O(1). Returns a read-only, insertion-ordered view frozen at this exact moment. No copying
+	/// happens here.
+	/// </summary>
+	/// <remarks>
+	/// Dispose the returned view as soon possible. Once every outstanding snapshot has been disposed,
+	/// the dictionary reverts to fully in-place as if no snapshot had ever been taken. 
+	/// </remarks>
+	public ISnapshotView<TKey, TValue> GetSnapshot()
+	{
+		_latestSnapshotEpoch = _epoch;
+		_latestSnapshotEntrySlotCount = EntrySlotCount;
+		_latestSnapshotOrderTail = _orderTail;
+
+		_epoch++;
+		_outstandingSnapshots++;
+		return new SnapshotView(this, _slots, _values, _orderNext, _orderHead, Count);
+	}
+
+	// Called by SnapshotView.Dispose(). Once the last outstanding snapshot is released, no view
+	// can observe any array any more, so the floor is reset and writes go back to being fully in
+	// place.
+	private void ReleaseSnapshot()
+	{
+		if (_outstandingSnapshots > 0 && --_outstandingSnapshots == 0)
+		{
+			_latestSnapshotEpoch = -1;
+			_latestSnapshotEntrySlotCount = EntrySlotCount;
+			_latestSnapshotOrderTail = _orderTail;
+		}
+	}
+
+	public TValue this[TKey key]
+	{
+		get
+		{
+			var index = FindEntry(key, out _);
+			if (index < 0)
+			{
+				throw new KeyNotFoundException();
+			}
+
+			return _values[index];
+		}
+		set => SetCore(key, value, throwIfExists: false);
+	}
+
+	private KeyCollection KeysInternal => _keys ??= new KeyCollection(this);
+
+	private ValueCollection ValuesInternal => _valuesView ??= new ValueCollection(this);
+
+	public ICollection<TKey> Keys => KeysInternal;
+
+	public ICollection<TValue> Values => _valuesView ??= new ValueCollection(this);
+
+	public bool IsReadOnly => false;
+
+	public void Add(TKey key, TValue value)
+	{
+		SetCore(key, value, throwIfExists: true);
+	}
+
+	void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+	{
+		Add(item.Key, item.Value);
+	}
+
+	public bool ContainsKey(TKey key) => FindEntry(key, out _) >= 0;
+
+	public bool Contains(KeyValuePair<TKey, TValue> item)
+	{
+		var index = FindEntry(item.Key, out _);
+		return index >= 0 && EqualityComparer<TValue>.Default.Equals(_values[index], item.Value);
+	}
+
+	public bool TryGetValue(TKey key, out TValue value)
+	{
+		var index = FindEntry(key, out _);
+		if (index < 0)
+		{
+			value = default!;
+			return false;
+		}
+
+		value = _values[index];
+		return true;
+	}
+
+	public void Clear()
+	{
+		if (Count == 0 && EntrySlotCount == 0)
+		{
+			return;
+		}
+
+		// No snapshot ever reads the bucket array, so it is always safe to zero in place.
+		Array.Clear(_buckets, 0, _buckets.Length);
+
+		if (_slotsEpoch <= _latestSnapshotEpoch || _valuesEpoch <= _latestSnapshotEpoch || _orderNextEpoch <= _latestSnapshotEpoch)
+		{
+			// At least one array is still visible to an outstanding snapshot, so it has to be
+			// abandoned rather than zeroed. Replace the whole set together, since slot indices are
+			// only meaningful if every array is the same length.
+			_slots = [];
+			_values = [];
+			_orderNext = [];
+			_orderPrev = [];
+			_slotsEpoch = _epoch;
+			_valuesEpoch = _epoch;
+			_orderNextEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+		else
+		{
+			// Don't keep the cleared entries' keys/values alive.
+			Array.Clear(_slots, 0, EntrySlotCount);
+			Array.Clear(_values, 0, EntrySlotCount);
+		}
+
+		EntrySlotCount = 0;
+		Count = 0;
+		_orderHead = -1;
+		_orderTail = -1;
+		_freeListHead = -1;
+		_freeListCount = 0;
+		_version++;
+	}
+
+	public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+	{
+		if (array is null)
+		{
+			throw new ArgumentNullException(nameof(array));
+		}
+
+		if (arrayIndex < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+		}
+
+		if (array.Length - arrayIndex < Count)
+		{
+			throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.", nameof(array));
+		}
+
+		var destinationIndex = arrayIndex;
+		for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+		{
+			array[destinationIndex++] = new KeyValuePair<TKey, TValue>(_slots[sourceIndex].Key, _values[sourceIndex]);
+		}
+	}
+
+	public bool Remove(TKey key)
+	{
+		var index = FindEntry(key, out var bucket);
+		if (index < 0)
+		{
+			return false;
+		}
+
+		RemoveAt(index, bucket);
+		return true;
+	}
+
+	public bool Remove(KeyValuePair<TKey, TValue> item)
+	{
+		var index = FindEntry(item.Key, out var bucket);
+		if (index < 0 || !EqualityComparer<TValue>.Default.Equals(_values[index], item.Value))
+		{
+			return false;
+		}
+
+		RemoveAt(index, bucket);
+		return true;
+	}
+
+	public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+	{
+		var version = _version;
+		var i = _orderHead;
+		while (i >= 0)
+		{
+			yield return new KeyValuePair<TKey, TValue>(_slots[i].Key, _values[i]);
+
+			if (_version != version)
+			{
+				throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+			}
+
+			i = _orderNext[i];
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	// Returns the index of the entry for `key`, or -1, and always reports the key's bucket so callers
+	// never have to hash it twice. Touches only _buckets and _slots.
+	private int FindEntry(TKey key, out int bucket)
+	{
+		bucket = BucketIndex(_comparer, key, _buckets.Length);
+		var slots = _slots;
+		for (var i = _buckets[bucket] - 1; i >= 0; i = slots[i].HashNext)
+		{
+			if (_comparer.Equals(slots[i].Key, key))
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	private void SetCore(TKey key, TValue value, bool throwIfExists)
+	{
+		var existing = FindEntry(key, out var bucket);
+		if (existing < 0)
+		{
+			Insert(key, value, bucket);
+			return;
+		}
+
+		if (throwIfExists)
+		{
+			throw new ArgumentException($"An item with the key '{key}' has already been added.");
+		}
+
+		// Move-to-end on modify.
+		// The value is written in place and only the order links move.
+		// The key and hash chain are untouched, so _slots does not need copying here.
+		EnsureValuesWritable(existing);
+		_values[existing] = value;
+
+		if (existing != _orderTail)
+		{
+			EnsureOrderNextWritable(_orderPrev[existing]);
+			EnsureOrderNextWritable(existing);
+			EnsureOrderNextWritable(_orderTail);
+
+			OrderUnlink(existing);
+			OrderAppend(existing);
+		}
+
+		_version++;
+	}
+
+	private void Insert(TKey key, TValue value, int bucket)
+	{
+		int index;
+		if (_freeListCount > 0)
+		{
+			// Reusing a free slot never needs a copy. Either we have already copied since the last
+			// snapshot (in which case the arrays are private anyway), or no visible slot has been
+			// freed since the snapshot which means it is in neither the order list nor any bucket
+			// chain the snapshot can walk.
+			index = _freeListHead;
+			_freeListHead = _slots[index].HashNext;
+			_freeListCount--;
+		}
+		else
+		{
+			if (EntrySlotCount == _slots.Length)
+			{
+				Grow();
+			}
+
+			index = EntrySlotCount;
+			EntrySlotCount++;
+		}
+
+		_slots[index].Key = key;
+		_slots[index].HashNext = _buckets[bucket] - 1;
+		_values[index] = value;
+		_buckets[bucket] = index + 1;
+		Count++;
+		_version++;
+
+		// This check is purely defensive. It never actually triggers a cloning of _orderNext as
+		// that would mean _orderTail is behind a snapshot's tail which can only happen during a
+		// remove or a move-to-end update and both of those operations clone _orderNext
+		EnsureOrderNextWritable(_orderTail);
+		OrderAppend(index);
+
+		if (Count > _buckets.Length)
+		{
+			Rehash();
+		}
+	}
+
+	private void RemoveAt(int index, int bucket)
+	{
+		var chainPrev = -1;
+		for (var i = _buckets[bucket] - 1; i >= 0; i = _slots[i].HashNext)
+		{
+			if (i == index)
+			{
+				break;
+			}
+
+			chainPrev = i;
+		}
+
+		var orderPrev = _orderPrev[index];
+
+		EnsureSlotsWritable(index);
+		EnsureValuesWritable(index);
+		EnsureOrderNextWritable(orderPrev);
+		EnsureOrderNextWritable(index);
+
+		if (chainPrev < 0)
+		{
+			_buckets[bucket] = _slots[index].HashNext + 1;
+		}
+		else
+		{
+			_slots[chainPrev].HashNext = _slots[index].HashNext;
+		}
+
+		OrderUnlink(index);
+
+		_slots[index].Key = default!;
+		_values[index] = default!;
+		_orderNext[index] = -1;
+		_orderPrev[index] = -1;
+
+		_slots[index].HashNext = _freeListHead;
+		_freeListHead = index;
+		_freeListCount++;
+
+		Count--;
+		_version++;
+	}
+
+	private void OrderUnlink(int index)
+	{
+		var prev = _orderPrev[index];
+		var next = _orderNext[index];
+
+		if (prev >= 0)
+		{
+			_orderNext[prev] = next;
+		}
+		else
+		{
+			_orderHead = next;
+		}
+
+		if (next >= 0)
+		{
+			_orderPrev[next] = prev;
+		}
+		else
+		{
+			_orderTail = prev;
+		}
+	}
+
+	private void OrderAppend(int index)
+	{
+		_orderPrev[index] = _orderTail;
+		_orderNext[index] = -1;
+
+		if (_orderTail >= 0)
+		{
+			// Appending to _orderTail is always safe because snapshots stop reading at the count
+			// they froze.
+			_orderNext[_orderTail] = index;
+		}
+		else
+		{
+			_orderHead = index;
+		}
+
+		_orderTail = index;
+	}
+
+	// A snapshot can observe a slot's key, hash link and value only if the slot existed when it was
+	// taken. Everything at or beyond _latestSnapshotEntrySlotCount is invisible to it.
+	private void EnsureSlotsWritable(int index)
+	{
+		if (index < _latestSnapshotEntrySlotCount && _slotsEpoch <= _latestSnapshotEpoch)
+		{
+			var newSlots = new Slot[_slots.Length];
+			Array.Copy(_slots, newSlots, _slots.Length);
+			_slots = newSlots;
+
+			_slotsEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+	}
+
+	private void EnsureValuesWritable(int index)
+	{
+		if (index < _latestSnapshotEntrySlotCount && _valuesEpoch <= _latestSnapshotEpoch)
+		{
+			var newValues = new TValue[_values.Length];
+			Array.Copy(_values, newValues, _values.Length);
+			_values = newValues;
+
+			_valuesEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+	}
+
+	private void EnsureOrderNextWritable(int index)
+	{
+		// A snapshot stops after emitting the entry count it froze, so the frozen tail's forward link
+		// is never read.
+		if (index >= 0 && index != _latestSnapshotOrderTail &&
+			index < _latestSnapshotEntrySlotCount && _orderNextEpoch <= _latestSnapshotEpoch)
+		{
+			var newOrderNext = new int[_orderNext.Length];
+			Array.Copy(_orderNext, newOrderNext, _orderNext.Length);
+			_orderNext = newOrderNext;
+
+			_orderNextEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+	}
+
+	// No guards needed for _buckets, Slot.HashNext and _orderPrev. A SnapshotView is enumerate-only
+	// and forward-only. It reads the key, the value, and the forward order link up to a maximum of
+	// its frozen count.
+
+	private void Grow()
+	{
+		var capacity = _slots.Length == 0 ? 4 : _slots.Length * 2;
+
+		var slots = new Slot[capacity];
+		Array.Copy(_slots, slots, EntrySlotCount);
+		_slots = slots;
+
+		var values = new TValue[capacity];
+		Array.Copy(_values, values, EntrySlotCount);
+		_values = values;
+
+		var orderNext = new int[capacity];
+		Array.Copy(_orderNext, orderNext, EntrySlotCount);
+		_orderNext = orderNext;
+
+		var orderPrev = new int[capacity];
+		Array.Copy(_orderPrev, orderPrev, EntrySlotCount);
+		_orderPrev = orderPrev;
+
+		_slotsEpoch = _epoch;
+		_valuesEpoch = _epoch;
+		_orderNextEpoch = _epoch;
+	}
+
+	// Re-partitions every entry across a larger bucket array. This rewrites only hash links and the
+	// bucket array itself, neither of which a snapshot reads, so it needs no copy at all.
+	private void Rehash()
+	{
+		var bucketCount = _buckets.Length * 2;
+		var buckets = new int[bucketCount];
+
+		for (var i = _orderHead; i >= 0; i = _orderNext[i])
+		{
+			var bucket = BucketIndex(_comparer, _slots[i].Key, bucketCount);
+			_slots[i].HashNext = buckets[bucket] - 1;
+			buckets[bucket] = i + 1;
+		}
+
+		_buckets = buckets;
+	}
+
+	void IDeserializationCallback.OnDeserialization(object sender)
+	{
+		var versionBefore = _version;
+
+		var ordered = new List<KeyValuePair<TKey, TValue>>(Count);
+		for (var i = _orderHead; i >= 0; i = _orderNext[i])
+		{
+			ordered.Add(new KeyValuePair<TKey, TValue>(_slots[i].Key, _values[i]));
+		}
+
+		InitializeEmpty(BucketCountFor(ordered.Count), CapacityFor(ordered.Count));
+
+		foreach (var entry in ordered)
+		{
+			Insert(entry.Key, entry.Value, BucketIndex(_comparer, entry.Key, _buckets.Length));
+		}
+
+		// Undo version increments caused by Insert above
+		_version = versionBefore;
+	}
+
+	private sealed class KeyCollection : ICollection<TKey>, ICollection
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+
+		public KeyCollection(SequencedSnapshotDictionary<TKey, TValue> owner)
+		{
+			_owner = owner;
+		}
+
+		public int Count => _owner.Count;
+		bool ICollection<TKey>.IsReadOnly => true;
+
+		bool ICollection<TKey>.Contains(TKey item)
+		{
+			return _owner.ContainsKey(item);
+		}
+
+		public void CopyTo(TKey[] array, int arrayIndex)
+		{
+			if (array is null)
+			{
+				throw new ArgumentNullException(nameof(array));
+			}
+
+			if (arrayIndex < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+			}
+
+			if (array.Length - arrayIndex < Count)
+			{
+				throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.", nameof(array));
+			}
+
+			var i = arrayIndex;
+			for (var e = _owner._orderHead; e >= 0; e = _owner._orderNext[e])
+			{
+				array[i++] = _owner._slots[e].Key;
+			}
+		}
+
+		public IEnumerator<TKey> GetEnumerator()
+		{
+			var version = _owner._version;
+			var i = _owner._orderHead;
+			while (i >= 0)
+			{
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified during enumeration.");
+				}
+
+				var next = _owner._orderNext[i];
+				yield return _owner._slots[i].Key;
+
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified during enumeration.");
+				}
+
+				i = next;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		void ICollection<TKey>.Add(TKey item) => throw new NotSupportedException("Keys collection is read-only.");
+		void ICollection<TKey>.Clear() => throw new NotSupportedException("Keys collection is read-only.");
+		bool ICollection<TKey>.Remove(TKey item) => throw new NotSupportedException("Keys collection is read-only.");
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			_owner.KeyCopyTo(array, index);
+		}
+
+		bool ICollection.IsSynchronized => false;
+
+		object ICollection.SyncRoot => _owner;
+	}
+
+	private sealed class ValueCollection : ICollection<TValue>, ICollection
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+
+		public ValueCollection(SequencedSnapshotDictionary<TKey, TValue> owner)
+		{
+			_owner = owner;
+		}
+
+		public int Count => _owner.Count;
+		bool ICollection<TValue>.IsReadOnly => true;
+
+		bool ICollection<TValue>.Contains(TValue item)
+		{
+			var valueComparer = EqualityComparer<TValue>.Default;
+
+			for (var i = _owner._orderHead; i >= 0; i = _owner._orderNext[i])
+			{
+				if (valueComparer.Equals(_owner._values[i], item))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public void CopyTo(TValue[] array, int arrayIndex)
+		{
+			if (array is null)
+			{
+				throw new ArgumentNullException(nameof(array));
+			}
+
+			if (arrayIndex < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+			}
+
+			if (array.Length - arrayIndex < Count)
+			{
+				throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.", nameof(array));
+			}
+
+			var i = arrayIndex;
+			for (var e = _owner._orderHead; e >= 0; e = _owner._orderNext[e])
+			{
+				array[i++] = _owner._values[e];
+			}
+		}
+
+		public IEnumerator<TValue> GetEnumerator()
+		{
+			var version = _owner._version;
+			var i = _owner._orderHead;
+			while (i >= 0)
+			{
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+				}
+
+				var next = _owner._orderNext[i];
+				yield return _owner._values[i];
+
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+				}
+
+				i = next;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		void ICollection<TValue>.Add(TValue item) => throw new NotSupportedException("Values collection is read-only.");
+		void ICollection<TValue>.Clear() => throw new NotSupportedException("Values collection is read-only.");
+		bool ICollection<TValue>.Remove(TValue item) => throw new NotSupportedException("Values collection is read-only.");
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			_owner.ValueCopyTo(array, index);
+		}
+
+		bool ICollection.IsSynchronized => false;
+		object ICollection.SyncRoot => _owner;
+	}
+
+	/// <summary>
+	/// A read-only, insertion-ordered view of a <see cref="SequencedSnapshotDictionary{TKey,TValue}"/>
+	/// frozen at the moment <see cref="SequencedSnapshotDictionary{TKey,TValue}.GetSnapshot"/> was
+	/// called.
+	/// </summary>
+	private sealed class SnapshotView : ISnapshotView<TKey, TValue>
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+		private readonly Slot[] _slots;
+		private readonly TValue[] _values;
+		private readonly int[] _orderNext;
+		private readonly int _head;
+		private readonly int _count;
+		private bool _disposed;
+
+		internal SnapshotView(
+			SequencedSnapshotDictionary<TKey, TValue> owner,
+			Slot[] slots,
+			TValue[] values,
+			int[] orderNext,
+			int head,
+			int count)
+		{
+			_owner = owner;
+			_slots = slots;
+			_values = values;
+			_orderNext = orderNext;
+			_head = head;
+			_count = count;
+		}
+
+		public int Count
+		{
+			get
+			{
+				ThrowIfDisposed();
+				return _count;
+			}
+		}
+
+		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+		{
+			ThrowIfDisposed();
+			return EnumerateEntries();
+		}
+
+		private IEnumerator<KeyValuePair<TKey, TValue>> EnumerateEntries()
+		{
+			// Walk exactly the number of entries that were live at the freeze and no further. That
+			// bound is what makes appends after the snapshot free: the last entry emitted is the
+			// frozen tail, whose forward link is the only one an append rewrites, and it is never read.
+			var i = _head;
+			for (var emitted = 0; emitted < _count && i >= 0; emitted++)
+			{
+				ThrowIfDisposed();
+				yield return new KeyValuePair<TKey, TValue>(_slots[i].Key, _values[i]);
+				i = _orderNext[i];
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		private void ThrowIfDisposed()
+		{
+			if (_disposed)
+			{
+				throw new ObjectDisposedException(nameof(SnapshotView));
+			}
+		}
+
+		public void Dispose()
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+			_owner.ReleaseSnapshot();
+		}
+	}
+
+	private static int BucketIndex(IEqualityComparer<TKey> comparer, TKey key, int bucketCount)
+	{
+		// MurmurHash3 avalanche to spread more evenly.
+		var h = unchecked((uint) comparer.GetHashCode(key));
+		unchecked
+		{
+			h ^= h >> 16;
+			h *= 0x85ebca6bu;
+			h ^= h >> 13;
+			h *= 0xc2b2ae35u;
+			h ^= h >> 16;
+		}
+		return (int) (h & (uint) (bucketCount - 1));
+	}
+
+	// --- IDictionary explicit members ---
+	bool ICollection.IsSynchronized => false;
+
+	object ICollection.SyncRoot => this;
+
+	bool IDictionary.IsFixedSize => false;
+
+	bool IDictionary.IsReadOnly => false;
+
+	ICollection IDictionary.Keys => KeysInternal;
+
+	ICollection IDictionary.Values => ValuesInternal;
+
+	object IDictionary.this[object key]
+	{
+		get
+		{
+			if (IsCompatibleKey(key))
+			{
+				if (TryGetValue((TKey) key, out var value))
+				{
+					return value;
+				}
+			}
+
+			return null;
+		}
+		set
+		{
+			if (key == null)
+			{
+				throw new ArgumentNullException(nameof(key));
+			}
+
+			if (default(TKey) != null && value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			try
+			{
+				var tempKey = (TKey) key;
+				try
+				{
+					this[tempKey] = (TValue) value!;
+				}
+				catch (InvalidCastException)
+				{
+					throw new ArgumentException(nameof(value));
+				}
+			}
+			catch (InvalidCastException)
+			{
+				throw new ArgumentException(nameof(key));
+			}
+		}
+	}
+
+	private static bool IsCompatibleKey(object key)
+	{
+		if (key == null)
+		{
+			throw new ArgumentNullException(nameof(key));
+		}
+		return key is TKey;
+	}
+
+	void IDictionary.Add(object key, object value)
+	{
+		if (key == null)
+		{
+			throw new ArgumentNullException(nameof(key));
+		}
+
+		if (default(TKey) != null && value == null)
+		{
+			throw new ArgumentNullException(nameof(value));
+		}
+
+		try
+		{
+			var tempKey = (TKey) key;
+
+			try
+			{
+				Add(tempKey, (TValue) value!);
+			}
+			catch (InvalidCastException)
+			{
+				throw new ArgumentException(nameof(value));
+			}
+		}
+		catch (InvalidCastException)
+		{
+			throw new ArgumentException(nameof(key));
+		}
+	}
+
+	bool IDictionary.Contains(object key)
+	{
+		if (IsCompatibleKey(key))
+		{
+			return ContainsKey((TKey) key);
+		}
+
+		return false;
+	}
+
+	IDictionaryEnumerator IDictionary.GetEnumerator() => new DictionaryEnumerator(this);
+
+	private sealed class DictionaryEnumerator : IDictionaryEnumerator
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+		private readonly int _version;
+		private int _current;
+
+		public DictionaryEnumerator(SequencedSnapshotDictionary<TKey, TValue> owner)
+		{
+			_owner = owner;
+			_version = owner._version;
+			_current = owner._orderHead;
+		}
+
+		public bool MoveNext()
+		{
+			if (_current < 0)
+			{
+				return false;
+			}
+
+			Entry = new DictionaryEntry(_owner._slots[_current].Key, _owner._values[_current]);
+
+			if (_version != _owner._version)
+			{
+				throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+			}
+
+			_current = _owner._orderNext[_current];
+
+			return true;
+		}
+
+		public void Reset()
+		{
+			if (_version != _owner._version)
+			{
+				throw new InvalidOperationException("Dictionary has changed. Cannot reset.");
+			}
+
+			_current = _owner._orderHead;
+		}
+
+		public object Current => Entry;
+
+		public object Key => Entry.Key;
+
+		public object Value => Entry.Value;
+
+		public DictionaryEntry Entry { get; private set; }
+	}
+
+	void IDictionary.Remove(object key)
+	{
+		if (IsCompatibleKey(key))
+		{
+			Remove((TKey) key);
+		}
+	}
+
+	void ICollection.CopyTo(Array array, int index)
+	{
+		KeyCopyTo(array, index);
+	}
+
+	private void KeyCopyTo(Array array, int index)
+	{
+		if (array == null)
+		{
+			throw new ArgumentNullException(nameof(array));
+		}
+
+		if (array.Rank != 1)
+		{
+			throw new ArgumentException("Multi dimension array not supported", nameof(array));
+		}
+
+		if (array.GetLowerBound(0) != 0)
+		{
+			throw new ArgumentException("Non-zero lower bound not supported", nameof(array));
+		}
+
+		if ((uint) index > (uint) array.Length)
+		{
+			throw new ArgumentOutOfRangeException(nameof(index));
+		}
+
+		if (array.Length - index < Count)
+		{
+			throw new ArgumentException("The array is too small to copy the elements.", nameof(array));
+		}
+
+		if (array is TKey[] keys)
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				keys[destinationIndex++] = _slots[sourceIndex].Key;
+			}
+
+			return;
+		}
+
+		if (array is not object[] objects)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+
+		try
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				objects[destinationIndex++] = _slots[sourceIndex].Key;
+			}
+		}
+		catch (ArrayTypeMismatchException)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+	}
+
+	private void ValueCopyTo(Array array, int index)
+	{
+		if (array == null)
+		{
+			throw new ArgumentNullException(nameof(array));
+		}
+
+		if (array.Rank != 1)
+		{
+			throw new ArgumentException("Multi dimension array not supported", nameof(array));
+		}
+
+		if (array.GetLowerBound(0) != 0)
+		{
+			throw new ArgumentException("Non-zero lower bound not supported", nameof(array));
+		}
+
+		if ((uint) index > (uint) array.Length)
+		{
+			throw new ArgumentOutOfRangeException(nameof(index));
+		}
+
+		if (array.Length - index < Count)
+		{
+			throw new ArgumentException("The array is too small to copy the elements.", nameof(array));
+		}
+
+		if (array is TValue[] value)
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				value[destinationIndex++] = _values[sourceIndex];
+			}
+
+			return;
+		}
+
+		if (array is not object[] objects)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+
+		try
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				objects[destinationIndex++] = _values[sourceIndex];
+			}
+		}
+		catch (ArrayTypeMismatchException)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+	}
+}

--- a/src/NHibernate/Util/SequencedSnapshotDictionary.cs
+++ b/src/NHibernate/Util/SequencedSnapshotDictionary.cs
@@ -1,0 +1,1242 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace NHibernate.Util;
+
+/// <summary>
+/// A read-only view of a dictionary. Dispose it as soon as possible.
+/// </summary>
+internal interface ISnapshotView<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IDisposable;
+
+/// <summary>
+/// A dictionary with whose entries are sequenced based on the order in which they were
+/// added or modified and implements snapshotting with copy-on-write.
+/// </summary>
+/// <remarks>
+/// This class is not thread safe.
+/// The core dictionary implementation is based on <see cref="System.Collections.Generic.Dictionary{TKey,TValue}" />
+/// </remarks>
+/// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+[Serializable]
+internal sealed class SequencedSnapshotDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IDeserializationCallback
+	where TKey : notnull
+{
+	/// <summary>
+	/// The hot half of an entry: everything a lookup probe needs, and nothing else. Kept deliberately
+	/// narrow.
+	/// </summary>
+	[Serializable]
+	private struct Slot
+	{
+		public TKey Key;
+
+		// Index of the next entry in the same bucket chain, -1 for the end of the chain. Doubles as
+		// the free-list link while the slot is unused.
+		public int HashNext;
+	}
+
+	private readonly IEqualityComparer<TKey> _comparer;
+
+	// Physical slot order is meaningless. Iteration order is the _orderPrev/_orderNext list.
+	private Slot[] _slots;
+	private TValue[] _values;
+	private int[] _orderNext;
+	private int[] _orderPrev;
+
+	// Ends of the iteration-order list, -1 when empty.
+	private int _orderHead;
+	private int _orderTail;
+
+	// Head of the free-slot list (-1 when empty) and its length.
+	private int _freeListHead;
+	private int _freeListCount;
+
+	// Per-bucket chain head stored as (entry index + 1), so the default 0 means "empty" and a
+	// freshly allocated array needs no initialization pass. Must be rebuilt on deserialization
+	// as hash codes are not stable.
+	[NonSerialized]
+	private int[] _buckets;
+
+	// Epoch each array was last (re)created at. An array whose epoch is <= _latestSnapshotEpoch is
+	// potentially shared with an outstanding snapshot and must be copied before it can be written.
+	// Only the three arrays a snapshot actually reads need one.
+	[NonSerialized]
+	private int _slotsEpoch;
+	[NonSerialized]
+	private int _valuesEpoch;
+	[NonSerialized]
+	private int _orderNextEpoch;
+	
+	// Only increments whenever a snapshot is taken
+	[NonSerialized]
+	private int _epoch; 
+	
+	// Arrays with epoch <= this must be copied before mutation. -1 when there are no active snapshots.
+	// Only the latest snapshot is tracked as the snapshot constraint of the latest snapshot includes
+	// the constraints of any snapshot before it. A change that would affect an earlier snapshot will
+	// always affect a newer snapshot (so any change that affects any snapshot will always affect the
+	// latest snapshot).
+	[NonSerialized]
+	private int _latestSnapshotEpoch;
+
+	// EntrySlotCount as of the latest GetSnapshot(). A write is observable (and requires cloning) if
+	// its epoch <= latestSnapshotEpoch AND index < _latestSnapshotEntrySlotCount.
+	[NonSerialized]
+	private int _latestSnapshotEntrySlotCount;
+	
+	// _orderTail as of the latest GetSnapshot(). Tracked for an optimization in _orderNext updates where
+	// if index == _latestSnapshotTail then the update to _orderNext is not meaningfully observable by
+	// any outstanding snapshot.
+	[NonSerialized]
+	private int _latestSnapshotOrderTail;
+
+	[NonSerialized]
+	private int _version; // bumped on every mutation to fail enumerate-and-update scenarios
+
+	[NonSerialized]
+	private int _outstandingSnapshots;
+
+	// Number of array copies performed to preserve isolation for an outstanding snapshot. Exposed for
+	// tests to verify that disposing snapshots promptly avoids this cost; not incremented by
+	// growth/rehash, which are unrelated to snapshotting.
+	[NonSerialized]
+	internal int CopyOnWriteCount;
+
+	[NonSerialized]
+	private KeyCollection _keys;
+	[NonSerialized]
+	private ValueCollection _valuesView;
+
+	public SequencedSnapshotDictionary(int capacity = 16, IEqualityComparer<TKey> comparer = null)
+	{
+		if (capacity < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(capacity));
+		}
+
+		_comparer = comparer ?? EqualityComparer<TKey>.Default;
+		InitializeEmpty(BucketCountFor(capacity), CapacityFor(capacity));
+	}
+
+	private static int BucketCountFor(int liveCount)
+	{
+		var bucketCount = 1;
+		while (bucketCount < liveCount)
+		{
+			bucketCount <<= 1;
+		}
+
+		return bucketCount;
+	}
+
+	private static int CapacityFor(int neededCount)
+	{
+		if (neededCount <= 0)
+		{
+			return 0;
+		}
+
+		var capacity = 4;
+		while (capacity < neededCount)
+		{
+			capacity <<= 1;
+		}
+
+		return capacity;
+	}
+
+	private void InitializeEmpty(int bucketCount, int capacity)
+	{
+		_buckets = new int[bucketCount];
+		if (capacity == 0)
+		{
+			_slots = [];
+			_values = [];
+			_orderNext = [];
+			_orderPrev = [];
+		}
+		else
+		{
+			_slots = new Slot[capacity];
+			_values = new TValue[capacity];
+			_orderNext = new int[capacity];
+			_orderPrev = new int[capacity];
+		}
+
+		EntrySlotCount = 0;
+		Count = 0;
+		_orderHead = -1;
+		_orderTail = -1;
+		_freeListHead = -1;
+		_freeListCount = 0;
+
+		_epoch = 0;
+		_slotsEpoch = 0;
+		_valuesEpoch = 0;
+		_orderNextEpoch = 0;
+		_latestSnapshotEpoch = -1;
+		_latestSnapshotEntrySlotCount = 0;
+		_latestSnapshotOrderTail = -1;
+		_version = 0;
+		_outstandingSnapshots = 0;
+		CopyOnWriteCount = 0;
+		_keys = null;
+		_valuesView = null;
+	}
+
+	public int Count { get; private set; }
+
+	// Number of SnapshotView instances handed out that have not yet been
+	// disposed. Should return to zero once every taken snapshot has been released.
+	// Exposed for tests.
+	internal int OutstandingSnapshots => _outstandingSnapshots;
+
+	// How many slots have ever been handed out. Free-list reuse is what keeps this
+	// pinned to the high-water mark of live entries instead of growing with write volume.
+	// This number only ever goes up in Insert up or gets reset to 0 in Clear.
+	// Exposed for tests.
+	internal int EntrySlotCount { get; private set; }
+
+	/// <summary>
+	/// O(1). Returns a read-only, insertion-ordered view frozen at this exact moment. No copying
+	/// happens here.
+	/// </summary>
+	/// <remarks>
+	/// Dispose the returned view as soon possible. Once every outstanding snapshot has been disposed,
+	/// the dictionary reverts to fully in-place as if no snapshot had ever been taken. 
+	/// </remarks>
+	public ISnapshotView<TKey, TValue> GetSnapshot()
+	{
+		_latestSnapshotEpoch = _epoch;
+		_latestSnapshotEntrySlotCount = EntrySlotCount;
+		_latestSnapshotOrderTail = _orderTail;
+		
+		_epoch++;
+		_outstandingSnapshots++;
+		return new SnapshotView(this, _slots, _values, _orderNext, _orderHead, Count);
+	}
+
+	// Called by SnapshotView.Dispose(). Once the last outstanding snapshot is released, no view
+	// can observe any array any more, so the floor is reset and writes go back to being fully in
+	// place.
+	private void ReleaseSnapshot()
+	{
+		if (_outstandingSnapshots > 0 && --_outstandingSnapshots == 0)
+		{
+			_latestSnapshotEpoch = -1;
+			_latestSnapshotEntrySlotCount = EntrySlotCount;
+			_latestSnapshotOrderTail = _orderTail;
+		}
+	}
+
+	public TValue this[TKey key]
+	{
+		get
+		{
+			var index = FindEntry(key, out _);
+			if (index < 0)
+			{
+				throw new KeyNotFoundException();
+			}
+
+			return _values[index];
+		}
+		set => SetCore(key, value, throwIfExists: false);
+	}
+	
+	private KeyCollection KeysInternal => _keys ??= new KeyCollection(this);
+	
+	private ValueCollection ValuesInternal => _valuesView ??= new ValueCollection(this);
+
+	public ICollection<TKey> Keys => KeysInternal;
+	
+	public ICollection<TValue> Values => _valuesView ??= new ValueCollection(this);
+	
+	public bool IsReadOnly => false;
+
+	public void Add(TKey key, TValue value)
+	{
+		SetCore(key, value, throwIfExists: true);
+	}
+
+	void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+	{
+		Add(item.Key, item.Value);
+	}
+
+	public bool ContainsKey(TKey key) => FindEntry(key, out _) >= 0;
+
+	public bool Contains(KeyValuePair<TKey, TValue> item)
+	{
+		var index = FindEntry(item.Key, out _);
+		return index >= 0 && EqualityComparer<TValue>.Default.Equals(_values[index], item.Value);
+	}
+
+	public bool TryGetValue(TKey key, out TValue value)
+	{
+		var index = FindEntry(key, out _);
+		if (index < 0)
+		{
+			value = default!;
+			return false;
+		}
+
+		value = _values[index];
+		return true;
+	}
+
+	public void Clear()
+	{
+		if (Count == 0 && EntrySlotCount == 0)
+		{
+			return;
+		}
+
+		// No snapshot ever reads the bucket array, so it is always safe to zero in place.
+		Array.Clear(_buckets, 0, _buckets.Length);
+
+		if (_slotsEpoch <= _latestSnapshotEpoch || _valuesEpoch <= _latestSnapshotEpoch || _orderNextEpoch <= _latestSnapshotEpoch)
+		{
+			// At least one array is still visible to an outstanding snapshot, so it has to be
+			// abandoned rather than zeroed. Replace the whole set together, since slot indices are
+			// only meaningful if every array is the same length.
+			_slots = [];
+			_values = [];
+			_orderNext = [];
+			_orderPrev = [];
+			_slotsEpoch = _epoch;
+			_valuesEpoch = _epoch;
+			_orderNextEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+		else
+		{
+			// Don't keep the cleared entries' keys/values alive.
+			Array.Clear(_slots, 0, EntrySlotCount);
+			Array.Clear(_values, 0, EntrySlotCount);
+		}
+
+		EntrySlotCount = 0;
+		Count = 0;
+		_orderHead = -1;
+		_orderTail = -1;
+		_freeListHead = -1;
+		_freeListCount = 0;
+		_version++;
+	}
+
+	public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+	{
+		if (array is null)
+		{
+			throw new ArgumentNullException(nameof(array));
+		}
+
+		if (arrayIndex < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+		}
+
+		if (array.Length - arrayIndex < Count)
+		{
+			throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.", nameof(array));
+		}
+
+		var destinationIndex = arrayIndex;
+		for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+		{
+			array[destinationIndex++] = new KeyValuePair<TKey, TValue>(_slots[sourceIndex].Key, _values[sourceIndex]);
+		}
+	}
+
+	public bool Remove(TKey key)
+	{
+		var index = FindEntry(key, out var bucket);
+		if (index < 0)
+		{
+			return false;
+		}
+
+		RemoveAt(index, bucket);
+		return true;
+	}
+
+	public bool Remove(KeyValuePair<TKey, TValue> item)
+	{
+		var index = FindEntry(item.Key, out var bucket);
+		if (index < 0 || !EqualityComparer<TValue>.Default.Equals(_values[index], item.Value))
+		{
+			return false;
+		}
+
+		RemoveAt(index, bucket);
+		return true;
+	}
+
+	public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+	{
+		var version = _version;
+		var i = _orderHead;
+		while (i >= 0)
+		{
+			yield return new KeyValuePair<TKey, TValue>(_slots[i].Key, _values[i]);
+
+			if (_version != version)
+			{
+				throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+			}
+
+			i = _orderNext[i];
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	// Returns the index of the entry for `key`, or -1, and always reports the key's bucket so callers
+	// never have to hash it twice. Touches only _buckets and _slots.
+	private int FindEntry(TKey key, out int bucket)
+	{
+		bucket = BucketIndex(_comparer, key, _buckets.Length);
+		var slots = _slots;
+		for (var i = _buckets[bucket] - 1; i >= 0; i = slots[i].HashNext)
+		{
+			if (_comparer.Equals(slots[i].Key, key))
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	private void SetCore(TKey key, TValue value, bool throwIfExists)
+	{
+		var existing = FindEntry(key, out var bucket);
+		if (existing < 0)
+		{
+			Insert(key, value, bucket);
+			return;
+		}
+
+		if (throwIfExists)
+		{
+			throw new ArgumentException($"An item with the key '{key}' has already been added.");
+		}
+
+		// Move-to-end on modify.
+		// The value is written in place and only the order links move.
+		// The key and hash chain are untouched, so _slots does not need copying here.
+		EnsureValuesWritable(existing);
+		_values[existing] = value;
+
+		if (existing != _orderTail)
+		{
+			EnsureOrderNextWritable(_orderPrev[existing]);
+			EnsureOrderNextWritable(existing);
+			EnsureOrderNextWritable(_orderTail);
+			
+			OrderUnlink(existing);
+			OrderAppend(existing);
+		}
+
+		_version++;
+	}
+
+	private void Insert(TKey key, TValue value, int bucket)
+	{
+		int index;
+		if (_freeListCount > 0)
+		{
+			// Reusing a free slot never needs a copy. Either we have already copied since the last
+			// snapshot (in which case the arrays are private anyway), or no visible slot has been
+			// freed since the snapshot which means it is in neither the order list nor any bucket
+			// chain the snapshot can walk.
+			index = _freeListHead;
+			_freeListHead = _slots[index].HashNext;
+			_freeListCount--;
+		}
+		else
+		{
+			if (EntrySlotCount == _slots.Length)
+			{
+				Grow();
+			}
+
+			index = EntrySlotCount;
+			EntrySlotCount++;
+		}
+		
+		_slots[index].Key = key;
+		_slots[index].HashNext = _buckets[bucket] - 1;
+		_values[index] = value;
+		_buckets[bucket] = index + 1;
+		Count++;
+		_version++;
+		
+		// This check is purely defensive. It never actually triggers a cloning of _orderNext as
+		// that would mean _orderTail is behind a snapshot's tail which can only happen during a
+		// remove or a move-to-end update and both of those operations clone _orderNext
+		EnsureOrderNextWritable(_orderTail);
+		OrderAppend(index);
+
+		if (Count > _buckets.Length)
+		{
+			Rehash();
+		}
+	}
+
+	private void RemoveAt(int index, int bucket)
+	{
+		var chainPrev = -1;
+		for (var i = _buckets[bucket] - 1; i >= 0; i = _slots[i].HashNext)
+		{
+			if (i == index)
+			{
+				break;
+			}
+
+			chainPrev = i;
+		}
+
+		var orderPrev = _orderPrev[index];
+
+		EnsureSlotsWritable(index);
+		EnsureValuesWritable(index);
+		EnsureOrderNextWritable(orderPrev);
+		EnsureOrderNextWritable(index);
+
+		if (chainPrev < 0)
+		{
+			_buckets[bucket] = _slots[index].HashNext + 1;
+		}
+		else
+		{
+			_slots[chainPrev].HashNext = _slots[index].HashNext;
+		}
+
+		OrderUnlink(index);
+
+		_slots[index].Key = default!;
+		_values[index] = default!;
+		_orderNext[index] = -1;
+		_orderPrev[index] = -1;
+		
+		_slots[index].HashNext = _freeListHead;
+		_freeListHead = index;
+		_freeListCount++;
+
+		Count--;
+		_version++;
+	}
+
+	private void OrderUnlink(int index)
+	{
+		var prev = _orderPrev[index];
+		var next = _orderNext[index];
+
+		if (prev >= 0)
+		{
+			_orderNext[prev] = next;
+		}
+		else
+		{
+			_orderHead = next;
+		}
+
+		if (next >= 0)
+		{
+			_orderPrev[next] = prev;
+		}
+		else
+		{
+			_orderTail = prev;
+		}
+	}
+
+	private void OrderAppend(int index)
+	{
+		_orderPrev[index] = _orderTail;
+		_orderNext[index] = -1;
+
+		if (_orderTail >= 0)
+		{
+			// Appending to _orderTail is always safe because snapshots stop reading at the count
+			// they froze.
+			_orderNext[_orderTail] = index;
+		}
+		else
+		{
+			_orderHead = index;
+		}
+
+		_orderTail = index;
+	}
+
+	// A snapshot can observe a slot's key, hash link and value only if the slot existed when it was
+	// taken. Everything at or beyond _latestSnapshotEntrySlotCount is invisible to it.
+	private void EnsureSlotsWritable(int index)
+	{
+		if (index < _latestSnapshotEntrySlotCount && _slotsEpoch <= _latestSnapshotEpoch)
+		{
+			var newSlots = new Slot[_slots.Length];
+			Array.Copy(_slots, newSlots, _slots.Length);
+			_slots = newSlots;
+			
+			_slotsEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+	}
+
+	private void EnsureValuesWritable(int index)
+	{
+		if (index < _latestSnapshotEntrySlotCount && _valuesEpoch <= _latestSnapshotEpoch)
+		{
+			var newValues = new TValue[_values.Length];
+			Array.Copy(_values, newValues, _values.Length);
+			_values = newValues;
+			
+			_valuesEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+	}
+
+	private void EnsureOrderNextWritable(int index)
+	{
+		// A snapshot stops after emitting the entry count it froze, so the frozen tail's forward link
+		// is never read.
+		if (index >= 0 && index != _latestSnapshotOrderTail && 
+		    index < _latestSnapshotEntrySlotCount && _orderNextEpoch <= _latestSnapshotEpoch)
+		{
+			var newOrderNext = new int[_orderNext.Length];
+			Array.Copy(_orderNext, newOrderNext, _orderNext.Length);
+			_orderNext = newOrderNext;
+			
+			_orderNextEpoch = _epoch;
+			CopyOnWriteCount++;
+		}
+	}
+
+	// No guards needed for _buckets, Slot.HashNext and _orderPrev. A SnapshotView is enumerate-only
+	// and forward-only. It reads the key, the value, and the forward order link up to a maximum of
+	// its frozen count.
+
+	private void Grow()
+	{
+		var capacity = _slots.Length == 0 ? 4 : _slots.Length * 2;
+
+		var slots = new Slot[capacity];
+		Array.Copy(_slots, slots, EntrySlotCount);
+		_slots = slots;
+
+		var values = new TValue[capacity];
+		Array.Copy(_values, values, EntrySlotCount);
+		_values = values;
+
+		var orderNext = new int[capacity];
+		Array.Copy(_orderNext, orderNext, EntrySlotCount);
+		_orderNext = orderNext;
+
+		var orderPrev = new int[capacity];
+		Array.Copy(_orderPrev, orderPrev, EntrySlotCount);
+		_orderPrev = orderPrev;
+
+		_slotsEpoch = _epoch;
+		_valuesEpoch = _epoch;
+		_orderNextEpoch = _epoch;
+	}
+
+	// Re-partitions every entry across a larger bucket array. This rewrites only hash links and the
+	// bucket array itself, neither of which a snapshot reads, so it needs no copy at all.
+	private void Rehash()
+	{
+		var bucketCount = _buckets.Length * 2;
+		var buckets = new int[bucketCount];
+
+		for (var i = _orderHead; i >= 0; i = _orderNext[i])
+		{
+			var bucket = BucketIndex(_comparer, _slots[i].Key, bucketCount);
+			_slots[i].HashNext = buckets[bucket] - 1;
+			buckets[bucket] = i + 1;
+		}
+
+		_buckets = buckets;
+	}
+
+	void IDeserializationCallback.OnDeserialization(object sender)
+	{
+		var versionBefore = _version;
+		
+		var ordered = new List<KeyValuePair<TKey, TValue>>(Count);
+		for (var i = _orderHead; i >= 0; i = _orderNext[i])
+		{
+			ordered.Add(new KeyValuePair<TKey, TValue>(_slots[i].Key, _values[i]));
+		}
+
+		InitializeEmpty(BucketCountFor(ordered.Count), CapacityFor(ordered.Count));
+
+		foreach (var entry in ordered)
+		{
+			Insert(entry.Key, entry.Value, BucketIndex(_comparer, entry.Key, _buckets.Length));
+		}
+
+		// Undo version increments caused by Insert above
+		_version = versionBefore;
+	}
+
+	private sealed class KeyCollection : ICollection<TKey>, ICollection
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+
+		public KeyCollection(SequencedSnapshotDictionary<TKey, TValue> owner)
+		{
+			_owner = owner;
+		}
+
+		public int Count => _owner.Count;
+		bool ICollection<TKey>.IsReadOnly => true;
+
+		bool ICollection<TKey>.Contains(TKey item)
+		{
+			return _owner.ContainsKey(item);
+		}
+
+		public void CopyTo(TKey[] array, int arrayIndex)
+		{
+			if (array is null)
+			{
+				throw new ArgumentNullException(nameof(array));
+			}
+
+			if (arrayIndex < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+			}
+
+			if (array.Length - arrayIndex < Count)
+			{
+				throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.", nameof(array));
+			}
+
+			var i = arrayIndex;
+			for (var e = _owner._orderHead; e >= 0; e = _owner._orderNext[e])
+			{
+				array[i++] = _owner._slots[e].Key;
+			}
+		}
+
+		public IEnumerator<TKey> GetEnumerator()
+		{
+			var version = _owner._version;
+			var i = _owner._orderHead;
+			while (i >= 0)
+			{
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified during enumeration.");
+				}
+
+				var next = _owner._orderNext[i];
+				yield return _owner._slots[i].Key;
+
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified during enumeration.");
+				}
+
+				i = next;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		void ICollection<TKey>.Add(TKey item) => throw new NotSupportedException("Keys collection is read-only.");
+		void ICollection<TKey>.Clear() => throw new NotSupportedException("Keys collection is read-only.");
+		bool ICollection<TKey>.Remove(TKey item) => throw new NotSupportedException("Keys collection is read-only.");
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			_owner.KeyCopyTo(array, index);
+		}
+
+		bool ICollection.IsSynchronized => false;
+
+		object ICollection.SyncRoot => _owner;
+	}
+
+	private sealed class ValueCollection : ICollection<TValue>, ICollection
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+
+		public ValueCollection(SequencedSnapshotDictionary<TKey, TValue> owner)
+		{
+			_owner = owner;
+		}
+
+		public int Count => _owner.Count;
+		bool ICollection<TValue>.IsReadOnly => true;
+
+		bool ICollection<TValue>.Contains(TValue item)
+		{
+			var valueComparer = EqualityComparer<TValue>.Default;
+			
+			for (var i = _owner._orderHead; i >= 0; i = _owner._orderNext[i])
+			{
+				if (valueComparer.Equals(_owner._values[i], item))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public void CopyTo(TValue[] array, int arrayIndex)
+		{
+			if (array is null)
+			{
+				throw new ArgumentNullException(nameof(array));
+			}
+
+			if (arrayIndex < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+			}
+
+			if (array.Length - arrayIndex < Count)
+			{
+				throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.", nameof(array));
+			}
+
+			var i = arrayIndex;
+			for (var e = _owner._orderHead; e >= 0; e = _owner._orderNext[e])
+			{
+				array[i++] = _owner._values[e];
+			}
+		}
+
+		public IEnumerator<TValue> GetEnumerator()
+		{
+			var version = _owner._version;
+			var i = _owner._orderHead;
+			while (i >= 0)
+			{
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+				}
+
+				var next = _owner._orderNext[i];
+				yield return _owner._values[i];
+
+				if (_owner._version != version)
+				{
+					throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+				}
+
+				i = next;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		void ICollection<TValue>.Add(TValue item) => throw new NotSupportedException("Values collection is read-only.");
+		void ICollection<TValue>.Clear() => throw new NotSupportedException("Values collection is read-only.");
+		bool ICollection<TValue>.Remove(TValue item) => throw new NotSupportedException("Values collection is read-only.");
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			_owner.ValueCopyTo(array, index);
+		}
+
+		bool ICollection.IsSynchronized => false;
+		object ICollection.SyncRoot => _owner;
+	}
+
+	/// <summary>
+	/// A read-only, insertion-ordered view of a <see cref="SequencedSnapshotDictionary{TKey,TValue}"/>
+	/// frozen at the moment <see cref="SequencedSnapshotDictionary{TKey,TValue}.GetSnapshot"/> was
+	/// called.
+	/// </summary>
+	private sealed class SnapshotView : ISnapshotView<TKey, TValue>
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+		private readonly Slot[] _slots;
+		private readonly TValue[] _values;
+		private readonly int[] _orderNext;
+		private readonly int _head;
+		private readonly int _count;
+		private bool _disposed;
+
+		internal SnapshotView(
+			SequencedSnapshotDictionary<TKey, TValue> owner,
+			Slot[] slots,
+			TValue[] values,
+			int[] orderNext,
+			int head,
+			int count)
+		{
+			_owner = owner;
+			_slots = slots;
+			_values = values;
+			_orderNext = orderNext;
+			_head = head;
+			_count = count;
+		}
+
+		public int Count
+		{
+			get
+			{
+				ThrowIfDisposed();
+				return _count;
+			}
+		}
+
+		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+		{
+			ThrowIfDisposed();
+			return EnumerateEntries();
+		}
+
+		private IEnumerator<KeyValuePair<TKey, TValue>> EnumerateEntries()
+		{
+			// Walk exactly the number of entries that were live at the freeze and no further. That
+			// bound is what makes appends after the snapshot free: the last entry emitted is the
+			// frozen tail, whose forward link is the only one an append rewrites, and it is never read.
+			var i = _head;
+			for (var emitted = 0; emitted < _count && i >= 0; emitted++)
+			{
+				ThrowIfDisposed();
+				yield return new KeyValuePair<TKey, TValue>(_slots[i].Key, _values[i]);
+				i = _orderNext[i];
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		private void ThrowIfDisposed()
+		{
+			if (_disposed)
+			{
+				throw new ObjectDisposedException(nameof(SnapshotView));
+			}
+		}
+
+		public void Dispose()
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+			_owner.ReleaseSnapshot();
+		}
+	}
+	
+	private static int BucketIndex(IEqualityComparer<TKey> comparer, TKey key, int bucketCount)
+	{
+		// MurmurHash3 avalanche to spread more evenly.
+		var h = unchecked((uint)comparer.GetHashCode(key));
+		unchecked
+		{
+			h ^= h >> 16;
+			h *= 0x85ebca6bu;
+			h ^= h >> 13;
+			h *= 0xc2b2ae35u;
+			h ^= h >> 16;
+		}
+		return (int)(h & (uint)(bucketCount - 1));
+	}
+	
+	// --- IDictionary explicit members ---
+	bool ICollection.IsSynchronized => false;
+
+	object ICollection.SyncRoot => this;
+
+	bool IDictionary.IsFixedSize => false;
+
+	bool IDictionary.IsReadOnly => false;
+
+	ICollection IDictionary.Keys => KeysInternal;
+
+	ICollection IDictionary.Values => ValuesInternal;
+
+	object IDictionary.this[object key]
+	{
+		get
+		{
+			if (IsCompatibleKey(key))
+			{
+				if (TryGetValue((TKey)key, out var value))
+				{
+					return value;
+				}
+			}
+
+			return null;
+		}
+		set
+		{
+			if (key == null)
+			{
+				throw new ArgumentNullException(nameof(key));
+			}
+			
+			if (default(TKey) != null && value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			try
+			{
+				var tempKey = (TKey)key;
+				try
+				{
+					this[tempKey] = (TValue)value!;
+				}
+				catch (InvalidCastException)
+				{
+					throw new ArgumentException(nameof(value));
+				}
+			}
+			catch (InvalidCastException)
+			{
+				throw new ArgumentException(nameof(key));
+			}
+		}
+	}
+
+	private static bool IsCompatibleKey(object key)
+	{
+		if (key == null)
+		{
+			throw new ArgumentNullException(nameof(key));
+		}
+		return key is TKey;
+	}
+
+	void IDictionary.Add(object key, object value)
+	{
+		if (key == null)
+		{
+			throw new ArgumentNullException(nameof(key));
+		}
+
+		if (default(TKey) != null && value == null)
+		{
+			throw new ArgumentNullException(nameof(value));
+		}
+
+		try
+		{
+			var tempKey = (TKey)key;
+
+			try
+			{
+				Add(tempKey, (TValue)value!);
+			}
+			catch (InvalidCastException)
+			{
+				throw new ArgumentException(nameof(value));
+			}
+		}
+		catch (InvalidCastException)
+		{
+			throw new ArgumentException(nameof(key));
+		}
+	}
+
+	bool IDictionary.Contains(object key)
+	{
+		if (IsCompatibleKey(key))
+		{
+			return ContainsKey((TKey)key);
+		}
+
+		return false;
+	}
+
+	IDictionaryEnumerator IDictionary.GetEnumerator() => new DictionaryEnumerator(this);
+
+	private sealed class DictionaryEnumerator : IDictionaryEnumerator
+	{
+		private readonly SequencedSnapshotDictionary<TKey, TValue> _owner;
+		private readonly int _version;
+		private int _current;
+
+		public DictionaryEnumerator(SequencedSnapshotDictionary<TKey, TValue> owner)
+		{
+			_owner = owner;
+			_version = owner._version;
+			_current = owner._orderHead;
+		}
+
+		public bool MoveNext()
+		{
+			if (_current < 0)
+			{
+				return false;
+			}
+			
+			Entry = new DictionaryEntry(_owner._slots[_current].Key, _owner._values[_current]);
+
+			if (_version != _owner._version)
+			{
+				throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+			}
+
+			_current = _owner._orderNext[_current];
+			
+			return true;
+		}
+
+		public void Reset()
+		{
+			if (_version != _owner._version)
+			{
+				throw new InvalidOperationException("Dictionary has changed. Cannot reset.");
+			}
+
+			_current = _owner._orderHead;
+		}
+
+		public object Current => Entry;
+		
+		public object Key => Entry.Key;
+		
+		public object Value => Entry.Value;
+		
+		public DictionaryEntry Entry { get; private set; }
+	}
+
+	void IDictionary.Remove(object key)
+	{
+		if (IsCompatibleKey(key))
+		{
+			Remove((TKey)key);
+		}
+	}
+	
+	void ICollection.CopyTo(Array array, int index)
+	{
+		KeyCopyTo(array, index);
+	}
+
+	private void KeyCopyTo(Array array, int index)
+	{
+		if (array == null)
+		{
+			throw new ArgumentNullException(nameof(array));
+		}
+
+		if (array.Rank != 1)
+		{
+			throw new ArgumentException("Multi dimension array not supported", nameof(array));
+		}
+
+		if (array.GetLowerBound(0) != 0)
+		{
+			throw new ArgumentException("Non-zero lower bound not supported", nameof(array));
+		}
+
+		if ((uint)index > (uint)array.Length)
+		{
+			throw new  ArgumentOutOfRangeException(nameof(index));
+		}
+
+		if (array.Length - index < Count)
+		{
+			throw new ArgumentException("The array is too small to copy the elements.", nameof(array));
+		}
+
+		if (array is TKey[] keys)
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				keys[destinationIndex++] = _slots[sourceIndex].Key;
+			}
+			
+			return;
+		}
+
+		if (array is not object[] objects)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+
+		try
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				objects[destinationIndex++] = _slots[sourceIndex].Key;
+			}
+		}
+		catch (ArrayTypeMismatchException)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+	}
+	
+	private void ValueCopyTo(Array array, int index)
+	{
+		if (array == null)
+		{
+			throw new ArgumentNullException(nameof(array));
+		}
+
+		if (array.Rank != 1)
+		{
+			throw new ArgumentException("Multi dimension array not supported", nameof(array));
+		}
+
+		if (array.GetLowerBound(0) != 0)
+		{
+			throw new ArgumentException("Non-zero lower bound not supported", nameof(array));
+		}
+
+		if ((uint)index > (uint)array.Length)
+		{
+			throw new  ArgumentOutOfRangeException(nameof(index));
+		}
+
+		if (array.Length - index < Count)
+		{
+			throw new ArgumentException("The array is too small to copy the elements.", nameof(array));
+		}
+
+		if (array is TValue[] value)
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				value[destinationIndex++] = _values[sourceIndex];
+			}
+			
+			return;
+		}
+
+		if (array is not object[] objects)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+
+		try
+		{
+			var destinationIndex = index;
+			for (var sourceIndex = _orderHead; sourceIndex >= 0; sourceIndex = _orderNext[sourceIndex])
+			{
+				objects[destinationIndex++] = _values[sourceIndex];
+			}
+		}
+		catch (ArrayTypeMismatchException)
+		{
+			throw new ArgumentException("Invalid array type", nameof(array));
+		}
+	}
+}

--- a/src/NHibernate/Util/SnapshotViewerAdapter.cs
+++ b/src/NHibernate/Util/SnapshotViewerAdapter.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace NHibernate.Util;
+
+internal sealed class SnapshotViewAdapter<TKey, TValue> : ISnapshotView<TKey, TValue>
+{
+	private readonly IReadOnlyCollection<KeyValuePair<TKey, TValue>> _keyValuePairs;
+
+	internal SnapshotViewAdapter(IReadOnlyCollection<KeyValuePair<TKey, TValue>> keyValuePairs)
+	{
+		_keyValuePairs = keyValuePairs;
+	}
+
+	public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _keyValuePairs.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	public int Count => _keyValuePairs.Count;
+	public void Dispose() {}
+}
+
+internal sealed class DictionarySnapshotViewAdapter<TKey, TValue> : ISnapshotView<TKey, TValue>
+{
+	private readonly IDictionary _dictionary;
+
+	internal DictionarySnapshotViewAdapter(IDictionary dictionary)
+	{
+		_dictionary = dictionary;
+	}
+
+	public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+	{
+		var enumerator = _dictionary.GetEnumerator();
+		while (enumerator.MoveNext())
+		{
+			yield return new KeyValuePair<TKey, TValue>((TKey)enumerator.Key, (TValue)enumerator.Value);
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	public int Count => _dictionary.Count;
+	public void Dispose() {}
+}

--- a/src/NHibernate/Util/SnapshotViewerAdapter.cs
+++ b/src/NHibernate/Util/SnapshotViewerAdapter.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NHibernate.Util;
+
+internal sealed class SnapshotViewAdapter<TKey, TValue> : ISnapshotView<TKey, TValue>
+{
+	private readonly IReadOnlyCollection<KeyValuePair<TKey, TValue>> _keyValuePairs;
+
+	internal SnapshotViewAdapter(IReadOnlyCollection<KeyValuePair<TKey, TValue>> keyValuePairs)
+	{
+		_keyValuePairs = keyValuePairs;
+	}
+
+	public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _keyValuePairs.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	public int Count => _keyValuePairs.Count;
+	public void Dispose() { }
+}
+
+internal sealed class DictionarySnapshotViewAdapter<TKey, TValue> : ISnapshotView<TKey, TValue>
+{
+	private readonly IDictionary _dictionary;
+
+	internal DictionarySnapshotViewAdapter(IDictionary dictionary)
+	{
+		_dictionary = dictionary;
+	}
+
+	public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+	{
+		var enumerator = _dictionary.GetEnumerator();
+		while (enumerator.MoveNext())
+		{
+			yield return new KeyValuePair<TKey, TValue>((TKey) enumerator.Key, (TValue) enumerator.Value);
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	public int Count => _dictionary.Count;
+	public void Dispose() { }
+}


### PR DESCRIPTION
Continues from https://github.com/nhibernate/nhibernate-core/pull/3762#discussion_r3730197930
Addresses https://github.com/nhibernate/nhibernate-core/issues/3788

### Benchmarks before
| Method                  | EntryCount | Mean        | Error     | StdDev    | Median      | Gen0        | Gen1       | Gen2       | Allocated  |
|------------------------ |----------- |------------:|----------:|----------:|------------:|------------:|-----------:|-----------:|-----------:|
| Flush_NoPendingChanges  | 1000       |   164.94 ms |  3.278 ms |  6.315 ms |   166.17 ms |  21000.0000 |  1000.0000 |          - |  253.01 MB |
| Flush_WithDirtyEntities | 1000       |   494.30 ms |  9.154 ms | 19.107 ms |   486.58 ms |  40000.0000 |  2000.0000 |  1000.0000 |   485.4 MB |
| Flush_WithNewWrites     | 1000       |    42.43 ms |  0.842 ms |  1.285 ms |    42.32 ms |   2000.0000 |  1000.0000 |          - |   24.78 MB |
| Flush_NoPendingChanges  | 5000       |   996.19 ms | 18.029 ms | 20.039 ms |   991.64 ms | 109000.0000 | 31000.0000 | 11000.0000 | 1264.68 MB |
| Flush_WithDirtyEntities | 5000       | 3,406.53 ms | 67.236 ms | 77.429 ms | 3,394.60 ms | 207000.0000 | 72000.0000 | 12000.0000 | 2426.96 MB |
| Flush_WithNewWrites     | 5000       |   217.27 ms |  3.666 ms |  3.061 ms |   217.55 ms |  12000.0000 |  4000.0000 |  2000.0000 |  123.31 MB |

### Benchmarks after
| Method                  | EntryCount | Mean        | Error     | StdDev    | Gen0        | Gen1       | Gen2       | Allocated  |
|------------------------ |----------- |------------:|----------:|----------:|------------:|-----------:|-----------:|-----------:|
| Flush_NoPendingChanges  | 1000       |   143.63 ms |  2.867 ms |  4.112 ms |  18000.0000 |  1000.0000 |          - |  222.13 MB |
| Flush_WithDirtyEntities | 1000       |   457.79 ms |  8.116 ms |  9.967 ms |  37000.0000 |  3000.0000 |  1000.0000 |  454.52 MB |
| Flush_WithNewWrites     | 1000       |    38.44 ms |  0.763 ms |  1.690 ms |   2000.0000 |  1000.0000 |          - |   24.31 MB |
| Flush_NoPendingChanges  | 5000       |   764.26 ms | 14.852 ms | 19.312 ms |  93000.0000 |  2000.0000 |  1000.0000 | 1110.19 MB |
| Flush_WithDirtyEntities | 5000       | 2,966.58 ms | 38.978 ms | 34.553 ms | 200000.0000 | 73000.0000 | 11000.0000 | 2272.48 MB |
| Flush_WithNewWrites     | 5000       |   197.08 ms |  3.895 ms |  7.689 ms |  11000.0000 |  4000.0000 |  2000.0000 |  122.43 MB |