### PR TITLE
Increase Firebird 4 id length and decimal precision limits

### DIFF
--- a/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
@@ -1,0 +1,25 @@
+using NHibernate.Dialect;
+using NUnit.Framework;
+
+namespace NHibernate.Test.DialectTest
+{
+	[TestFixture]
+	public class Firebird4DialectFixture
+	{
+		private readonly Firebird4Dialect _dialect = new Firebird4Dialect();
+
+		[Test]
+		public void MaxAliasLengthIsRaisedToTheFirebird4Limit()
+		{
+			Assert.That(_dialect.MaxAliasLength, Is.EqualTo(63));
+		}
+
+		[Test]
+		public void GetTypeNameDecimalWithPrecisionGreaterThan18ReturnsThatPrecision()
+		{
+			var result = _dialect.GetTypeName(NHibernateUtil.Decimal.SqlType, 0, 29, 2);
+
+			Assert.That(result, Is.EqualTo("DECIMAL(29, 2)"));
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -1,9 +1,24 @@
+using System.Data;
 using NHibernate.Dialect.Function;
 
 namespace NHibernate.Dialect
 {
 	public class Firebird4Dialect: Firebird3Dialect
 	{
+		/// <inheritdoc />
+		/// <remarks>
+		/// Firebird 4 increases the identifier length limit from 31 to 63 characters.
+		/// </remarks>
+		public override int MaxAliasLength => 63;
+
+		protected override void RegisterColumnTypes()
+		{
+			base.RegisterColumnTypes();
+			// Firebird 4 raises the maximum precision of exact numeric types from 18 to 38. 29 is the
+			// maximum a .Net decimal can hold.
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p, $s)");
+		}
+
 		public override string CurrentTimestampSelectString => "select LOCALTIMESTAMP from RDB$DATABASE";
 
 		protected override void RegisterFunctions()

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -584,7 +584,6 @@ namespace NHibernate.Dialect
 
 		// As of Firebird 2.5 documentation, limit is 30/31 (not all source are concordant), with some
 		// cases supporting more but considered as bugs and no more tolerated in v3.
-		// It seems it may be extended to 63 for Firebird v4.
 		/// <inheritdoc />
 		public override int MaxAliasLength => 30;
 

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -13,6 +13,8 @@ override NHibernate.Dialect.Firebird3Dialect.NoColumnsInsertString.get -> string
 override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsPooledSequences.get -> bool
+override NHibernate.Dialect.Firebird4Dialect.MaxAliasLength.get -> int
+override NHibernate.Dialect.Firebird4Dialect.RegisterColumnTypes() -> void
 override NHibernate.Dialect.MySQL8Dialect.ForUpdateNowaitString.get -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateNowaitString(string aliases) -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateString(string aliases) -> string


### PR DESCRIPTION
Raise the maximum alias length of the Firebird 4 dialect to 63 characters, and the maximum precision of a decimal column to 29 digits.

Firebird 4 increases the identifier length limit from 31 to 63 characters, and the precision of exact numeric types from 18 to 38 digits. 29 digits is the maximum that a .NET decimal can hold. Before this change, a mapping with a precision above 18 silently became `DECIMAL(18, 5)`.

This changes the generated DDL and the generated aliases of an application that uses the Firebird 4 dialect.