### PR TITLE
Register Firebird 3 statistical aggregate functions

### DIFF
--- a/src/NHibernate/Dialect/Firebird3Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird3Dialect.cs
@@ -1,3 +1,4 @@
+using NHibernate.Dialect.Function;
 using NHibernate.Id;
 using NHibernate.SqlCommand;
 
@@ -13,6 +14,16 @@ namespace NHibernate.Dialect
 	/// </remarks>
 	public class Firebird3Dialect : FirebirdDialect
 	{
+		protected override void RegisterFunctions()
+		{
+			base.RegisterFunctions();
+			// Firebird 3 adds the SQL standard statistical aggregates.
+			RegisterFunction("stddev", new StandardSQLFunction("stddev_samp", NHibernateUtil.Double));
+			RegisterFunction("stddev_samp", new StandardSQLFunction("stddev_samp", NHibernateUtil.Double));
+			RegisterFunction("variance", new StandardSQLFunction("var_samp", NHibernateUtil.Double));
+			RegisterFunction("var_samp", new StandardSQLFunction("var_samp", NHibernateUtil.Double));
+		}
+
 		public override SqlString GetLimitString(SqlString queryString, SqlString offset, SqlString limit)
 		{
 			var result = new SqlStringBuilder(queryString);

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ override NHibernate.Dialect.Firebird3Dialect.GetSequenceNextValString(string seq
 override NHibernate.Dialect.Firebird3Dialect.IdentityColumnString.get -> string
 override NHibernate.Dialect.Firebird3Dialect.NativeIdentifierGeneratorClass.get -> System.Type
 override NHibernate.Dialect.Firebird3Dialect.NoColumnsInsertString.get -> string
+override NHibernate.Dialect.Firebird3Dialect.RegisterFunctions() -> void
 override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsPooledSequences.get -> bool


### PR DESCRIPTION
Register the `stddev_samp` and `var_samp` aggregate functions that Firebird 3 adds, and alias them as `stddev` and `variance`.