### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.github/workflows/GenerateAsyncCode.yml
+++ b/.github/workflows/GenerateAsyncCode.yml
@@ -1,6 +1,6 @@
 name: Generate Async code
 
-on: 
+on:
   pull_request_target:
     paths:
       - '**.cs'


### PR DESCRIPTION
Remove trailing whitespace from the async generation workflow. This pull request also verifies the AppVeyor custom commit status context and the merge queue.