### PR TITLE
Keep official GitHub actions on their major version tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "config:recommended"
   ],
   "configMigration": true,
   "pruneStaleBranches": false,
@@ -16,14 +15,16 @@
   ],
   "packageRules": [
     {
-      "description": "Do not pin digests for official GitHub actions",
-      "matchManagers": [
-        "github-actions"
+      "description": "Pin third-party actions to a digest",
+      "matchDepTypes": [
+        "action"
       ],
       "matchDepNames": [
-        "actions/**"
+        "!actions/**"
       ],
-      "pinDigests": false
+      "extends": [
+        "helpers:pinGitHubActionDigestsToSemver"
+      ]
     },
     {
       "matchSourceUrls": [


### PR DESCRIPTION
Keep the official GitHub actions on their major version tag, and pin the other actions to a digest with a SemVer comment.

The digest helper applied to all actions. It hid the major tags, and Renovate changed `actions/checkout@v6` to `actions/checkout@v7.0.1`.