### PR TITLE
Open a separate Renovate PR for each major version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   ],
   "configMigration": true,
   "pruneStaleBranches": false,
+  "separateMultipleMajor": true,
   "automerge": true,
   "platformAutomerge": true,
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
Enable `separateMultipleMajor` so a dependency that is several major versions behind gets one PR per version, instead of a single PR that jumps straight to the newest version.