### PR TITLE
Linq: call RemoveRedundantCast in pre transform

### DIFF
--- a/build-common/NHibernate.props
+++ b/build-common/NHibernate.props
@@ -5,7 +5,7 @@
     <NhVersion     Condition="'$(NhVersion)' == ''"    >5.7</NhVersion>
     <VersionPatch  Condition="'$(VersionPatch)'  == ''">0</VersionPatch>
     <!-- Clear VersionSuffix for making release and set it to dev for making development builds -->
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">dev</VersionSuffix>
     <LangVersion Condition="'$(MSBuildProjectExtension)' != '.vbproj'">14.0</LangVersion>
 
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(NhVersion).$(VersionPatch)</VersionPrefix>

--- a/src/NHibernate.Test/Async/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Async/Linq/WhereTests.cs
@@ -499,6 +499,96 @@ namespace NHibernate.Test.Linq
 
 			Assert.That(query.Count, Is.EqualTo(2));
 		}
+		
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayContainsAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await ((from user in db.Users
+			             where names.Contains(user.Name)
+			             select user).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayContainsWithExplicitCastAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await (db.Users.Where(user => ((string[])names).Contains(user.Name)).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayContainsWithExplicitAsAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await (db.Users.Where(user => (names as string[]).Contains(user.Name)).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayEnumerableContainsWithExplicitCastAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await (db.Users.Where(user => Enumerable.Contains((string[])names, user.Name)).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayEnumerableContainsWithExplicitAsAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await (db.Users.Where(user => Enumerable.Contains((names as string[]), user.Name)).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
+#nullable enable
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithArrayContainsNullableEnabledAsync()
+		{
+			var names = new[] { "ayende", "rahien" };
+
+			var query = await ((from user in db.Users
+			             where names.Contains(user.Name)
+			             select user).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
+		// The compiler casts the array to its own type before it converts it to a span, because an expression
+		// tree cannot hold the nullable annotations. The cast must not hide the evaluated array from the
+		// generator.
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayContainsNullableEnabledAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await (db.Users.Where(user => names.Contains(user.Name)).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public async Task UsersWithTypedArrayEnumerableContainsNullableEnabledAsync()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = await (db.Users.Where(user => Enumerable.Contains(names, user.Name)).ToListAsync());
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+#nullable restore
 
 		[Test]
 		public async Task UsersWithListContainsAsync()

--- a/src/NHibernate.Test/Linq/WhereTests.cs
+++ b/src/NHibernate.Test/Linq/WhereTests.cs
@@ -487,6 +487,96 @@ namespace NHibernate.Test.Linq
 
 			Assert.That(query.Count, Is.EqualTo(2));
 		}
+		
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayContains()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = (from user in db.Users
+			             where names.Contains(user.Name)
+			             select user).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayContainsWithExplicitCast()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = db.Users.Where(user => ((string[])names).Contains(user.Name)).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayContainsWithExplicitAs()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = db.Users.Where(user => (names as string[]).Contains(user.Name)).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayEnumerableContainsWithExplicitCast()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = db.Users.Where(user => Enumerable.Contains((string[])names, user.Name)).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayEnumerableContainsWithExplicitAs()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = db.Users.Where(user => Enumerable.Contains((names as string[]), user.Name)).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
+#nullable enable
+		[Test(Description = "GH-3802")]
+		public void UsersWithArrayContainsNullableEnabled()
+		{
+			var names = new[] { "ayende", "rahien" };
+
+			var query = (from user in db.Users
+			             where names.Contains(user.Name)
+			             select user).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+
+		// The compiler casts the array to its own type before it converts it to a span, because an expression
+		// tree cannot hold the nullable annotations. The cast must not hide the evaluated array from the
+		// generator.
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayContainsNullableEnabled()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = db.Users.Where(user => names.Contains(user.Name)).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+		
+		[Test(Description = "GH-3802")]
+		public void UsersWithTypedArrayEnumerableContainsNullableEnabled()
+		{
+			var names = new string[] { "ayende", "rahien" };
+
+			var query = db.Users.Where(user => Enumerable.Contains(names, user.Name)).ToList();
+
+			Assert.That(query.Count, Is.EqualTo(2));
+		}
+#nullable restore
 
 		[Test]
 		public void UsersWithListContains()

--- a/src/NHibernate/Linq/NhRelinqQueryParser.cs
+++ b/src/NHibernate/Linq/NhRelinqQueryParser.cs
@@ -90,6 +90,7 @@ namespace NHibernate.Linq
 			// NH-3799 (#1173): must supply the implicit GetValueOrDefault() default value before
 			// parameterization occurs, otherwise it gets inlined as a literal.
 			preTransformerRegistry.Register(new AddGetValueOrDefaultArgument());
+			preTransformerRegistry.Register(new RemoveRedundantCast());
 			expressionTransformerRegistrar?.Register(preTransformerRegistry);
 
 			return new TransformingExpressionTreeProcessor(preTransformerRegistry).Process;

--- a/src/NHibernate/Linq/NhRelinqQueryParser.cs
+++ b/src/NHibernate/Linq/NhRelinqQueryParser.cs
@@ -87,6 +87,7 @@ namespace NHibernate.Linq
 			// NH-3247: must remove .Net compiler char to int conversion before
 			// parameterization occurs.
 			preTransformerRegistry.Register(new RemoveCharToIntConversion());
+			preTransformerRegistry.Register(new RemoveRedundantCast());
 			expressionTransformerRegistrar?.Register(preTransformerRegistry);
 
 			return new TransformingExpressionTreeProcessor(preTransformerRegistry).Process;


### PR DESCRIPTION
Fixes #3802 