### PR TITLE
Increase Firebird 4 identifier length limit to 63 characters

### DIFF
--- a/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
@@ -1,0 +1,17 @@
+using NHibernate.Dialect;
+using NUnit.Framework;
+
+namespace NHibernate.Test.DialectTest
+{
+	[TestFixture]
+	public class Firebird4DialectFixture
+	{
+		private readonly Firebird4Dialect _dialect = new Firebird4Dialect();
+
+		[Test]
+		public void MaxAliasLengthIsRaisedToTheFirebird4Limit()
+		{
+			Assert.That(_dialect.MaxAliasLength, Is.EqualTo(63));
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -4,6 +4,12 @@ namespace NHibernate.Dialect
 {
 	public class Firebird4Dialect: Firebird3Dialect
 	{
+		/// <inheritdoc />
+		/// <remarks>
+		/// Firebird 4 increases the identifier length limit from 31 to 63 characters.
+		/// </remarks>
+		public override int MaxAliasLength => 63;
+
 		public override string CurrentTimestampSelectString => "select LOCALTIMESTAMP from RDB$DATABASE";
 
 		protected override void RegisterFunctions()

--- a/src/NHibernate/Dialect/FirebirdDialect.cs
+++ b/src/NHibernate/Dialect/FirebirdDialect.cs
@@ -584,7 +584,6 @@ namespace NHibernate.Dialect
 
 		// As of Firebird 2.5 documentation, limit is 30/31 (not all source are concordant), with some
 		// cases supporting more but considered as bugs and no more tolerated in v3.
-		// It seems it may be extended to 63 for Firebird v4.
 		/// <inheritdoc />
 		public override int MaxAliasLength => 30;
 

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ override NHibernate.Dialect.Firebird3Dialect.NoColumnsInsertString.get -> string
 override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsPooledSequences.get -> bool
+override NHibernate.Dialect.Firebird4Dialect.MaxAliasLength.get -> int
 override NHibernate.Dialect.MySQL8Dialect.ForUpdateNowaitString.get -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateNowaitString(string aliases) -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateString(string aliases) -> string


### PR DESCRIPTION
Increase the maximum alias length of the Firebird 4 dialect from 30 to 63 characters. Firebird 4 increases the identifier length limit from 31 to 63 characters.

This changes the aliases that an application generates with the Firebird 4 dialect.