### PR TITLE
Use LOCALTIMESTAMP for Firebird 4 current timestamp function

### DIFF
--- a/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
@@ -1,0 +1,18 @@
+using NHibernate.Dialect;
+using NUnit.Framework;
+
+namespace NHibernate.Test.DialectTest
+{
+	[TestFixture]
+	public class Firebird4DialectFixture
+	{
+		private readonly Firebird4Dialect _dialect = new Firebird4Dialect();
+
+		[Test]
+		public void CurrentTimestampIsNotTimeZoneAware()
+		{
+			Assert.That(_dialect.CurrentTimestampSQLFunctionName, Is.EqualTo("localtimestamp"));
+			Assert.That(_dialect.CurrentTimestampSelectString, Is.EqualTo("select LOCALTIMESTAMP from RDB$DATABASE"));
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -2,14 +2,25 @@ using NHibernate.Dialect.Function;
 
 namespace NHibernate.Dialect
 {
-	public class Firebird4Dialect: Firebird3Dialect
+	/// <summary>
+	/// A dialect for Firebird 4 and above.
+	/// </summary>
+	public class Firebird4Dialect : Firebird3Dialect
 	{
+		/// <inheritdoc />
+		/// <remarks>
+		/// <c>CURRENT_TIMESTAMP</c> is time zone aware since Firebird 4, <c>LOCALTIMESTAMP</c> is not.
+		/// </remarks>
 		public override string CurrentTimestampSelectString => "select LOCALTIMESTAMP from RDB$DATABASE";
+
+		/// <inheritdoc />
+		public override string CurrentTimestampSQLFunctionName => "localtimestamp";
 
 		protected override void RegisterFunctions()
 		{
 			base.RegisterFunctions();
 			RegisterFunction("current_timestamp", new NoArgSQLFunction("localtimestamp", NHibernateUtil.LocalDateTime, false));
+			RegisterFunction("localtimestamp", new NoArgSQLFunction("localtimestamp", NHibernateUtil.LocalDateTime, false));
 		}
 	}
 }

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ override NHibernate.Dialect.Firebird3Dialect.NoColumnsInsertString.get -> string
 override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsPooledSequences.get -> bool
+override NHibernate.Dialect.Firebird4Dialect.CurrentTimestampSQLFunctionName.get -> string
 override NHibernate.Dialect.MySQL8Dialect.ForUpdateNowaitString.get -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateNowaitString(string aliases) -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateString(string aliases) -> string


### PR DESCRIPTION
Use `LOCALTIMESTAMP` as the current timestamp SQL function of the Firebird 4 dialect, and register it by its own name.

`CURRENT_TIMESTAMP` is time zone aware since Firebird 4. The dialect already reads the current timestamp with `LOCALTIMESTAMP`, but the function name that HQL puts into a bulk insert stayed `CURRENT_TIMESTAMP`.