### PR TITLE
Increase Firebird 4 decimal precision limit to 29 digits

### DIFF
--- a/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
+++ b/src/NHibernate.Test/DialectTest/Firebird4DialectFixture.cs
@@ -1,0 +1,19 @@
+using NHibernate.Dialect;
+using NUnit.Framework;
+
+namespace NHibernate.Test.DialectTest
+{
+	[TestFixture]
+	public class Firebird4DialectFixture
+	{
+		private readonly Firebird4Dialect _dialect = new Firebird4Dialect();
+
+		[Test]
+		public void GetTypeNameDecimalWithPrecisionGreaterThan18ReturnsThatPrecision()
+		{
+			var result = _dialect.GetTypeName(NHibernateUtil.Decimal.SqlType, 0, 29, 2);
+
+			Assert.That(result, Is.EqualTo("DECIMAL(29, 2)"));
+		}
+	}
+}

--- a/src/NHibernate/Dialect/Firebird4Dialect.cs
+++ b/src/NHibernate/Dialect/Firebird4Dialect.cs
@@ -1,9 +1,18 @@
+using System.Data;
 using NHibernate.Dialect.Function;
 
 namespace NHibernate.Dialect
 {
 	public class Firebird4Dialect: Firebird3Dialect
 	{
+		protected override void RegisterColumnTypes()
+		{
+			base.RegisterColumnTypes();
+			// Firebird 4 raises the maximum precision of exact numeric types from 18 to 38. 29 is the
+			// maximum a .Net decimal can hold.
+			RegisterColumnType(DbType.Decimal, 29, "DECIMAL($p, $s)");
+		}
+
 		public override string CurrentTimestampSelectString => "select LOCALTIMESTAMP from RDB$DATABASE";
 
 		protected override void RegisterFunctions()

--- a/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/NHibernate/PublicAPI/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ override NHibernate.Dialect.Firebird3Dialect.NoColumnsInsertString.get -> string
 override NHibernate.Dialect.Firebird3Dialect.SupportsIdentityColumns.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsInsertSelectIdentity.get -> bool
 override NHibernate.Dialect.Firebird3Dialect.SupportsPooledSequences.get -> bool
+override NHibernate.Dialect.Firebird4Dialect.RegisterColumnTypes() -> void
 override NHibernate.Dialect.MySQL8Dialect.ForUpdateNowaitString.get -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateNowaitString(string aliases) -> string
 override NHibernate.Dialect.MySQL8Dialect.GetForUpdateString(string aliases) -> string


### PR DESCRIPTION
Increase the maximum precision of a decimal column of the Firebird 4 dialect from 18 to 29 digits. Firebird 4 increases the precision of exact numeric types from 18 to 38 digits, and 29 digits is the maximum that a .NET `decimal` can hold.

Before this change, a mapping with a precision above 18 silently became `DECIMAL(18, 5)`.

This changes the DDL that an application generates with the Firebird 4 dialect.