### PR TITLE
Support for `for update nowait` and `for update of` locks in the MySQL 8 dialect

### DIFF
--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -71,16 +71,16 @@ jobs:
               Add-Content -Path 'C:\firebird\databases.conf' -Value "`r`nnhibernate = C:\firebird\nhibernate.fdb`r`n{`r`n    MaxUnflushedWrites = -1`r`n    MaxUnflushedWriteTime = -1`r`n}"
               Restart-Service FirebirdServerDefaultInstance
           - DB: MySQL
-            CONNECTION_STRING: "Server=localhost;Uid=root;Password=nhibernate;Database=nhibernate;Old Guids=True;SslMode=none;"
+            CONNECTION_STRING: "Server=localhost;Uid=root;Password=nhibernate;Database=nhibernate;SslMode=none;AllowPublicKeyRetrieval=true;"
             OS: ubuntu-latest
             DB_INIT: |
               sudo service mysql stop
-              docker run --name mysql -e MYSQL_ROOT_PASSWORD=nhibernate -e MYSQL_USER=nhibernate -e MYSQL_PASSWORD=nhibernate -e MYSQL_DATABASE=nhibernate -p 3306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -d mysql:5.7 mysqld --lower_case_table_names=1 --character-set-server=utf8 --collation-server=utf8_general_ci
+              docker run --name mysql -e MYSQL_ROOT_PASSWORD=nhibernate -e MYSQL_USER=nhibernate -e MYSQL_PASSWORD=nhibernate -e MYSQL_DATABASE=nhibernate -p 3306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -d mysql:8.4 mysqld --lower_case_table_names=1 --character-set-server=utf8 --collation-server=utf8_general_ci
           - DB: MySQL
-            CONNECTION_STRING: "Server=127.0.0.1;Uid=root;Database=nhibernate;Old Guids=True;SslMode=none;CharSet=utf8;"
+            CONNECTION_STRING: "Server=127.0.0.1;Uid=root;Database=nhibernate;SslMode=none;CharSet=utf8;"
             OS: windows-latest
             DB_INIT: |
-              choco install mysql --version 5.7.44 --no-progress
+              choco install mysql --version 8.4.6 --no-progress
               & 'C:\tools\mysql\current\bin\mysql' --user=root -e 'CREATE DATABASE nhibernate CHARACTER SET utf8 COLLATE utf8_general_ci;'
           - DB: Oracle
             CONNECTION_STRING: "User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XEPDB1)))"

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -80,8 +80,15 @@ jobs:
             CONNECTION_STRING: "Server=127.0.0.1;Uid=root;Database=nhibernate;SslMode=none;CharSet=utf8;"
             OS: windows-latest
             DB_INIT: |
-              choco install mysql --version 8.4.6 --no-progress
-              & 'C:\tools\mysql\current\bin\mysql' --user=root -e 'CREATE DATABASE nhibernate CHARACTER SET utf8 COLLATE utf8_general_ci;'
+              # The CDN keeps only the newest patch. Update the version when the download fails.
+              $mysql = 'mysql-8.4.11-winx64'
+              iwr "https://cdn.mysql.com/Downloads/MySQL-8.4/$mysql.zip" -OutFile mysql.zip -MaximumRetryCount 3 -RetryIntervalSec 15
+              Expand-Archive mysql.zip C:\
+              cd C:\$mysql\bin
+              ./mysqld --initialize-insecure
+              ./mysqld --install MySQL
+              Start-Service MySQL
+              ./mysql --user=root -e 'CREATE DATABASE nhibernate CHARACTER SET utf8 COLLATE utf8_general_ci;'
           - DB: Oracle
             CONNECTION_STRING: "User ID=nhibernate;Password=nhibernate;Metadata Pooling=false;Self Tuning=false;Data Source=(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = XEPDB1)))"
             OS: ubuntu-latest

--- a/.github/workflows/NetCoreTests.yml
+++ b/.github/workflows/NetCoreTests.yml
@@ -75,7 +75,7 @@ jobs:
             OS: ubuntu-latest
             DB_INIT: |
               sudo service mysql stop
-              docker run --name mysql -e MYSQL_ROOT_PASSWORD=nhibernate -e MYSQL_USER=nhibernate -e MYSQL_PASSWORD=nhibernate -e MYSQL_DATABASE=nhibernate -p 3306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -d mysql:8.4 mysqld --lower_case_table_names=1 --character-set-server=utf8 --collation-server=utf8_general_ci
+              docker run --name mysql -e MYSQL_ROOT_PASSWORD=nhibernate -e MYSQL_USER=nhibernate -e MYSQL_PASSWORD=nhibernate -e MYSQL_DATABASE=nhibernate -p 3306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -d mysql:8.4 mysqld --lower_case_table_names=1 --character-set-server=utf8 --collation-server=utf8_general_ci --skip-log-bin --innodb-flush-log-at-trx-commit=2
           - DB: MySQL
             CONNECTION_STRING: "Server=127.0.0.1;Uid=root;Database=nhibernate;SslMode=none;CharSet=utf8;"
             OS: windows-latest
@@ -84,6 +84,8 @@ jobs:
               $mysql = 'mysql-8.4.11-winx64'
               iwr "https://cdn.mysql.com/Downloads/MySQL-8.4/$mysql.zip" -OutFile mysql.zip -MaximumRetryCount 3 -RetryIntervalSec 15
               Expand-Archive mysql.zip C:\
+              # The tests do not need a binary log or a durable commit.
+              Set-Content C:\$mysql\my.ini @('[mysqld]', 'skip_log_bin', 'innodb_flush_log_at_trx_commit=2')
               cd C:\$mysql\bin
               ./mysqld --initialize-insecure
               ./mysqld --install MySQL

--- a/psake.ps1
+++ b/psake.ps1
@@ -20,9 +20,9 @@ Task Set-Configuration {
             'dialect' = 'NHibernate.Dialect.Firebird4Dialect'
         };
         'MySQL' = @{
-            'connection.connection_string' = 'Server=127.0.0.1;Uid=root;Pwd=Password12!;Database=nhibernate;Old Guids=True;SslMode=none;';
+            'connection.connection_string' = 'Server=127.0.0.1;Uid=root;Pwd=Password12!;Database=nhibernate;SslMode=none;AllowPublicKeyRetrieval=true;';
             'connection.driver_class' = 'NHibernate.Driver.MySqlDataDriver';
-            'dialect' = 'NHibernate.Dialect.MySQL5Dialect'
+            'dialect' = 'NHibernate.Dialect.MySQL8Dialect'
         };
         'Odbc' = @{
             # The OdbcDriver inherits SupportsMultipleOpenReaders=true from DriverBase, which requires Mars_Connection=yes for SQL Server.

--- a/src/NHibernate.Config.Templates/MySql.cfg.xml
+++ b/src/NHibernate.Config.Templates/MySql.cfg.xml
@@ -9,8 +9,8 @@ for your own use before compile tests in VisualStudio.
 		<property name="connection.driver_class">NHibernate.Driver.MySqlDataDriver</property>
 		<property name="connection.connection_string">
 			Database=nhibernate;Data Source=localhost;User Id=nhibernate;Password=;
-			Old Guids=True;
+			AllowPublicKeyRetrieval=true;
 		</property>
-		<property name="dialect">NHibernate.Dialect.MySQL5Dialect</property>
+		<property name="dialect">NHibernate.Dialect.MySQL8Dialect</property>
 	</session-factory>
 </hibernate-configuration>

--- a/src/NHibernate.Test/Async/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Async/Linq/QueryLock.cs
@@ -90,6 +90,22 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public async Task CanSetLockOnJoinWithoutLockingTheOtherTableAsync()
+		{
+			Assume.That(Dialect.SupportsForUpdateOf, Is.True, "Dialect locks all the tables of the query");
+
+			using (session.BeginTransaction())
+			{
+				var result = await ((from c in db.Customers
+				              from o in c.Orders.WithLock(LockMode.Upgrade)
+				              select o).ToListAsync());
+
+				Assert.That(result, Has.Count.EqualTo(830));
+				await (AssertSeparateTransactionCanLockAsync(result[0].Customer.CustomerId));
+			}
+		}
+
+		[Test]
 		public async Task CanSetLockOnJoinOuterAsync()
 		{
 			using (session.BeginTransaction())
@@ -232,6 +248,29 @@ namespace NHibernate.Test.Linq
 			catch (Exception ex)
 			{
 				return Task.FromException<object>(ex);
+			}
+		}
+
+		private async Task AssertSeparateTransactionCanLockAsync(string customerId, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			Assume.That(
+				TestDialect.SupportsNoWaitLock || !TestDialect.HasBrokenQueryTimeoutOnLockWait,
+				Is.True,
+				"The data provider is unable to interrupt a query waiting for a lock");
+
+			using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
+			using (var s2 = OpenSession())
+			using (s2.BeginTransaction())
+			{
+				var result = await ((
+						from e in s2.Query<Customer>()
+						where e.CustomerId == customerId
+						select e
+					).WithLock(LockMode.UpgradeNoWait)
+					 .WithOptions(o => o.SetTimeout(5))
+					 .ToListAsync(cancellationToken));
+
+				Assert.That(result, Has.Count.EqualTo(1), "The customer should not have been locked.");
 			}
 		}
 

--- a/src/NHibernate.Test/Async/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Async/Linq/QueryLock.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Linq;
 using System.Transactions;
-using NHibernate.Dialect;
 using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Driver;
 using NHibernate.Engine;
@@ -205,7 +204,7 @@ namespace NHibernate.Test.Linq
 			try
 			{
 				Assume.That(
-					!TestDialect.HasBrokenQueryTimeoutOnLockWait,
+					TestDialect.SupportsNoWaitLock || !TestDialect.HasBrokenQueryTimeoutOnLockWait,
 					Is.True,
 					"The data provider is unable to interrupt a query waiting for a lock");
 
@@ -240,8 +239,7 @@ namespace NHibernate.Test.Linq
 		[Description("Verify that different lock modes are respected even if the query is otherwise exactly the same.")]
 		public async Task CanChangeLockModeForQueryAsync()
 		{
-			// Limit to a few dialects where we know the "nowait" keyword is used to make life easier.
-			Assume.That(Dialect is MsSql2000Dialect || Dialect is Oracle8iDialect || Dialect is PostgreSQL81Dialect);
+			Assume.That(TestDialect.SupportsNoWaitLock, Is.True, "Dialect does not have a no-wait lock");
 
 			using (session.BeginTransaction())
 			{

--- a/src/NHibernate.Test/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Linq/QueryLock.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Transactions;
-using NHibernate.Dialect;
 using NHibernate.DomainModel.Northwind.Entities;
 using NHibernate.Driver;
 using NHibernate.Engine;
@@ -191,7 +190,7 @@ namespace NHibernate.Test.Linq
 		private void AssertSeparateTransactionIsLockedOut(string customerId)
 		{
 			Assume.That(
-				!TestDialect.HasBrokenQueryTimeoutOnLockWait,
+				TestDialect.SupportsNoWaitLock || !TestDialect.HasBrokenQueryTimeoutOnLockWait,
 				Is.True,
 				"The data provider is unable to interrupt a query waiting for a lock");
 
@@ -220,8 +219,7 @@ namespace NHibernate.Test.Linq
 		[Description("Verify that different lock modes are respected even if the query is otherwise exactly the same.")]
 		public void CanChangeLockModeForQuery()
 		{
-			// Limit to a few dialects where we know the "nowait" keyword is used to make life easier.
-			Assume.That(Dialect is MsSql2000Dialect || Dialect is Oracle8iDialect || Dialect is PostgreSQL81Dialect);
+			Assume.That(TestDialect.SupportsNoWaitLock, Is.True, "Dialect does not have a no-wait lock");
 
 			using (session.BeginTransaction())
 			{

--- a/src/NHibernate.Test/Linq/QueryLock.cs
+++ b/src/NHibernate.Test/Linq/QueryLock.cs
@@ -78,6 +78,22 @@ namespace NHibernate.Test.Linq
 		}
 
 		[Test]
+		public void CanSetLockOnJoinWithoutLockingTheOtherTable()
+		{
+			Assume.That(Dialect.SupportsForUpdateOf, Is.True, "Dialect locks all the tables of the query");
+
+			using (session.BeginTransaction())
+			{
+				var result = (from c in db.Customers
+				              from o in c.Orders.WithLock(LockMode.Upgrade)
+				              select o).ToList();
+
+				Assert.That(result, Has.Count.EqualTo(830));
+				AssertSeparateTransactionCanLock(result[0].Customer.CustomerId);
+			}
+		}
+
+		[Test]
 		public void CanSetLockOnJoinOuter()
 		{
 			using (session.BeginTransaction())
@@ -212,6 +228,29 @@ namespace NHibernate.Test.Linq
 						Assert.That(result2, Is.Not.Null);
 					},
 					"Expected an exception to indicate locking failure due to already locked.");
+			}
+		}
+
+		private void AssertSeparateTransactionCanLock(string customerId)
+		{
+			Assume.That(
+				TestDialect.SupportsNoWaitLock || !TestDialect.HasBrokenQueryTimeoutOnLockWait,
+				Is.True,
+				"The data provider is unable to interrupt a query waiting for a lock");
+
+			using (new TransactionScope(TransactionScopeOption.Suppress))
+			using (var s2 = OpenSession())
+			using (s2.BeginTransaction())
+			{
+				var result = (
+						from e in s2.Query<Customer>()
+						where e.CustomerId == customerId
+						select e
+					).WithLock(LockMode.UpgradeNoWait)
+					 .WithOptions(o => o.SetTimeout(5))
+					 .ToList();
+
+				Assert.That(result, Has.Count.EqualTo(1), "The customer should not have been locked.");
 			}
 		}
 

--- a/src/NHibernate.Test/TestContainerSetup.cs
+++ b/src/NHibernate.Test/TestContainerSetup.cs
@@ -20,7 +20,7 @@ namespace NHibernate.Test
 		private const string FirebirdSqlImage = "firebirdsql/firebird:4";
 		private const string MariaDbImage = "mariadb:10.10";
 		private const string MsSqlImage = "mcr.microsoft.com/mssql/server:2019-latest";
-		private const string MySqlImage = "mysql:5.7";
+		private const string MySqlImage = "mysql:8.4";
 		private const string OracleImage = "gvenzl/oracle-xe:21-slim";
 		private const string PostgreSqlImage = "postgres:13";
 

--- a/src/NHibernate.Test/TestDialect.cs
+++ b/src/NHibernate.Test/TestDialect.cs
@@ -77,6 +77,11 @@ namespace NHibernate.Test
 		/// </summary>
 		public virtual bool SupportsSelectForUpdateOnOuterJoin => SupportsSelectForUpdate;
 
+		/// <summary>
+		/// Some dialects do not have a no-wait lock.
+		/// </summary>
+		public virtual bool SupportsNoWaitLock => false;
+
 		public virtual bool SupportsHavingWithoutGroupBy => true;
 
 		public virtual bool SupportsComplexExpressionInGroupBy => true;

--- a/src/NHibernate.Test/TestDialects/MsSql2008TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/MsSql2008TestDialect.cs
@@ -14,6 +14,8 @@ namespace NHibernate.Test.TestDialects
 		/// </summary>
 		public override bool SupportsSelectForUpdateWithPaging => false;
 
+		public override bool SupportsNoWaitLock => true;
+
 		/// <inheritdoc />
 		/// <remarks>Canceling a query hangs under Linux with Sql2008ClientDriver. (It may be a data provider bug fixed with MicrosoftDataSqlClientDriver.)</remarks>
 		public override bool SupportsCancelQuery => !RuntimeInformation.IsOSPlatform(OSPlatform.Linux);

--- a/src/NHibernate.Test/TestDialects/MySQL8TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/MySQL8TestDialect.cs
@@ -8,5 +8,7 @@ namespace NHibernate.Test.TestDialects
 		}
 
 		public override bool SupportsNoWaitLock => true;
+
+		public override bool SupportsCorrelatedColumnsInSubselectJoin => true;
 	}
 }

--- a/src/NHibernate.Test/TestDialects/MySQL8TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/MySQL8TestDialect.cs
@@ -1,0 +1,12 @@
+namespace NHibernate.Test.TestDialects
+{
+	public class MySQL8TestDialect : MySQL5TestDialect
+	{
+		public MySQL8TestDialect(Dialect.Dialect dialect)
+			: base(dialect)
+		{
+		}
+
+		public override bool SupportsNoWaitLock => true;
+	}
+}

--- a/src/NHibernate.Test/TestDialects/Oracle10gTestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/Oracle10gTestDialect.cs
@@ -17,6 +17,8 @@ namespace NHibernate.Test.TestDialects
 
 		public override bool SupportsAggregateInSubSelect => true;
 
+		public override bool SupportsNoWaitLock => true;
+
 		public override bool SupportsSqlType(SqlType sqlType)
 		{
 			// The Oracle dialects define types for DbType the Oracle driver does not support.

--- a/src/NHibernate.Test/TestDialects/PostgreSQL83TestDialect.cs
+++ b/src/NHibernate.Test/TestDialects/PostgreSQL83TestDialect.cs
@@ -9,6 +9,8 @@
 
 		public override bool SupportsSelectForUpdateOnOuterJoin => false;
 
+		public override bool SupportsNoWaitLock => true;
+
 		public override bool SupportsNullCharactersInUtfStrings => false;
 
 		/// <summary>

--- a/src/NHibernate/Dialect/MySQL8Dialect.cs
+++ b/src/NHibernate/Dialect/MySQL8Dialect.cs
@@ -5,5 +5,12 @@ namespace NHibernate.Dialect
 	public class MySQL8Dialect : MySQL57Dialect
 	{
 		public MySQL8Dialect() => RegisterColumnType(DbType.Boolean, "BOOLEAN");
+
+		/// <summary>
+		/// MySQL supports no-wait locks since 8.0.1.
+		/// </summary>
+		public override string ForUpdateNowaitString => " for update nowait";
+
+		public override string GetForUpdateNowaitString(string aliases) => ForUpdateNowaitString;
 	}
 }

--- a/src/NHibernate/Dialect/MySQL8Dialect.cs
+++ b/src/NHibernate/Dialect/MySQL8Dialect.cs
@@ -11,6 +11,13 @@ namespace NHibernate.Dialect
 		/// </summary>
 		public override string ForUpdateNowaitString => " for update nowait";
 
-		public override string GetForUpdateNowaitString(string aliases) => ForUpdateNowaitString;
+		/// <summary>
+		/// MySQL locks only the named tables since 8.0.1. It names tables, not columns.
+		/// </summary>
+		public override bool SupportsForUpdateOf => true;
+
+		public override string GetForUpdateString(string aliases) => ForUpdateString + " of " + aliases;
+
+		public override string GetForUpdateNowaitString(string aliases) => ForUpdateString + " of " + aliases + " nowait";
 	}
 }

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -7,3 +7,5 @@ override NHibernate.Dialect.Firebird3Dialect.NativeIdentifierGeneratorClass.get 
 override NHibernate.Dialect.Firebird3Dialect.NoColumnsInsertString.get -> string
 override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
+override NHibernate.Dialect.MySQL8Dialect.ForUpdateNowaitString.get -> string
+override NHibernate.Dialect.MySQL8Dialect.GetForUpdateNowaitString(string aliases) -> string

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -9,3 +9,5 @@ override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
 override NHibernate.Dialect.MySQL8Dialect.ForUpdateNowaitString.get -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateNowaitString(string aliases) -> string
+override NHibernate.Dialect.MySQL8Dialect.GetForUpdateString(string aliases) -> string
+override NHibernate.Dialect.MySQL8Dialect.SupportsForUpdateOf.get -> bool


### PR DESCRIPTION
Supports `for update nowait` and `for update of` with MySQL 8. MySQL supports both clauses from 8.0.1.

Run tests with MySQL 8.4 and the MySQL 8 dialect. The MySQL 8 saves GUID values in `char(36)` columns, so removed `Old Guids=True` from the connection strings.

Installs the MySQL from the archives, because the chocolatey package downloads from the CDN, which keeps only the newest patch release.