### PR TITLE
Fix AutoJoinTransaction lost in serialization

### DIFF
--- a/src/NHibernate.Test/SystemTransactions/AutoJoinSettingFixture.cs
+++ b/src/NHibernate.Test/SystemTransactions/AutoJoinSettingFixture.cs
@@ -1,5 +1,7 @@
 using System.Transactions;
 using NHibernate.Cfg;
+using NHibernate.Engine;
+using NHibernate.Util;
 using NUnit.Framework;
 
 namespace NHibernate.Test.SystemTransactions
@@ -50,6 +52,23 @@ namespace NHibernate.Test.SystemTransactions
 					s.GetSessionImplementation().TransactionContext,
 					autoJoin ? Is.Not.Null : Is.Null);
 			}
+		}
+
+		// Adapted from Hazzik bug report, #3782.
+		[Theory]
+		public void AutoJoinTransactionSurvivesSerialization(bool? autoJoin)
+		{
+			var sb = Sfi.WithOptions();
+			if (autoJoin.HasValue)
+				sb.AutoJoinTransaction(autoJoin.Value);
+
+			using var session = sb.OpenSession();
+			var before = ((ISessionImplementor) session).ConnectionManager.ShouldAutoJoinTransaction;
+
+			var deserialized = (ISession) SerializationHelper.Deserialize(SerializationHelper.Serialize(session));
+			var after = ((ISessionImplementor) deserialized).ConnectionManager.ShouldAutoJoinTransaction;
+
+			Assert.That(after, Is.EqualTo(before));
 		}
 	}
 }

--- a/src/NHibernate/AdoNet/ConnectionManager.cs
+++ b/src/NHibernate/AdoNet/ConnectionManager.cs
@@ -386,11 +386,12 @@ namespace NHibernate.AdoNet
 		private ConnectionManager(SerializationInfo info, StreamingContext context)
 		{
 			_ownConnection = info.GetBoolean("ownConnection");
-			Session = (ISessionImplementor)info.GetValue("session", typeof(ISessionImplementor));
+			Session = (ISessionImplementor) info.GetValue("session", typeof(ISessionImplementor));
 			_connectionReleaseMode =
-				(ConnectionReleaseMode)info.GetValue("connectionReleaseMode", typeof(ConnectionReleaseMode));
-			_interceptor = (IInterceptor)info.GetValue("interceptor", typeof(IInterceptor));
+				(ConnectionReleaseMode) info.GetValue("connectionReleaseMode", typeof(ConnectionReleaseMode));
+			_interceptor = (IInterceptor) info.GetValue("interceptor", typeof(IInterceptor));
 			_connectionAccess = (IConnectionAccess) info.GetValue("connectionAccess", typeof(IConnectionAccess));
+			ShouldAutoJoinTransaction = info.GetBoolean("ShouldAutoJoinTransaction");
 		}
 
 		[SecurityCritical]
@@ -401,6 +402,7 @@ namespace NHibernate.AdoNet
 			info.AddValue("connectionReleaseMode", _connectionReleaseMode, typeof(ConnectionReleaseMode));
 			info.AddValue("interceptor", _interceptor, typeof(IInterceptor));
 			info.AddValue("connectionAccess", _connectionAccess, typeof(IConnectionAccess));
+			info.AddValue("ShouldAutoJoinTransaction", ShouldAutoJoinTransaction);
 		}
 
 		#endregion


### PR DESCRIPTION
Fixes #3782

That is a 5.0 regression. Targeting the earliest version still supported.

Possible breaking change: serialized sessions with previous versions will not be deserializable.