### PR TITLE
Register Firebird 4 built-in functions

### DIFF
--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Dialect
 			RegisterFunction("current_timestamp", new NoArgSQLFunction("localtimestamp", NHibernateUtil.LocalDateTime, false));
 			RegisterFunction("localtimestamp", new NoArgSQLFunction("localtimestamp", NHibernateUtil.LocalDateTime, false));
 
-      RegisterFunction("base64_encode", new StandardSQLFunction("base64_encode", NHibernateUtil.String));
+			RegisterFunction("base64_encode", new StandardSQLFunction("base64_encode", NHibernateUtil.String));
 			RegisterFunction("base64_decode", new StandardSQLFunction("base64_decode", NHibernateUtil.Binary));
 			RegisterFunction("hex_encode", new StandardSQLFunction("hex_encode", NHibernateUtil.String));
 			RegisterFunction("hex_decode", new StandardSQLFunction("hex_decode", NHibernateUtil.Binary));

--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -10,6 +10,12 @@ namespace NHibernate.Dialect
 		{
 			base.RegisterFunctions();
 			RegisterFunction("current_timestamp", new NoArgSQLFunction("localtimestamp", NHibernateUtil.LocalDateTime, false));
+			RegisterFunction("base64_encode", new StandardSQLFunction("base64_encode", NHibernateUtil.String));
+			RegisterFunction("base64_decode", new StandardSQLFunction("base64_decode", NHibernateUtil.Binary));
+			RegisterFunction("hex_encode", new StandardSQLFunction("hex_encode", NHibernateUtil.String));
+			RegisterFunction("hex_decode", new StandardSQLFunction("hex_decode", NHibernateUtil.Binary));
+			RegisterFunction("first_day", new SQLFunctionTemplate(NHibernateUtil.Date, "first_day(of month from ?1)"));
+			RegisterFunction("last_day", new SQLFunctionTemplate(NHibernateUtil.Date, "last_day(of month from ?1)"));
 		}
 	}
 }


### PR DESCRIPTION
Register these Firebird 4 built-in functions:

- `base64_encode`, `base64_decode`
- `hex_encode`, `hex_decode`
- `first_day`, `last_day` - the first and the last day of the month, as `last_day` does in the Oracle and MySQL dialects