### PR TITLE
Skip lock tests with timeout on MySql.Data above 8.0.30

### DIFF
--- a/src/NHibernate.Test/Async/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Async/Linq/QueryLock.cs
@@ -204,6 +204,11 @@ namespace NHibernate.Test.Linq
 		{
 			try
 			{
+				Assume.That(
+					TestDialect.SupportsQueryTimeoutOnLockWait,
+					Is.True,
+					"The data provider is unable to interrupt a query waiting for a lock");
+
 				using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
 				using (var s2 = OpenSession())
 				using (s2.BeginTransaction())

--- a/src/NHibernate.Test/Async/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Async/Linq/QueryLock.cs
@@ -205,7 +205,7 @@ namespace NHibernate.Test.Linq
 			try
 			{
 				Assume.That(
-					TestDialect.SupportsQueryTimeoutOnLockWait,
+					!TestDialect.HasBrokenQueryTimeoutOnLockWait,
 					Is.True,
 					"The data provider is unable to interrupt a query waiting for a lock");
 

--- a/src/NHibernate.Test/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Linq/QueryLock.cs
@@ -191,7 +191,7 @@ namespace NHibernate.Test.Linq
 		private void AssertSeparateTransactionIsLockedOut(string customerId)
 		{
 			Assume.That(
-				TestDialect.SupportsQueryTimeoutOnLockWait,
+				!TestDialect.HasBrokenQueryTimeoutOnLockWait,
 				Is.True,
 				"The data provider is unable to interrupt a query waiting for a lock");
 

--- a/src/NHibernate.Test/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Linq/QueryLock.cs
@@ -190,6 +190,11 @@ namespace NHibernate.Test.Linq
 
 		private void AssertSeparateTransactionIsLockedOut(string customerId)
 		{
+			Assume.That(
+				TestDialect.SupportsQueryTimeoutOnLockWait,
+				Is.True,
+				"The data provider is unable to interrupt a query waiting for a lock");
+
 			using (new TransactionScope(TransactionScopeOption.Suppress))
 			using (var s2 = OpenSession())
 			using (s2.BeginTransaction())

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -72,6 +72,12 @@ namespace NHibernate.Test
 		/// </summary>
 		public virtual bool SupportsSelectForUpdateOnOuterJoin => SupportsSelectForUpdate;
 
+		/// <summary>
+		/// Some data providers are unable to interrupt a query waiting for a lock, leaving its timeout to
+		/// never elapse.
+		/// </summary>
+		public virtual bool SupportsQueryTimeoutOnLockWait => true;
+
 		public virtual bool SupportsHavingWithoutGroupBy => true;
 
 		public virtual bool SupportsComplexExpressionInGroupBy => true;

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -55,6 +55,11 @@ namespace NHibernate.Test
 		/// </summary>
 		public virtual bool HasBrokenDecimalType => false;
 
+		/// <summary>
+		/// Some data providers cannot interrupt a query waiting for a lock.
+		/// </summary>
+		public virtual bool HasBrokenQueryTimeoutOnLockWait => false;
+
 		public virtual bool SupportsNullCharactersInUtfStrings => true;
 
 		/// <summary>
@@ -71,11 +76,6 @@ namespace NHibernate.Test
 		///  Some databases do not support SELECT FOR UPDATE in conjunction with outer joins 
 		/// </summary>
 		public virtual bool SupportsSelectForUpdateOnOuterJoin => SupportsSelectForUpdate;
-
-		/// <summary>
-		/// Some data providers cannot interrupt a query waiting for a lock.
-		/// </summary>
-		public virtual bool SupportsQueryTimeoutOnLockWait => true;
 
 		public virtual bool SupportsHavingWithoutGroupBy => true;
 

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -73,8 +73,7 @@ namespace NHibernate.Test
 		public virtual bool SupportsSelectForUpdateOnOuterJoin => SupportsSelectForUpdate;
 
 		/// <summary>
-		/// Some data providers are unable to interrupt a query waiting for a lock, leaving its timeout to
-		/// never elapse.
+		/// Some data providers cannot interrupt a query waiting for a lock.
 		/// </summary>
 		public virtual bool SupportsQueryTimeoutOnLockWait => true;
 

--- a/src/NHibernate.Test/TestDialects/MySQL5TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/MySQL5TestDialect.cs
@@ -32,7 +32,7 @@ namespace NHibernate.Test.TestDialects
 		/// <summary>
 		/// MySql.Data after 8.0.30 never ends a query waiting for a lock.
 		/// </summary>
-		public override bool SupportsQueryTimeoutOnLockWait =>
-			typeof(MySqlConnection).Assembly.GetName().Version <= new System.Version(8, 0, 30, 0);
+		public override bool HasBrokenQueryTimeoutOnLockWait =>
+			typeof(MySqlConnection).Assembly.GetName().Version > new System.Version(8, 0, 30, 0);
 	}
 }

--- a/src/NHibernate.Test/TestDialects/MySQL5TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/MySQL5TestDialect.cs
@@ -1,4 +1,6 @@
-﻿namespace NHibernate.Test.TestDialects
+﻿using MySql.Data.MySqlClient;
+
+namespace NHibernate.Test.TestDialects
 {
 	public class MySQL5TestDialect : TestDialect
 	{
@@ -26,5 +28,13 @@
 		/// MySQL data provider may be wrecked by transaction scope timeouts to the point of causing even the teardown to fail.
 		/// </summary>
 		public override bool SupportsTransactionScopeTimeouts => false;
+
+		/// <summary>
+		/// MySql.Data does not end a query waiting for a lock: neither the query timeout nor a cancellation
+		/// interrupts it, and once the timeout has elapsed, the connection stops processing the server answer
+		/// too, leaving the query pending forever.
+		/// </summary>
+		public override bool SupportsQueryTimeoutOnLockWait =>
+			typeof(MySqlConnection).Assembly.GetName().Version < new System.Version(8, 0, 30);
 	}
 }

--- a/src/NHibernate.Test/TestDialects/MySQL5TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/MySQL5TestDialect.cs
@@ -30,11 +30,9 @@ namespace NHibernate.Test.TestDialects
 		public override bool SupportsTransactionScopeTimeouts => false;
 
 		/// <summary>
-		/// MySql.Data does not end a query waiting for a lock: neither the query timeout nor a cancellation
-		/// interrupts it, and once the timeout has elapsed, the connection stops processing the server answer
-		/// too, leaving the query pending forever.
+		/// MySql.Data after 8.0.30 never ends a query waiting for a lock.
 		/// </summary>
 		public override bool SupportsQueryTimeoutOnLockWait =>
-			typeof(MySqlConnection).Assembly.GetName().Version < new System.Version(8, 0, 30);
+			typeof(MySqlConnection).Assembly.GetName().Version <= new System.Version(8, 0, 30, 0);
 	}
 }


### PR DESCRIPTION
Skip the lock tests that need a query timeout when the MySql.Data version is later than 8.0.30.

In these versions, the query timeout does not stop a query that waits for a lock. The test run then never ends.
